### PR TITLE
fix: 사역 그룹 생성/수정 기능 개선

### DIFF
--- a/backend/src/churches/members/entity/member.entity.ts
+++ b/backend/src/churches/members/entity/member.entity.ts
@@ -128,6 +128,7 @@ export class MemberModel extends BaseModel {
   })
   baptism: BaptismEnum;
 
+  // TODO 멤버 삭제 시 EducationEnrollment 도 같이 삭제되어야 함.
   @OneToMany(
     () => EducationEnrollmentModel,
     (educationEnrollment) => educationEnrollment.member,


### PR DESCRIPTION
# 주요 내용
- 사역 그룹 이름 중복 검사 범위 수정
- 사역 그룹 수정 기능 버그 수정

# 세부 내용
## 이름 중복 검사 로직 개선
- 동일 소속 그룹 내에서만 이름 중복 검사
- 다른 부모 그룹에 속한 경우 동일 이름 허용

## 부모 그룹 수정 기능 강화
- null 값 입력 시 최상위 그룹으로 변경 가능
- 계층 구조 변경 로직 개선

## 버그 수정
- 이름만 변경할 때 업데이트 되지 않는 문제 해결