### PR TITLE
refactor: EducationService에서 education-session 및 education-enrollment 분리

### DIFF
--- a/backend/src/churches/management/controller/education/education-enrollments.controller.ts
+++ b/backend/src/churches/management/controller/education/education-enrollments.controller.ts
@@ -18,11 +18,15 @@ import { TransactionInterceptor } from '../../../../common/interceptor/transacti
 import { QueryRunner } from '../../../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
 import { UpdateEducationEnrollmentDto } from '../../dto/education/enrollments/update-education-enrollment.dto';
+import { EducationEnrollmentService } from '../../service/education/education-enrollment.service';
 
 @ApiTags('Management:Educations:Enrollments')
 @Controller('educations/:educationId/terms/:educationTermId/enrollments')
 export class EducationEnrollmentsController {
-  constructor(private readonly educationsService: EducationsService) {}
+  constructor(
+    private readonly educationsService: EducationsService,
+    private readonly educationEnrollmentsService: EducationEnrollmentService,
+  ) {}
 
   @Get()
   getEducationEnrollments(
@@ -31,12 +35,19 @@ export class EducationEnrollmentsController {
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
     @Query() dto: GetEducationEnrollmentDto,
   ) {
-    return this.educationsService.getEducationEnrollments(
+    return this.educationEnrollmentsService.getEducationEnrollments(
       churchId,
       educationId,
       educationTermId,
       dto,
     );
+
+    /*return this.educationsService.getEducationEnrollments(
+      churchId,
+      educationId,
+      educationTermId,
+      dto,
+    );*/
   }
 
   @Post()
@@ -48,7 +59,7 @@ export class EducationEnrollmentsController {
     @Body() dto: CreateEducationEnrollmentDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.educationsService.createEducationEnrollment(
+    return this.educationEnrollmentsService.createEducationEnrollment(
       churchId,
       educationId,
       educationTermId,
@@ -67,7 +78,7 @@ export class EducationEnrollmentsController {
     @Body() dto: UpdateEducationEnrollmentDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.educationsService.updateEducationEnrollment(
+    return this.educationEnrollmentsService.updateEducationEnrollment(
       churchId,
       educationId,
       educationTermId,
@@ -86,7 +97,7 @@ export class EducationEnrollmentsController {
     @Param('educationEnrollmentId', ParseIntPipe) educationEnrollmentId: number,
     @QueryRunner() qr: QR,
   ) {
-    return this.educationsService.deleteEducationEnrollment(
+    return this.educationEnrollmentsService.deleteEducationEnrollment(
       churchId,
       educationId,
       educationTermId,

--- a/backend/src/churches/management/controller/education/education-sessions.controller.ts
+++ b/backend/src/churches/management/controller/education/education-sessions.controller.ts
@@ -9,17 +9,20 @@ import {
   Post,
   UseInterceptors,
 } from '@nestjs/common';
-import { EducationsService } from '../../service/education/educations.service';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { TransactionInterceptor } from '../../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm/query-runner/QueryRunner';
 import { UpdateEducationSessionDto } from '../../dto/education/sessions/update-education-session.dto';
+import { EducationSessionService } from '../../service/education/educaiton-session.service';
 
 @ApiTags('Management:Educations:Sessions')
 @Controller('educations/:educationId/terms/:educationTermId/sessions')
 export class EducationSessionsController {
-  constructor(private readonly educationsService: EducationsService) {}
+  constructor(
+    //private readonly educationsService: EducationsService
+    private readonly educationSessionsService: EducationSessionService,
+  ) {}
 
   @ApiOperation({ summary: '교육 회차 조회' })
   @Get()
@@ -28,11 +31,16 @@ export class EducationSessionsController {
     @Param('educationId', ParseIntPipe) educationId: number,
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
   ) {
-    return this.educationsService.getEducationSessions(
+    return this.educationSessionsService.getEducationSessions(
       churchId,
       educationId,
       educationTermId,
     );
+    /*return this.educationsService.getEducationSessions(
+      churchId,
+      educationId,
+      educationTermId,
+    );*/
   }
 
   @ApiOperation({ summary: '교육 회차 생성' })
@@ -44,12 +52,18 @@ export class EducationSessionsController {
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
     @QueryRunner() qr: QR,
   ) {
-    return this.educationsService.createSingleEducationSession(
+    return this.educationSessionsService.createSingleEducationSession(
       churchId,
       educationId,
       educationTermId,
       qr,
     );
+    /*return this.educationsService.createSingleEducationSession(
+      churchId,
+      educationId,
+      educationTermId,
+      qr,
+    );*/
   }
 
   @ApiOperation({ summary: '특정 교육 회차 조회' })
@@ -60,12 +74,18 @@ export class EducationSessionsController {
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
     @Param('educationSessionId', ParseIntPipe) educationSessionId: number,
   ) {
-    return this.educationsService.getEducationSessionById(
+    return this.educationSessionsService.getEducationSessionById(
       churchId,
       educationId,
       educationTermId,
       educationSessionId,
     );
+    /*return this.educationsService.getEducationSessionById(
+      churchId,
+      educationId,
+      educationTermId,
+      educationSessionId,
+    );*/
   }
 
   @ApiOperation({ summary: '교육 진행 내용 업데이트' })
@@ -79,7 +99,7 @@ export class EducationSessionsController {
     @Body() dto: UpdateEducationSessionDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.educationsService.updateEducationSession(
+    return this.educationSessionsService.updateEducationSession(
       churchId,
       educationId,
       educationTermId,
@@ -87,6 +107,14 @@ export class EducationSessionsController {
       dto,
       qr,
     );
+    /*return this.educationsService.updateEducationSession(
+      churchId,
+      educationId,
+      educationTermId,
+      educationSessionId,
+      dto,
+      qr,
+    );*/
   }
 
   @ApiOperation({
@@ -103,12 +131,20 @@ export class EducationSessionsController {
     @Param('educationSessionId', ParseIntPipe) educationSessionId: number,
     @QueryRunner() qr: QR,
   ) {
-    return this.educationsService.deleteEducationSessions(
+    return this.educationSessionsService.deleteEducationSessions(
       churchId,
       educationId,
       educationTermId,
       educationSessionId,
       qr,
     );
+
+    /*return this.educationsService.deleteEducationSessions(
+      churchId,
+      educationId,
+      educationTermId,
+      educationSessionId,
+      qr,
+    );*/
   }
 }

--- a/backend/src/churches/management/service/education/educaiton-session.service.ts
+++ b/backend/src/churches/management/service/education/educaiton-session.service.ts
@@ -1,6 +1,312 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EducationSessionModel } from '../../entity/education/education-session.entity';
+import { In, MoreThan, QueryRunner, Repository } from 'typeorm';
+import { EducationTermModel } from '../../entity/education/education-term.entity';
+import { EducationEnrollmentModel } from '../../entity/education/education-enrollment.entity';
+import { SessionAttendanceModel } from '../../entity/education/session-attendance.entity';
+import { UpdateEducationSessionDto } from '../../dto/education/sessions/update-education-session.dto';
 
 @Injectable()
 export class EducationSessionService {
-  constructor() {}
+  constructor(
+    @InjectRepository(EducationSessionModel)
+    private readonly educationSessionsRepository: Repository<EducationSessionModel>,
+    @InjectRepository(EducationTermModel)
+    private readonly educationTermsRepository: Repository<EducationTermModel>,
+    @InjectRepository(EducationEnrollmentModel)
+    private readonly educationEnrollmentsRepository: Repository<EducationEnrollmentModel>,
+    @InjectRepository(SessionAttendanceModel)
+    private readonly sessionAttendanceRepository: Repository<SessionAttendanceModel>,
+  ) {}
+
+  private getEducationSessionsRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(EducationSessionModel)
+      : this.educationSessionsRepository;
+  }
+
+  private getEducationTermsRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(EducationTermModel)
+      : this.educationTermsRepository;
+  }
+
+  private getEducationEnrollmentsRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(EducationEnrollmentModel)
+      : this.educationEnrollmentsRepository;
+  }
+
+  private getSessionAttendanceRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(SessionAttendanceModel)
+      : this.sessionAttendanceRepository;
+  }
+
+  async getEducationSessions(
+    churchId: number,
+    educationId: number,
+    educationTermId: number,
+  ) {
+    const educationSessionsRepository = this.getEducationSessionsRepository();
+
+    return educationSessionsRepository.find({
+      where: {
+        educationTerm: {
+          educationId,
+          education: {
+            churchId,
+          },
+        },
+        educationTermId,
+      },
+      order: {
+        session: 'asc',
+      },
+    });
+  }
+
+  async getEducationSessionById(
+    churchId: number,
+    educationId: number,
+    educationTermId: number,
+    educationSessionId: number,
+    qr?: QueryRunner,
+  ) {
+    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
+
+    const session = await educationSessionsRepository.findOne({
+      where: {
+        id: educationSessionId,
+        educationTermId,
+        educationTerm: {
+          educationId,
+          education: {
+            churchId,
+          },
+        },
+      },
+    });
+
+    if (!session) {
+      throw new NotFoundException('해당 교육 세션을 찾을 수 없습니다.');
+    }
+
+    return session;
+  }
+
+  async createSingleEducationSession(
+    churchId: number,
+    educationId: number,
+    educationTermId: number,
+    qr: QueryRunner,
+  ) {
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
+
+    const educationTerm = await educationTermsRepository.findOne({
+      where: {
+        id: educationTermId,
+        educationId,
+      },
+      relations: {
+        educationEnrollments: true,
+      },
+    });
+
+    if (!educationTerm) {
+      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+    }
+
+    const lastSession = await educationSessionsRepository.findOne({
+      where: {
+        educationTermId: educationTermId,
+      },
+      order: {
+        session: 'desc',
+      },
+    });
+
+    const newSessionNumber = lastSession ? lastSession.session + 1 : 1;
+
+    // 교육 세션 생성
+    const newSession = await educationSessionsRepository.save({
+      session: newSessionNumber,
+      educationTermId,
+    });
+
+    await Promise.all([
+      // 교육 세션 개수 업데이트
+      educationTermsRepository.increment(
+        { id: educationTermId },
+        'numberOfSessions',
+        1,
+      ),
+      // 세션 출석 정보 생성
+      this.getSessionAttendanceRepository(qr).save(
+        educationTerm.educationEnrollments.map((enrollment) => ({
+          educationSessionId: newSession.id,
+          educationEnrollmentId: enrollment.id,
+        })),
+      ),
+    ]);
+
+    return this.getEducationSessionById(
+      churchId,
+      educationId,
+      educationTermId,
+      newSession.id,
+      qr,
+    );
+  }
+
+  async updateEducationSession(
+    churchId: number,
+    educationId: number,
+    educationTermId: number,
+    educationSessionId: number,
+    dto: UpdateEducationSessionDto,
+    qr: QueryRunner,
+  ) {
+    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+
+    const targetSession = await this.getEducationSessionById(
+      churchId,
+      educationId,
+      educationTermId,
+      educationSessionId,
+      qr,
+    );
+
+    /*
+    기존 session 의 isDone 이 true
+    --> dto.isDone = true -> isDoneCount 변화 X
+    --> dto.isDone = false -> isDoneCount 감소
+    */
+    if (dto.isDone !== undefined && dto.isDone !== targetSession.isDone) {
+      if (dto.isDone) {
+        //console.log('isDoneCount 증가');
+        //await this.incrementIsDoneCount(educationTermId, qr);
+        await educationTermsRepository.increment(
+          { id: educationTermId },
+          'isDoneCount',
+          1,
+        );
+      } else if (!dto.isDone) {
+        //console.log('isDoneCount 감소');
+        //await this.decrementIsDoneCount(educationTermId, qr);
+        await educationTermsRepository.decrement(
+          { id: educationTermId },
+          'isDoneCount',
+          1,
+        );
+      }
+    }
+
+    /*
+    기존 session 의 isDone 이 false
+    --> dto.isDone = true -> isDoneCount 증가
+    --> dto.isDone = false --> isDoneCount 변화 X
+     */
+
+    const result = await educationSessionsRepository.update(
+      {
+        id: targetSession.id,
+      },
+      {
+        content: dto.content,
+        sessionDate: dto.sessionDate,
+        isDone: dto.isDone,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException('해당 교육 회차를 찾을 수 없습니다.');
+    }
+
+    return educationSessionsRepository.findOne({
+      where: { id: educationSessionId },
+    });
+  }
+
+  async deleteEducationSessions(
+    churchId: number,
+    educationId: number,
+    educationTermId: number,
+    educationSessionId: number,
+    qr: QueryRunner,
+  ) {
+    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
+
+    const targetSession = await this.getEducationSessionById(
+      churchId,
+      educationId,
+      educationTermId,
+      educationSessionId,
+      qr,
+    );
+
+    // 세션 삭제
+    await educationSessionsRepository.softDelete({
+      id: educationSessionId,
+      educationTermId,
+    });
+
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+
+    // 다른 회차들 session 번호 수정
+    await educationSessionsRepository.decrement(
+      { educationTermId, session: MoreThan(targetSession.session) },
+      'session',
+      1,
+    );
+
+    // 해당 기수의 세션 개수 업데이트
+    await educationTermsRepository.decrement(
+      { id: educationTermId },
+      'numberOfSessions',
+      1,
+    );
+
+    if (targetSession.isDone) {
+      await educationTermsRepository.decrement(
+        { id: educationTermId },
+        'isDoneCount',
+        1,
+      );
+      //await this.decrementIsDoneCount(educationTermId, qr);
+    }
+
+    // 해당 세션 하위의 출석 정보 삭제
+    const sessionAttendanceRepository = this.getSessionAttendanceRepository(qr);
+
+    const attendances = await sessionAttendanceRepository.find({
+      where: {
+        educationSessionId,
+      },
+    });
+
+    // 삭제할 세션에 출석한 교육 대상자 ID
+    const attendedEnrollmentIds = attendances
+      .filter((attendance) => attendance.isPresent)
+      .map((attendance) => attendance.educationEnrollmentId);
+
+    // 해당 세션의 출석 정보 삭제
+    await sessionAttendanceRepository.softDelete({
+      educationSessionId: educationSessionId,
+    });
+
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    await educationEnrollmentsRepository.decrement(
+      { id: In(attendedEnrollmentIds) },
+      'attendanceCount',
+      1,
+    );
+
+    return `educationSessionId: ${educationSessionId} deleted`;
+  }
 }

--- a/backend/src/churches/management/service/education/education-enrollment.service.ts
+++ b/backend/src/churches/management/service/education/education-enrollment.service.ts
@@ -1,6 +1,465 @@
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EducationEnrollmentModel } from '../../entity/education/education-enrollment.entity';
+import { QueryRunner, Repository } from 'typeorm';
+import { GetEducationEnrollmentDto } from '../../dto/education/enrollments/get-education-enrollment.dto';
+import { EducationEnrollmentOrderEnum } from '../../const/education/order.enum';
+import { CreateEducationEnrollmentDto } from '../../dto/education/enrollments/create-education-enrollment.dto';
+import { UpdateEducationEnrollmentDto } from '../../dto/education/enrollments/update-education-enrollment.dto';
+import { MembersService } from '../../../members/service/members.service';
+import { EducationTermModel } from '../../entity/education/education-term.entity';
+import { SessionAttendanceModel } from '../../entity/education/session-attendance.entity';
+import { EducationStatus } from '../../const/education/education-status.enum';
 
 @Injectable()
 export class EducationEnrollmentService {
-  constructor() {}
+  constructor(
+    @InjectRepository(EducationTermModel)
+    private readonly educationTermsRepository: Repository<EducationTermModel>,
+    @InjectRepository(EducationEnrollmentModel)
+    private readonly educationEnrollmentsRepository: Repository<EducationEnrollmentModel>,
+    @InjectRepository(SessionAttendanceModel)
+    private readonly sessionAttendancesRepository: Repository<SessionAttendanceModel>,
+    private readonly membersService: MembersService,
+  ) {}
+
+  private CountColumnMap = {
+    [EducationStatus.IN_PROGRESS]: 'inProgressCount',
+    [EducationStatus.COMPLETED]: 'completedCount',
+    [EducationStatus.INCOMPLETE]: 'incompleteCount',
+  };
+
+  private getEducationEnrollmentsRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(EducationEnrollmentModel)
+      : this.educationEnrollmentsRepository;
+  }
+
+  private getSessionAttendanceRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(SessionAttendanceModel)
+      : this.sessionAttendancesRepository;
+  }
+
+  private getEducationTermsRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(EducationTermModel)
+      : this.educationTermsRepository;
+  }
+
+  async getEducationEnrollments(
+    churchId: number,
+    educationId: number,
+    educationTermId: number,
+    dto: GetEducationEnrollmentDto,
+    qr?: QueryRunner,
+  ) {
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    const [result, totalCount] = await Promise.all([
+      educationEnrollmentsRepository.find({
+        where: {
+          educationTermId,
+          educationTerm: {
+            educationId,
+            education: {
+              churchId,
+            },
+          },
+        },
+        relations: {
+          member: {
+            group: true,
+            groupRole: true,
+            officer: true,
+          },
+        },
+        order: {
+          [dto.order]: dto.orderDirection,
+          createdAt:
+            dto.order === EducationEnrollmentOrderEnum.createdAt
+              ? undefined
+              : 'desc',
+        },
+        take: dto.take,
+        skip: dto.take * (dto.page - 1),
+      }),
+      educationEnrollmentsRepository.count({
+        where: {
+          educationTermId,
+          educationTerm: {
+            educationId,
+            education: {
+              churchId,
+            },
+          },
+        },
+      }),
+    ]);
+
+    return {
+      data: result,
+      totalCount,
+      count: result.length,
+      page: dto.page,
+    };
+  }
+
+  async getEducationEnrollmentModelById(
+    educationEnrollmentId: number,
+    qr?: QueryRunner,
+  ) {
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    const enrollment = await educationEnrollmentsRepository.findOne({
+      where: {
+        id: educationEnrollmentId,
+      },
+    });
+
+    if (!enrollment) {
+      throw new NotFoundException('해당 교육 대상자 내역을 찾을 수 없습니다.');
+    }
+
+    return enrollment;
+  }
+
+  async getEducationEnrollmentById(
+    churchId: number,
+    educationId: number,
+    educationTermId: number,
+    educationEnrollmentId: number,
+    qr?: QueryRunner,
+  ) {
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    const enrollment = await educationEnrollmentsRepository.findOne({
+      where: {
+        educationTerm: {
+          educationId,
+          education: {
+            churchId,
+          },
+        },
+        educationTermId,
+        id: educationEnrollmentId,
+      },
+    });
+
+    if (!enrollment) {
+      throw new NotFoundException('해당 교육 대상자 내역을 찾을 수 없습니다.');
+    }
+
+    return enrollment;
+  }
+
+  async isExistEnrollment(
+    educationTermId: number,
+    memberId: number,
+    qr?: QueryRunner,
+  ) {
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    const enrollment = await educationEnrollmentsRepository.findOne({
+      where: {
+        educationTermId,
+        memberId,
+      },
+    });
+
+    return !!enrollment;
+  }
+
+  async createEducationEnrollment(
+    churchId: number,
+    educationId: number,
+    educationTermId: number,
+    dto: CreateEducationEnrollmentDto,
+    qr: QueryRunner,
+  ) {
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository();
+
+    const member = await this.membersService.getMemberModelById(
+      churchId,
+      dto.memberId,
+      {},
+      qr,
+    );
+
+    const [educationTerm, isExistEnrollment] = await Promise.all([
+      this.educationTermsRepository.findOne({
+        where: {
+          id: educationTermId,
+          educationId,
+          education: {
+            churchId,
+          },
+        },
+        relations: {
+          //instructor: true,
+          educationSessions: true,
+        },
+      }),
+      /*this.getEducationTermModelById(
+        churchId,
+        educationId,
+        educationTermId,
+        qr,
+      ),*/
+      this.isExistEnrollment(educationTermId, member.id, qr),
+    ]);
+
+    if (!educationTerm) {
+      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+    }
+
+    if (isExistEnrollment) {
+      throw new BadRequestException('이미 교육 대상자로 등록된 교인입니다.');
+    }
+
+    // enrollment 생성
+    const enrollment = await educationEnrollmentsRepository.save({
+      member,
+      educationTerm,
+      status: dto.status,
+      note: dto.note,
+    });
+
+    // 교육 등록 생성 후속 작업
+    const educationSessionIds = educationTerm.educationSessions.map(
+      (session) => session.id,
+    );
+
+    const sessionAttendanceRepository = this.getSessionAttendanceRepository(qr);
+
+    // 수강 대상 교인 수 증가 + 세션의 출석 정보 생성
+    await Promise.all([
+      this.incrementEnrollmentCount(educationTermId, qr),
+      this.incrementEducationStatusCount(educationTermId, dto.status, qr),
+      sessionAttendanceRepository.save(
+        educationSessionIds.map((sessionSessionId) => {
+          return {
+            educationSessionId: sessionSessionId,
+            educationEnrollmentId: enrollment.id,
+          };
+        }),
+      ),
+    ]);
+
+    return educationEnrollmentsRepository.findOne({
+      where: {
+        id: enrollment.id,
+      },
+      relations: {
+        member: {
+          group: true,
+          groupRole: true,
+          officer: true,
+        },
+      },
+    });
+  }
+
+  async incrementEnrollmentCount(educationTermId: number, qr: QueryRunner) {
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+
+    const result = await educationTermsRepository.increment(
+      { id: educationTermId },
+      'enrollmentCount',
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+    }
+
+    return result;
+  }
+
+  async incrementEducationStatusCount(
+    educationTermId: number,
+    status: EducationStatus,
+    qr: QueryRunner,
+  ) {
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+
+    const result = await educationTermsRepository.increment(
+      {
+        id: educationTermId,
+      },
+      this.CountColumnMap[status],
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+    }
+
+    return result;
+  }
+
+  async updateEducationEnrollment(
+    churchId: number,
+    educationId: number,
+    educationTermId: number,
+    educationEnrollmentId: number,
+    dto: UpdateEducationEnrollmentDto,
+    qr: QueryRunner,
+  ) {
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    const targetEducationEnrollment = await this.getEducationEnrollmentById(
+      churchId,
+      educationId,
+      educationTermId,
+      educationEnrollmentId,
+      qr,
+    );
+
+    // 교육 이수 상태 변경 시 해당 기수의 이수자 통계 업데이트
+    // 교육 이수 상태를 변경 && 기존 이수 상태와 다를 경우
+    if (dto.status && dto.status !== targetEducationEnrollment.status) {
+      await Promise.all([
+        // 기존 status 감소
+        this.decrementEducationStatusCount(
+          educationTermId,
+          targetEducationEnrollment.status,
+          qr,
+        ),
+        // 새 status 증가
+        this.incrementEducationStatusCount(educationTermId, dto.status, qr),
+      ]);
+    }
+
+    // 교육등록 업데이트
+    await educationEnrollmentsRepository.update(
+      {
+        id: educationEnrollmentId,
+        educationTermId,
+      },
+      {
+        status: dto.status,
+        note: dto.note,
+      },
+    );
+
+    return educationEnrollmentsRepository.findOne({
+      where: {
+        id: targetEducationEnrollment.id,
+      },
+      relations: {
+        member: {
+          group: true,
+          groupRole: true,
+          officer: true,
+        },
+      },
+    });
+  }
+
+  async decrementEducationStatusCount(
+    educationTermId: number,
+    status: EducationStatus,
+    qr: QueryRunner,
+  ) {
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+
+    const result = await educationTermsRepository.decrement(
+      {
+        id: educationTermId,
+      },
+      this.CountColumnMap[status],
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+    }
+
+    return result;
+  }
+
+  async deleteEducationEnrollment(
+    churchId: number,
+    educationId: number,
+    educationTermId: number,
+    educationEnrollmentId: number,
+    qr: QueryRunner,
+    memberDeleted: boolean = false,
+  ) {
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    const targetEnrollment = await this.getEducationEnrollmentById(
+      churchId,
+      educationId,
+      educationTermId,
+      educationEnrollmentId,
+      qr,
+    );
+
+    const member = memberDeleted
+      ? await this.membersService.getDeleteMemberModelById(
+          churchId,
+          targetEnrollment.memberId,
+          { educations: true },
+          qr,
+        )
+      : await this.membersService.getMemberModelById(
+          churchId,
+          targetEnrollment.memberId,
+          { educations: true },
+          qr,
+        );
+
+    await Promise.all([
+      // 교인 - 교육 관계 해제
+      this.membersService.endMemberEducation(member, educationEnrollmentId, qr),
+      // 등록 인원 감소
+      this.decrementEnrollmentCount(educationTermId, qr),
+      // 상태별 카운트 감소
+      this.decrementEducationStatusCount(
+        educationTermId,
+        targetEnrollment.status,
+        qr,
+      ),
+      // 교육 등록 삭제
+      educationEnrollmentsRepository.softDelete({
+        id: educationEnrollmentId,
+        educationTermId,
+      }),
+      // 출석 정보 삭제
+      this.getSessionAttendanceRepository(qr).softDelete({
+        educationEnrollmentId,
+      }),
+    ]);
+
+    return `educationEnrollment: ${educationEnrollmentId} deleted`;
+  }
+
+  async decrementEnrollmentCount(educationTermId: number, qr: QueryRunner) {
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+
+    const result = await educationTermsRepository.decrement(
+      { id: educationTermId },
+      'enrollmentCount',
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+    }
+
+    return result;
+  }
 }


### PR DESCRIPTION
## 주요 내용
EducationService에서 `education-session` 및 `education-enrollment` 관련 메소드를 각각 `EducationSessionService`와 `EducationEnrollmentService`로 분리하여 서비스의 역할을 명확하게 정리하였습니다.

## 세부 내용
- `education-session` 관련 로직을 `EducationSessionService`로 이동
- `education-enrollment` 관련 로직을 `EducationEnrollmentService`로 이동
- `EducationService`에서 불필요한 의존성 제거 및 역할 분리
- 코드 구조 개선 및 유지보수성 향상

이번 변경을 통해 서비스 간 책임이 명확해졌으며, 코드의 모듈성이 향상되어 유지보수가 용이해졌습니다. 🚀