### PR TITLE
refactor: 교인 목록 조회 시 기존 교육이수 항목 제외

### DIFF
--- a/backend/src/churches/members/const/default-find-options.const.ts
+++ b/backend/src/churches/members/const/default-find-options.const.ts
@@ -9,7 +9,8 @@ export const DefaultMemberRelationOption: FindOptionsRelations<MemberModel> = {
   },
   officer: true,
   ministries: true,
-  educations: true,
+  //educations: true,
+  educationHistory: true,
   group: true,
 };
 
@@ -33,9 +34,11 @@ export const DefaultMemberSelectOption: FindOptionsSelect<MemberModel> = {
     id: true,
     name: true,
   },
-  educations: {
+  educationHistory: {
     id: true,
-    name: true,
+    educationId: true,
+    educationName: true,
+    status: true,
   },
   group: {
     id: true,


### PR DESCRIPTION
## 주요 내용
- 교인 목록 조회 시 기존 educations 필드 제외
- 새로운 교육이수 이력(educationHistory)으로 전환

## 세부 내용
### 조회 옵션 변경
- select 옵션에서 educations 제외
- relation 옵션에서 educations 제외

### 참고사항
- MemberModel 의 educations 필드는 유지
- 추후 전체 리팩토링 시 제거 예정