### PR TITLE
feat: QueryFailedError 전역 필터 추가

### DIFF
--- a/backend/src/common/filter/typeorm-exception.filter.ts
+++ b/backend/src/common/filter/typeorm-exception.filter.ts
@@ -1,0 +1,37 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+} from '@nestjs/common';
+import { QueryFailedError } from 'typeorm';
+
+@Catch(QueryFailedError)
+export class TypeOrmExceptionFilter implements ExceptionFilter {
+  catch(exception: any, host: ArgumentsHost): any {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+
+    const error: any = exception;
+
+    let statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
+    let message = '데이터 저장 실패';
+    let errorType = 'Internal Server Error';
+
+    if (error.code === '23505') {
+      statusCode = HttpStatus.BAD_REQUEST;
+      errorType = 'Bad Request';
+      message = '이미 존재하는 데이터입니다. 다른 값을 입력해주세요.';
+    } else if (error.code === '23503') {
+      statusCode = HttpStatus.BAD_REQUEST;
+      errorType = 'Bad Request';
+      message = '연관된 데이터가 존재하여 삭제할 수 없습니다.';
+    }
+
+    response.status(HttpStatus.BAD_REQUEST).json({
+      message,
+      error: errorType,
+      statusCode,
+    });
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { GetHandlerGuard } from './common/guard/get-handler.guard';
+import { TypeOrmExceptionFilter } from './common/filter/typeorm-exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -25,6 +26,8 @@ async function bootstrap() {
       forbidNonWhitelisted: true,
     }),
   );
+
+  app.useGlobalFilters(new TypeOrmExceptionFilter());
 
   app.useGlobalGuards(new GetHandlerGuard());
 


### PR DESCRIPTION
# 주요 내용
- QueryFailedError의 전역 예외 처리 필터 구현
- 사용자 친화적인 에러 메시지 제공

# 세부 내용
- InternalServerError 대신 구체적인 에러 응답 제공
- DB 에러 코드별 적절한 예외 처리
- 클라이언트에 더 명확한 에러 메시지 전달