### PR TITLE
feat: 교인 목록 조회 시 선택적 컬럼 조회 기능 추가

### DIFF
--- a/backend/src/churches/enum/get-member-order.enum.ts
+++ b/backend/src/churches/enum/get-member-order.enum.ts
@@ -3,8 +3,8 @@ export enum GetMemberOrderEnum {
   name = 'name',
   birth = 'birth',
   gender = 'gender',
-  school = 'school',
-  previousChurch = 'previousChurch',
+  /*school = 'school',
+  previousChurch = 'previousChurch',*/
   groupId = 'groupId',
   officerId = 'officerId',
   officerStartDate = 'officerStartDate',

--- a/backend/src/churches/members/const/default-find-options.const.ts
+++ b/backend/src/churches/members/const/default-find-options.const.ts
@@ -44,7 +44,7 @@ export const DefaultMemberSelectOption: FindOptionsSelect<MemberModel> = {
 };
 
 export const DefaultMembersRelationOption: FindOptionsRelations<MemberModel> = {
-  guidedBy: true,
+  //guidedBy: true,
   group: true,
   ministries: true,
   educations: true,
@@ -52,10 +52,6 @@ export const DefaultMembersRelationOption: FindOptionsRelations<MemberModel> = {
 };
 
 export const DefaultMembersSelectOption: FindOptionsSelect<MemberModel> = {
-  /*guidedBy: {
-    id: true,
-    name: true,
-  },*/
   id: true,
   name: true,
   createdAt: true,

--- a/backend/src/churches/members/decorator/query-boolean.decorator.ts
+++ b/backend/src/churches/members/decorator/query-boolean.decorator.ts
@@ -1,0 +1,15 @@
+import { Transform } from 'class-transformer';
+import { BadRequestException } from '@nestjs/common';
+
+export function QueryBoolean() {
+  return Transform(
+    ({ key, obj }) => {
+      const value = obj[key];
+
+      if (value === 'true') return true;
+      if (value === 'false') return false;
+      throw new BadRequestException(`property ${key} must be a boolean value`);
+    },
+    { toClassOnly: true },
+  );
+}

--- a/backend/src/churches/members/dto/get-member.dto.ts
+++ b/backend/src/churches/members/dto/get-member.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
   IsArray,
+  IsBoolean,
   IsDate,
   IsEnum,
   IsIn,
@@ -19,6 +20,7 @@ import {
   TransformStringArray,
 } from '../decorator/transform-array';
 import { MarriageOptions } from '../const/marriage-options.const';
+import { QueryBoolean } from '../decorator/query-boolean.decorator';
 
 export class GetMemberDto /*extends PartialType(PickType(MemberModel, ['name']))*/ {
   @ApiProperty({
@@ -63,6 +65,98 @@ export class GetMemberDto /*extends PartialType(PickType(MemberModel, ['name']))
   @IsIn(['asc', 'desc', 'ASC', 'DESC'])
   @IsOptional()
   orderDirection: 'asc' | 'desc' | 'ASC' | 'DESC';
+
+  @ApiProperty({
+    required: false,
+  })
+  @QueryBoolean()
+  @IsBoolean()
+  @IsOptional()
+  select__mobilePhone?: boolean;
+
+  @ApiProperty({
+    required: false,
+  })
+  @QueryBoolean()
+  @IsBoolean()
+  @IsOptional()
+  select__group?: boolean;
+
+  @ApiProperty({
+    required: false,
+  })
+  @QueryBoolean()
+  @IsBoolean()
+  @IsOptional()
+  select__birth?: boolean;
+
+  @ApiProperty({
+    required: false,
+  })
+  @QueryBoolean()
+  @IsBoolean()
+  @IsOptional()
+  select__gender?: boolean;
+
+  @ApiProperty({ required: false })
+  @QueryBoolean()
+  @IsBoolean()
+  @IsOptional()
+  select__officer?: boolean;
+
+  @ApiProperty({ required: false })
+  @QueryBoolean()
+  @IsBoolean()
+  @IsOptional()
+  select__ministries?: boolean;
+
+  @ApiProperty({ required: false })
+  @QueryBoolean()
+  @IsBoolean()
+  @IsOptional()
+  select__educations?: boolean;
+
+  @ApiProperty({ required: false })
+  @QueryBoolean()
+  @IsBoolean()
+  @IsOptional()
+  select__marriage?: boolean;
+
+  @ApiProperty({ required: false })
+  @QueryBoolean()
+  @IsBoolean()
+  @IsOptional()
+  select__createdAt?: boolean;
+
+  @ApiProperty({ required: false })
+  @QueryBoolean()
+  @IsBoolean()
+  @IsOptional()
+  select__address?: boolean;
+
+  @ApiProperty({ required: false })
+  @QueryBoolean()
+  @IsBoolean()
+  @IsOptional()
+  select__homePhone?: boolean;
+
+  @ApiProperty({ required: false })
+  @QueryBoolean()
+  @IsBoolean()
+  @IsOptional()
+  select__occupation?: boolean;
+
+  @ApiProperty({ required: false })
+  @QueryBoolean()
+  @IsBoolean()
+  @IsOptional()
+  select__school?: boolean;
+
+  @ApiProperty({ required: false })
+  @QueryBoolean()
+  @IsBoolean()
+  @IsOptional()
+  select__vehicleNumber?: boolean;
 
   @ApiProperty({
     name: 'createAfter',
@@ -185,7 +279,6 @@ export class GetMemberDto /*extends PartialType(PickType(MemberModel, ['name']))
   @ApiProperty({
     name: 'vehicleNumber',
     description: '차량번호 4자리',
-    example: '1234',
     type: String,
     isArray: true,
     required: false,


### PR DESCRIPTION
## 주요 내용
- 사용자가 원하는 컬럼만 선택하여 조회하는 기능 구현
- 컬럼 미선택 시 기본 컬럼 세트 적용

## 세부 내용
### 선택적 컬럼 조회
- 사용자가 필요한 컬럼만 선택하여 조회 가능
- 불필요한 데이터 전송 최소화

### 기본 컬럼 세트
- 컬럼 미선택 시 기본 컬럼으로 응답
- 필수 정보를 포함한 기본 컬럼 구성
- 기본값 상수로 분리하여 관리