### PR TITLE
feat: 교인 사역 이력 관리 기능 개선

### DIFF
--- a/backend/src/churches/members-settings/const/swagger/ministry/controller.swagger.ts
+++ b/backend/src/churches/members-settings/const/swagger/ministry/controller.swagger.ts
@@ -1,0 +1,73 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+export const ApiGetMemberMinistry = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교인의 전체 사역 이력 조회',
+      description:
+        '<p>교인의 전체 사역을 조회합니다.</p>' +
+        '<p>1. 시작일, 2. 생성일 기준 정렬</p>' +
+        '<p>기본값: 최신순 (desc)</p>',
+    }),
+  );
+
+export const ApiPostMemberMinistry = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교인에게 사역 부여',
+      description:
+        '<p>교인에게 새로운 사역을 부여합니다.</p>' +
+        '<p>사역을 부여하면 사역 이력이 생성됩니다.</p>' +
+        '<p>시작 날짜를 입력하지 않을 경우 현재 날짜로 지정됩니다.</p>' +
+        '<p>시작 날짜는 현재 날짜를 앞설 수 없습니다.</p>',
+    }),
+  );
+
+export const ApiDeleteMemberMinistry = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교인의 사역 종료',
+      description:
+        '<p>교인에게 부여된 현재 사역을 종료합니다.</p>' +
+        '<p>종료 시점의 사역 이름과 사역 그룹이 저장됩니다.</p>' +
+        '<p>사역 그룹의 위계는 __ 로 구분됩니다. <i>ex) 사역그룹1__사역그룹1-3__사역그룹1-3-2</i></p>' +
+        '<p>종료 날짜를 입력하지 않을 경우 현재 날짜로 지정됩니다.</p>' +
+        '<p>종료 날짜는 시작 날짜를 앞설 수 없습니다.</p>',
+    }),
+  );
+
+export const ApiGetMinistryHistory = () =>
+  applyDecorators(
+    ApiOperation({
+      deprecated: true,
+      summary: '교인의 종료된 사역 이력 조회',
+      description:
+        '<p>교인의 종료된 사역 이력을 조회힙니다.</p>' +
+        '<p>현재 부역 중인 사역은 조회되지 않습니다.</p>' +
+        '<p>1. 종료일, 2. 시작일, 3. 생성일 기준 정렬</p>' +
+        '<p>기본값: 최신순 (desc)</p>',
+    }),
+  );
+
+export const ApiPatchMinistryHistory = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교인의 사역 이력 수정',
+      description:
+        '<p>사역 이력을 수정합니다.</p>' +
+        '<p>이력의 시작, 종료 날짜를 수정할 수 있습니다.</p>' +
+        '<p>시작일은 종료일보다 뒤일 수 없고, 종료일은 시작일보다 앞설 수 없습니다.</p>',
+    }),
+  );
+
+export const ApiDeleteMinistryHistory = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교인의 사역 이력 삭제',
+      description:
+        '<p>사역 이력을 삭제합니다. (사역 종료와 다름)</p>' +
+        '<p>이력의 삭제는 종료된 이력만 삭제할 수 있습니다.</p>' +
+        '<p>사역 이력을 삭제하여 교인이 해당 사역을 하지 않은 것으로 처리됩니다.</p>',
+    }),
+  );

--- a/backend/src/churches/members-settings/controller/member-ministry.controller.ts
+++ b/backend/src/churches/members-settings/controller/member-ministry.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Query,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
@@ -16,6 +17,16 @@ import { TransactionInterceptor } from '../../../common/interceptor/transaction.
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
 import { EndMemberMinistryDto } from '../dto/ministry/end-member-ministry.dto';
+import { GetMinistryHistoryDto } from '../dto/ministry/get-ministry-history.dto';
+import { UpdateMinistryHistoryDto } from '../dto/ministry/update-ministry-history.dto';
+import {
+  ApiDeleteMemberMinistry,
+  ApiDeleteMinistryHistory,
+  ApiGetMemberMinistry,
+  ApiGetMinistryHistory,
+  ApiPatchMinistryHistory,
+  ApiPostMemberMinistry,
+} from '../const/swagger/ministry/controller.swagger';
 
 @ApiTags('Churches:Members:Ministries')
 @Controller('ministries')
@@ -23,17 +34,24 @@ export class MemberMinistryController {
   constructor(private readonly memberMinistryService: MemberMinistryService) {}
 
   // 교인의 사역 조회 (현재)
+  @ApiGetMemberMinistry()
   @Get()
   getMemberMinistry(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
+    @Query() dto: GetMinistryHistoryDto,
   ) {
-    return this.memberMinistryService.getMemberMinistry(churchId, memberId);
+    return this.memberMinistryService.getCurrentMemberMinistry(
+      churchId,
+      memberId,
+      dto,
+    );
   }
 
   // 교인에게 현재 사역 부여
   // member 와 N:N relation 추가
   // ministryHistory 추가 (시작일)
+  @ApiPostMemberMinistry()
   @Post()
   @UseInterceptors(TransactionInterceptor)
   postMemberMinistry(
@@ -53,7 +71,7 @@ export class MemberMinistryController {
   // 교인의 현재 사역 수정
   // N:N relation 수정
   // 현재 ministryHistory 의 ministry 수정 (날짜 수정은 patchMinistryHistory 에서 담당)
-  @Patch(':ministryId')
+  //@Patch(':ministryId')
   patchMemberMinistry(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
@@ -65,6 +83,7 @@ export class MemberMinistryController {
   // 교인의 현재 사역 삭제 + 종료
   // N:N relation 삭제
   // 현재 ministryHistory 삭제 + 해당 MinistryHistoryModel 에 endDate 추가
+  @ApiDeleteMemberMinistry()
   @Delete(':ministryId')
   @UseInterceptors(TransactionInterceptor)
   deleteMemberMinistry(
@@ -85,34 +104,53 @@ export class MemberMinistryController {
   }
 
   // 교인의 사역 이력 조회
-  @Get('history')
+  @ApiGetMinistryHistory()
+  //@Get('history')
   getMinistryHistory(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
+    @Query() dto: GetMinistryHistoryDto,
   ) {
-    return 'get history';
+    /*return this.memberMinistryService.getMinistryHistory(
+      churchId,
+      memberId,
+      dto,
+    );*/
+    //return 'get history';
   }
 
   // 교인의 사역 이력 수정
   // 사역의 시작 날짜, 종료 날짜만 수정 가능
+  @ApiPatchMinistryHistory()
   @Patch('history/:ministryHistoryId')
   patchMinistryHistory(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
-    @Param('ministryHistoryHistoryId', ParseIntPipe)
-    ministryHistoryHistoryId: number,
+    @Param('ministryHistoryId', ParseIntPipe)
+    ministryHistoryId: number,
+    @Body() dto: UpdateMinistryHistoryDto,
   ) {
-    return 'patch ministryHistory';
+    return this.memberMinistryService.updateMinistryHistory(
+      churchId,
+      memberId,
+      ministryHistoryId,
+      dto,
+    );
   }
 
   // 교인의 사역 이력 삭제
+  @ApiDeleteMinistryHistory()
   @Delete('history/:ministryHistoryId')
   deleteMinistryHistory(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
-    @Param('ministryHistoryHistoryId', ParseIntPipe)
-    ministryHistoryHistoryId: number,
+    @Param('ministryHistoryId', ParseIntPipe)
+    ministryHistoryId: number,
   ) {
-    return 'delete ministryHistory';
+    return this.memberMinistryService.deleteMinistryHistory(
+      churchId,
+      memberId,
+      ministryHistoryId,
+    );
   }
 }

--- a/backend/src/churches/members-settings/dto/ministry/create-member-ministry.dto.ts
+++ b/backend/src/churches/members-settings/dto/ministry/create-member-ministry.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDate, IsNumber, Min } from 'class-validator';
+import { IsDate, IsNumber, IsOptional, Min } from 'class-validator';
 
 export class CreateMemberMinistryDto {
   @ApiProperty({
@@ -11,7 +11,10 @@ export class CreateMemberMinistryDto {
 
   @ApiProperty({
     description: '사역 시작일',
+    default: new Date(),
+    required: false,
   })
+  @IsOptional()
   @IsDate()
-  startDate: Date;
+  startDate: Date = new Date();
 }

--- a/backend/src/churches/members-settings/dto/ministry/get-ministry-history.dto.ts
+++ b/backend/src/churches/members-settings/dto/ministry/get-ministry-history.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn } from 'class-validator';
+
+export class GetMinistryHistoryDto {
+  @ApiProperty({
+    description: '정렬 오름차순 / 내림차순',
+    required: false,
+  })
+  @IsIn(['asc', 'desc', 'ASC', 'DESC'])
+  orderDirection: 'asc' | 'desc' | 'ASC' | 'DESC' = 'desc';
+}

--- a/backend/src/churches/members-settings/dto/ministry/update-ministry-history.dto.ts
+++ b/backend/src/churches/members-settings/dto/ministry/update-ministry-history.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDate, IsOptional, ValidateIf } from 'class-validator';
+import { IsAfterDate } from '../../../settings/decorator/is-valid-end-date.decorator';
+
+export class UpdateMinistryHistoryDto {
+  @ApiProperty({
+    description: '사역 이력 시작일',
+    required: false,
+  })
+  @IsOptional()
+  @IsDate()
+  startDate: Date;
+
+  @ApiProperty({
+    description: '사역 이력 종료일',
+    required: false,
+  })
+  @IsOptional()
+  @IsDate()
+  @ValidateIf((o) => o.startDate)
+  @IsAfterDate('startDate')
+  endDate: Date;
+}

--- a/backend/src/churches/settings/service/ministry/ministry.service.ts
+++ b/backend/src/churches/settings/service/ministry/ministry.service.ts
@@ -5,7 +5,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { MinistryModel } from '../../entity/ministry/ministry.entity';
-import { IsNull, QueryRunner, Repository } from 'typeorm';
+import { FindOptionsRelations, IsNull, QueryRunner, Repository } from 'typeorm';
 import { CreateMinistryDto } from '../../dto/ministry/create-ministry.dto';
 import { UpdateMinistryDto } from '../../dto/ministry/update-ministry.dto';
 import { MinistryExceptionMessage } from '../../const/exception/ministry/ministry.exception';
@@ -45,6 +45,7 @@ export class MinistryService {
   async getMinistryModelById(
     churchId: number,
     ministryId: number,
+    relationOptions: FindOptionsRelations<MinistryModel>,
     qr?: QueryRunner,
   ) {
     const ministryRepository = this.getMinistryRepository(qr);
@@ -175,6 +176,7 @@ export class MinistryService {
     const targetMinistry = await this.getMinistryModelById(
       churchId,
       ministryId,
+      {},
       qr,
     );
 

--- a/backend/src/churches/settings/settings.module.ts
+++ b/backend/src/churches/settings/settings.module.ts
@@ -80,6 +80,7 @@ import { MinistryGroupsController } from './controller/ministry/ministry-groups.
   exports: [
     SettingsService,
     MinistryService,
+    MinistryGroupService,
     GroupsService,
     EducationsService,
     GroupsRolesService,


### PR DESCRIPTION
# 주요 내용
- 사역 이력 조회 API 통합
- 사역 종료 시 메타데이터 저장 기능 추가
- 이력 관리 기능 제한사항 구현

# 세부 내용
## API 구조 개선
- 진행중/종료된 이력 조회 엔드포인트 통합
- 서비스 레이어에서 이력 데이터 일괄 조회 로직으로 변경

## 사역 종료 기능 강화
- 종료 시점의 사역명 저장
- 종료 시점의 사역 그룹 구조 스냅샷 저장

## 이력 관리 제한사항
- 날짜 입력 제한
 - 시작일/종료일 모두 현재 날짜를 초과할 수 없음
 - 시작일은 종료일을 초과할 수 없음
- 진행중인 이력
 - 종료일 입력/수정 불가
 - 시작일만 수정 가능
- 종료된 이력
 - 시작일/종료일 모두 수정 가능