### PR TITLE
feat: 교육이수 이력 정렬 기능 개선

### DIFF
--- a/backend/src/churches/members-settings/controller/education-history.controller.ts
+++ b/backend/src/churches/members-settings/controller/education-history.controller.ts
@@ -8,9 +8,10 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Query,
   UseInterceptors,
 } from '@nestjs/common';
-import { MemberEducationService } from '../service/member-education.service';
+import { EducationHistoryService } from '../service/education-history.service';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
@@ -18,12 +19,13 @@ import { QueryRunner as QR } from 'typeorm/query-runner/QueryRunner';
 import { CreateEducationHistoryDto } from '../dto/education/create-education-history.dto';
 import { UpdateEducationHistoryDto } from '../dto/education/update-education-history.dto';
 import { UpdateEducationHistoryPipe } from '../pipe/update-education-history-pipe.service';
+import { GetEducationHistoryDto } from '../dto/education/get-education-history.dto';
 
 @ApiTags('Churches:Members:Educations')
 @Controller('educations')
-export class MemberEducationController {
+export class EducationHistoryController {
   constructor(
-    private readonly memberEducationService: MemberEducationService,
+    private readonly educationHistoryService: EducationHistoryService,
   ) {}
 
   @ApiOperation({
@@ -34,8 +36,9 @@ export class MemberEducationController {
   getMemberEducationHistory(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
+    @Query() dto: GetEducationHistoryDto,
   ) {
-    return this.memberEducationService.getMemberEducationHistory(memberId);
+    return this.educationHistoryService.getEducationHistory(memberId, dto);
   }
 
   @ApiOperation({
@@ -52,7 +55,7 @@ export class MemberEducationController {
     @Body() dto: CreateEducationHistoryDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.memberEducationService.createMemberEducationHistory(
+    return this.educationHistoryService.createEducationHistory(
       churchId,
       memberId,
       dto,
@@ -94,7 +97,7 @@ export class MemberEducationController {
     @Body(UpdateEducationHistoryPipe) dto: UpdateEducationHistoryDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.memberEducationService.updateEducationHistory(
+    return this.educationHistoryService.updateEducationHistory(
       churchId,
       memberId,
       educationHistoryId,
@@ -117,7 +120,7 @@ export class MemberEducationController {
     @Param('educationHistoryId', ParseIntPipe) educationHistoryId: number,
     @QueryRunner() qr: QR,
   ) {
-    return this.memberEducationService.deleteEducationHistory(
+    return this.educationHistoryService.deleteEducationHistory(
       memberId,
       educationHistoryId,
       qr,

--- a/backend/src/churches/members-settings/controller/member-settings.controller.ts
+++ b/backend/src/churches/members-settings/controller/member-settings.controller.ts
@@ -15,7 +15,7 @@ import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { UpdateMemberOfficerPipe } from '../pipe/update-member-officer.pipe';
 import { MemberMinistryService } from '../service/member-ministry.service';
 import { UpdateMemberMinistryDto } from '../dto/update-member-ministry.dto';
-import { MemberEducationService } from '../service/member-education.service';
+import { EducationHistoryService } from '../service/education-history.service';
 import { UpdateMemberGroupDto } from '../dto/update-member-group.dto';
 import { MemberGroupService } from '../service/member-group.service';
 import { UpdateMemberGroupPipe } from '../pipe/update-member-group.pipe';
@@ -26,7 +26,7 @@ export class MemberSettingsController {
   constructor(
     private readonly memberOfficerService: MemberOfficerService,
     private readonly memberMinistryService: MemberMinistryService,
-    private readonly memberEducationService: MemberEducationService,
+    private readonly memberEducationService: EducationHistoryService,
     private readonly memberGroupService: MemberGroupService,
   ) {}
 

--- a/backend/src/churches/members-settings/dto/education/get-education-history.dto.ts
+++ b/backend/src/churches/members-settings/dto/education/get-education-history.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsOptional } from 'class-validator';
+
+export class GetEducationHistoryDto {
+  @ApiProperty({
+    description: '정렬 오름차순 / 내림차순',
+    default: 'desc',
+    required: false,
+  })
+  @IsIn(['asc', 'desc', 'ASC', 'DESC'])
+  @IsOptional()
+  orderDirection: 'asc' | 'desc' | 'ASC' | 'DESC' = 'desc';
+}

--- a/backend/src/churches/members-settings/members-settings.module.ts
+++ b/backend/src/churches/members-settings/members-settings.module.ts
@@ -6,10 +6,10 @@ import { MemberOfficerService } from './service/member-officer.service';
 import { MemberSettingsController } from './controller/member-settings.controller';
 import { RouterModule } from '@nestjs/core';
 import { MemberMinistryService } from './service/member-ministry.service';
-import { MemberEducationService } from './service/member-education.service';
+import { EducationHistoryService } from './service/education-history.service';
 import { MemberGroupService } from './service/member-group.service';
 import { EducationHistoryModel } from './entity/education-history.entity';
-import { MemberEducationController } from './controller/member-education.controller';
+import { EducationHistoryController } from './controller/education-history.controller';
 
 @Module({
   imports: [
@@ -27,9 +27,9 @@ import { MemberEducationController } from './controller/member-education.control
   providers: [
     MemberOfficerService,
     MemberMinistryService,
-    MemberEducationService,
+    EducationHistoryService,
     MemberGroupService,
   ],
-  controllers: [MemberSettingsController, MemberEducationController],
+  controllers: [MemberSettingsController, EducationHistoryController],
 })
 export class MembersSettingsModule {}

--- a/backend/src/churches/members-settings/service/education-history.service.ts
+++ b/backend/src/churches/members-settings/service/education-history.service.ts
@@ -13,9 +13,10 @@ import { CreateEducationHistoryDto } from '../dto/education/create-education-his
 import { UpdateEducationHistoryDto } from '../dto/education/update-education-history.dto';
 import { EducationsService } from '../../settings/service/educations.service';
 import { EducationStatus } from '../const/education-status.enum';
+import { GetEducationHistoryDto } from '../dto/education/get-education-history.dto';
 
 @Injectable()
-export class MemberEducationService {
+export class EducationHistoryService {
   constructor(
     private readonly membersService: MembersService,
     private readonly settingsService: SettingsService,
@@ -30,18 +31,20 @@ export class MemberEducationService {
       : this.educationHistoryRepository;
   }
 
-  getMemberEducationHistory(memberId: number) {
+  getEducationHistory(memberId: number, dto: GetEducationHistoryDto) {
     return this.educationHistoryRepository.find({
       where: {
         memberId,
       },
       order: {
-        endDate: 'desc',
+        endDate: dto.orderDirection,
+        startDate: dto.orderDirection,
+        createdAt: dto.orderDirection,
       },
     });
   }
 
-  async getMemberEducationHistoryById(
+  async getEducationHistoryById(
     id: number,
     memberId: number,
     qr?: QueryRunner,
@@ -59,7 +62,7 @@ export class MemberEducationService {
     return history;
   }
 
-  async createMemberEducationHistory(
+  async createEducationHistory(
     churchId: number,
     memberId: number,
     dto: CreateEducationHistoryDto,
@@ -113,7 +116,7 @@ export class MemberEducationService {
     // 상태 변경 --> 이전 상태 인원수 감소, 새 상태 인원수 증가
     const educationHistoryRepository = this.getEducationHistoryRepository(qr);
 
-    const educationHistory = await this.getMemberEducationHistoryById(
+    const educationHistory = await this.getEducationHistoryById(
       educationHistoryId,
       memberId,
       qr,


### PR DESCRIPTION
## 주요 내용
- 교육이수 이력 정렬 방향 선택 기능 추가
- 다중 기준 정렬 로직 구현

## 세부 내용
### 정렬 옵션
- 오름차순/내림차순 선택 가능
- 종료일 → 시작일 → 생성일 순서로 정렬

### 기본 정렬 순서
1. 종료일 (endDate)
2. 시작일 (startDate)
3. 생성일 (createdAt)