### PR TITLE
feat: 그룹, 그룹 역할, 사역 삭제 제한 추가

### DIFF
--- a/backend/src/churches/management/controller/group/groups.controller.ts
+++ b/backend/src/churches/management/controller/group/groups.controller.ts
@@ -34,7 +34,7 @@ export class GroupsController {
     @Body() dto: CreateGroupDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.groupsService.postGroup(churchId, dto, qr);
+    return this.groupsService.createGroup(churchId, dto, qr);
   }
 
   @Get(':groupId')

--- a/backend/src/churches/management/controller/ministry/ministries.controller.ts
+++ b/backend/src/churches/management/controller/ministry/ministries.controller.ts
@@ -8,12 +8,16 @@ import {
   Patch,
   Post,
   Query,
+  UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { MinistryService } from '../../service/ministry/ministry.service';
 import { CreateMinistryDto } from '../../dto/ministry/create-ministry.dto';
 import { UpdateMinistryDto } from '../../dto/ministry/update-ministry.dto';
 import { GetMinistryDto } from '../../dto/ministry/get-ministry.dto';
+import { TransactionInterceptor } from '../../../../common/interceptor/transaction.interceptor';
+import { QueryRunner } from '../../../../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm';
 
 @ApiTags('Management:Ministries')
 @Controller('ministries')
@@ -29,11 +33,13 @@ export class MinistriesController {
   }
 
   @Post()
+  @UseInterceptors(TransactionInterceptor)
   postMinistries(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Body() dto: CreateMinistryDto,
+    @QueryRunner() qr: QR,
   ) {
-    return this.ministryService.createMinistry(churchId, dto);
+    return this.ministryService.createMinistry(churchId, dto, qr);
   }
 
   @Get(':ministryId')
@@ -49,18 +55,18 @@ export class MinistriesController {
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('ministryId', ParseIntPipe) ministryId: number,
     @Body() dto: UpdateMinistryDto,
-    //@Query() ministryGroupId: MinistryGroupIdDto,
+    @QueryRunner() qr: QR,
   ) {
-    //return `${churchId} ${ministryGroupId.ministryGroupId} ${ministryId}`;
-
-    return this.ministryService.updateMinistry(churchId, ministryId, dto);
+    return this.ministryService.updateMinistry(churchId, ministryId, dto, qr);
   }
 
   @Delete(':ministryId')
+  @UseInterceptors(TransactionInterceptor)
   deleteMinistry(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('ministryId', ParseIntPipe) ministryId: number,
+    @QueryRunner() qr: QR,
   ) {
-    return this.ministryService.deleteMinistry(churchId, ministryId);
+    return this.ministryService.deleteMinistry(churchId, ministryId, qr);
   }
 }

--- a/backend/src/churches/management/controller/officer/officers.controller.ts
+++ b/backend/src/churches/management/controller/officer/officers.controller.ts
@@ -7,11 +7,15 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { CreateOfficerDto } from '../../dto/officer/create-officer.dto';
 import { UpdateOfficerDto } from '../../dto/officer/update-officer.dto';
 import { OfficersService } from '../../service/officer/officers.service';
+import { QueryRunner } from '../../../../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm';
+import { TransactionInterceptor } from '../../../../common/interceptor/transaction.interceptor';
 
 @ApiTags('Settings:Officers')
 @Controller('officers')
@@ -24,27 +28,33 @@ export class OfficersController {
   }
 
   @Post()
+  @UseInterceptors(TransactionInterceptor)
   postOfficer(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Body() dto: CreateOfficerDto,
+    @QueryRunner() qr: QR,
   ) {
-    return this.officersService.postOfficer(churchId, dto);
+    return this.officersService.createOfficer(churchId, dto, qr);
   }
 
   @Patch(':officerId')
+  @UseInterceptors(TransactionInterceptor)
   patchOfficer(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('officerId', ParseIntPipe) officerId: number,
     @Body() dto: UpdateOfficerDto,
+    @QueryRunner() qr: QR,
   ) {
-    return this.officersService.updateOfficer(churchId, officerId, dto);
+    return this.officersService.updateOfficer(churchId, officerId, dto, qr);
   }
 
   @Delete(':officerId')
+  @UseInterceptors(TransactionInterceptor)
   deleteOfficer(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('officerId', ParseIntPipe) officerId: number,
+    @QueryRunner() qr: QR,
   ) {
-    return this.officersService.deleteOfficer(churchId, officerId);
+    return this.officersService.deleteOfficer(churchId, officerId, qr);
   }
 }

--- a/backend/src/churches/management/entity/group/group-role.entity.ts
+++ b/backend/src/churches/management/entity/group/group-role.entity.ts
@@ -1,12 +1,22 @@
-import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
+import {
+  BeforeRemove,
+  BeforeSoftRemove,
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  OneToMany,
+  Unique,
+} from 'typeorm';
 import { BaseModel } from '../../../../common/entity/base.entity';
 import { GroupModel } from './group.entity';
 import { ChurchModel } from '../../../entity/church.entity';
 import { GroupHistoryModel } from '../../../members-management/entity/group-history.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
+import { ConflictException } from '@nestjs/common';
 
 @Entity()
-//@Unique(['role', 'groupId'])
+@Unique(['role', 'groupId'])
 export class GroupRoleModel extends BaseModel {
   @Column()
   role: string;
@@ -30,4 +40,15 @@ export class GroupRoleModel extends BaseModel {
 
   @OneToMany(() => GroupHistoryModel, (groupHistory) => groupHistory.groupRole)
   history: GroupHistoryModel[];
+
+  @BeforeRemove()
+  @BeforeSoftRemove()
+  async preventIfHasMembers() {
+    if (this.members.length > 0) {
+      const memberNames = this.members.map((m) => m.name).join(', ');
+      throw new ConflictException(
+        `해당 그룹 역할을 가진 교인이 존재합니다.\n(${memberNames})`,
+      );
+    }
+  }
 }

--- a/backend/src/churches/management/entity/group/group.entity.ts
+++ b/backend/src/churches/management/entity/group/group.entity.ts
@@ -1,11 +1,22 @@
-import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
+import {
+  BeforeRemove,
+  BeforeSoftRemove,
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  OneToMany,
+  Unique,
+} from 'typeorm';
 import { ChurchModel } from '../../../entity/church.entity';
 import { GroupRoleModel } from './group-role.entity';
 import { GroupHistoryModel } from '../../../members-management/entity/group-history.entity';
 import { BaseModel } from '../../../../common/entity/base.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
+import { ConflictException } from '@nestjs/common';
 
 @Entity()
+@Unique(['name', 'parentGroupId', 'churchId'])
 export class GroupModel extends BaseModel {
   @Column()
   name: string;
@@ -33,7 +44,7 @@ export class GroupModel extends BaseModel {
   @Column({ default: 0 })
   membersCount: number;
 
-  @OneToMany(() => MemberModel, (member) => member.groupHistory)
+  @OneToMany(() => MemberModel, (member) => member.group)
   members: MemberModel[];
 
   @OneToMany(() => GroupRoleModel, (groupRole) => groupRole.group)
@@ -41,4 +52,14 @@ export class GroupModel extends BaseModel {
 
   @OneToMany(() => GroupHistoryModel, (history) => history.group)
   history: GroupHistoryModel[];
+
+  @BeforeRemove()
+  @BeforeSoftRemove()
+  preventIfHasChildGroup() {
+    if (this.childGroupIds.length > 0 || this.membersCount > 0) {
+      throw new ConflictException(
+        '해당 그룹에 속한 하위 그룹 또는 교인이 존재합니다.',
+      );
+    }
+  }
 }

--- a/backend/src/churches/management/entity/ministry/ministry-group.entity.ts
+++ b/backend/src/churches/management/entity/ministry/ministry-group.entity.ts
@@ -1,7 +1,16 @@
-import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
+import {
+  BeforeRemove,
+  BeforeSoftRemove,
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  OneToMany,
+} from 'typeorm';
 import { ChurchModel } from '../../../entity/church.entity';
 import { MinistryModel } from './ministry.entity';
 import { BaseModel } from '../../../../common/entity/base.entity';
+import { ConflictException } from '@nestjs/common';
 
 @Entity()
 export class MinistryGroupModel extends BaseModel {
@@ -36,4 +45,14 @@ export class MinistryGroupModel extends BaseModel {
 
   @OneToMany(() => MinistryModel, (ministry) => ministry.ministryGroup)
   ministries: MinistryModel[];
+
+  @BeforeRemove()
+  @BeforeSoftRemove()
+  preventIfHasChild() {
+    if (this.childMinistryGroupIds.length > 0 || this.ministries.length > 0) {
+      throw new ConflictException(
+        '해당 사역 그룹에 속한 하위 사역 그룹 또는 사역이 존재합니다.',
+      );
+    }
+  }
 }

--- a/backend/src/churches/management/exception-messages/exception-messages.const.ts
+++ b/backend/src/churches/management/exception-messages/exception-messages.const.ts
@@ -8,7 +8,7 @@ export const MANAGEMENT_EXCEPTION = {
     NOT_FOUND: '해당 사역을 찾을 수 없습니다.',
   },
   GroupModel: {
-    ALREADY_EXIST: '이미 존재하는 소그룹입니다.',
+    ALREADY_EXIST: '이미 존재하는 그룹입니다.',
     PARENT_NOT_FOUND: '해당 상위 그룹을 찾을 수 없습니다.',
     NOT_FOUND: `해당 그룹을 찾을 수 없습니다.`,
   },

--- a/backend/src/churches/management/service/education/educations.service.ts
+++ b/backend/src/churches/management/service/education/educations.service.ts
@@ -1,7 +1,6 @@
 import {
   BadRequestException,
   Injectable,
-  InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';

--- a/backend/src/churches/management/service/group/groups-roles.service.ts
+++ b/backend/src/churches/management/service/group/groups-roles.service.ts
@@ -108,6 +108,9 @@ export class GroupsRolesService {
         groupId,
         id: groupRoleId,
       },
+      relations: {
+        members: true,
+      },
     });
 
     if (!role) {
@@ -196,6 +199,22 @@ export class GroupsRolesService {
 
   async deleteGroupRole(churchId: number, groupId: number, roleId: number) {
     const groupRolesRepository = this.getGroupRolesRepository();
+
+    const targetGroupRole = await this.getGroupRoleById(
+      churchId,
+      groupId,
+      roleId,
+    );
+
+    if (targetGroupRole.members) {
+      const member = targetGroupRole.members
+        .map((member) => member.name)
+        .join(', ');
+
+      throw new BadRequestException(
+        `해당 그룹 역할을 가진 교인이 존재합니다.\n${member}`,
+      );
+    }
 
     const result = await groupRolesRepository.softDelete({
       id: roleId,

--- a/backend/src/churches/management/service/ministry/ministry.service.ts
+++ b/backend/src/churches/management/service/ministry/ministry.service.ts
@@ -232,6 +232,18 @@ export class MinistryService {
   async deleteMinistry(churchId: number, ministryId: number, qr?: QueryRunner) {
     const ministryRepository = this.getMinistryRepository(qr);
 
+    const targetMinistry = await this.getMinistryById(churchId, ministryId, qr);
+
+    if (targetMinistry.membersCount) {
+      const member = targetMinistry.members
+        .map((member) => member.name)
+        .join(' ');
+
+      throw new BadRequestException(
+        `해당 사역을 가진 교인이 존재합니다.\n(${member})`,
+      );
+    }
+
     const result = await ministryRepository.softDelete({
       id: ministryId,
       churchId,


### PR DESCRIPTION
# 주요 내용
1:N 관계가 설정된 경우 그룹, 그룹 역할, 사역, 사역 그룹, 직분 삭제를 제한하도록 수정

# 세부 내용
## 삭제 제한 로직
- 그룹 삭제 시 관련 데이터 확인 후 삭제 가능 여부 검증
- 그룹 역할 삭제 시 소속 교인 확인
- 사역 삭제 시 소속 교인 확인
- 사역 그룹 삭제 시 관련 데이터 확인 후 삭제 가능 여부 검증
- 직분 삭제 시 관련 데이터 확인 후 삭제 가능 여부 검증
- 소속 교인 또는 관련 데이터가 존재하면 삭제 요청 거부

## 삭제 검증 방식 개선
- `@BeforeRemove`, `@BeforeSoftRemove`를 적용하여 삭제 전 검증 로직 추가

## 동시성 문제 해결
- 그룹, 그룹 역할, 사역, 사역 그룹, 직분의 생성 시 UNIQUE 제약 조건 추가하여 중복 생성 방지