### PR TITLE
refactor: EducationService에서 SessionAttendance 관련 로직 분리

### DIFF
--- a/backend/src/churches/management/controller/education/session-attendance.controller.ts
+++ b/backend/src/churches/management/controller/education/session-attendance.controller.ts
@@ -22,13 +22,17 @@ import {
   ApiLoadSessionAttendance,
   ApiPatchSessionAttendance,
 } from '../../const/swagger/session-attendance/controller.swagger';
+import { SessionAttendanceService } from '../../service/education/session-attendance.service';
 
 @ApiTags('Management:Educations:Attendance')
 @Controller(
   'educations/:educationId/terms/:educationTermId/sessions/:sessionId/attendance',
 )
 export class SessionAttendanceController {
-  constructor(private readonly educationsService: EducationsService) {}
+  constructor(
+    private readonly educationsService: EducationsService,
+    private readonly sessionAttendanceService: SessionAttendanceService,
+  ) {}
 
   @ApiGetSessionAttendance()
   @Get()
@@ -39,13 +43,20 @@ export class SessionAttendanceController {
     @Param('sessionId', ParseIntPipe) sessionId: number,
     @Query() dto: GetAttendanceDto,
   ) {
-    return this.educationsService.getSessionAttendance(
+    return this.sessionAttendanceService.getSessionAttendance(
       churchId,
       educationId,
       educationTermId,
       sessionId,
       dto,
     );
+    /*return this.educationsService.getSessionAttendance(
+      churchId,
+      educationId,
+      educationTermId,
+      sessionId,
+      dto,
+    );*/
   }
 
   @ApiLoadSessionAttendance()
@@ -78,7 +89,7 @@ export class SessionAttendanceController {
     @Body() dto: UpdateAttendanceDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.educationsService.updateSessionAttendance(
+    return this.sessionAttendanceService.updateSessionAttendance(
       churchId,
       educationId,
       educationTermId,
@@ -87,5 +98,14 @@ export class SessionAttendanceController {
       dto,
       qr,
     );
+    /*return this.educationsService.updateSessionAttendance(
+      churchId,
+      educationId,
+      educationTermId,
+      sessionId,
+      attendanceId,
+      dto,
+      qr,
+    );*/
   }
 }

--- a/backend/src/churches/management/service/education/educations.service.ts
+++ b/backend/src/churches/management/service/education/educations.service.ts
@@ -16,8 +16,6 @@ import { EducationOrderEnum } from '../../const/education/order.enum';
 import { MembersService } from '../../../members/service/members.service';
 import { EducationEnrollmentModel } from '../../entity/education/education-enrollment.entity';
 import { SessionAttendanceModel } from '../../entity/education/session-attendance.entity';
-import { UpdateAttendanceDto } from '../../dto/education/attendance/update-attendance.dto';
-import { GetAttendanceDto } from '../../dto/education/attendance/get-attendance.dto';
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 import { MemberDeletedEvent } from '../../../members/events/member.event';
 
@@ -468,54 +466,6 @@ export class EducationsService {
     return `educationEnrollment: ${educationEnrollmentId} deleted`;
   }
 
-  async incrementIsDoneCount(educationTermId: number, qr: QueryRunner) {
-    const educationTermsRepository = this.getEducationTermsRepository(qr);
-
-    const result = await educationTermsRepository.increment(
-      { id: educationTermId },
-      'isDoneCount',
-      1,
-    );
-
-    if (result.affected === 0) {
-      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
-    }
-
-    return result;
-  }
-
-  async decrementIsDoneCount(educationTermId: number, qr: QueryRunner) {
-    const educationTermsRepository = this.getEducationTermsRepository(qr);
-
-    const result = await educationTermsRepository.decrement(
-      { id: educationTermId },
-      'isDoneCount',
-      1,
-    );
-
-    if (result.affected === 0) {
-      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
-    }
-
-    return result;
-  }
-
-  async incrementEnrollmentCount(educationTermId: number, qr: QueryRunner) {
-    const educationTermsRepository = this.getEducationTermsRepository(qr);
-
-    const result = await educationTermsRepository.increment(
-      { id: educationTermId },
-      'enrollmentCount',
-      1,
-    );
-
-    if (result.affected === 0) {
-      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
-    }
-
-    return result;
-  }
-
   async decrementEnrollmentCount(educationTermId: number, qr: QueryRunner) {
     const educationTermsRepository = this.getEducationTermsRepository(qr);
 
@@ -532,7 +482,55 @@ export class EducationsService {
     return result;
   }
 
-  async incrementEducationStatusCount(
+  /*async incrementIsDoneCount(educationTermId: number, qr: QueryRunner) {
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+
+    const result = await educationTermsRepository.increment(
+      { id: educationTermId },
+      'isDoneCount',
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+    }
+
+    return result;
+  }*/
+
+  /*async decrementIsDoneCount(educationTermId: number, qr: QueryRunner) {
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+
+    const result = await educationTermsRepository.decrement(
+      { id: educationTermId },
+      'isDoneCount',
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+    }
+
+    return result;
+  }*/
+
+  /*async incrementEnrollmentCount(educationTermId: number, qr: QueryRunner) {
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+
+    const result = await educationTermsRepository.increment(
+      { id: educationTermId },
+      'enrollmentCount',
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+    }
+
+    return result;
+  }*/
+
+  /*async incrementEducationStatusCount(
     educationTermId: number,
     status: EducationStatus,
     qr: QueryRunner,
@@ -552,7 +550,7 @@ export class EducationsService {
     }
 
     return result;
-  }
+  }*/
 
   async decrementEducationStatusCount(
     educationTermId: number,
@@ -582,7 +580,7 @@ export class EducationsService {
       : this.sessionAttendanceRepository;
   }
 
-  async getSessionAttendance(
+  /*async getSessionAttendance(
     churchId: number,
     educationId: number,
     educationTermId: number,
@@ -633,9 +631,9 @@ export class EducationsService {
       count: result.length,
       page: dto.page,
     };
-  }
+  }*/
 
-  async getSessionAttendanceModelById(
+  /*async getSessionAttendanceModelById(
     churchId: number,
     educationId: number,
     educationTermId: number,
@@ -666,9 +664,9 @@ export class EducationsService {
     }
 
     return sessionAttendance;
-  }
+  }*/
 
-  async updateSessionAttendance(
+  /*async updateSessionAttendance(
     churchId: number,
     educationId: number,
     educationTermId: number,
@@ -680,11 +678,11 @@ export class EducationsService {
     // 출석 업데이트 시 Enrollment 의 출석 횟수 변경
     // sessionAttendance, educationEnrollment 필요
 
-    /**
+    /!**
      * 업데이트 대상
      *  1. 출석 --> sessionAttendance, educationEnrollment 수정
      *  2. 비고 --> sessionAttendance 만 수정
-     */
+     *!/
     const sessionAttendanceRepository = this.getSessionAttendanceRepository(qr);
 
     const sessionAttendance = await this.getSessionAttendanceModelById(
@@ -717,9 +715,9 @@ export class EducationsService {
         id: sessionAttendanceId,
       },
     });
-  }
+  }*/
 
-  private async updateAttendanceCount(
+  /*private async updateAttendanceCount(
     sessionAttendance: SessionAttendanceModel,
     qr: QueryRunner,
   ) {
@@ -748,7 +746,7 @@ export class EducationsService {
         attendanceCount: attendanceCount,
       },
     );
-  }
+  }*/
 
   /*async getEducationTerms(
     churchId: number,

--- a/backend/src/churches/management/service/education/session-attendance.service.ts
+++ b/backend/src/churches/management/service/education/session-attendance.service.ts
@@ -1,6 +1,202 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { SessionAttendanceModel } from '../../entity/education/session-attendance.entity';
+import { QueryRunner, Repository } from 'typeorm';
+import { GetAttendanceDto } from '../../dto/education/attendance/get-attendance.dto';
+import { UpdateAttendanceDto } from '../../dto/education/attendance/update-attendance.dto';
+import { EducationEnrollmentModel } from '../../entity/education/education-enrollment.entity';
 
 @Injectable()
 export class SessionAttendanceService {
-  constructor() {}
+  constructor(
+    @InjectRepository(EducationEnrollmentModel)
+    private readonly educationEnrollmentsRepository: Repository<EducationEnrollmentModel>,
+    @InjectRepository(SessionAttendanceModel)
+    private readonly sessionAttendanceRepository: Repository<SessionAttendanceModel>,
+  ) {}
+
+  private getEducationEnrollmentsRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(EducationEnrollmentModel)
+      : this.educationEnrollmentsRepository;
+  }
+
+  private getSessionAttendanceRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(SessionAttendanceModel)
+      : this.sessionAttendanceRepository;
+  }
+
+  async getSessionAttendance(
+    churchId: number,
+    educationId: number,
+    educationTermId: number,
+    educationSessionId: number,
+    dto: GetAttendanceDto,
+  ) {
+    const sessionAttendanceRepository = this.getSessionAttendanceRepository();
+
+    const [result, totalCount] = await Promise.all([
+      sessionAttendanceRepository.find({
+        where: {
+          educationSession: {
+            educationTermId,
+            educationTerm: {
+              educationId,
+              education: {
+                churchId,
+              },
+            },
+          },
+          educationSessionId,
+        },
+        relations: {
+          educationEnrollment: {
+            member: {
+              group: true,
+              groupRole: true,
+              officer: true,
+            },
+          },
+        },
+        order: {
+          [dto.order]: dto.orderDirection,
+        },
+        take: dto.take,
+        skip: dto.take * (dto.page - 1),
+      }),
+      sessionAttendanceRepository.count({
+        where: {
+          educationSessionId,
+        },
+      }),
+    ]);
+
+    return {
+      data: result,
+      totalCount,
+      count: result.length,
+      page: dto.page,
+    };
+  }
+
+  async getSessionAttendanceModelById(
+    churchId: number,
+    educationId: number,
+    educationTermId: number,
+    educationSessionId: number,
+    sessionAttendanceId: number,
+    qr?: QueryRunner,
+  ) {
+    const sessionAttendanceRepository = this.getSessionAttendanceRepository(qr);
+
+    const sessionAttendance = await sessionAttendanceRepository.findOne({
+      where: {
+        id: sessionAttendanceId,
+        educationSessionId,
+        educationSession: {
+          educationTermId,
+          educationTerm: {
+            educationId,
+            education: {
+              churchId,
+            },
+          },
+        },
+      },
+    });
+
+    if (!sessionAttendance) {
+      throw new NotFoundException('해당 세션 출석 정보를 찾을 수 없습니다.');
+    }
+
+    return sessionAttendance;
+  }
+
+  async updateSessionAttendance(
+    churchId: number,
+    educationId: number,
+    educationTermId: number,
+    educationSessionId: number,
+    sessionAttendanceId: number,
+    dto: UpdateAttendanceDto,
+    qr: QueryRunner,
+  ) {
+    // 출석 업데이트 시 Enrollment 의 출석 횟수 변경
+    // sessionAttendance, educationEnrollment 필요
+
+    /**
+     * 업데이트 대상
+     *  1. 출석 --> sessionAttendance, educationEnrollment 수정
+     *  2. 비고 --> sessionAttendance 만 수정
+     */
+    const sessionAttendanceRepository = this.getSessionAttendanceRepository(qr);
+
+    const sessionAttendance = await this.getSessionAttendanceModelById(
+      churchId,
+      educationId,
+      educationTermId,
+      educationSessionId,
+      sessionAttendanceId,
+    );
+
+    // sessionAttendance 업데이트
+    await sessionAttendanceRepository.update(
+      {
+        id: sessionAttendanceId,
+      },
+      {
+        isPresent: dto.isPresent,
+        note: dto.note,
+      },
+    );
+
+    // 출석 정보 업데이트 시
+    // isPresent 가 boolean 이기 때문에 undefined 로 판단
+    if (dto.isPresent !== undefined) {
+      await this.updateAttendanceCount(sessionAttendance, qr);
+    }
+
+    return sessionAttendanceRepository.findOne({
+      where: {
+        id: sessionAttendanceId,
+      },
+    });
+  }
+
+  private async updateAttendanceCount(
+    sessionAttendance: SessionAttendanceModel,
+    qr: QueryRunner,
+  ) {
+    const sessionAttendanceRepository = this.getSessionAttendanceRepository(qr);
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    const [enrollment, attendanceCount] = await Promise.all([
+      educationEnrollmentsRepository.findOne({
+        where: {
+          id: sessionAttendance.educationEnrollmentId,
+        },
+      }),
+      sessionAttendanceRepository.count({
+        where: {
+          educationEnrollmentId: sessionAttendance.educationEnrollmentId,
+          isPresent: true,
+        },
+      }),
+    ]);
+
+    if (!enrollment) {
+      throw new NotFoundException('해당 교육 대상자 내역을 찾을 수 없습니다.');
+    }
+
+    await educationEnrollmentsRepository.update(
+      {
+        id: enrollment.id,
+      },
+      {
+        attendanceCount: attendanceCount,
+      },
+    );
+  }
 }


### PR DESCRIPTION
## 주요 내용
EducationService에서 `SessionAttendance` 관련 메소드를 `SessionAttendanceService`로 분리하여 서비스의 역할을 명확하게 정리하였습니다.

## 세부 내용
- `SessionAttendance` 관련 로직을 `SessionAttendanceService`로 이동
- `EducationService`에서 불필요한 의존성 제거 및 역할 분리
- 코드 구조 개선 및 유지보수성 향상

이번 변경을 통해 서비스 간 책임이 명확해졌으며, 코드의 모듈성이 향상되어 유지보수가 용이해졌습니다. 🚀