### PR TITLE
refactor: 가족관계 설정 로직 정리 및 DTO 구조 개선

### DIFF
--- a/backend/src/churches/entity/church.entity.ts
+++ b/backend/src/churches/entity/church.entity.ts
@@ -27,7 +27,7 @@ export class ChurchModel extends BaseModel {
   @Column({ default: 0 })
   dailyRequestAttempts: number;
 
-  @Column({ default: new Date('1900-01-01') })
+  @Column({ default: new Date('1900-01-01'), type: 'timestamptz' })
   lastRequestDate: Date;
 
   @OneToMany(() => RequestInfoModel, (requestInfo) => requestInfo.church)

--- a/backend/src/churches/members/controller/members-family.controller.ts
+++ b/backend/src/churches/members/controller/members-family.controller.ts
@@ -10,24 +10,25 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { CreateFamilyDto } from '../dto/family/create-family.dto';
-import { FamilyService } from '../service/family.service';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
 import { ApiTags } from '@nestjs/swagger';
 import { UpdateFamilyDto } from '../dto/family/update-family.dto';
+import { MembersService } from '../service/members.service';
 
 @ApiTags('Churches:Members:Family')
 @Controller(':memberId/family')
 export class MembersFamilyController {
-  constructor(private readonly familyService: FamilyService) {}
+  constructor(private readonly memberService: MembersService) {}
 
   @Get()
   getFamilyMember(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
   ) {
-    return this.familyService.getFamilyMember(churchId, memberId);
+    return this.memberService.getFamilyRelation(churchId, memberId);
+    //return this.familyService.getFamilyMember(churchId, memberId);
   }
 
   @Post()
@@ -38,12 +39,12 @@ export class MembersFamilyController {
     @Body() createFamilyDto: CreateFamilyDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.familyService.postFamilyMember(
+    /*return this.familyService.postFamilyMember(
       churchId,
       memberId,
       createFamilyDto,
       qr,
-    );
+    );*/
   }
 
   @Post('fetch-family')
@@ -54,13 +55,21 @@ export class MembersFamilyController {
     @Body() dto: CreateFamilyDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.familyService.fetchFamilyRelation(
+    return this.memberService.fetchFamilyRelation(
       churchId,
       memberId,
       dto.familyId,
       dto.relation,
       qr,
     );
+
+    /*return this.familyService.fetchFamilyRelation(
+      churchId,
+      memberId,
+      dto.familyId,
+      dto.relation,
+      qr,
+    );*/
   }
 
   @Patch(':familyMemberId')
@@ -72,13 +81,20 @@ export class MembersFamilyController {
     @Body() dto: UpdateFamilyDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.familyService.patchFamilyRelation(
-      churchId,
+    return this.memberService.patchFamilyRelation(
       memberId,
       familyMemberId,
       dto.relation,
       qr,
     );
+
+    /*return this.familyService.patchFamilyRelation(
+      churchId,
+      memberId,
+      familyMemberId,
+      dto.relation,
+      qr,
+    );*/
   }
 
   @Delete(':familyMemberId')
@@ -87,10 +103,12 @@ export class MembersFamilyController {
     @Param('memberId', ParseIntPipe) memberId: number,
     @Param('familyMemberId', ParseIntPipe) familyMemberId: number,
   ) {
-    return this.familyService.deleteFamilyRelation(
+    return this.memberService.deleteFamilyRelation(memberId, familyMemberId);
+
+    /*return this.familyService.deleteFamilyRelation(
       churchId,
       memberId,
       familyMemberId,
-    );
+    );*/
   }
 }

--- a/backend/src/churches/members/controller/members.controller.ts
+++ b/backend/src/churches/members/controller/members.controller.ts
@@ -19,6 +19,7 @@ import { QueryRunner as QR } from 'typeorm';
 import { UpdateMemberDto } from '../dto/update-member.dto';
 import { DefaultMemberRelationOption } from '../const/default-find-options.const';
 import { GetMemberDto } from '../dto/get-member.dto';
+import { FamilyRelationPipe } from '../pipe/family-relation.pipe';
 
 @ApiTags('Churches:Members')
 @Controller()
@@ -37,7 +38,7 @@ export class MembersController {
   @UseInterceptors(TransactionInterceptor)
   postMember(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Body() dto: CreateMemberDto,
+    @Body(FamilyRelationPipe) dto: CreateMemberDto,
     @QueryRunner() qr: QR,
   ) {
     return this.membersService.createMember(churchId, dto, qr);

--- a/backend/src/churches/members/dto/create-member.dto.ts
+++ b/backend/src/churches/members/dto/create-member.dto.ts
@@ -63,7 +63,8 @@ export class CreateMemberDto {
     name: 'relation',
     description: '가족 관계',
     example: '어머니',
-    default: '가족',
+    default: FamilyRelation.DEFAULT,
+    required: false,
   })
   @IsString()
   @IsIn(Object.values(FamilyRelation))

--- a/backend/src/churches/members/pipe/family-relation.pipe.ts
+++ b/backend/src/churches/members/pipe/family-relation.pipe.ts
@@ -1,0 +1,29 @@
+import {
+  ArgumentMetadata,
+  Injectable,
+  InternalServerErrorException,
+  PipeTransform,
+} from '@nestjs/common';
+import { CreateMemberDto } from '../dto/create-member.dto';
+import { FamilyRelation } from '../const/family-relation.const';
+import { CreateRequestInfoDto } from '../../request-info/dto/create-request-info.dto';
+
+@Injectable()
+export class FamilyRelationPipe implements PipeTransform {
+  transform(value: any, metadata: ArgumentMetadata): CreateMemberDto {
+    if (
+      !(value instanceof CreateMemberDto) &&
+      !(value instanceof CreateRequestInfoDto)
+    ) {
+      throw new InternalServerErrorException(
+        'CreateMemberDto 또는 CreateRequestInfoDto 가 사용되는 요청 흐름의 해당 DTO 를 받는 @Body 데코레이터에서만 사용 가능',
+      );
+    }
+
+    if (value.familyMemberId && !value.relation) {
+      value.relation = FamilyRelation.DEFAULT;
+    }
+
+    return value;
+  }
+}

--- a/backend/src/churches/request-info/dto/create-request-info.dto.ts
+++ b/backend/src/churches/request-info/dto/create-request-info.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { RequestInfoModel } from '../entity/request-info.entity';
 import {
+  IsIn,
   IsNotEmpty,
   IsNumber,
   IsOptional,
@@ -8,12 +9,13 @@ import {
   Length,
 } from 'class-validator';
 import { TransformName } from '../../decorator/transform-name';
+import { FamilyRelation } from '../../members/const/family-relation.const';
 
 export class CreateRequestInfoDto extends PickType(RequestInfoModel, [
   'name',
   'mobilePhone',
-  'guideId',
-  'familyId',
+  /*'guidedById',
+  'familyId',*/
 ]) {
   @ApiProperty({
     name: 'name',
@@ -36,22 +38,36 @@ export class CreateRequestInfoDto extends PickType(RequestInfoModel, [
   override mobilePhone: string;
 
   @ApiProperty({
-    name: 'guideId',
+    name: 'guidedById',
     description: '인도자 ID',
     example: 12,
     required: false,
   })
   @IsNumber()
   @IsOptional()
-  override guideId?: number;
+  guidedById?: number;
+  //override guidedById?: number;
 
   @ApiProperty({
-    name: 'familyId',
+    name: 'familyMemberId',
     description: '가족 ID',
     example: 21,
     required: false,
   })
   @IsNumber()
   @IsOptional()
-  override familyId?: number;
+  familyMemberId?: number;
+  //override familyId?: number;
+
+  @ApiProperty({
+    name: 'relation',
+    description: '가족 관계',
+    example: FamilyRelation.MOTHER,
+    default: FamilyRelation.DEFAULT,
+    required: false,
+  })
+  @IsString()
+  @IsIn(Object.values(FamilyRelation))
+  @IsOptional()
+  relation?: string;
 }

--- a/backend/src/churches/request-info/dto/submit-request-info.dto.ts
+++ b/backend/src/churches/request-info/dto/submit-request-info.dto.ts
@@ -1,3 +1,8 @@
 import { CreateMemberDto } from '../../members/dto/create-member.dto';
+import { OmitType } from '@nestjs/swagger';
 
-export class SubmitRequestInfoDto extends CreateMemberDto {}
+export class SubmitRequestInfoDto extends OmitType(CreateMemberDto, [
+  'guidedById',
+  'familyMemberId',
+  'relation',
+]) {}

--- a/backend/src/churches/request-info/entity/request-info.entity.ts
+++ b/backend/src/churches/request-info/entity/request-info.entity.ts
@@ -21,12 +21,6 @@ export class RequestInfoModel extends BaseModel {
   @Index()
   mobilePhone: string;
 
-  @Column({ nullable: true })
-  guideId?: number;
-
-  @Column({ nullable: true })
-  familyId?: number;
-
   @Column({ default: 1 })
   requestInfoAttempts: number;
 

--- a/backend/src/churches/request-info/request-info.controller.ts
+++ b/backend/src/churches/request-info/request-info.controller.ts
@@ -21,6 +21,7 @@ import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
 import { GetRequestInfoDto } from './dto/get-request-info.dto';
 import { SubmitRequestInfoDto } from './dto/submit-request-info.dto';
+import { FamilyRelationPipe } from '../members/pipe/family-relation.pipe';
 
 @ApiTags('Churches:Request-Info')
 @Controller('churches/:churchId/request')
@@ -40,7 +41,7 @@ export class RequestInfoController {
   async postRequestInfo(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Query('isTest') isTest: boolean,
-    @Body() dto: CreateRequestInfoDto,
+    @Body(FamilyRelationPipe) dto: CreateRequestInfoDto,
     @QueryRunner() qr: QR,
   ) {
     const requestInfo = await this.requestInfoService.createRequestInfo(


### PR DESCRIPTION
## 주요 내용
- 가족관계 설정 로직의 호출 구조 개선
- 입력 요청 DTO와 교인 생성 DTO 속성 이름 통일
- 입력 요청 DTO에 가족관계 설정 기능 추가

## 세부 내용
### 가족관계 설정 로직 개선
- 기존: 외부에서 FamilyService의 가족관계 설정 메소드를 직접 호출
- 변경: MemberService를 통해 FamilyService의 가족관계 설정 메소드 호출
- 교인과 관련된 모든 처리를 MemberService에서 담당하도록 개선

### DTO 속성 통일
- 일관성 있는 명명 규칙 적용
 - `guideId` → `guidedById`
 - `familyId` → `familyMemberId`

### 기능 추가
- 입력 요청 DTO에 가족관계 설정 프로퍼티 추가
 - `relation` 필드 추가로 가족관계 정보 전달 가능