### PR TITLE
feat: 교인 정보 입력 요청 검증 강화 및 관계 설정 수정

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -56,6 +56,8 @@ import { DummyDataService } from './dummy-data.service';
         PROTOCOL: Joi.string().required(),
         HOST: Joi.string().required(),
         PORT: Joi.number().required(),
+        CLIENT_HOST: Joi.string().required(),
+        CLIENT_PORT: Joi.number().required(),
         // 메시지 API
         SMS_API_KEY: Joi.string().required(),
         SMS_API_SECRET: Joi.string().required(),

--- a/backend/src/churches/members/entity/member.entity.ts
+++ b/backend/src/churches/members/entity/member.entity.ts
@@ -6,6 +6,7 @@ import {
   ManyToMany,
   ManyToOne,
   OneToMany,
+  OneToOne,
 } from 'typeorm';
 import { BaseModel } from '../../../common/entity/base.entity';
 import { GenderEnum } from '../const/enum/gender.enum';
@@ -23,6 +24,7 @@ import { MinistryHistoryModel } from '../../members-management/entity/ministry-h
 import { GroupRoleModel } from '../../management/entity/group/group-role.entity';
 import { OfficerHistoryModel } from '../../members-management/entity/officer-history.entity';
 import { Exclude } from 'class-transformer';
+import { RequestInfoModel } from '../../request-info/entity/request-info.entity';
 
 @Entity()
 //@Unique(['name', 'mobilePhone', 'churchId'])
@@ -34,6 +36,9 @@ export class MemberModel extends BaseModel {
 
   @ManyToOne(() => ChurchModel, (church) => church.members)
   church: ChurchModel;
+
+  @OneToOne(() => RequestInfoModel, (requestInfo) => requestInfo.member)
+  requestInfo: RequestInfoModel;
 
   @Index()
   @Column({ default: new Date() })

--- a/backend/src/churches/request-info/dto/create-request-info.dto.ts
+++ b/backend/src/churches/request-info/dto/create-request-info.dto.ts
@@ -7,6 +7,7 @@ import {
   IsOptional,
   IsString,
   Length,
+  Matches,
 } from 'class-validator';
 import { TransformName } from '../../decorator/transform-name';
 import { FamilyRelation } from '../../members/const/family-relation.const';
@@ -14,8 +15,6 @@ import { FamilyRelation } from '../../members/const/family-relation.const';
 export class CreateRequestInfoDto extends PickType(RequestInfoModel, [
   'name',
   'mobilePhone',
-  /*'guidedById',
-  'familyId',*/
 ]) {
   @ApiProperty({
     name: 'name',
@@ -25,6 +24,9 @@ export class CreateRequestInfoDto extends PickType(RequestInfoModel, [
   @IsString()
   @IsNotEmpty()
   @TransformName()
+  @Matches(/^[a-zA-Z0-9가-힣 \-]+$/, {
+    message: '특수문자는 사용할 수 없습니다.',
+  })
   override name: string;
 
   @ApiProperty({
@@ -35,6 +37,7 @@ export class CreateRequestInfoDto extends PickType(RequestInfoModel, [
   @IsString()
   @IsNotEmpty()
   @Length(10, 11)
+  @Matches(/^[0-9]+$/, { message: '숫자만 입력 가능합니다' })
   override mobilePhone: string;
 
   @ApiProperty({
@@ -46,7 +49,6 @@ export class CreateRequestInfoDto extends PickType(RequestInfoModel, [
   @IsNumber()
   @IsOptional()
   guidedById?: number;
-  //override guidedById?: number;
 
   @ApiProperty({
     name: 'familyMemberId',
@@ -57,7 +59,6 @@ export class CreateRequestInfoDto extends PickType(RequestInfoModel, [
   @IsNumber()
   @IsOptional()
   familyMemberId?: number;
-  //override familyId?: number;
 
   @ApiProperty({
     name: 'relation',

--- a/backend/src/churches/request-info/dto/validate-request-info.dto.ts
+++ b/backend/src/churches/request-info/dto/validate-request-info.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { RequestInfoModel } from '../entity/request-info.entity';
-import { IsNotEmpty, IsString, Length } from 'class-validator';
+import { IsNotEmpty, IsString, Length, Matches } from 'class-validator';
 import { TransformName } from '../../decorator/transform-name';
 
 export class ValidateRequestInfoDto extends PickType(RequestInfoModel, [
@@ -15,6 +15,9 @@ export class ValidateRequestInfoDto extends PickType(RequestInfoModel, [
   @IsString()
   @IsNotEmpty()
   @TransformName()
+  @Matches(/^[a-zA-Z0-9가-힣 \-]+$/, {
+    message: '특수문자는 사용할 수 없습니다.',
+  })
   override name: string;
 
   @ApiProperty({
@@ -25,5 +28,6 @@ export class ValidateRequestInfoDto extends PickType(RequestInfoModel, [
   @IsString()
   @IsNotEmpty()
   @Length(10, 11)
+  @Matches(/^[0-9]+$/, { message: '숫자만 입력 가능합니다' })
   override mobilePhone: string;
 }

--- a/backend/src/churches/request-info/entity/request-info.entity.ts
+++ b/backend/src/churches/request-info/entity/request-info.entity.ts
@@ -1,38 +1,59 @@
-import { Column, Entity, Index, ManyToOne, Unique } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToOne,
+  Unique,
+} from 'typeorm';
 import { ChurchModel } from '../../entity/church.entity';
 import { BaseModel } from '../../../common/entity/base.entity';
+import { MemberModel } from '../../members/entity/member.entity';
+import { Exclude } from 'class-transformer';
 
 @Entity()
 @Unique(['churchId', 'name', 'mobilePhone'])
 export class RequestInfoModel extends BaseModel {
   @Column()
   @Index()
+  @Exclude()
   churchId: number;
+
+  @ManyToOne(() => ChurchModel, (church) => church.requestInfos)
+  @JoinColumn({ name: 'churchId' })
+  church: ChurchModel;
 
   @Column()
   @Index()
+  @Exclude()
   memberId: number;
 
-  @Column()
+  @OneToOne(() => MemberModel, (member) => member.requestInfo)
+  @JoinColumn({ name: 'memberId' })
+  member: MemberModel;
+
+  @Column({ length: 30, comment: '교인 이름' })
   @Index()
   name: string;
 
-  @Column()
+  @Column({ length: 15, comment: '휴대폰 전화 번호' })
   @Index()
   mobilePhone: string;
 
-  @Column({ default: 1 })
+  @Column({ default: 1, comment: '정보 요청 문자 전송 횟수' })
   requestInfoAttempts: number;
 
-  @Column({ default: 0 })
+  @Column({ default: 0, comment: '정보 입력 시도 횟수' })
   validateAttempts: number;
 
-  @Column({ nullable: true, type: 'timestamptz' })
+  @Column({
+    nullable: true,
+    type: 'timestamptz',
+    comment: '정보 입력 유효 날짜',
+  })
   requestInfoExpiresAt: Date;
 
   @Column({ default: false })
   isValidated: boolean;
-
-  @ManyToOne(() => ChurchModel, (church) => church.requestInfos)
-  church: ChurchModel;
 }

--- a/backend/src/churches/request-info/service/messages.service.ts
+++ b/backend/src/churches/request-info/service/messages.service.ts
@@ -1,10 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
-import * as dotenv from 'dotenv';
 import { COOLSMS_CLIENT } from '../provider/coolsms.provider';
 import { ICoolSMS } from '../provider/coolsms.interface';
 import { ConfigService } from '@nestjs/config';
-
-dotenv.config();
 
 @Injectable()
 export class MessagesService {

--- a/backend/src/churches/request-info/service/request-limit-validator.service.ts
+++ b/backend/src/churches/request-info/service/request-limit-validator.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import * as dotenv from 'dotenv';
 import { REQUEST_CONSTANTS } from '../const/request-info.const';
 import { ChurchModel } from '../../entity/church.entity';
 import {
@@ -9,8 +8,6 @@ import {
 import { DateUtils } from '../utils/date-utils.util';
 import { RequestInfoModel } from '../entity/request-info.entity';
 import { ConfigService } from '@nestjs/config';
-
-dotenv.config();
 
 @Injectable()
 export class RequestLimitValidatorService {
@@ -48,14 +45,11 @@ export class RequestLimitValidatorService {
     if (
       requestInfo.requestInfoAttempts < this.DAILY_REQUEST_INFO_RETRY_LIMITS
     ) {
-      //await requestService.increaseRequestAttempts(requestInfo, qr);
       return { isValid: true, type: RequestLimitValidationType.INCREASE };
     }
 
     // 날짜 변경 시 초대 횟수 초기화
     if (DateUtils.isNewDay(new Date(), requestInfo.updatedAt)) {
-      //await requestService.initRequestInfoAttempts(requestInfo, qr);
-      //requestInfo.requestInfoAttempts = 0;
       return { isValid: true, type: RequestLimitValidationType.INIT };
     }
 


### PR DESCRIPTION
## 주요 내용
교인 정보 입력 요청 시 데이터 검증을 강화하고, 누락된 관계 설정을 수정하였습니다.
또한, 엔티티의 `JoinColumn` 명시를 개선하고, 서비스 레이어의 코드 정리를 진행하였습니다.

## 세부 내용
### 데이터 검증 강화
- 이름 필드에서 특수문자 입력 금지
- 전화번호 필드에서 숫자 외 입력 금지

### 엔티티 관계 설정 수정
- 교인 정보 입력 요청 데이터와 교인과의 `relation` 누락 문제 해결
- `JoinColumn`을 명확하게 명시하여 관계 설정을 명확하게 개선

### 서비스 레이어 코드 정리
- 메소드 분리를 통해 코드 가독성과 재사용성 향상
- 불필요한 코드 삭제 및 로직 최적화

이번 변경을 통해 데이터 무결성을 강화하고, 관계 설정의 명확성을 높였으며, 서비스 레이어의 유지보수성을 개선하였습니다. 🚀