### PR TITLE
refactor: 교인 엔티티 제약 변경 및 검증 로직 개선

### DIFF
--- a/backend/src/churches/members/controller/members.controller.ts
+++ b/backend/src/churches/members/controller/members.controller.ts
@@ -18,7 +18,6 @@ import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
 import { UpdateMemberDto } from '../dto/update-member.dto';
 import { GetMemberDto } from '../dto/get-member.dto';
-import { HardDeleteMemberRelationOptions } from '../const/default-find-options.const';
 
 @ApiTags('Churches:Members')
 @Controller()
@@ -70,7 +69,7 @@ export class MembersController {
     return this.membersService.softDeleteMember(churchId, memberId, qr);
   }
 
-  @Get(':memberId/deleted')
+  /*@Get(':memberId/deleted')
   getDeletedMember(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
@@ -98,5 +97,5 @@ export class MembersController {
     @QueryRunner() qr: QR,
   ) {
     return this.membersService.hardDeleteMember(churchId, memberId, qr);
-  }
+  }*/
 }

--- a/backend/src/churches/members/dto/create-member.dto.ts
+++ b/backend/src/churches/members/dto/create-member.dto.ts
@@ -11,6 +11,7 @@ import {
   IsOptional,
   IsString,
   Length,
+  Matches,
   MaxLength,
 } from 'class-validator';
 import { TransformName } from '../../decorator/transform-name';
@@ -38,6 +39,9 @@ export class CreateMemberDto {
   @IsString()
   @TransformName()
   @IsNotEmpty()
+  @Matches(/^[a-zA-Z0-9가-힣 \-]+$/, {
+    message: '특수문자는 사용할 수 없습니다.',
+  })
   @MaxLength(30)
   name: string;
 
@@ -159,6 +163,9 @@ export class CreateMemberDto {
   @IsString()
   @IsNotEmpty()
   @IsOptional()
+  @Matches(/^[a-zA-Z0-9가-힣 \-]+$/, {
+    message: '특수문자는 사용할 수 없습니다.',
+  })
   @MaxLength(30)
   occupation?: string;
 
@@ -171,6 +178,9 @@ export class CreateMemberDto {
   @IsString()
   @IsNotEmpty()
   @IsOptional()
+  @Matches(/^[a-zA-Z0-9가-힣 \-]+$/, {
+    message: '특수문자는 사용할 수 없습니다.',
+  })
   @MaxLength(30)
   school?: string;
 

--- a/backend/src/churches/members/entity/member.entity.ts
+++ b/backend/src/churches/members/entity/member.entity.ts
@@ -1,5 +1,4 @@
 import {
-  BeforeRemove,
   Column,
   Entity,
   Index,
@@ -7,7 +6,6 @@ import {
   ManyToMany,
   ManyToOne,
   OneToMany,
-  Unique,
 } from 'typeorm';
 import { BaseModel } from '../../../common/entity/base.entity';
 import { GenderEnum } from '../const/enum/gender.enum';
@@ -25,10 +23,9 @@ import { MinistryHistoryModel } from '../../members-management/entity/ministry-h
 import { GroupRoleModel } from '../../management/entity/group/group-role.entity';
 import { OfficerHistoryModel } from '../../members-management/entity/officer-history.entity';
 import { Exclude } from 'class-transformer';
-import { InternalServerErrorException } from '@nestjs/common';
 
 @Entity()
-@Unique(['name', 'mobilePhone', 'churchId'])
+//@Unique(['name', 'mobilePhone', 'churchId'])
 export class MemberModel extends BaseModel {
   @Column()
   @Index()
@@ -177,8 +174,10 @@ export class MemberModel extends BaseModel {
 
   @OneToMany(() => GroupHistoryModel, (groupHistory) => groupHistory.member)
   groupHistory: GroupHistoryModel[];
+}
 
-  @BeforeRemove()
+/*
+@BeforeRemove()
   preventIfHasRelations() {
     if (this.family.length > 0) {
       // 가족 relation 확인
@@ -222,4 +221,4 @@ export class MemberModel extends BaseModel {
       );
     }
   }
-}
+ */

--- a/backend/src/churches/members/service/members.service.ts
+++ b/backend/src/churches/members/service/members.service.ts
@@ -1,6 +1,5 @@
 import {
   BadRequestException,
-  ConflictException,
   Injectable,
   InternalServerErrorException,
   NotFoundException,
@@ -12,7 +11,6 @@ import {
   FindOptionsRelations,
   FindOptionsWhere,
   IsNull,
-  Not,
   QueryRunner,
   Repository,
 } from 'typeorm';
@@ -28,7 +26,6 @@ import { MinistryModel } from '../../management/entity/ministry/ministry.entity'
 import {
   DefaultMemberRelationOption,
   DefaultMemberSelectOption,
-  HardDeleteMemberRelationOptions,
 } from '../const/default-find-options.const';
 import { GroupModel } from '../../management/entity/group/group.entity';
 import { GroupRoleModel } from '../../management/entity/group/group-role.entity';
@@ -204,7 +201,7 @@ export class MembersService {
 
     const membersRepository = this.getMembersRepository(qr);
 
-    /*const isExist = await this.isExistMemberByNameAndMobilePhone(
+    const isExist = await this.isExistMemberByNameAndMobilePhone(
       churchId,
       dto.name,
       dto.mobilePhone,
@@ -213,9 +210,9 @@ export class MembersService {
 
     if (isExist) {
       throw new BadRequestException('이미 존재하는 교인입니다.');
-    }*/
+    }
 
-    const existingMember = await membersRepository.findOne({
+    /*const existingMember = await membersRepository.findOne({
       where: {
         churchId,
         name: dto.name,
@@ -232,7 +229,7 @@ export class MembersService {
       } else {
         throw new BadRequestException('이미 존재하는 교인입니다.');
       }
-    }
+    }*/
 
     // 인도자 처리
     if (dto.guidedById) {
@@ -317,36 +314,6 @@ export class MembersService {
     });*/
   }
 
-  private async cascadeDeleteMember(
-    churchId: number,
-    deletedMember: MemberModel,
-    qr: QueryRunner,
-  ) {
-    const membersRepository = this.getMembersRepository(qr);
-    // 인도자 relation 끊기
-    // 삭제 대상에게 인도된 사람들
-    await membersRepository.update(
-      { guidedById: deletedMember.id, churchId },
-      { guidedById: null },
-    );
-
-    // 가족 관계 삭제
-    /*await this.familyService.cascadeRemoveAllFamilyRelations(
-      deletedMember.id,
-      qr,
-    );*/
-    // 사역 종료 + 삭제
-    await this.endAllMemberMinistry(deletedMember, qr);
-
-    // 직분 종료 + 삭제
-    await this.endMemberOfficer(deletedMember, qr);
-
-    // 교육 삭제
-
-    // 그룹 종료 + 삭제
-    await this.endMemberGroup(deletedMember, qr);
-  }
-
   // 교인 soft delete
   // 교육 등록도 soft delete
   async softDeleteMember(
@@ -383,7 +350,7 @@ export class MembersService {
 
   // soft delete 된 교인 복구
   // 교인에 딸린 educationEnrollment 복구
-  async restoreMember(churchId: number, memberId: number, qr: QueryRunner) {
+  /*async restoreMember(churchId: number, memberId: number, qr: QueryRunner) {
     const membersRepository = this.getMembersRepository(qr);
 
     const restoreTarget = await membersRepository.findOne({
@@ -402,12 +369,12 @@ export class MembersService {
     await membersRepository.restore({ id: restoreTarget.id });
 
     return this.getMemberById(churchId, memberId, qr);
-  }
+  }*/
 
   // 교인 완전 삭제
   // TODO member 와 연관된 history 삭제 + educationEnrollment 삭제
   // TODO 삭제가 빈번하게 일어날지 체크 필요
-  async hardDeleteMember(churchId: number, memberId: number, qr: QueryRunner) {
+  /*async hardDeleteMember(churchId: number, memberId: number, qr: QueryRunner) {
     const membersRepository = this.getMembersRepository(qr);
 
     const hardDeleteTarget = await membersRepository.findOne({
@@ -467,12 +434,12 @@ export class MembersService {
       throw new NotFoundException();
     }
 
-    console.log(targetMember);
+    //console.log(targetMember);
 
     await membersRepository.remove(targetMember);
 
     return `memberId ${memberId} hard deleted`;
-  }
+  }*/
 
   private async isExistMemberById(
     churchId: number,


### PR DESCRIPTION
## 주요 내용
교인의 unique 제약을 삭제하고, 서비스 레이어에서 중복 체크하도록 변경하였습니다.
또한, 교인의 복구 및 완전 삭제 기능을 제거하고, 이름 등에 특수문자 사용을 제한하였습니다.

## 세부 내용
- 교인 엔티티의 unique 제약 조건 제거
- 서비스 레이어에서 중복 여부를 검사하는 로직 추가
- 교인 복구 및 완전 삭제 기능 제거
- 이름 및 특정 필드에서 특수문자 입력 제한
- 데이터 무결성을 유지하기 위한 유효성 검사 강화