### PR TITLE
refactor: 교인 목록 조회 기능 개선

### DIFF
--- a/backend/src/churches/enum/get-member-order.enum.ts
+++ b/backend/src/churches/enum/get-member-order.enum.ts
@@ -1,5 +1,5 @@
 export enum GetMemberOrderEnum {
-  createdAt = 'createdAt',
+  //createdAt = 'createdAt',
   updatedAt = 'updatedAt',
   registeredAt = 'registeredAt',
   name = 'name',

--- a/backend/src/churches/members/controller/members.controller.ts
+++ b/backend/src/churches/members/controller/members.controller.ts
@@ -31,6 +31,7 @@ export class MembersController {
     @Param('churchId', ParseIntPipe) churchId: number,
     @Query() dto: GetMemberDto,
   ) {
+    //console.log(dto);
     return this.membersService.getMembers(churchId, dto);
   }
 

--- a/backend/src/churches/members/decorator/transform-array.ts
+++ b/backend/src/churches/members/decorator/transform-array.ts
@@ -5,7 +5,7 @@ export function TransformNumberArray() {
     if (!Array.isArray(value)) {
       return [Number(value)];
     }
-    return value.map(Number);
+    return [...new Set(value)].map(Number);
   });
 }
 
@@ -14,6 +14,7 @@ export function TransformStringArray() {
     if (!Array.isArray(value)) {
       return [value];
     }
-    return value;
+    return [...new Set(value)];
+    //return value;
   });
 }

--- a/backend/src/churches/members/dto/get-member.dto.ts
+++ b/backend/src/churches/members/dto/get-member.dto.ts
@@ -49,12 +49,12 @@ export class GetMemberDto /*extends PartialType(PickType(MemberModel, ['name']))
     name: 'order',
     description: '정렬 기준',
     enum: GetMemberOrderEnum,
-    default: GetMemberOrderEnum.createdAt,
+    default: GetMemberOrderEnum.registeredAt,
     required: false,
   })
   @IsEnum(GetMemberOrderEnum)
   @IsOptional()
-  order: GetMemberOrderEnum = GetMemberOrderEnum.createdAt;
+  order: GetMemberOrderEnum = GetMemberOrderEnum.registeredAt;
 
   @ApiProperty({
     name: 'orderDirection',
@@ -159,6 +159,22 @@ export class GetMemberDto /*extends PartialType(PickType(MemberModel, ['name']))
   select__vehicleNumber?: boolean;
 
   @ApiProperty({
+    description: '등록일자 ~부터',
+    required: false,
+  })
+  @IsDate()
+  @IsOptional()
+  registerAfter?: Date;
+
+  @ApiProperty({
+    description: '등록일자 ~까지',
+    required: false,
+  })
+  @IsDate()
+  @IsOptional()
+  registerBefore?: Date;
+
+  /*@ApiProperty({
     name: 'createAfter',
     description: '생성일자 ~부터',
     //default: '1800-01-01',
@@ -176,7 +192,7 @@ export class GetMemberDto /*extends PartialType(PickType(MemberModel, ['name']))
   })
   @IsDate()
   @IsOptional()
-  createBefore?: Date; // = new Date();
+  createBefore?: Date; // = new Date();*/
 
   @ApiProperty({
     name: 'name',
@@ -198,7 +214,7 @@ export class GetMemberDto /*extends PartialType(PickType(MemberModel, ['name']))
   @IsOptional()
   mobilePhone?: string;
 
-  @ApiProperty({
+  /*@ApiProperty({
     name: 'marriage',
     description: '결혼 여부',
     enum: MarriageOptions,
@@ -206,7 +222,18 @@ export class GetMemberDto /*extends PartialType(PickType(MemberModel, ['name']))
   })
   @IsEnum(MarriageOptions)
   @IsOptional()
-  marriage?: MarriageOptions;
+  marriage?: MarriageOptions;*/
+
+  @ApiProperty({
+    description: '결혼 여부',
+    enum: MarriageOptions,
+    isArray: true,
+    required: false,
+  })
+  @TransformStringArray()
+  @IsEnum(MarriageOptions, { each: true })
+  @IsOptional()
+  marriage?: MarriageOptions[];
 
   @ApiProperty({
     name: 'birthAfter',
@@ -226,7 +253,7 @@ export class GetMemberDto /*extends PartialType(PickType(MemberModel, ['name']))
   @IsOptional()
   birthBefore?: Date;
 
-  @ApiProperty({
+  /*@ApiProperty({
     name: 'gender',
     description: '성별',
     enum: GenderEnum,
@@ -234,7 +261,18 @@ export class GetMemberDto /*extends PartialType(PickType(MemberModel, ['name']))
   })
   @IsEnum(GenderEnum)
   @IsOptional()
-  gender?: GenderEnum;
+  gender?: GenderEnum;*/
+
+  @ApiProperty({
+    description: '성별',
+    enum: GenderEnum,
+    isArray: true,
+    required: false,
+  })
+  @TransformStringArray()
+  @IsEnum(GenderEnum, { each: true })
+  @IsOptional()
+  gender?: GenderEnum[];
 
   @ApiProperty({
     name: 'school',
@@ -292,7 +330,7 @@ export class GetMemberDto /*extends PartialType(PickType(MemberModel, ['name']))
   vehicleNumber?: string[];
 
   @ApiProperty({
-    name: 'groupId',
+    name: 'group',
     description: '소그룹 ID',
     type: Number,
     isArray: true,
@@ -301,10 +339,10 @@ export class GetMemberDto /*extends PartialType(PickType(MemberModel, ['name']))
   @TransformNumberArray()
   @IsNumber({}, { each: true })
   @IsOptional()
-  groupId?: number[];
+  group?: number[];
 
   @ApiProperty({
-    name: 'officerId',
+    name: 'officer',
     description: '직분 ID',
     type: Number,
     isArray: true,
@@ -313,10 +351,10 @@ export class GetMemberDto /*extends PartialType(PickType(MemberModel, ['name']))
   @TransformNumberArray()
   @IsNumber({}, { each: true })
   @IsOptional()
-  officerId?: number[];
+  officer?: number[];
 
   @ApiProperty({
-    name: 'ministryId',
+    name: 'ministries',
     description: '사역 ID',
     type: Number,
     isArray: true,
@@ -325,10 +363,10 @@ export class GetMemberDto /*extends PartialType(PickType(MemberModel, ['name']))
   @TransformNumberArray()
   @IsNumber({}, { each: true })
   @IsOptional()
-  ministryId?: number[];
+  ministries: number[];
 
   @ApiProperty({
-    name: 'educationId',
+    name: 'educations',
     description: '교육 ID',
     type: Number,
     isArray: true,
@@ -337,9 +375,9 @@ export class GetMemberDto /*extends PartialType(PickType(MemberModel, ['name']))
   @TransformNumberArray()
   @IsNumber({}, { each: true })
   @IsOptional()
-  educationId?: number[];
+  educations?: number[];
 
-  @ApiProperty({
+  /*@ApiProperty({
     name: 'baptism',
     description: '신급',
     enum: BaptismEnum,
@@ -347,5 +385,17 @@ export class GetMemberDto /*extends PartialType(PickType(MemberModel, ['name']))
   })
   @IsEnum(BaptismEnum)
   @IsOptional()
-  baptism?: BaptismEnum;
+  baptism?: BaptismEnum;*/
+
+  @ApiProperty({
+    name: 'baptism',
+    description: '신급',
+    enum: BaptismEnum,
+    isArray: true,
+    required: false,
+  })
+  @TransformStringArray()
+  @IsEnum(BaptismEnum, { each: true })
+  @IsOptional()
+  baptism?: BaptismEnum[];
 }


### PR DESCRIPTION
## 주요 내용
- 필터링 옵션 다중 선택 지원
- 날짜 기준 변경 및 컬럼명 통일
- 필터링과 조회 컬럼 연동

## 세부 내용
### 필터링 개선
- 성별, 결혼정보, 신급 다중 선택 지원
- 생성일자(createdAt) → 등록일자(registeredAt) 변경

### 컬럼명 통일
- DTO 필드명을 엔티티 컬럼명과 일치하도록 수정
- ministryId, educationId, groupId, officerId 명칭 통일

### 조회 로직 개선
- 필터링 조건이 있는 컬럼은 응답에 자동 포함