### PR TITLE
feat: 그룹 구조 관리 기능 개선

### DIFF
--- a/backend/src/churches/members-settings/service/group-history.service.ts
+++ b/backend/src/churches/members-settings/service/group-history.service.ts
@@ -94,7 +94,13 @@ export class GroupHistoryService {
 
     this.validateDate(dto);
 
-    const group = await this.groupsService.getGroupById(
+    /*const group = await this.groupsService.getGroupById(
+      churchId,
+      dto.groupId,
+      qr,
+    );*/
+
+    const group = await this.groupsService.getGroupModelById(
       churchId,
       dto.groupId,
       qr,

--- a/backend/src/churches/members/entity/member.entity.ts
+++ b/backend/src/churches/members/entity/member.entity.ts
@@ -21,6 +21,7 @@ import { EducationHistoryModel } from '../../members-settings/entity/education-h
 import { GroupHistoryModel } from '../../members-settings/entity/group-history.entity';
 import { EducationTermModel } from '../../settings/entity/education/education-term.entity';
 import { EducationEnrollmentModel } from '../../settings/entity/education/education-enrollment.entity';
+import { GroupModel } from '../../settings/entity/group/group.entity';
 
 @Entity()
 @Unique(['churchId', 'name', 'mobilePhone'])
@@ -140,6 +141,9 @@ export class MemberModel extends BaseModel {
 
   /*@ManyToOne(() => GroupModel, (group) => group.members)
   group: GroupModel;*/
+
+  @OneToMany(() => GroupModel, (group) => group.members)
+  currentGroup: GroupModel;
 
   @OneToMany(() => GroupHistoryModel, (groupHistory) => groupHistory.member)
   group: GroupHistoryModel[];

--- a/backend/src/churches/settings/const/exception/group/group.exception.ts
+++ b/backend/src/churches/settings/const/exception/group/group.exception.ts
@@ -1,0 +1,8 @@
+export const GroupExceptionMessage = {
+  NOT_FOUND: '해당 그룹을 찾을 수 없습니다.',
+  ALREADY_EXIST: '이미 존재하는 그룹입니다.',
+  LIMIT_DEPTH_REACHED: '더 이상 하위 그룹을 생성할 수 없습니다.',
+  CANNOT_SET_SUBGROUP_AS_PARENT:
+    '현재 하위 그룹을 새로운 상위 그룹으로 지정할 수 없습니다.',
+  GROUP_HAS_DEPENDENCIES: '해당 그룹에 속한 하위 그룹 또는 교인이 존재합니다.',
+};

--- a/backend/src/churches/settings/controller/groups.controller.ts
+++ b/backend/src/churches/settings/controller/groups.controller.ts
@@ -16,8 +16,6 @@ import { UpdateGroupDto } from '../dto/group/update-group.dto';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
-// import { CreateGroupRoleDto } from '../dto/group/create-group-role.dto';
-// import { UpdateGroupRoleDto } from '../dto/group/update-group-role.dto';
 
 @ApiTags('Settings:Groups')
 @Controller('groups')
@@ -44,9 +42,7 @@ export class GroupsController {
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('groupId', ParseIntPipe) groupId: number,
   ) {
-    return this.groupsService.getGroupById(churchId, groupId, undefined, {
-      //members: true,
-    });
+    return this.groupsService.getGroupByIdWithParents(churchId, groupId);
   }
 
   @Patch(':groupId')

--- a/backend/src/churches/settings/dto/group/create-group.dto.ts
+++ b/backend/src/churches/settings/dto/group/create-group.dto.ts
@@ -24,5 +24,5 @@ export class CreateGroupDto extends PickType(GroupModel, [
   })
   @IsNumber()
   @IsOptional()
-  override parentGroupId?: number;
+  override parentGroupId: number;
 }

--- a/backend/src/churches/settings/entity/group/group.entity.ts
+++ b/backend/src/churches/settings/entity/group/group.entity.ts
@@ -1,25 +1,17 @@
-import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
+import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
 import { ChurchModel } from '../../../entity/church.entity';
-import { BaseChurchSettingModel } from '../base-church-setting.entity';
 import { GroupRoleModel } from './group-role.entity';
 import { GroupHistoryModel } from '../../../members-settings/entity/group-history.entity';
+import { BaseModel } from '../../../../common/entity/base.entity';
+import { MemberModel } from '../../../members/entity/member.entity';
 
 @Entity()
-export class GroupModel extends BaseChurchSettingModel {
-  /*
-  @Index()
-  @Column()
-  churchId: number;
-
+export class GroupModel extends BaseModel {
   @Column()
   name: string;
 
-  @Column({ default: 0 })
-  membersCount: number;
-   */
-
-  @Column({ nullable: true })
-  parentGroupId?: number;
+  @Column({ type: 'int', nullable: true })
+  parentGroupId: number | null;
 
   @ManyToOne(() => GroupModel, (group) => group.childGroups)
   parentGroup: GroupModel;
@@ -30,11 +22,18 @@ export class GroupModel extends BaseChurchSettingModel {
   @OneToMany(() => GroupModel, (group) => group.parentGroup)
   childGroups: GroupModel[];
 
+  @Column()
+  @Index()
+  churchId: number;
+
   @ManyToOne(() => ChurchModel, (church) => church.groups)
   church: ChurchModel;
 
-  /*@OneToMany(() => MemberModel, (member) => member.group)
-  members: MemberModel[];*/
+  @Column({ default: 0 })
+  membersCount: number;
+
+  @OneToMany(() => MemberModel, (member) => member.group)
+  members: MemberModel[];
 
   @OneToMany(() => GroupRoleModel, (groupRole) => groupRole.group)
   roles: GroupRoleModel[];

--- a/backend/src/churches/settings/service/groups-roles.service.ts
+++ b/backend/src/churches/settings/service/groups-roles.service.ts
@@ -122,7 +122,7 @@ export class GroupsRolesService {
     groupId: number,
     dto: CreateGroupRoleDto,
   ) {
-    const group = await this.groupsService.getGroupById(churchId, groupId);
+    const group = await this.groupsService.getGroupModelById(churchId, groupId);
 
     const groupRolesRepository = this.getGroupRolesRepository();
 

--- a/backend/src/churches/settings/service/groups.service.ts
+++ b/backend/src/churches/settings/service/groups.service.ts
@@ -5,11 +5,12 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { GroupModel } from '../entity/group/group.entity';
-import { FindOptionsRelations, IsNull, QueryRunner, Repository } from 'typeorm';
+import { IsNull, QueryRunner, Repository } from 'typeorm';
 import { ChurchesService } from '../../churches.service';
 import { CreateGroupDto } from '../dto/group/create-group.dto';
 import { UpdateGroupDto } from '../dto/group/update-group.dto';
 import { SETTING_EXCEPTION } from '../exception-messages/exception-messages.const';
+import { GroupExceptionMessage } from '../const/exception/group/group.exception';
 
 @Injectable()
 export class GroupsService {
@@ -58,11 +59,27 @@ export class GroupsService {
     });
   }
 
-  async getGroupById(
+  async getGroupModelById(churchId: number, groupId: number, qr?: QueryRunner) {
+    const groupsRepository = this.getGroupRepository(qr);
+
+    const group = await groupsRepository.findOne({
+      where: {
+        id: groupId,
+        churchId,
+      },
+    });
+
+    if (!group) {
+      throw new NotFoundException(GroupExceptionMessage.NOT_FOUND);
+    }
+
+    return group;
+  }
+
+  async getGroupByIdWithParents(
     churchId: number,
     groupId: number,
     qr?: QueryRunner,
-    relationOptions?: FindOptionsRelations<GroupModel>,
   ) {
     await this.checkChurchExist(churchId, qr);
 
@@ -70,37 +87,89 @@ export class GroupsService {
 
     const group = await groupsRepository.findOne({
       where: { churchId, id: groupId },
-      relations: { roles: true, ...relationOptions },
+      relations: { roles: true },
     });
 
     if (!group) {
-      throw new NotFoundException(SETTING_EXCEPTION.GroupModel.NOT_FOUND);
+      throw new NotFoundException(GroupExceptionMessage.NOT_FOUND);
     }
 
-    return group;
+    return {
+      ...group,
+      parentGroups: await this.getParentGroups(groupId, groupsRepository),
+    };
+  }
+
+  private async getParentGroups(
+    groupId: number,
+    groupsRepository: Repository<GroupModel>,
+  ) {
+    const parents = await groupsRepository.query(
+      `
+    WITH RECURSIVE parent_groups AS (
+      -- 초기 그룹의 부모
+      SELECT g.* 
+      FROM group_model g
+      JOIN group_model child 
+      ON g.id = child."parentGroupId"
+      WHERE child.id = $1
+      
+      UNION ALL
+      
+      -- 재귀적으로 부모의 부모 찾기
+      SELECT g.*
+      FROM group_model g
+      JOIN parent_groups pg 
+      ON g.id = pg."parentGroupId"
+    )
+    SELECT * FROM parent_groups;
+    `,
+      [groupId],
+    );
+
+    let result: {
+      id: number;
+      name: string;
+      parentGroupId: number | null;
+      depth: number;
+    }[] = [];
+    parents.forEach((parent: GroupModel, i: number) => {
+      result.unshift({
+        id: parent.id,
+        name: parent.name,
+        parentGroupId: parent.parentGroupId,
+        depth: parents.length - i,
+      });
+    });
+
+    return result;
   }
 
   async postGroup(churchId: number, dto: CreateGroupDto, qr?: QueryRunner) {
     await this.checkChurchExist(churchId, qr);
 
     if (await this.isExistGroup(churchId, dto.name, qr)) {
-      throw new BadRequestException(SETTING_EXCEPTION.GroupModel.ALREADY_EXIST);
+      throw new BadRequestException(GroupExceptionMessage.ALREADY_EXIST);
     }
 
     const groupsRepository = this.getGroupRepository(qr);
 
     // 상위 그룹 지정 시
     if (dto.parentGroupId) {
-      const parentGroup = await groupsRepository.findOne({
-        where: {
-          id: dto.parentGroupId,
-          churchId: churchId,
-        },
-      });
+      const parentGroup = await this.getGroupModelById(
+        churchId,
+        dto.parentGroupId,
+        qr,
+      );
 
-      if (!parentGroup) {
-        throw new NotFoundException(
-          SETTING_EXCEPTION.GroupModel.PARENT_NOT_FOUND,
+      const grandParentGroups = await this.getParentGroups(
+        parentGroup.id,
+        groupsRepository,
+      );
+
+      if (grandParentGroups.length + 1 === 5) {
+        throw new BadRequestException(
+          GroupExceptionMessage.LIMIT_DEPTH_REACHED,
         );
       }
 
@@ -172,7 +241,7 @@ export class GroupsService {
       // 컴퓨터의 폴더 구조와 동일한 방식
       if (beforeUpdateGroup.childGroupIds.includes(dto.parentGroupId)) {
         throw new BadRequestException(
-          '현재 하위 그룹을 새로운 상위 그룹으로 지정할 수 없습니다.',
+          GroupExceptionMessage.CANNOT_SET_SUBGROUP_AS_PARENT,
         );
       }
 
@@ -246,7 +315,7 @@ export class GroupsService {
       deleteTarget.membersCount !== 0
     ) {
       throw new BadRequestException(
-        '해당 그룹에 속한 하위 그룹 또는 교인이 존재합니다.',
+        GroupExceptionMessage.GROUP_HAS_DEPENDENCIES,
       );
     }
 


### PR DESCRIPTION
## 주요 내용
- 그룹 조회 시 부모 그룹 정보 포함
- 하위 그룹 생성 시 최대 깊이 제한 추가

## 세부 내용
### 그룹 조회 개선
- 재귀 쿼리를 사용한 모든 상위 그룹 조회
- 그룹 상세 정보에 부모 그룹 목록 포함

### 구조 제한 추가
- 하위 그룹 생성 시 최대 깊이(depth 5) 제한
- 제한 초과 시 BadRequest 에러 발생