### PR TITLE
feat: 말단 그룹 대상 일괄 역할 생성 기능 추가

### DIFF
--- a/backend/src/churches/settings/controller/groups-roles.controller.ts
+++ b/backend/src/churches/settings/controller/groups-roles.controller.ts
@@ -14,9 +14,18 @@ import { ApiTags } from '@nestjs/swagger';
 import { GroupsRolesService } from '../service/groups-roles.service';
 
 @ApiTags('Groups:Settings:Roles')
+// churches/{churchId}/settings
 @Controller('groups')
 export class GroupsRolesController {
   constructor(private readonly groupsRolesService: GroupsRolesService) {}
+
+  @Post('roles')
+  createRoleForAllGroups(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Body() dto: CreateGroupRoleDto,
+  ) {
+    return this.groupsRolesService.createRoleForAllGroups(churchId, dto);
+  }
 
   @Get(':groupId/role')
   getGroupRoles(

--- a/backend/src/churches/settings/entity/group-role.entity.ts
+++ b/backend/src/churches/settings/entity/group-role.entity.ts
@@ -1,9 +1,10 @@
-import { Column, Entity, Index, ManyToOne } from 'typeorm';
+import { Column, Entity, Index, ManyToOne, Unique } from 'typeorm';
 import { BaseModel } from '../../../common/entity/base.entity';
 import { GroupModel } from './group.entity';
 import { ChurchModel } from '../../entity/church.entity';
 
 @Entity()
+@Unique(['role', 'groupId'])
 export class GroupRoleModel extends BaseModel {
   @Column()
   role: string;


### PR DESCRIPTION
## 주요 내용
- 교회 내 말단 그룹들에 동일한 역할 일괄 생성
- 그룹별 성공/실패 결과 분리 반환

## 세부 내용
### 기능 구현
- 자식 그룹이 없는 말단 그룹 필터링
- Promise.allSettled 를 사용한 병렬 처리
- 그룹별 역할 생성 결과 추적

### 응답 형식
- successResults: 역할 생성 성공한 그룹 정보 (id, name)
- failedResults: 역할 생성 실패한 그룹 정보 (id, name, message)