### PR TITLE
refactor: MinistryDomainService 인터페이스 선언 및 적용

### DIFF
--- a/backend/src/churches/members-management/members-management.module.ts
+++ b/backend/src/churches/members-management/members-management.module.ts
@@ -17,9 +17,9 @@ import { ManagementModule } from '../../management/management.module';
 import { EducationEnrollmentModel } from '../../management/entity/education/education-enrollment.entity';
 import { GroupsDomainModule } from '../../management/groups/groups-domain/groups-domain.module';
 import { ChurchesDomainModule } from '../churches-domain/churches-domain.module';
-import { OfficersModule } from '../../management/officers/officers.module';
 import { MinistriesModule } from '../../management/ministries/ministries.module';
 import { OfficersDomainModule } from '../../management/officers/officer-domain/officers-domain.module';
+import { MinistriesDomainModule } from '../../management/ministries/ministries-domain/ministries-domain.module';
 
 @Module({
   imports: [
@@ -39,12 +39,13 @@ import { OfficersDomainModule } from '../../management/officers/officer-domain/o
     MembersModule,
     ManagementModule,
     //GroupsModule,
+    //OfficersModule,
     // 임시 import
-    OfficersModule,
     MinistriesModule,
-    //
+    // Domain Modules
     GroupsDomainModule,
     OfficersDomainModule,
+    MinistriesDomainModule,
     ChurchesDomainModule,
   ],
   exports: [],

--- a/backend/src/management/groups/const/exception/group.exception.ts
+++ b/backend/src/management/groups/const/exception/group.exception.ts
@@ -1,4 +1,4 @@
-export const GroupExceptionMessage = {
+export const GroupException = {
   NOT_FOUND: '해당 그룹을 찾을 수 없습니다.',
   ALREADY_EXIST: '이미 존재하는 그룹입니다.',
   LIMIT_DEPTH_REACHED: '더 이상 하위 그룹을 생성할 수 없습니다.',

--- a/backend/src/management/groups/groups-domain/groups-domain.service.ts
+++ b/backend/src/management/groups/groups-domain/groups-domain.service.ts
@@ -15,7 +15,7 @@ import { FindOptionsRelations, IsNull, QueryRunner, Repository } from 'typeorm';
 import { GroupModel } from '../entity/group.entity';
 import { UpdateGroupDto } from '../dto/update-group.dto';
 import { InjectRepository } from '@nestjs/typeorm';
-import { GroupExceptionMessage } from '../const/exception/group.exception';
+import { GroupException } from '../const/exception/group.exception';
 
 @Injectable()
 export class GroupsDomainService implements IGroupsDomainService {
@@ -64,7 +64,7 @@ export class GroupsDomainService implements IGroupsDomainService {
     });
 
     if (!group) {
-      throw new NotFoundException(GroupExceptionMessage.NOT_FOUND);
+      throw new NotFoundException(GroupException.NOT_FOUND);
     }
 
     return group;
@@ -83,7 +83,7 @@ export class GroupsDomainService implements IGroupsDomainService {
     );
 
     if (isExistingGroup) {
-      throw new BadRequestException(GroupExceptionMessage.ALREADY_EXIST);
+      throw new BadRequestException(GroupException.ALREADY_EXIST);
     }
 
     if (dto.parentGroupId) {
@@ -108,7 +108,7 @@ export class GroupsDomainService implements IGroupsDomainService {
     );
 
     if (result.affected === 0) {
-      throw new NotFoundException(GroupExceptionMessage.NOT_FOUND);
+      throw new NotFoundException(GroupException.NOT_FOUND);
     }
 
     return true;
@@ -131,16 +131,14 @@ export class GroupsDomainService implements IGroupsDomainService {
     });
 
     if (!deleteTarget) {
-      throw new NotFoundException(GroupExceptionMessage.NOT_FOUND);
+      throw new NotFoundException(GroupException.NOT_FOUND);
     }
 
     if (
       deleteTarget.childGroupIds.length > 0 ||
       deleteTarget.membersCount > 0
     ) {
-      throw new BadRequestException(
-        GroupExceptionMessage.GROUP_HAS_DEPENDENCIES,
-      );
+      throw new BadRequestException(GroupException.GROUP_HAS_DEPENDENCIES);
     }
 
     await groupsRepository.softRemove(deleteTarget);
@@ -179,7 +177,7 @@ export class GroupsDomainService implements IGroupsDomainService {
     });
 
     if (!group) {
-      throw new NotFoundException(GroupExceptionMessage.NOT_FOUND);
+      throw new NotFoundException(GroupException.NOT_FOUND);
     }
 
     return group;
@@ -296,7 +294,7 @@ export class GroupsDomainService implements IGroupsDomainService {
     );
 
     if (result.affected === 0) {
-      throw new NotFoundException(GroupExceptionMessage.NOT_FOUND);
+      throw new NotFoundException(GroupException.NOT_FOUND);
     }
 
     return true;
@@ -318,7 +316,7 @@ export class GroupsDomainService implements IGroupsDomainService {
     });
 
     if (!updateTargetGroup) {
-      throw new NotFoundException(GroupExceptionMessage.NOT_FOUND);
+      throw new NotFoundException(GroupException.NOT_FOUND);
     }
 
     // 그룹 이름을 변경하는 경우 중복 확인
@@ -326,7 +324,7 @@ export class GroupsDomainService implements IGroupsDomainService {
       dto.name &&
       (await this.isExistGroup(churchId, dto.name, qr, dto.parentGroupId))
     ) {
-      throw new BadRequestException(GroupExceptionMessage.ALREADY_EXIST);
+      throw new BadRequestException(GroupException.ALREADY_EXIST);
     }
 
     if (dto.parentGroupId) {
@@ -344,14 +342,14 @@ export class GroupsDomainService implements IGroupsDomainService {
       });
 
       if (!newParentGroup) {
-        throw new NotFoundException(GroupExceptionMessage.NOT_FOUND);
+        throw new NotFoundException(GroupException.NOT_FOUND);
       }
 
       // 종속 관계를 역전시키려는 경우
       // A -> B 관계를 직접 A <- B 로 바꾸려는 경우
       if (updateTargetGroup.childGroupIds.includes(dto.parentGroupId)) {
         throw new BadRequestException(
-          GroupExceptionMessage.CANNOT_SET_SUBGROUP_AS_PARENT,
+          GroupException.CANNOT_SET_SUBGROUP_AS_PARENT,
         );
       }
 
@@ -402,7 +400,7 @@ export class GroupsDomainService implements IGroupsDomainService {
     );
 
     if (result.affected === 0) {
-      throw new NotFoundException(GroupExceptionMessage.NOT_FOUND);
+      throw new NotFoundException(GroupException.NOT_FOUND);
     }
 
     const updatedGroup = await groupsRepository.findOne({
@@ -449,7 +447,7 @@ export class GroupsDomainService implements IGroupsDomainService {
     });
 
     if (!parentGroup) {
-      throw new NotFoundException(GroupExceptionMessage.NOT_FOUND);
+      throw new NotFoundException(GroupException.NOT_FOUND);
     }
 
     const grandParentGroups = await this.findParentGroups(
@@ -460,7 +458,7 @@ export class GroupsDomainService implements IGroupsDomainService {
 
     // 그룹의 depth 는 5 를 넘을 수 없음.
     if (grandParentGroups.length + 1 === 5) {
-      throw new BadRequestException(GroupExceptionMessage.LIMIT_DEPTH_REACHED);
+      throw new BadRequestException(GroupException.LIMIT_DEPTH_REACHED);
     }
 
     const newGroup = await groupsRepository.save({

--- a/backend/src/management/ministries/const/ministry-group.exception.ts
+++ b/backend/src/management/ministries/const/ministry-group.exception.ts
@@ -1,0 +1,4 @@
+export const MinistryGroupException = {
+  NOT_FOUND: '해당 사역 그룹을 찾을 수 없습니다.',
+  ALREADY_EXIST: '',
+};

--- a/backend/src/management/ministries/const/ministry.exception.ts
+++ b/backend/src/management/ministries/const/ministry.exception.ts
@@ -1,4 +1,4 @@
-export const MinistryExceptionMessage = {
+export const MinistryException = {
   NOT_FOUND: '해당 사역을 찾을 수 없습니다.',
   ALREADY_EXIST: '해당 사역 그룹에 이미 존재하는 사역 이름입니다.',
 };

--- a/backend/src/management/ministries/controller/ministries.controller.ts
+++ b/backend/src/management/ministries/controller/ministries.controller.ts
@@ -51,6 +51,7 @@ export class MinistriesController {
   }
 
   @Patch(':ministryId')
+  @UseInterceptors(TransactionInterceptor)
   patchMinistry(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('ministryId', ParseIntPipe) ministryId: number,

--- a/backend/src/management/ministries/entity/ministry-group.entity.ts
+++ b/backend/src/management/ministries/entity/ministry-group.entity.ts
@@ -1,14 +1,5 @@
-import {
-  BeforeRemove,
-  BeforeSoftRemove,
-  Column,
-  Entity,
-  Index,
-  ManyToOne,
-  OneToMany,
-} from 'typeorm';
+import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
 import { MinistryModel } from './ministry.entity';
-import { ConflictException } from '@nestjs/common';
 import { BaseModel } from '../../../common/entity/base.entity';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 
@@ -46,7 +37,7 @@ export class MinistryGroupModel extends BaseModel {
   @OneToMany(() => MinistryModel, (ministry) => ministry.ministryGroup)
   ministries: MinistryModel[];
 
-  @BeforeRemove()
+  /*@BeforeRemove()
   @BeforeSoftRemove()
   preventIfHasChild() {
     if (this.childMinistryGroupIds.length > 0 || this.ministries.length > 0) {
@@ -54,5 +45,5 @@ export class MinistryGroupModel extends BaseModel {
         '해당 사역 그룹에 속한 하위 사역 그룹 또는 사역이 존재합니다.',
       );
     }
-  }
+  }*/
 }

--- a/backend/src/management/ministries/ministries-domain/interface/ministries-domain.service.interface.ts
+++ b/backend/src/management/ministries/ministries-domain/interface/ministries-domain.service.interface.ts
@@ -1,3 +1,57 @@
+import { ChurchModel } from '../../../../churches/entity/church.entity';
+import { GetMinistryDto } from '../../dto/get-ministry.dto';
+import { FindOptionsRelations, QueryRunner } from 'typeorm';
+import { MinistryModel } from '../../entity/ministry.entity';
+import { CreateMinistryDto } from '../../dto/create-ministry.dto';
+import { MinistryGroupModel } from '../../entity/ministry-group.entity';
+import { UpdateMinistryDto } from '../../dto/update-ministry.dto';
+
 export const IMINISTRIES_DOMAIN_SERVICE = Symbol('IMINISTRIES_DOMAIN_SERVICE');
 
-export interface IMinistriesDomainService {}
+export interface IMinistriesDomainService {
+  findMinistries(
+    church: ChurchModel,
+    dto: GetMinistryDto,
+    qr?: QueryRunner,
+  ): Promise<MinistryModel[]>;
+
+  findMinistryModelById(
+    church: ChurchModel,
+    ministryId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<MinistryModel>,
+  ): Promise<MinistryModel>;
+
+  findMinistryById(
+    church: ChurchModel,
+    ministryId: number,
+    qr?: QueryRunner,
+  ): Promise<MinistryModel>;
+
+  createMinistry(
+    church: ChurchModel,
+    dto: CreateMinistryDto,
+    qr?: QueryRunner,
+    ministryGroup?: MinistryGroupModel,
+  ): Promise<MinistryModel>;
+
+  updateMinistry(
+    church: ChurchModel,
+    targetMinistry: MinistryModel,
+    dto: UpdateMinistryDto,
+    qr: QueryRunner,
+    newMinistryGroup?: MinistryGroupModel,
+  ): Promise<MinistryModel>;
+
+  deleteMinistry(ministry: MinistryModel, qr?: QueryRunner): Promise<string>;
+
+  incrementMembersCount(
+    ministry: MinistryModel,
+    qr: QueryRunner,
+  ): Promise<boolean>;
+
+  decrementMembersCount(
+    ministry: MinistryModel,
+    qr: QueryRunner,
+  ): Promise<boolean>;
+}

--- a/backend/src/management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface.ts
+++ b/backend/src/management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface.ts
@@ -1,5 +1,18 @@
+import { MinistryGroupModel } from '../../entity/ministry-group.entity';
+
 export const IMINISTRY_GROUPS_DOMAIN_SERVICE = Symbol(
   'IMINISTRY_GROUPS_DOMAIN_SERVICE',
 );
+
+export interface ParentMinistryGroup {
+  id: number;
+  name: string;
+  parentMinistryGroupId: number | null;
+  depth: number;
+}
+
+export interface MinistryGroupWithParentGroups extends MinistryGroupModel {
+  parentMinistryGroups: ParentMinistryGroup[];
+}
 
 export interface IMinistryGroupsDomainService {}

--- a/backend/src/management/ministries/ministries-domain/ministries-domain.service.ts
+++ b/backend/src/management/ministries/ministries-domain/ministries-domain.service.ts
@@ -1,5 +1,234 @@
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { IMinistriesDomainService } from './interface/ministries-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { MinistryModel } from '../entity/ministry.entity';
+import { FindOptionsRelations, IsNull, QueryRunner, Repository } from 'typeorm';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { GetMinistryDto } from '../dto/get-ministry.dto';
+import { MinistryException } from '../const/ministry.exception';
+import { CreateMinistryDto } from '../dto/create-ministry.dto';
+import { MinistryGroupModel } from '../entity/ministry-group.entity';
+import { UpdateMinistryDto } from '../dto/update-ministry.dto';
+import { OfficersException } from '../../officers/const/exception/officers.exception';
 
 @Injectable()
-export class MinistriesDomainService implements IMinistriesDomainService {}
+export class MinistriesDomainService implements IMinistriesDomainService {
+  constructor(
+    @InjectRepository(MinistryModel)
+    private readonly ministriesRepository: Repository<MinistryModel>,
+  ) {}
+
+  private getMinistriesRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(MinistryModel)
+      : this.ministriesRepository;
+  }
+
+  private async isExistMinistry(
+    churchId: number,
+    ministryGroupId: number,
+    name: string,
+    qr?: QueryRunner,
+  ) {
+    const ministriesRepository = this.getMinistriesRepository(qr);
+
+    const ministry = await ministriesRepository.findOne({
+      where: {
+        churchId,
+        ministryGroupId: ministryGroupId ? ministryGroupId : IsNull(),
+        name,
+      },
+    });
+
+    return !!ministry;
+  }
+
+  async findMinistries(
+    church: ChurchModel,
+    dto: GetMinistryDto,
+    qr?: QueryRunner,
+  ) {
+    const ministriesRepository = this.getMinistriesRepository(qr);
+
+    return ministriesRepository.find({
+      where: {
+        churchId: church.id,
+        ministryGroupId:
+          dto.ministryGroupId === 0 ? IsNull() : dto.ministryGroupId,
+      },
+      order: {
+        [dto.order]: dto.orderDirection,
+        id: 'asc',
+      },
+    });
+  }
+
+  async findMinistryModelById(
+    church: ChurchModel,
+    ministryId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<MinistryModel>,
+  ) {
+    const ministriesRepository = this.getMinistriesRepository(qr);
+
+    const ministry = await ministriesRepository.findOne({
+      where: {
+        id: ministryId,
+        churchId: church.id,
+      },
+      relations: relationOptions ? relationOptions : { ministryGroup: true },
+    });
+
+    if (!ministry) {
+      throw new NotFoundException(MinistryException.NOT_FOUND);
+    }
+
+    return ministry;
+  }
+
+  async findMinistryById(
+    church: ChurchModel,
+    ministryId: number,
+    qr?: QueryRunner,
+  ) {
+    const ministriesRepository = this.getMinistriesRepository(qr);
+
+    const ministry = await ministriesRepository.findOne({
+      where: {
+        churchId: church.id,
+        id: ministryId,
+      },
+      relations: {
+        members: true,
+      },
+    });
+
+    if (!ministry) {
+      throw new NotFoundException(MinistryException.NOT_FOUND);
+    }
+
+    return ministry;
+  }
+
+  async createMinistry(
+    church: ChurchModel,
+    dto: CreateMinistryDto,
+    qr?: QueryRunner,
+    ministryGroup?: MinistryGroupModel,
+  ) {
+    const ministriesRepository = this.getMinistriesRepository(qr);
+
+    const isExistMinistry = await this.isExistMinistry(
+      church.id,
+      dto.ministryGroupId,
+      dto.name,
+      qr,
+    );
+
+    if (isExistMinistry) {
+      throw new BadRequestException(MinistryException.ALREADY_EXIST);
+    }
+
+    return ministriesRepository.save({
+      name: dto.name,
+      churchId: church.id,
+      ministryGroup,
+    });
+  }
+
+  async updateMinistry(
+    church: ChurchModel,
+    targetMinistry: MinistryModel,
+    dto: UpdateMinistryDto,
+    qr: QueryRunner,
+    newMinistryGroup?: MinistryGroupModel,
+  ) {
+    const ministriesRepository = this.getMinistriesRepository(qr);
+
+    const newMinistryGroupId = newMinistryGroup ? newMinistryGroup.id : 0;
+    const newName = dto.name ? dto.name : targetMinistry.name;
+
+    const isExist = await this.isExistMinistry(
+      church.id,
+      newMinistryGroupId,
+      newName,
+      qr,
+    );
+
+    if (isExist) {
+      throw new BadRequestException(MinistryException.ALREADY_EXIST);
+    }
+
+    const result = await ministriesRepository.update(
+      {
+        id: targetMinistry.id,
+        deletedAt: IsNull(),
+      },
+      {
+        name: dto.name,
+        ministryGroupId: newMinistryGroupId ? newMinistryGroupId : undefined,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException(MinistryException.NOT_FOUND);
+    }
+
+    return this.findMinistryById(church, targetMinistry.id, qr);
+  }
+
+  async deleteMinistry(ministry: MinistryModel, qr?: QueryRunner) {
+    if (ministry.membersCount !== 0) {
+      throw new BadRequestException(OfficersException.HAS_DEPENDENCIES);
+    }
+
+    const ministriesRepository = this.getMinistriesRepository(qr);
+
+    const result = await ministriesRepository.softDelete({
+      id: ministry.id,
+      deletedAt: IsNull(),
+    });
+
+    if (result.affected === 0) {
+      throw new NotFoundException(MinistryException.NOT_FOUND);
+    }
+
+    return `ministryId ${ministry.id} deleted`;
+  }
+
+  async incrementMembersCount(ministry: MinistryModel, qr: QueryRunner) {
+    const ministriesRepository = this.getMinistriesRepository(qr);
+
+    const result = await ministriesRepository.increment(
+      { id: ministry.id, deletedAt: IsNull() },
+      'membersCount',
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException(MinistryException.NOT_FOUND);
+    }
+
+    return true;
+  }
+
+  async decrementMembersCount(ministry: MinistryModel, qr: QueryRunner) {
+    const ministriesRepository = this.getMinistriesRepository(qr);
+
+    const result = await ministriesRepository.decrement(
+      { id: ministry.id, deletedAt: IsNull() },
+      'membersCount',
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException(MinistryException.NOT_FOUND);
+    }
+
+    return true;
+  }
+}

--- a/backend/src/management/ministries/ministries-domain/ministry-groups-domain.service.ts
+++ b/backend/src/management/ministries/ministries-domain/ministry-groups-domain.service.ts
@@ -1,6 +1,167 @@
-import { Injectable } from '@nestjs/common';
-import { IMinistryGroupsDomainService } from './interface/ministry-groups-domain.service.interface';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  IMinistryGroupsDomainService,
+  MinistryGroupWithParentGroups,
+  ParentMinistryGroup,
+} from './interface/ministry-groups-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { MinistryGroupModel } from '../entity/ministry-group.entity';
+import { FindOptionsRelations, IsNull, QueryRunner, Repository } from 'typeorm';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { MinistryGroupException } from '../const/ministry-group.exception';
+import { CreateMinistryGroupDto } from '../dto/create-ministry-group.dto';
 
 @Injectable()
 export class MinistryGroupsDomainService
-  implements IMinistryGroupsDomainService {}
+  implements IMinistryGroupsDomainService
+{
+  constructor(
+    @InjectRepository(MinistryGroupModel)
+    private readonly ministryGroupsRepository: Repository<MinistryGroupModel>,
+  ) {}
+
+  private getMinistryGroupsRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(MinistryGroupModel)
+      : this.ministryGroupsRepository;
+  }
+
+  private async isExistMinistryGroup(
+    church: ChurchModel,
+    name: string,
+    parentMinistryGroup?: MinistryGroupModel,
+    qr?: QueryRunner,
+  ) {
+    const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
+
+    const group = await ministryGroupsRepository.findOne({
+      where: {
+        churchId: church.id,
+        parentMinistryGroupId: parentMinistryGroup
+          ? parentMinistryGroup.id
+          : IsNull(),
+        name,
+      },
+    });
+
+    return !!group;
+  }
+
+  async getMinistryGroups(church: ChurchModel, qr?: QueryRunner) {
+    const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
+
+    return ministryGroupsRepository.find({
+      where: {
+        churchId: church.id,
+      },
+      order: { createdAt: 'ASC' },
+    });
+  }
+
+  async findMinistryGroupModelById(
+    church: ChurchModel,
+    ministryGroupId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<MinistryGroupModel>,
+  ) {
+    const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
+
+    const ministryGroup = await ministryGroupsRepository.findOne({
+      where: {
+        churchId: church.id,
+        id: ministryGroupId,
+      },
+      relations: {
+        ...relationOptions,
+      },
+    });
+
+    if (!ministryGroup) {
+      throw new NotFoundException(MinistryGroupException.NOT_FOUND);
+    }
+
+    return ministryGroup;
+  }
+
+  async findMinistryGroupById(
+    church: ChurchModel,
+    ministryGroupId: number,
+    qr?: QueryRunner,
+  ): Promise<MinistryGroupWithParentGroups> {
+    const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
+
+    const ministryGroup = await ministryGroupsRepository.findOne({
+      where: {
+        churchId: church.id,
+        id: ministryGroupId,
+      },
+      relations: {
+        ministries: true,
+      },
+    });
+
+    if (!ministryGroup) {
+      throw new NotFoundException(MinistryGroupException.NOT_FOUND);
+    }
+
+    return {
+      ...ministryGroup,
+      parentMinistryGroups: await this.findParentMinistryGroups(
+        church,
+        ministryGroup.id,
+      ),
+    };
+  }
+
+  async findParentMinistryGroups(
+    church: ChurchModel,
+    ministryGroupId: number,
+    qr?: QueryRunner,
+  ) {
+    const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
+
+    const parents = await ministryGroupsRepository.query(
+      `
+    WITH RECURSIVE parent_groups AS (
+      -- 초기 그룹의 부모
+      SELECT g.* 
+      FROM ministry_group_model g
+      JOIN ministry_group_model child 
+      ON g.id = child."parentMinistryGroupId"
+      WHERE child.id = $1 AND child."churchId" = $2
+      
+      UNION ALL
+      
+      -- 재귀적으로 부모의 부모 찾기
+      SELECT g.*
+      FROM ministry_group_model g
+      JOIN parent_groups pg 
+      ON g.id = pg."parentMinistryGroupId"
+    )
+    SELECT * FROM parent_groups;
+    `,
+      [ministryGroupId, church.id],
+    );
+
+    let result: ParentMinistryGroup[] = [];
+
+    parents.forEach((parent: MinistryGroupModel, i: number) => {
+      result.unshift({
+        id: parent.id,
+        name: parent.name,
+        parentMinistryGroupId: parent.parentMinistryGroupId,
+        depth: parents.length - i,
+      });
+    });
+
+    return result;
+  }
+
+  async createMinistryGroup(
+    church: ChurchModel,
+    dto: CreateMinistryGroupDto,
+    qr: QueryRunner,
+  ) {
+    const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
+  }
+}

--- a/backend/src/management/ministries/ministries.module.ts
+++ b/backend/src/management/ministries/ministries.module.ts
@@ -24,6 +24,6 @@ import { MinistriesDomainModule } from './ministries-domain/ministries-domain.mo
   ],
   controllers: [MinistriesController, MinistryGroupsController],
   providers: [MinistryService, MinistryGroupService],
-  exports: [MinistryService, MinistryGroupService],
+  exports: [MinistryGroupService],
 })
 export class MinistriesModule {}

--- a/backend/src/management/ministries/service/ministry-group.service.ts
+++ b/backend/src/management/ministries/service/ministry-group.service.ts
@@ -13,6 +13,10 @@ import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
 } from '../../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IMINISTRY_GROUPS_DOMAIN_SERVICE,
+  IMinistryGroupsDomainService,
+} from '../ministries-domain/interface/ministry-groups-domain.service.interface';
 
 @Injectable()
 export class MinistryGroupService {
@@ -22,6 +26,8 @@ export class MinistryGroupService {
 
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IMINISTRY_GROUPS_DOMAIN_SERVICE)
+    private readonly ministryGroupsDomainService: IMinistryGroupsDomainService,
   ) {}
 
   private getMinistryGroupRepository(qr?: QueryRunner) {

--- a/backend/src/management/officers/const/exception/officers.exception.ts
+++ b/backend/src/management/officers/const/exception/officers.exception.ts
@@ -1,4 +1,5 @@
 export const OfficersException = {
   NOT_FOUND: '해당 직분을 찾을 수 없습니다.',
   ALREADY_EXIST: '이미 존재하는 직분입니다.',
+  HAS_DEPENDENCIES: '해당 사역에 속한 교인이 존재합니다.',
 };


### PR DESCRIPTION
## 주요 내용
`MinistriesDomainModule` 내에서 `MinistryDomainService`의 인터페이스를 선언하고 구현하였으며, 기존에 `MinistryService`를 의존하던 코드들을 `MinistryDomainService`를 의존하도록 변경하였습니다.

## 세부 내용
- `MinistryDomainService` 인터페이스 선언 및 구현
- 기존 `MinistryService`를 의존하던 코드에서 `MinistryDomainService`를 사용하도록 변경
- 인터페이스 기반 DI 적용으로 결합도 감소 및 확장성 향상

이번 변경을 통해 `Ministry` 관련 도메인 로직이 보다 명확하게 분리되었으며,
인터페이스를 활용한 구조 개선으로 유지보수성과 확장성이 향상되었습니다. 🚀