### PR TITLE
Member 내 데이터 정리

### DIFF
--- a/backend/src/churches/members/dto/create-member.dto.ts
+++ b/backend/src/churches/members/dto/create-member.dto.ts
@@ -5,6 +5,7 @@ import {
   IsBoolean,
   IsDate,
   IsEnum,
+  IsIn,
   IsNotEmpty,
   IsNumber,
   IsOptional,
@@ -15,6 +16,7 @@ import { TransformName } from '../../decorator/transform-name';
 import { GenderEnum } from '../../enum/gender.enum';
 import { IsValidVehicleNumber } from '../decorator/is-valid-vehicle-number.decorator';
 import { BaptismEnum } from '../enum/baptism.enum';
+import { FamilyRelation } from '../const/family-relation.const';
 
 export class CreateMemberDto {
   @ApiProperty({
@@ -46,6 +48,27 @@ export class CreateMemberDto {
   @IsNumber()
   @IsOptional()
   guidedById?: number;
+
+  @ApiProperty({
+    name: 'familyMemberId',
+    description: '가족 교인 ID',
+    example: 12,
+    required: false,
+  })
+  @IsNumber()
+  @IsOptional()
+  familyMemberId?: number;
+
+  @ApiProperty({
+    name: 'relation',
+    description: '가족 관계',
+    example: '어머니',
+    default: '가족',
+  })
+  @IsString()
+  @IsIn(Object.values(FamilyRelation))
+  @IsOptional()
+  relation?: string;
 
   @ApiProperty({
     name: 'isLunar',
@@ -173,6 +196,17 @@ export class CreateMemberDto {
   baptism?: BaptismEnum;
 
   @ApiProperty({
+    name: 'previousChurch',
+    description: '이전 교회',
+    example: 'a교회',
+    required: false,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @IsOptional()
+  previousChurch?: string;
+
+  /*@ApiProperty({
     name: 'positionId',
     description: '직급 id',
     example: 3,
@@ -201,16 +235,5 @@ export class CreateMemberDto {
   @IsString()
   @IsNotEmpty()
   @IsOptional()
-  positionStartChurch?: string;
-
-  @ApiProperty({
-    name: 'previousChurch',
-    description: '이전 교회',
-    example: 'a교회',
-    required: false,
-  })
-  @IsString()
-  @IsNotEmpty()
-  @IsOptional()
-  previousChurch?: string;
+  positionStartChurch?: string;*/
 }

--- a/backend/src/churches/members/dto/update-member.dto.ts
+++ b/backend/src/churches/members/dto/update-member.dto.ts
@@ -1,12 +1,13 @@
-import { ApiProperty, OmitType } from '@nestjs/swagger';
+import { OmitType } from '@nestjs/swagger';
 import { CreateMemberDto } from './create-member.dto';
-import { IsArray, IsNumber, IsOptional } from 'class-validator';
 
 export class UpdateMemberDto extends OmitType(CreateMemberDto, [
   'name',
   'mobilePhone',
+  'familyMemberId',
+  'relation',
 ]) {
-  @ApiProperty({
+  /*@ApiProperty({
     name: 'ministryId',
     description: '사역 ID',
     example: 3,
@@ -35,5 +36,5 @@ export class UpdateMemberDto extends OmitType(CreateMemberDto, [
   @IsArray()
   @IsNumber({}, { each: true })
   @IsOptional()
-  educationId?: number[];
+  educationId?: number[];*/
 }

--- a/backend/src/churches/members/entity/member.entity.ts
+++ b/backend/src/churches/members/entity/member.entity.ts
@@ -23,6 +23,13 @@ import { FamilyModel } from './family.entity';
 export class MemberModel extends BaseModel {
   @Column()
   @Index()
+  churchId: number;
+
+  @ManyToOne(() => ChurchModel, (church) => church.members)
+  church: ChurchModel;
+
+  @Column()
+  @Index()
   name: string;
 
   @Column()
@@ -66,6 +73,20 @@ export class MemberModel extends BaseModel {
   @Column({ nullable: true, type: 'simple-array', default: null })
   vehicleNumber: string[];
 
+  @Column({ nullable: true })
+  guidedById: number;
+
+  // 나를 인도한 사람
+  @ManyToOne(() => MemberModel, (member) => member.guiding)
+  guidedBy: MemberModel;
+
+  // 내가 인도한 사람
+  @OneToMany(() => MemberModel, (member) => member.guidedBy)
+  guiding: MemberModel;
+
+  @Column({ nullable: true, comment: '이전교회 이름' })
+  previousChurch: string;
+
   @ManyToMany(() => MinistryModel, (ministry) => ministry.members)
   @JoinTable()
   ministries: MinistryModel[];
@@ -92,27 +113,7 @@ export class MemberModel extends BaseModel {
   @Column({ enum: BaptismEnum, nullable: true, comment: '신급' })
   baptism: BaptismEnum;
 
-  @Column({ nullable: true, comment: '이전교회 이름' })
-  previousChurch: string;
-
-  @Column()
-  churchId: number;
-
   @ManyToMany(() => EducationModel, (education) => education.members)
   @JoinTable()
   educations: EducationModel[];
-
-  @ManyToOne(() => ChurchModel, (church) => church.members)
-  church: ChurchModel;
-
-  @Column({ nullable: true })
-  guidedById: number;
-
-  // 나를 인도한 사람
-  @ManyToOne(() => MemberModel, (member) => member.guiding)
-  guidedBy: MemberModel;
-
-  // 내가 인도한 사람
-  @OneToMany(() => MemberModel, (member) => member.guidedBy)
-  guiding: MemberModel;
 }

--- a/backend/src/churches/members/members.module.ts
+++ b/backend/src/churches/members/members.module.ts
@@ -17,7 +17,7 @@ import { MembersFamilyController } from './controller/members-family.controller'
     ]),
     ChurchesModule,
   ],
-  exports: [MembersService],
+  exports: [MembersService, FamilyService],
   controllers: [MembersController, MembersFamilyController],
   providers: [MembersService, FamilyService],
 })

--- a/backend/src/churches/request-info/service/request-info.service.ts
+++ b/backend/src/churches/request-info/service/request-info.service.ts
@@ -24,6 +24,7 @@ import { UpdateMemberDto } from '../../members/dto/update-member.dto';
 import { RequestLimitValidatorService } from './request-limit-validator.service';
 import { DateUtils } from '../utils/date-utils.util';
 import { REQUEST_CONSTANTS } from '../const/request-info.const';
+import { FamilyService } from '../../members/service/family.service';
 
 dotenv.config();
 
@@ -34,6 +35,7 @@ export class RequestInfoService {
     private readonly requestInfosRepository: Repository<RequestInfoModel>,
     private readonly churchesService: ChurchesService,
     private readonly membersService: MembersService,
+    private readonly familyService: FamilyService,
     private readonly requestLimitValidator: RequestLimitValidatorService,
     private readonly messagesService: MessagesService,
   ) {}
@@ -146,9 +148,23 @@ export class RequestInfoService {
         )
       : await this.membersService.createMember(
           church.id,
-          { name: dto.name, mobilePhone: dto.mobilePhone },
+          {
+            name: dto.name,
+            mobilePhone: dto.mobilePhone,
+            guidedById: dto.guideId,
+          },
           qr,
         );
+
+    if (!isExistMember) {
+      await this.familyService.fetchFamilyRelation(
+        church.id,
+        member.id,
+        dto.familyId,
+        undefined,
+        qr,
+      );
+    }
 
     const repository = this.getRequestInfosRepository(qr);
     const newRequestInfo = await repository.save({


### PR DESCRIPTION
1. member 모듈 관리 데이터 정리
순수하게 member 와 관련된 데이터만 MemberModule 에서 관리하도록 변경.
직분, 사역, 소그룹, 교육이수와 같이 교회와 연관이 큰 데이터는 별도의 모듈에서 관리
2. 새 교인 입력 요청 시 인도자, 가족 등록 로직 적용 TODO FamilyService 와 MemberService 의존성을 바꿔서 member 를 생성하면서 가족 데이터도 생성할 수 있도록 변경 필요