### PR TITLE
feat: 사역의 그룹 소속 관리 기능 추가

### DIFF
--- a/backend/src/churches/settings/dto/ministry/create-ministry.dto.ts
+++ b/backend/src/churches/settings/dto/ministry/create-ministry.dto.ts
@@ -1,9 +1,20 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { MinistryModel } from '../../entity/ministry/ministry.entity';
-import { IsNotEmpty, IsString, Matches, MaxLength } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+  Min,
+} from 'class-validator';
 import { TransformName } from '../../../decorator/transform-name';
 
-export class CreateMinistryDto extends PickType(MinistryModel, ['name']) {
+export class CreateMinistryDto extends PickType(MinistryModel, [
+  'name',
+  'ministryGroupId',
+]) {
   @ApiProperty({
     name: 'name',
     description: '사역 이름',
@@ -18,4 +29,14 @@ export class CreateMinistryDto extends PickType(MinistryModel, ['name']) {
     message: '특수문자는 사용할 수 없습니다.',
   })
   override name: string;
+
+  @ApiProperty({
+    description: '사역 그룹 ID',
+    minimum: 1,
+    required: false,
+  })
+  @Min(1)
+  @IsNumber()
+  @IsOptional()
+  override ministryGroupId: number;
 }

--- a/backend/src/churches/settings/entity/ministry/ministry-group.entity.ts
+++ b/backend/src/churches/settings/entity/ministry/ministry-group.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
+import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
 import { ChurchModel } from '../../../entity/church.entity';
 import { MinistryModel } from './ministry.entity';
 import { BaseModel } from '../../../../common/entity/base.entity';
@@ -9,6 +9,7 @@ export class MinistryGroupModel extends BaseModel {
   name: string;
 
   @Column({ nullable: true })
+  @Index()
   parentMinistryGroupId: number;
 
   @ManyToOne(
@@ -27,6 +28,7 @@ export class MinistryGroupModel extends BaseModel {
   childMinistryGroups: MinistryGroupModel[];
 
   @Column()
+  @Index()
   churchId: number;
 
   @ManyToOne(() => ChurchModel, (church) => church.ministryGroups)

--- a/backend/src/churches/settings/entity/ministry/ministry.entity.ts
+++ b/backend/src/churches/settings/entity/ministry/ministry.entity.ts
@@ -20,6 +20,7 @@ export class MinistryModel extends BaseModel {
   church: ChurchModel;
 
   @Column({ nullable: true })
+  @Index()
   ministryGroupId: number;
 
   @ManyToOne(

--- a/backend/src/churches/settings/service/education/educations.service.ts
+++ b/backend/src/churches/settings/service/education/educations.service.ts
@@ -333,12 +333,14 @@ export class EducationsService {
 
     const education = await this.getEducationById(churchId, educationId, qr);
 
-    const instructor = await this.membersService.getMemberModelById(
-      churchId,
-      dto.instructorId,
-      {},
-      qr,
-    );
+    const instructor = dto.instructorId
+      ? await this.membersService.getMemberModelById(
+          churchId,
+          dto.instructorId,
+          {},
+          qr,
+        )
+      : undefined;
 
     const isExistEducationTerm = await this.isExistEducationTerm(
       educationId,


### PR DESCRIPTION
## 주요 내용
- 사역 생성 시 그룹 지정 기능
- 사역의 소속 그룹 변경 기능

## 세부 내용
### 사역 생성
- 사역 생성 시 그룹 지정 가능
- 그룹 미지정 시 ministryGroupId를 null로 처리

### 사역 수정
- 소속 그룹 변경 기능 추가
- 그룹 해제 시 ministryGroupId를 null로 변경