### PR TITLE
feat: Soft-delet e된 교인의 완전 삭제 기능 추가

### DIFF
--- a/backend/src/churches/management/service/education/educations.service.ts
+++ b/backend/src/churches/management/service/education/educations.service.ts
@@ -93,6 +93,7 @@ export class EducationsService {
             enrollment.educationTermId,
             enrollment.id,
             qr,
+            true,
           ),
         ),
       );
@@ -1297,6 +1298,7 @@ export class EducationsService {
     educationTermId: number,
     educationEnrollmentId: number,
     qr: QueryRunner,
+    memberDeleted: boolean = false,
   ) {
     const educationEnrollmentsRepository =
       this.getEducationEnrollmentsRepository(qr);
@@ -1309,12 +1311,19 @@ export class EducationsService {
       qr,
     );
 
-    const member = await this.membersService.getMemberModelById(
-      churchId,
-      targetEnrollment.memberId,
-      {},
-      qr,
-    );
+    const member = memberDeleted
+      ? await this.membersService.getDeleteMemberModelById(
+          churchId,
+          targetEnrollment.memberId,
+          { educations: true },
+          qr,
+        )
+      : await this.membersService.getMemberModelById(
+          churchId,
+          targetEnrollment.memberId,
+          { educations: true },
+          qr,
+        );
 
     await Promise.all([
       // 교인 - 교육 관계 해제

--- a/backend/src/churches/members/const/default-find-options.const.ts
+++ b/backend/src/churches/members/const/default-find-options.const.ts
@@ -110,3 +110,13 @@ export const DefaultMembersSelectOption: FindOptionsSelect<MemberModel> = {
     name: true,
   },
 };
+
+export const HardDeleteMemberRelationOptions: FindOptionsRelations<MemberModel> =
+  {
+    ...DefaultMemberRelationOption,
+    guiding: true,
+    instructingEducation: true,
+    ministryHistory: true,
+    officerHistory: true,
+    groupHistory: true,
+  };

--- a/backend/src/churches/members/controller/members-family.controller.ts
+++ b/backend/src/churches/members/controller/members-family.controller.ts
@@ -24,11 +24,15 @@ import {
   ApiPatchFamilyMember,
   ApiPostFamilyMember,
 } from '../const/swagger/member-family/controller.swagger';
+import { FamilyService } from '../service/family.service';
 
 @ApiTags('Churches:Members:Family')
 @Controller(':memberId/family')
 export class MembersFamilyController {
-  constructor(private readonly memberService: MembersService) {}
+  constructor(
+    private readonly memberService: MembersService,
+    private readonly familyService: FamilyService,
+  ) {}
 
   @ApiGetFamilyMember()
   @Get()
@@ -107,5 +111,14 @@ export class MembersFamilyController {
       memberId,
       familyMemberId,
     );
+  }
+
+  @Delete(':familyMemberId/test')
+  testDelete(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Param('familyMemberId', ParseIntPipe) familyMemberId: number,
+  ) {
+    return this.familyService.testDelete(memberId, familyMemberId);
   }
 }

--- a/backend/src/churches/members/controller/members.controller.ts
+++ b/backend/src/churches/members/controller/members.controller.ts
@@ -18,6 +18,7 @@ import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
 import { UpdateMemberDto } from '../dto/update-member.dto';
 import { GetMemberDto } from '../dto/get-member.dto';
+import { HardDeleteMemberRelationOptions } from '../const/default-find-options.const';
 
 @ApiTags('Churches:Members')
 @Controller()
@@ -66,7 +67,17 @@ export class MembersController {
     @Param('memberId', ParseIntPipe) memberId: number,
     @QueryRunner() qr: QR,
   ) {
-    return this.membersService.deleteMember(churchId, memberId, qr);
+    return this.membersService.softDeleteMember(churchId, memberId, qr);
+  }
+
+  @Get(':memberId/deleted')
+  getDeletedMember(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+  ) {
+    return this.membersService.getDeleteMemberModelById(churchId, memberId, {
+      ...HardDeleteMemberRelationOptions,
+    });
   }
 
   @Post(':memberId/restore')
@@ -77,5 +88,15 @@ export class MembersController {
     @QueryRunner() qr: QR,
   ) {
     return this.membersService.restoreMember(churchId, memberId, qr);
+  }
+
+  @Delete(':memberId/hard-delete')
+  @UseInterceptors(TransactionInterceptor)
+  hardDeleteMember(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.membersService.hardDeleteMember(churchId, memberId, qr);
   }
 }

--- a/backend/src/churches/members/entity/member.entity.ts
+++ b/backend/src/churches/members/entity/member.entity.ts
@@ -1,4 +1,5 @@
 import {
+  BeforeRemove,
   Column,
   Entity,
   Index,
@@ -24,6 +25,7 @@ import { MinistryHistoryModel } from '../../members-management/entity/ministry-h
 import { GroupRoleModel } from '../../management/entity/group/group-role.entity';
 import { OfficerHistoryModel } from '../../members-management/entity/officer-history.entity';
 import { Exclude } from 'class-transformer';
+import { InternalServerErrorException } from '@nestjs/common';
 
 @Entity()
 @Unique(['name', 'mobilePhone', 'churchId'])
@@ -105,7 +107,7 @@ export class MemberModel extends BaseModel {
 
   // 내가 인도한 사람
   @OneToMany(() => MemberModel, (member) => member.guidedBy)
-  guiding: MemberModel;
+  guiding: MemberModel[];
 
   @Column({ nullable: true, comment: '이전교회 이름' })
   previousChurch: string;
@@ -175,4 +177,49 @@ export class MemberModel extends BaseModel {
 
   @OneToMany(() => GroupHistoryModel, (groupHistory) => groupHistory.member)
   groupHistory: GroupHistoryModel[];
+
+  @BeforeRemove()
+  preventIfHasRelations() {
+    if (this.family.length > 0) {
+      // 가족 relation 확인
+      throw new InternalServerErrorException('family relation exception');
+    }
+
+    if (this.guiding.length > 0) {
+      // 인도자 relation 확인
+      throw new InternalServerErrorException('guiding relation exception');
+    }
+
+    if (this.instructingEducation.length > 0) {
+      // 진행자로 등록된 교육 relation
+      throw new InternalServerErrorException(
+        'instructing education relation exception',
+      );
+    }
+
+    if (this.ministries.length > 0 || this.ministryHistory.length > 0) {
+      // 사역과 N:N 관계, 사역 이력 1:N 관계
+      throw new InternalServerErrorException(
+        `ministries relation exception ${this.ministries.length} ${this.ministryHistory.length}`,
+      );
+    }
+
+    if (this.officerHistory.length > 0) {
+      // 직분 이력과 1:N 관계
+      throw new InternalServerErrorException(
+        'officer history relation exception',
+      );
+    }
+
+    if (this.educations.length > 0) {
+      // 교육 등록과 1 : N 관계
+      throw new InternalServerErrorException('educations relation exception');
+    }
+
+    if (this.groupHistory.length > 0) {
+      throw new InternalServerErrorException(
+        'education history relation exception',
+      );
+    }
+  }
 }

--- a/backend/src/churches/members/service/family.service.ts
+++ b/backend/src/churches/members/service/family.service.ts
@@ -227,6 +227,13 @@ export class FamilyService {
     });
   }
 
+  async testDelete(meId: number, familyMemberId: number) {
+    return this.familyRepository.softDelete({
+      meId: meId,
+      familyMemberId: familyMemberId,
+    });
+  }
+
   async cascadeDeleteAllFamilyRelation(deletedId: number, qr: QueryRunner) {
     const familyRepository = this.getFamilyRepository(qr);
 


### PR DESCRIPTION
## 주요 내용
Soft-delete 처리된 교인을 완전히 삭제하는 기능을 추가하였습니다.

## 세부 내용
- Soft-delete 된 교인을 DB 에서 완전히 삭제하는 로직 구현
- 교인 삭제 시 다음 관계 해제 처리
  - 가족 관계
  - 내가 인도한 교인과의 관계
  - 직분, 사역, 그룹과의 관계
- 추가 작업 필요:
  - 교인 완전 삭제 요청 시 `EventEmitter`를 활용하여 교인의 이력 데이터 삭제 처리