### PR TITLE
feat: 교인 그룹 이력 관리 기능 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -24,6 +24,7 @@ import { TempUserModel } from './auth/entity/temp-user.entity';
 import { UserModel } from './auth/entity/user.entity';
 import { GroupRoleModel } from './churches/settings/entity/group-role.entity';
 import { EducationHistoryModel } from './churches/members-settings/entity/education-history.entity';
+import { GroupHistoryModel } from './churches/members-settings/entity/group-history.entity';
 
 @Module({
   imports: [
@@ -95,6 +96,7 @@ import { EducationHistoryModel } from './churches/members-settings/entity/educat
           MinistryModel,
           GroupModel,
           GroupRoleModel,
+          GroupHistoryModel,
         ],
         synchronize: true,
       }),

--- a/backend/src/churches/members-settings/controller/group-history.controller.ts
+++ b/backend/src/churches/members-settings/controller/group-history.controller.ts
@@ -1,0 +1,141 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseInterceptors,
+} from '@nestjs/common';
+import { MemberGroupService } from '../service/member-group.service';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
+import { UpdateMemberGroupPipe } from '../pipe/update-member-group.pipe';
+import { UpdateMemberGroupDto } from '../dto/update-member-group.dto';
+import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm/query-runner/QueryRunner';
+import { GetGroupHistoryDto } from '../dto/group/get-group-history.dto';
+import { GroupHistoryService } from '../service/group-history.service';
+import { CreateGroupHistoryDto } from '../dto/group/create-group-history.dto';
+import { UpdateGroupHistoryDto } from '../dto/group/update-group-history.dto';
+
+@ApiTags('Churches:Members:Groups')
+@Controller('groups')
+export class GroupHistoryController {
+  constructor(
+    private readonly memberGroupService: MemberGroupService,
+    private readonly groupHistoryService: GroupHistoryService,
+  ) {}
+
+  @ApiOperation({
+    summary: '교인의 그룹 이력 조회',
+    description:
+      '<p>교인의 그룹 이력을 날짜 기준으로 조회합니다.</p>' +
+      '<p>정렬 기준</p>' +
+      '<p>1. 종료 날짜</p>' +
+      '<p>2. 시작 날짜</p>' +
+      '<p>3. 이력 생성 날짜</p>',
+  })
+  @Get()
+  getGroupHistory(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Query() dto: GetGroupHistoryDto,
+  ) {
+    return this.groupHistoryService.getGroupHistory(churchId, memberId, dto);
+  }
+
+  @ApiOperation({
+    summary: '교인의 그룹 이력 생성',
+    description:
+      '<p>교인의 그룹 이력을 생성합니다.</p>' +
+      '<p>필수값: 그룹 ID(groupId), 시작 날짜(startDate)</p>' +
+      '<p>선택값: 그룹 내 역할 ID(groupRoleId), 종료 날짜(endDate), 이전 그룹 자동 종료(autoEndDate)</p>' +
+      '<p><b>Exception 예시</b></p>' +
+      '<p>시작 날짜, 종료 날짜가 현재 날짜를 넘어서는 경우 BadRequestException</p>' +
+      '<p>시작 날짜, 종료 날짜를 모두 입력할 경우 --> 종료 날짜가 시작 날짜를 앞설 경우 BadRequestException</p>' +
+      '<p>소속이 종료되지 않은 상태에서 새로운 그룹 이력을 추가하는 경우 BadRequestException</p>',
+  })
+  @Post()
+  @UseInterceptors(TransactionInterceptor)
+  postGroupHistory(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Body() dto: CreateGroupHistoryDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.groupHistoryService.createGroupHistory(
+      churchId,
+      memberId,
+      dto,
+      qr,
+    );
+  }
+
+  @ApiOperation({
+    summary: '교인의 그룹 이력 수정',
+  })
+  @Patch(':groupHistoryId')
+  @UseInterceptors(TransactionInterceptor)
+  updateGroupHistory(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Param('groupHistoryId', ParseIntPipe) groupHistoryId: number,
+    @Body() dto: UpdateGroupHistoryDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.groupHistoryService.updateGroupHistory(
+      churchId,
+      memberId,
+      groupHistoryId,
+      dto,
+      qr,
+    );
+  }
+
+  @ApiOperation({
+    summary: '교인의 그룹 이력 삭제',
+  })
+  @Delete(':groupHistoryId')
+  @UseInterceptors(TransactionInterceptor)
+  deleteGroupHistory(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Param('groupHistoryId', ParseIntPipe) groupHistoryId: number,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.groupHistoryService.deleteGroupHistory(
+      memberId,
+      groupHistoryId,
+      qr,
+    );
+  }
+
+  @ApiOperation({
+    deprecated: true,
+    summary: '교인의 소그룹 수정/삭제',
+    description:
+      '<p>isDeleteEducation 가 true 일 경우 소그룹 삭제</p>' +
+      '<p>isDeleteEducation 필수, groupId 그룹 등록 시 필수, 그룹 삭제 시 생략 가능</p>' +
+      '<p>이미 소속된 소그룹 등록 시 BadRequestException("이미 등록된 소그룹입니다.")</p>' +
+      '<p>부여되지 않은 소그룹 삭제 시 BadRequestException("등록되지 않은 소그룹을 삭제할 수 없습니다.")</p>',
+  })
+  @Patch('groups')
+  @UseInterceptors(TransactionInterceptor)
+  patchMemberGroup(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Body(UpdateMemberGroupPipe) dto: UpdateMemberGroupDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.memberGroupService.updateMemberGroup(
+      churchId,
+      memberId,
+      dto,
+      qr,
+    );
+  }
+}

--- a/backend/src/churches/members-settings/controller/member-settings.controller.ts
+++ b/backend/src/churches/members-settings/controller/member-settings.controller.ts
@@ -15,10 +15,6 @@ import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { UpdateMemberOfficerPipe } from '../pipe/update-member-officer.pipe';
 import { MemberMinistryService } from '../service/member-ministry.service';
 import { UpdateMemberMinistryDto } from '../dto/update-member-ministry.dto';
-import { EducationHistoryService } from '../service/education-history.service';
-import { UpdateMemberGroupDto } from '../dto/update-member-group.dto';
-import { MemberGroupService } from '../service/member-group.service';
-import { UpdateMemberGroupPipe } from '../pipe/update-member-group.pipe';
 
 @ApiTags('Churches:Members:Settings')
 @Controller()
@@ -26,8 +22,8 @@ export class MemberSettingsController {
   constructor(
     private readonly memberOfficerService: MemberOfficerService,
     private readonly memberMinistryService: MemberMinistryService,
-    private readonly memberEducationService: EducationHistoryService,
-    private readonly memberGroupService: MemberGroupService,
+    //private readonly memberEducationService: EducationHistoryService,
+    //private readonly memberGroupService: MemberGroupService,
   ) {}
 
   @ApiOperation({
@@ -106,7 +102,7 @@ export class MemberSettingsController {
     );
   }*/
 
-  @ApiOperation({
+  /*@ApiOperation({
     summary: '교인의 소그룹 수정/삭제',
     description:
       '<p>isDeleteEducation 가 true 일 경우 소그룹 삭제</p>' +
@@ -128,5 +124,5 @@ export class MemberSettingsController {
       dto,
       qr,
     );
-  }
+  }*/
 }

--- a/backend/src/churches/members-settings/dto/group/create-group-history.dto.ts
+++ b/backend/src/churches/members-settings/dto/group/create-group-history.dto.ts
@@ -1,0 +1,47 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsDate, IsNumber, IsOptional, Min } from 'class-validator';
+import { IsValidHistoryDate } from '../../validator/is-valid-start-date.decorator';
+
+export class CreateGroupHistoryDto {
+  @ApiProperty({
+    description: '그룹 ID',
+    example: 1,
+  })
+  @IsNumber()
+  @Min(1)
+  groupId: number;
+
+  @ApiProperty({
+    description: '그룹 내 역할 ID',
+    required: false,
+  })
+  @IsNumber()
+  @IsOptional()
+  @Min(1)
+  groupRoleId: number;
+
+  @ApiProperty({
+    description: '그룹 시작일',
+    required: true,
+  })
+  @IsDate()
+  @IsValidHistoryDate()
+  startDate: Date;
+
+  @ApiProperty({
+    description: '그룹 종료일',
+    required: false,
+  })
+  @IsDate()
+  @IsValidHistoryDate()
+  @IsOptional()
+  endDate: Date;
+
+  @ApiProperty({
+    description: '이전 그룹이 있을 경우 오늘 날짜로 종료날짜 업데이트',
+    required: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  autoEndDate: boolean;
+}

--- a/backend/src/churches/members-settings/dto/group/get-group-history.dto.ts
+++ b/backend/src/churches/members-settings/dto/group/get-group-history.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsOptional } from 'class-validator';
+
+export class GetGroupHistoryDto {
+  @ApiProperty({
+    description: '정렬 오름차순 / 내림차순',
+    default: 'desc',
+    required: false,
+  })
+  @IsIn(['asc', 'desc', 'ASC', 'DESC'])
+  @IsOptional()
+  orderDirection: 'asc' | 'desc' | 'ASC' | 'DESC' = 'desc';
+}

--- a/backend/src/churches/members-settings/dto/group/update-group-history.dto.ts
+++ b/backend/src/churches/members-settings/dto/group/update-group-history.dto.ts
@@ -1,0 +1,7 @@
+import { OmitType, PartialType } from '@nestjs/swagger';
+import { CreateGroupHistoryDto } from './create-group-history.dto';
+
+export class UpdateGroupHistoryDto extends OmitType(
+  PartialType(CreateGroupHistoryDto),
+  ['autoEndDate'],
+) {}

--- a/backend/src/churches/members-settings/entity/group-history.entity.ts
+++ b/backend/src/churches/members-settings/entity/group-history.entity.ts
@@ -1,0 +1,36 @@
+import { Column, Entity, Index, ManyToOne } from 'typeorm';
+import { BaseModel } from '../../../common/entity/base.entity';
+import { GroupModel } from '../../settings/entity/group.entity';
+import { MemberModel } from '../../members/entity/member.entity';
+
+@Entity()
+export class GroupHistoryModel extends BaseModel {
+  @Index()
+  @Column()
+  groupId: number;
+
+  @Column()
+  groupName: string;
+
+  @ManyToOne(() => GroupModel, (group) => group.history)
+  group: GroupModel;
+
+  @Column({ type: 'bigint', nullable: true })
+  groupRoleId: number | null;
+
+  @Column({ type: 'text', nullable: true })
+  groupRoleName: string | null;
+
+  @Index()
+  @Column()
+  memberId: number;
+
+  @ManyToOne(() => MemberModel, (member) => member.groupHistory)
+  member: MemberModel;
+
+  @Column({ type: 'timestamptz' })
+  startDate: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  endDate: Date | null;
+}

--- a/backend/src/churches/members-settings/members-settings.module.ts
+++ b/backend/src/churches/members-settings/members-settings.module.ts
@@ -10,6 +10,9 @@ import { EducationHistoryService } from './service/education-history.service';
 import { MemberGroupService } from './service/member-group.service';
 import { EducationHistoryModel } from './entity/education-history.entity';
 import { EducationHistoryController } from './controller/education-history.controller';
+import { GroupHistoryController } from './controller/group-history.controller';
+import { GroupHistoryModel } from './entity/group-history.entity';
+import { GroupHistoryService } from './service/group-history.service';
 
 @Module({
   imports: [
@@ -19,7 +22,7 @@ import { EducationHistoryController } from './controller/education-history.contr
         module: MembersSettingsModule,
       },
     ]),
-    TypeOrmModule.forFeature([EducationHistoryModel]),
+    TypeOrmModule.forFeature([EducationHistoryModel, GroupHistoryModel]),
     MembersModule,
     SettingsModule,
   ],
@@ -29,7 +32,12 @@ import { EducationHistoryController } from './controller/education-history.contr
     MemberMinistryService,
     EducationHistoryService,
     MemberGroupService,
+    GroupHistoryService,
   ],
-  controllers: [MemberSettingsController, EducationHistoryController],
+  controllers: [
+    MemberSettingsController,
+    EducationHistoryController,
+    GroupHistoryController,
+  ],
 })
 export class MembersSettingsModule {}

--- a/backend/src/churches/members-settings/service/group-history.service.ts
+++ b/backend/src/churches/members-settings/service/group-history.service.ts
@@ -1,0 +1,278 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { GroupHistoryModel } from '../entity/group-history.entity';
+import { IsNull, QueryRunner, Repository } from 'typeorm';
+import { MembersService } from '../../members/service/members.service';
+import { GroupsService } from '../../settings/service/groups.service';
+import { GetGroupHistoryDto } from '../dto/group/get-group-history.dto';
+import { GroupsRolesService } from '../../settings/service/groups-roles.service';
+import { CreateGroupHistoryDto } from '../dto/group/create-group-history.dto';
+import { UpdateGroupHistoryDto } from '../dto/group/update-group-history.dto';
+
+@Injectable()
+export class GroupHistoryService {
+  constructor(
+    @InjectRepository(GroupHistoryModel)
+    private readonly groupHistoryRepository: Repository<GroupHistoryModel>,
+    private readonly membersService: MembersService,
+    private readonly groupsService: GroupsService,
+    private readonly groupsRolesService: GroupsRolesService,
+  ) {}
+
+  private getGroupHistoryRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(GroupHistoryModel)
+      : this.groupHistoryRepository;
+  }
+
+  getGroupHistory(churchId: number, memberId: number, dto: GetGroupHistoryDto) {
+    return this.groupHistoryRepository.find({
+      where: { memberId },
+      order: {
+        endDate: dto.orderDirection,
+        startDate: dto.orderDirection,
+        createdAt: dto.orderDirection,
+      },
+    });
+  }
+
+  async getGroupHistoryById(id: number, memberId: number, qr?: QueryRunner) {
+    const groupHistoryRepository = this.getGroupHistoryRepository(qr);
+
+    const groupHistory = await groupHistoryRepository.findOne({
+      where: {
+        id,
+        memberId,
+      },
+    });
+
+    if (!groupHistory) {
+      throw new NotFoundException('해당 그룹 이력이 존재하지 않습니다.');
+    }
+
+    return groupHistory;
+  }
+
+  async createGroupHistory(
+    churchId: number,
+    memberId: number,
+    dto: CreateGroupHistoryDto,
+    qr: QueryRunner,
+  ) {
+    const groupHistoryRepository = this.getGroupHistoryRepository(qr);
+
+    // 기존 그룹이 있는지 확인
+    const existHistory = await groupHistoryRepository.findOne({
+      where: {
+        memberId,
+        endDate: IsNull(),
+      },
+    });
+
+    // 기존 그룹이 있을 경우 자동으로 종료일 지정
+    if (existHistory && dto.autoEndDate) {
+      // 그룹 자동 종료
+      await groupHistoryRepository.update(
+        { id: existHistory.id },
+        {
+          endDate: dto.startDate,
+        },
+      );
+
+      // 종료된 그룹의 인원수 감소
+      await this.groupsService.decrementMembersCount(existHistory.groupId, qr);
+    }
+
+    // 기존 그룹 있을 경우 Exception
+    if (existHistory && !dto.autoEndDate) {
+      throw new BadRequestException('이미 소속 그룹이 존재하는 교인입니다.');
+    }
+
+    this.validateDate(dto);
+
+    const group = await this.groupsService.getGroupById(
+      churchId,
+      dto.groupId,
+      qr,
+    );
+
+    const member = await this.membersService.getMemberModelById(
+      churchId,
+      memberId,
+      {},
+      qr,
+    );
+
+    const groupRole = dto.groupRoleId
+      ? await this.groupsRolesService.getGroupRoleById(
+          churchId,
+          dto.groupId,
+          dto.groupRoleId,
+          qr,
+        )
+      : undefined;
+
+    const groupHistory = await groupHistoryRepository.save({
+      group: group,
+      groupName: group.name,
+      groupRoleId: groupRole && groupRole.id,
+      groupRoleName: groupRole && groupRole.role,
+      member: member,
+      startDate: dto.startDate,
+      endDate: dto.endDate,
+    });
+
+    await this.groupsService.incrementMembersCount(dto.groupId, qr);
+
+    return groupHistoryRepository.findOne({ where: { id: groupHistory.id } });
+  }
+
+  /**
+   * update 요소
+   *  1. 그룹 -> 바꾸려는 그룹 존재여부 확인, 기존 그룹 인원수 차감, 새로운 그룹 인원수 증가
+   *  2. 그룹 내 역할 -> 바꾸려는 역할 존재여부 확인
+   *  3. 시작날짜 -> 종료날짜보다 앞에 있는지
+   *  4. 종료날짜 -> 시작날짜보다 뒤에 있는지
+   */
+  async updateGroupHistory(
+    churchId: number,
+    memberId: number,
+    groupHistoryId: number,
+    dto: UpdateGroupHistoryDto,
+    qr: QueryRunner,
+  ) {
+    const groupHistoryRepository = this.getGroupHistoryRepository(qr);
+
+    const groupHistory = await this.getGroupHistoryById(
+      groupHistoryId,
+      memberId,
+      qr,
+    );
+
+    const newGroup = dto.groupId
+      ? await this.groupsService.getGroupById(churchId, dto.groupId, qr)
+      : undefined;
+
+    // 그룹 변경 시 새 그룹 인원수 증가, 기존 그룹 인원수 감소
+    if (newGroup) {
+      await this.groupsService.incrementMembersCount(newGroup.id, qr);
+      await this.groupsService.decrementMembersCount(groupHistory.groupId, qr);
+    }
+
+    // 새 그룹은 있지만 역할은 수정하지 않을 경우 기존 역할 삭제
+    const deleteRole = !!(newGroup && !dto.groupRoleId);
+
+    const groupRole = dto.groupRoleId
+      ? dto.groupId
+        ? await this.groupsRolesService.getGroupRoleById(
+            // 그룹과 역할을 모두 바꾸는 경우
+            churchId,
+            dto.groupId,
+            dto.groupRoleId,
+            qr,
+          )
+        : await this.groupsRolesService.getGroupRoleById(
+            // 역할만 바꾸는 경우
+            churchId,
+            groupHistory.groupId,
+            dto.groupRoleId,
+            qr,
+          )
+      : undefined;
+
+    this.validateDate(dto, groupHistory);
+
+    // 현재 그룹을 종료하는 경우
+    if (dto.endDate) {
+      await this.groupsService.decrementMembersCount(groupHistory.groupId, qr);
+    }
+
+    const result = await groupHistoryRepository.update(
+      {
+        id: groupHistoryId,
+      },
+      {
+        group: newGroup,
+        groupName: newGroup && newGroup.name,
+        groupRoleId: deleteRole ? null : groupRole && groupRole.id,
+        groupRoleName: deleteRole ? null : groupRole && groupRole.role,
+        startDate: dto.startDate,
+        endDate: dto.endDate,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException('해당 그룹 이력이 존재하지 않습니다.');
+    }
+
+    return groupHistoryRepository.findOne({ where: { id: groupHistory.id } });
+  }
+
+  private validateDate(
+    dto: CreateGroupHistoryDto | UpdateGroupHistoryDto,
+    groupHistory?: GroupHistoryModel,
+  ) {
+    // 종료일만 업데이트
+    if (!dto.startDate && dto.endDate) {
+      if (groupHistory && groupHistory.startDate > dto.endDate) {
+        throw new BadRequestException(
+          '그룹 종료일이 시작일보다 앞설 수 없습니다.',
+        );
+      }
+    }
+
+    // 시작일만 업데이트
+    if (dto.startDate && !dto.endDate) {
+      if (
+        groupHistory &&
+        groupHistory.endDate &&
+        dto.startDate > groupHistory.endDate
+      ) {
+        throw new BadRequestException(
+          '그룹 종료일이 시작일보다 앞설 수 없습니다.',
+        );
+      }
+    }
+
+    // 시작일, 종료일 업데이트
+    if (dto.startDate && dto.endDate) {
+      if (dto.startDate > dto.endDate) {
+        throw new BadRequestException(
+          '그룹 종료일이 시작일보다 앞설 수 없습니다.',
+        );
+      }
+    }
+  }
+
+  async deleteGroupHistory(
+    memberId: number,
+    groupHistoryId: number,
+    qr: QueryRunner,
+  ) {
+    const groupHistoryRepository = this.getGroupHistoryRepository(qr);
+
+    const groupHistory = await groupHistoryRepository.findOne({
+      where: {
+        id: groupHistoryId,
+        memberId: memberId,
+      },
+    });
+
+    if (!groupHistory) {
+      throw new NotFoundException('해당 그룹 이력이 존재하지 않습니다.');
+    }
+
+    await groupHistoryRepository.softDelete({
+      id: groupHistoryId,
+      deletedAt: IsNull(),
+    });
+
+    await this.groupsService.decrementMembersCount(groupHistory.groupId, qr);
+
+    return 'ok';
+  }
+}

--- a/backend/src/churches/members-settings/validator/is-valid-start-date.decorator.ts
+++ b/backend/src/churches/members-settings/validator/is-valid-start-date.decorator.ts
@@ -1,0 +1,57 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidatorOptions,
+} from 'class-validator';
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+
+@ValidatorConstraint({ name: 'IsValidHistoryDate', async: false })
+@Injectable()
+export class IsValidHistoryDateConstraint
+  implements ValidatorConstraintInterface
+{
+  defaultMessage(validationArguments?: ValidationArguments): string {
+    return '';
+  }
+
+  validate(
+    value: any,
+    validationArguments?: ValidationArguments,
+  ): Promise<boolean> | boolean {
+    if (!(value instanceof Date)) {
+      throw new InternalServerErrorException(
+        '시작날짜 검증 데코레이터 사용 오류',
+      );
+    }
+
+    const input = value.setHours(0, 0, 0, 0);
+
+    const now = new Date().setHours(0, 0, 0, 0);
+
+    if (input > now) {
+      throw new BadRequestException(
+        '이력의 날짜는 현재 날짜를 넘어설 수 없습니다.',
+      );
+    }
+
+    return true;
+  }
+}
+
+export function IsValidHistoryDate(validationOptions?: ValidatorOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsValidHistoryDateConstraint,
+    });
+  };
+}

--- a/backend/src/churches/members/entity/member.entity.ts
+++ b/backend/src/churches/members/entity/member.entity.ts
@@ -19,6 +19,7 @@ import { GroupModel } from '../../settings/entity/group.entity';
 import { FamilyModel } from './family.entity';
 import { MarriageOptions } from '../const/marriage-options.const';
 import { EducationHistoryModel } from '../../members-settings/entity/education-history.entity';
+import { GroupHistoryModel } from '../../members-settings/entity/group-history.entity';
 
 @Entity()
 @Unique(['churchId', 'name', 'mobilePhone'])
@@ -99,12 +100,6 @@ export class MemberModel extends BaseModel {
   @JoinTable()
   ministries: MinistryModel[];
 
-  @Column({ nullable: true, comment: '소그룹 ID' })
-  groupId: number | null;
-
-  @ManyToOne(() => GroupModel, (group) => group.members)
-  group: GroupModel;
-
   @Column({ nullable: true, comment: '직분 ID' })
   officerId: number | null;
 
@@ -133,4 +128,13 @@ export class MemberModel extends BaseModel {
     (educationHistory) => educationHistory.member,
   )
   educationHistory: EducationHistoryModel[];
+
+  @Column({ nullable: true, comment: '소그룹 ID' })
+  groupId: number | null;
+
+  @ManyToOne(() => GroupModel, (group) => group.members)
+  group: GroupModel;
+
+  @OneToMany(() => GroupHistoryModel, (groupHistory) => groupHistory.member)
+  groupHistory: GroupHistoryModel[];
 }

--- a/backend/src/churches/settings/controller/groups-roles.controller.ts
+++ b/backend/src/churches/settings/controller/groups-roles.controller.ts
@@ -13,7 +13,7 @@ import { UpdateGroupRoleDto } from '../dto/group/update-group-role.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { GroupsRolesService } from '../service/groups-roles.service';
 
-@ApiTags('Groups:Settings:Roles')
+@ApiTags('Settings:Groups:Roles')
 // churches/{churchId}/settings
 @Controller('groups')
 export class GroupsRolesController {

--- a/backend/src/churches/settings/entity/group.entity.ts
+++ b/backend/src/churches/settings/entity/group.entity.ts
@@ -3,9 +3,22 @@ import { MemberModel } from '../../members/entity/member.entity';
 import { ChurchModel } from '../../entity/church.entity';
 import { BaseChurchSettingModel } from './base-church-setting.entity';
 import { GroupRoleModel } from './group-role.entity';
+import { GroupHistoryModel } from '../../members-settings/entity/group-history.entity';
 
 @Entity()
 export class GroupModel extends BaseChurchSettingModel {
+  /*
+  @Index()
+  @Column()
+  churchId: number;
+
+  @Column()
+  name: string;
+
+  @Column({ default: 0 })
+  membersCount: number;
+   */
+
   @Column({ nullable: true })
   parentGroupId?: number;
 
@@ -26,4 +39,7 @@ export class GroupModel extends BaseChurchSettingModel {
 
   @OneToMany(() => GroupRoleModel, (groupRole) => groupRole.group)
   roles: GroupRoleModel[];
+
+  @OneToMany(() => GroupHistoryModel, (history) => history.group)
+  history: GroupHistoryModel[];
 }

--- a/backend/src/churches/settings/service/groups-roles.service.ts
+++ b/backend/src/churches/settings/service/groups-roles.service.ts
@@ -94,6 +94,29 @@ export class GroupsRolesService {
     });
   }
 
+  async getGroupRoleById(
+    churchId: number,
+    groupId: number,
+    groupRoleId: number,
+    qr?: QueryRunner,
+  ) {
+    const groupRolesRepository = this.getGroupRolesRepository(qr);
+
+    const role = await groupRolesRepository.findOne({
+      where: {
+        churchId,
+        groupId,
+        id: groupRoleId,
+      },
+    });
+
+    if (!role) {
+      throw new NotFoundException('해당 그룹에 존재하지 않는 역할입니다.');
+    }
+
+    return role;
+  }
+
   async createGroupRole(
     churchId: number,
     groupId: number,

--- a/backend/src/churches/settings/settings.module.ts
+++ b/backend/src/churches/settings/settings.module.ts
@@ -49,6 +49,11 @@ import { EducationsService } from './service/educations.service';
     GroupsRolesService,
     EducationsService,
   ],
-  exports: [SettingsService, GroupsService, EducationsService],
+  exports: [
+    SettingsService,
+    GroupsService,
+    EducationsService,
+    GroupsRolesService,
+  ],
 })
 export class SettingsModule {}


### PR DESCRIPTION
## 주요 내용
- 교인별 그룹 소속 이력 관리
- 동시 다중 그룹 소속 제한
- 자동 종료일 지정 기능

## 세부 내용
### 그룹 이력 관리
- 시작일, 종료일 기반 이력 관리
- 종료일 없는 이력이 현재 소속 그룹을 의미
- 진행중인 그룹 이력이 있는 경우 새 이력 생성 불가

### 자동 종료일 설정
- autoEndDate 옵션으로 이전 그룹 자동 종료
- 새 그룹 시작일을 이전 그룹의 종료일로 설정

### 제약 조건
- 한 교인은 동시에 하나의 그룹에만 소속 가능
- 종료일이 없는 진행중 이력은 최대 1개만 허용