### PR TITLE
feat: 사역 이름 중복 검사 범위 수정 및 null 처리 개선

### DIFF
--- a/backend/src/churches/settings/const/exception/ministry/ministry.exception.ts
+++ b/backend/src/churches/settings/const/exception/ministry/ministry.exception.ts
@@ -1,4 +1,4 @@
 export const MinistryExceptionMessage = {
   NOT_FOUND: '해당 사역을 찾을 수 없습니다.',
-  ALREADY_EXIST: '이미 존재하는 사역입니다.',
+  ALREADY_EXIST: '해당 사역 그룹에 이미 존재하는 사역 이름입니다.',
 };

--- a/backend/src/churches/settings/controller/ministry/ministries.controller.ts
+++ b/backend/src/churches/settings/controller/ministry/ministries.controller.ts
@@ -7,11 +7,13 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Query,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { MinistryService } from '../../service/ministry/ministry.service';
 import { CreateMinistryDto } from '../../dto/ministry/create-ministry.dto';
 import { UpdateMinistryDto } from '../../dto/ministry/update-ministry.dto';
+import { GetMinistryDto } from '../../dto/ministry/get-ministry.dto';
 
 @ApiTags('Management:Ministries')
 @Controller('ministries')
@@ -19,8 +21,11 @@ export class MinistriesController {
   constructor(private readonly ministryService: MinistryService) {}
 
   @Get()
-  getMinistries(@Param('churchId', ParseIntPipe) churchId: number) {
-    return this.ministryService.getMinistries(churchId);
+  getMinistries(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetMinistryDto,
+  ) {
+    return this.ministryService.getMinistries(churchId, dto);
   }
 
   @Post()
@@ -36,7 +41,7 @@ export class MinistriesController {
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('ministryId', ParseIntPipe) ministryId: number,
   ) {
-    return this.ministryService.getMinistryById(ministryId);
+    return this.ministryService.getMinistryById(churchId, ministryId);
   }
 
   @Patch(':ministryId')
@@ -44,7 +49,10 @@ export class MinistriesController {
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('ministryId', ParseIntPipe) ministryId: number,
     @Body() dto: UpdateMinistryDto,
+    //@Query() ministryGroupId: MinistryGroupIdDto,
   ) {
+    //return `${churchId} ${ministryGroupId.ministryGroupId} ${ministryId}`;
+
     return this.ministryService.updateMinistry(churchId, ministryId, dto);
   }
 

--- a/backend/src/churches/settings/dto/ministry/create-ministry.dto.ts
+++ b/backend/src/churches/settings/dto/ministry/create-ministry.dto.ts
@@ -1,5 +1,4 @@
-import { ApiProperty, PickType } from '@nestjs/swagger';
-import { MinistryModel } from '../../entity/ministry/ministry.entity';
+import { ApiProperty } from '@nestjs/swagger';
 import {
   IsNotEmpty,
   IsNumber,
@@ -11,10 +10,10 @@ import {
 } from 'class-validator';
 import { TransformName } from '../../../decorator/transform-name';
 
-export class CreateMinistryDto extends PickType(MinistryModel, [
+export class CreateMinistryDto /*extends PickType(MinistryModel, [
   'name',
   'ministryGroupId',
-]) {
+]) */ {
   @ApiProperty({
     name: 'name',
     description: '사역 이름',
@@ -28,15 +27,16 @@ export class CreateMinistryDto extends PickType(MinistryModel, [
   @Matches(/^[a-zA-Z0-9가-힣 \-]+$/, {
     message: '특수문자는 사용할 수 없습니다.',
   })
-  override name: string;
+  name: string;
 
   @ApiProperty({
-    description: '사역 그룹 ID',
-    minimum: 1,
+    description:
+      '지정/변경할 사역 그룹 ID (0 또는 undefined 일 경우 사역 그룹에 속하지 않음)',
+    minimum: 0,
     required: false,
   })
-  @Min(1)
+  @Min(0)
   @IsNumber()
   @IsOptional()
-  override ministryGroupId: number;
+  ministryGroupId: number;
 }

--- a/backend/src/churches/settings/dto/ministry/get-ministry.dto.ts
+++ b/backend/src/churches/settings/dto/ministry/get-ministry.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsNumber, IsOptional } from 'class-validator';
+
+export class GetMinistryDto {
+  @ApiProperty({
+    description: '사역 그룹 ID (0 일 경우 사역 그룹에 속하지 않은 사역 조회)',
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  ministryGroupId: number;
+
+  @ApiProperty({
+    description: '정렬 기준',
+    required: false,
+  })
+  @IsIn(['name', 'createdAt', 'updatedAt', 'ministryGroupId'])
+  @IsOptional()
+  order: string = 'createdAt';
+
+  @ApiProperty({
+    description: '정렬 오름차순 / 내림차순',
+    required: false,
+  })
+  @IsIn(['asc', 'desc', 'ASC', 'DESC'])
+  @IsOptional()
+  orderDirection: 'asc' | 'desc' | 'ASC' | 'DESC' = 'asc';
+}

--- a/backend/src/churches/settings/dto/ministry/ministry-group-id.dto.ts
+++ b/backend/src/churches/settings/dto/ministry/ministry-group-id.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsOptional, Min } from 'class-validator';
+
+export class MinistryGroupIdDto {
+  @ApiProperty({
+    description: '사역 그룹 ID (그룹 지정되지 않은 사역일 경우 생략)',
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  ministryGroupId: number;
+}

--- a/backend/src/churches/settings/entity/ministry/ministry.entity.ts
+++ b/backend/src/churches/settings/entity/ministry/ministry.entity.ts
@@ -21,7 +21,7 @@ export class MinistryModel extends BaseModel {
 
   @Column({ nullable: true })
   @Index()
-  ministryGroupId: number;
+  ministryGroupId: number | null;
 
   @ManyToOne(
     () => MinistryGroupModel,


### PR DESCRIPTION
## 주요 내용
- 사역 이름 중복 검사 범위를 그룹 단위로 변경
- 사역의 그룹 미소속 상태 표현 방식 변경

## 세부 내용
### 이름 중복 검사 개선
- 동일 그룹 내에서만 이름 중복 체크
- 다른 그룹에서는 동일 이름 허용

### 그룹 미소속 처리 변경
- null 대신 0을 사용하여 미소속 상태 표현
- 요청 파라미터의 number 타입에서 발생하는 null 처리 이슈 해결