### PR TITLE
fix: 생년월일이 없는 교인 검색

### DIFF
--- a/backend/src/churches/members/const/default-find-options.const.ts
+++ b/backend/src/churches/members/const/default-find-options.const.ts
@@ -42,3 +42,34 @@ export const DefaultMemberSelectOption: FindOptionsSelect<MemberModel> = {
     name: true,
   },
 };
+
+export const DefaultMembersRelationOption: FindOptionsRelations<MemberModel> = {
+  guidedBy: true,
+  group: true,
+  ministries: true,
+  educations: true,
+  officer: true,
+};
+
+export const DefaultMembersSelectOption: FindOptionsSelect<MemberModel> = {
+  guidedBy: {
+    id: true,
+    name: true,
+  },
+  group: {
+    id: true,
+    name: true,
+  },
+  ministries: {
+    id: true,
+    name: true,
+  },
+  educations: {
+    id: true,
+    name: true,
+  },
+  officer: {
+    id: true,
+    name: true,
+  },
+};

--- a/backend/src/churches/members/controller/members.controller.ts
+++ b/backend/src/churches/members/controller/members.controller.ts
@@ -31,6 +31,7 @@ export class MembersController {
     @Param('churchId', ParseIntPipe) churchId: number,
     @Query() dto: GetMemberDto,
   ) {
+    //return dto;
     return this.membersService.getMembers(churchId, dto);
   }
 

--- a/backend/src/churches/members/dto/get-member.dto.ts
+++ b/backend/src/churches/members/dto/get-member.dto.ts
@@ -74,23 +74,23 @@ export class GetMemberDto extends PartialType(PickType(MemberModel, ['name'])) {
     name: 'birthAfter',
     description: '생년월일 ~부터',
     example: '1990-01-01',
-    default: '1800-01-01',
+    //default: '1800-01-01',
     required: false,
   })
   @IsDate()
   @IsOptional()
-  birthAfter: Date = new Date('1800-01-01');
+  birthAfter?: Date; // = new Date('1800-01-01');
 
   @ApiProperty({
     name: 'birthBefore',
     description: '생년월일 ~까지',
     example: '2010-01-01',
-    default: new Date(),
+    //default: new Date(),
     required: false,
   })
   @IsDate()
   @IsOptional()
-  birthBefore: Date = new Date();
+  birthBefore?: Date; // = new Date();
 
   @ApiProperty({
     name: 'gender',

--- a/backend/src/churches/members/service/members.service.ts
+++ b/backend/src/churches/members/service/members.service.ts
@@ -14,7 +14,9 @@ import {
   FindOptionsWhere,
   ILike,
   IsNull,
+  LessThanOrEqual,
   Like,
+  MoreThanOrEqual,
   QueryRunner,
   Repository,
 } from 'typeorm';
@@ -30,7 +32,11 @@ import { GetMemberOrderEnum } from '../../enum/get-member-order.enum';
 import { UpdateMemberOfficerDto } from '../../members-settings/dto/update-member-officer.dto';
 import { UpdateMemberMinistryDto } from '../../members-settings/dto/update-member-ministry.dto';
 import { MinistryModel } from '../../settings/entity/ministry.entity';
-import { DefaultMemberSelectOption } from '../const/default-find-options.const';
+import {
+  DefaultMemberSelectOption,
+  DefaultMembersRelationOption,
+  DefaultMembersSelectOption,
+} from '../const/default-find-options.const';
 import { UpdateMemberEducationDto } from '../../members-settings/dto/update-member-education.dto';
 import { EducationModel } from '../../settings/entity/education.entity';
 import { UpdateMemberGroupDto } from '../../members-settings/dto/update-member-group.dto';
@@ -51,10 +57,25 @@ export class MembersService {
   async getMembers(churchId: number, dto: GetMemberDto, qr?: QueryRunner) {
     const membersRepository = this.getMembersRepository(qr);
 
+    const birthOption = (dto: GetMemberDto) => {
+      // 생년월일 앞뒤
+      if (dto.birthAfter && dto.birthBefore)
+        return Between(dto.birthAfter, dto.birthBefore);
+      // 생년월일 앞
+      if (dto.birthAfter && !dto.birthBefore)
+        return MoreThanOrEqual(dto.birthAfter);
+      // 생년월일 뒤
+      if (!dto.birthAfter && dto.birthBefore)
+        return LessThanOrEqual(dto.birthBefore);
+      // 생년월일 설정 없는 경우
+      return undefined;
+    };
+
     const findOptionsWhere: FindOptionsWhere<MemberModel> = {
       churchId,
       name: dto.name && ILike(`${dto.name}%`),
-      birth: Between(dto.birthAfter, dto.birthBefore),
+      //birth: Between(dto.birthAfter, dto.birthBefore),
+      birth: birthOption(dto),
       gender: dto?.gender,
       school: dto.school && Like(`%${dto.school}%`),
       vehicleNumber: dto.vehicleNumber && ArrayContains([dto.vehicleNumber]),
@@ -87,6 +108,8 @@ export class MembersService {
     const result = await membersRepository.find({
       where: findOptionsWhere,
       order: findOptionsOrder,
+      relations: DefaultMembersRelationOption,
+      select: DefaultMembersSelectOption,
       take: dto.take,
       skip: dto.take * (dto.page - 1),
     });


### PR DESCRIPTION
## 주요내용
- 교인 전체 리스트 조회 시 생년월일이 없는 교인이 누락되는 문제 해결
- 조회 시 직분, 사역, 소그룹, 교육이수 내용 추가