### PR TITLE
feat: 교인 엔티티 컬럼 길이 제한 추가

### DIFF
--- a/backend/src/churches/members/dto/create-member.dto.ts
+++ b/backend/src/churches/members/dto/create-member.dto.ts
@@ -11,6 +11,7 @@ import {
   IsOptional,
   IsString,
   Length,
+  MaxLength,
 } from 'class-validator';
 import { TransformName } from '../../decorator/transform-name';
 import { GenderEnum } from '../const/enum/gender.enum';
@@ -37,6 +38,7 @@ export class CreateMemberDto {
   @IsString()
   @TransformName()
   @IsNotEmpty()
+  @MaxLength(30)
   name: string;
 
   @ApiProperty({
@@ -121,6 +123,7 @@ export class CreateMemberDto {
   @IsString()
   @IsNotEmpty()
   @IsOptional()
+  @MaxLength(50)
   address?: string;
 
   @ApiProperty({
@@ -132,6 +135,7 @@ export class CreateMemberDto {
   @IsString()
   @IsNotEmpty()
   @IsOptional()
+  @MaxLength(50)
   detailAddress?: string;
 
   @ApiProperty({
@@ -143,6 +147,7 @@ export class CreateMemberDto {
   @IsString()
   @IsNotEmpty()
   @IsOptional()
+  @MaxLength(15)
   homePhone?: string;
 
   @ApiProperty({
@@ -154,6 +159,7 @@ export class CreateMemberDto {
   @IsString()
   @IsNotEmpty()
   @IsOptional()
+  @MaxLength(30)
   occupation?: string;
 
   @ApiProperty({
@@ -165,6 +171,7 @@ export class CreateMemberDto {
   @IsString()
   @IsNotEmpty()
   @IsOptional()
+  @MaxLength(30)
   school?: string;
 
   @ApiProperty({
@@ -216,5 +223,6 @@ export class CreateMemberDto {
   @IsString()
   @IsNotEmpty()
   @IsOptional()
+  @MaxLength(30)
   previousChurch?: string;
 }

--- a/backend/src/churches/members/entity/member.entity.ts
+++ b/backend/src/churches/members/entity/member.entity.ts
@@ -42,33 +42,33 @@ export class MemberModel extends BaseModel {
   @Column({ default: new Date() })
   registeredAt: Date;
 
-  @Column()
+  @Column({ length: 30, comment: '교인 이름' })
   @Index()
   name: string;
 
-  @Column()
+  @Column({ length: 15, comment: '휴대폰 전화 번호' })
   @Index()
   mobilePhone: string;
 
-  @Column({ default: false })
+  @Column({ default: false, comment: '생일 음력 여부' })
   isLunar: boolean;
 
   @Index()
-  @Column({ nullable: true })
+  @Column({ nullable: true, comment: '생년 월일' })
   birth: Date;
 
   @Index()
-  @Column({ enum: GenderEnum, nullable: true })
+  @Column({ enum: GenderEnum, nullable: true, comment: '성별' })
   gender: GenderEnum;
 
-  @Column({ nullable: true })
+  @Column({ length: 50, nullable: true, comment: '도로명 주소' })
   address: string;
 
-  @Column({ nullable: true })
+  @Column({ length: 50, nullable: true, comment: '상세 주소' })
   detailAddress: string;
 
   @Index()
-  @Column({ nullable: true })
+  @Column({ length: 15, nullable: true, comment: '집 전화 번호' })
   homePhone: string;
 
   // 가족 관계
@@ -79,22 +79,22 @@ export class MemberModel extends BaseModel {
   counterFamily: FamilyModel[];
 
   @Index()
-  @Column({ nullable: true })
+  @Column({ length: 30, nullable: true, comment: '직업' })
   occupation: string;
 
   @Index()
-  @Column({ nullable: true })
+  @Column({ length: 30, nullable: true, comment: '학교' })
   school: string;
 
   @Index()
-  @Column({ enum: MarriageOptions, nullable: true })
+  @Column({ enum: MarriageOptions, nullable: true, comment: '결혼 정보' })
   marriage: MarriageOptions;
 
-  @Column({ nullable: true })
+  @Column({ nullable: true, comment: '세부 결혼 정보' })
   marriageDetail: string;
 
   @Index()
-  @Column('text', { array: true, default: [] })
+  @Column('text', { array: true, default: [], comment: '차량 번호 4자리' })
   vehicleNumber: string[];
 
   @Column({ nullable: true })
@@ -109,7 +109,7 @@ export class MemberModel extends BaseModel {
   @OneToMany(() => MemberModel, (member) => member.guidedBy)
   guiding: MemberModel[];
 
-  @Column({ nullable: true, comment: '이전교회 이름' })
+  @Column({ length: 30, nullable: true, comment: '이전교회 이름' })
   previousChurch: string;
 
   @Index()

--- a/backend/src/churches/members/service/family.service.ts
+++ b/backend/src/churches/members/service/family.service.ts
@@ -175,8 +175,6 @@ export class FamilyService {
     relation: string,
     qr: QueryRunner,
   ) {
-    return this.getCounterRelation(relation, me);
-
     const familyRepository = this.getFamilyRepository(qr);
 
     const isExistRelation = await this.isExistFamilyRelation(
@@ -271,6 +269,21 @@ export class FamilyService {
 
     return familyRepository.remove(deleteTargets);
   }
+
+  private getCounterRelation(relation: string, me: MemberModel) {
+    if (this.neutralRelations.has(relation)) {
+      return relation;
+    }
+
+    if (this.genderBasedRelations[relation]) {
+      return me.gender === GenderEnum.male
+        ? this.genderBasedRelations[relation][0]
+        : this.genderBasedRelations[relation][1];
+    }
+
+    return FamilyRelation.FAMILY;
+  }
+
   private neutralRelations = new Set([
     FamilyRelation.BROTHER,
     FamilyRelation.SISTER,
@@ -314,8 +327,7 @@ export class FamilyService {
     [FamilyRelation.WIFE_MOTHER_IN_LAW]: FamilyRelation.SON_IN_LAW,
   };
 
-  private getCounterRelation(relation: string, me: MemberModel) {
-    /*switch (relation) {
+  /*switch (relation) {
       // 조부모 - 손자/손녀
       case FamilyRelation.GRANDFATHER:
       case FamilyRelation.GRANDMOTHER:
@@ -364,17 +376,4 @@ export class FamilyService {
       default:
         return FamilyRelation.FAMILY;
     }*/
-
-    if (this.neutralRelations.has(relation)) {
-      return relation;
-    }
-
-    if (this.genderBasedRelations[relation]) {
-      return me.gender === GenderEnum.male
-        ? this.genderBasedRelations[relation][0]
-        : this.genderBasedRelations[relation][1];
-    }
-
-    return FamilyRelation.FAMILY;
-  }
 }

--- a/backend/src/common/filter/typeorm-exception.filter.ts
+++ b/backend/src/common/filter/typeorm-exception.filter.ts
@@ -6,6 +6,10 @@ import {
 } from '@nestjs/common';
 import { QueryFailedError } from 'typeorm';
 
+const ErrorType = {
+  BAD_REQUEST: 'Bad Request',
+};
+
 @Catch(QueryFailedError)
 export class TypeOrmExceptionFilter implements ExceptionFilter {
   catch(exception: any, host: ArgumentsHost): any {
@@ -20,12 +24,16 @@ export class TypeOrmExceptionFilter implements ExceptionFilter {
 
     if (error.code === '23505') {
       statusCode = HttpStatus.BAD_REQUEST;
-      errorType = 'Bad Request';
+      errorType = ErrorType.BAD_REQUEST;
       message = '이미 존재하는 데이터입니다. 다른 값을 입력해주세요.';
     } else if (error.code === '23503') {
       statusCode = HttpStatus.BAD_REQUEST;
-      errorType = 'Bad Request';
+      errorType = ErrorType.BAD_REQUEST;
       message = '연관된 데이터가 존재하여 삭제할 수 없습니다.';
+    } else if (error.code === '22001') {
+      statusCode = HttpStatus.BAD_REQUEST;
+      errorType = ErrorType.BAD_REQUEST;
+      message = '허용된 데이터 길이를 초과하였습니다.';
     }
 
     response.status(HttpStatus.BAD_REQUEST).json({


### PR DESCRIPTION
## 주요 내용
교인(Entity) 내 컬럼 값들의 길이 제한을 설정하여 데이터 무결성을 강화하였습니다.

## 세부 내용
- 이름, 연락처, 주소 등 특정 컬럼에 최대 길이 제한 추가
- 데이터베이스 스키마 변경 반영
- 길이 초과 시 예외 처리 로직 추가