### PR TITLE
feat: MinistryGroupsDomainService 인터페이스 선언 및 계층 변경 기능 추가

### DIFF
--- a/backend/src/churches/members-management/members-management.module.ts
+++ b/backend/src/churches/members-management/members-management.module.ts
@@ -17,7 +17,6 @@ import { ManagementModule } from '../../management/management.module';
 import { EducationEnrollmentModel } from '../../management/entity/education/education-enrollment.entity';
 import { GroupsDomainModule } from '../../management/groups/groups-domain/groups-domain.module';
 import { ChurchesDomainModule } from '../churches-domain/churches-domain.module';
-import { MinistriesModule } from '../../management/ministries/ministries.module';
 import { OfficersDomainModule } from '../../management/officers/officer-domain/officers-domain.module';
 import { MinistriesDomainModule } from '../../management/ministries/ministries-domain/ministries-domain.module';
 
@@ -38,10 +37,10 @@ import { MinistriesDomainModule } from '../../management/ministries/ministries-d
     ]),
     MembersModule,
     ManagementModule,
+    // 임시 import
     //GroupsModule,
     //OfficersModule,
-    // 임시 import
-    MinistriesModule,
+    //MinistriesModule,
     // Domain Modules
     GroupsDomainModule,
     OfficersDomainModule,

--- a/backend/src/churches/members-management/service/member-ministry.service.ts
+++ b/backend/src/churches/members-management/service/member-ministry.service.ts
@@ -12,7 +12,6 @@ import { CreateMemberMinistryDto } from '../dto/ministry/create-member-ministry.
 import { EndMemberMinistryDto } from '../dto/ministry/end-member-ministry.dto';
 import { GetMinistryHistoryDto } from '../dto/ministry/get-ministry-history.dto';
 import { UpdateMinistryHistoryDto } from '../dto/ministry/update-ministry-history.dto';
-import { MinistryGroupService } from '../../../management/ministries/service/ministry-group.service';
 import {
   IMINISTRIES_DOMAIN_SERVICE,
   IMinistriesDomainService,
@@ -21,20 +20,24 @@ import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
 } from '../../churches-domain/interface/churches-domain.service.interface';
+import {
+  IMINISTRY_GROUPS_DOMAIN_SERVICE,
+  IMinistryGroupsDomainService,
+} from '../../../management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface';
 
 @Injectable()
 export class MemberMinistryService {
   constructor(
-    private readonly membersService: MembersService,
-    //private readonly ministryService: MinistryService,
-    private readonly ministryGroupService: MinistryGroupService,
     @InjectRepository(MinistryHistoryModel)
     private readonly ministryHistoryRepository: Repository<MinistryHistoryModel>,
+    private readonly membersService: MembersService,
 
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,
     @Inject(IMINISTRIES_DOMAIN_SERVICE)
     private readonly ministriesDomainService: IMinistriesDomainService,
+    @Inject(IMINISTRY_GROUPS_DOMAIN_SERVICE)
+    private readonly ministryGroupsDomainService: IMinistryGroupsDomainService,
   ) {}
 
   private getMinistryHistoryRepository(qr?: QueryRunner) {
@@ -120,9 +123,14 @@ export class MemberMinistryService {
   ) {
     const ministryGroupId = ministryHistory.ministry.ministryGroupId;
 
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
     const ministryParentGroups = ministryGroupId
-      ? await this.ministryGroupService.getParentMinistryGroups(
-          churchId,
+      ? await this.ministryGroupsDomainService.findParentMinistryGroups(
+          church,
           ministryGroupId,
           qr,
         )

--- a/backend/src/management/ministries/const/ministry-group.exception.ts
+++ b/backend/src/management/ministries/const/ministry-group.exception.ts
@@ -1,4 +1,8 @@
 export const MinistryGroupException = {
   NOT_FOUND: '해당 사역 그룹을 찾을 수 없습니다.',
-  ALREADY_EXIST: '',
+  ALREADY_EXIST: '이미 존재하는 사역 그룹입니다.',
+  LIMIT_DEPTH_REACHED: '더 이상 하위 그룹을 생성할 수 없습니다.',
+  CANNOT_SET_SUBGROUP_AS_PARENT:
+    '현재 하위 그룹을 새로운 상위 그룹으로 지정할 수 없습니다.',
+  GROUP_HAS_DEPENDENCIES: '해당 그룹에 속한 사역이 존재합니다.',
 };

--- a/backend/src/management/ministries/controller/ministries.controller.ts
+++ b/backend/src/management/ministries/controller/ministries.controller.ts
@@ -10,7 +10,7 @@ import {
   Query,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { MinistryService } from '../service/ministry.service';
 import { CreateMinistryDto } from '../dto/create-ministry.dto';
 import { UpdateMinistryDto } from '../dto/update-ministry.dto';
@@ -50,6 +50,11 @@ export class MinistriesController {
     return this.ministryService.getMinistryById(churchId, ministryId);
   }
 
+  @ApiOperation({
+    summary: '사역 수정',
+    description:
+      '소속 사역 그룹을 없애려는 경우 ministryGroupId 를 0 으로 설정',
+  })
   @Patch(':ministryId')
   @UseInterceptors(TransactionInterceptor)
   patchMinistry(

--- a/backend/src/management/ministries/controller/ministry-groups.controller.ts
+++ b/backend/src/management/ministries/controller/ministry-groups.controller.ts
@@ -10,7 +10,7 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { MinistryGroupService } from '../service/ministry-group.service';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CreateMinistryGroupDto } from '../dto/create-ministry-group.dto';
 import { QueryRunner as QR } from 'typeorm';
 import { UpdateMinistryGroupDto } from '../dto/update-ministry-group.dto';
@@ -48,6 +48,11 @@ export class MinistryGroupsController {
     );
   }
 
+  @ApiOperation({
+    summary: '사역 그룹 수정',
+    description:
+      '최상위 그룹으로 설정하려는 경우 parentMinistryGroupId 를 0 으로 설정',
+  })
   @Patch(':ministryGroupId')
   @UseInterceptors(TransactionInterceptor)
   patchMinistryGroup(

--- a/backend/src/management/ministries/entity/ministry-group.entity.ts
+++ b/backend/src/management/ministries/entity/ministry-group.entity.ts
@@ -10,7 +10,7 @@ export class MinistryGroupModel extends BaseModel {
 
   @Column({ nullable: true })
   @Index()
-  parentMinistryGroupId: number;
+  parentMinistryGroupId: number | null;
 
   @ManyToOne(
     () => MinistryGroupModel,

--- a/backend/src/management/ministries/entity/ministry.entity.ts
+++ b/backend/src/management/ministries/entity/ministry.entity.ts
@@ -1,6 +1,4 @@
 import {
-  BeforeRemove,
-  BeforeSoftRemove,
   Column,
   Entity,
   Index,
@@ -10,7 +8,6 @@ import {
   Unique,
 } from 'typeorm';
 import { MinistryGroupModel } from './ministry-group.entity';
-import { ConflictException } from '@nestjs/common';
 import { BaseModel } from '../../../common/entity/base.entity';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { MemberModel } from '../../../churches/members/entity/member.entity';
@@ -51,7 +48,7 @@ export class MinistryModel extends BaseModel {
   )
   ministryHistory: MinistryModel[];
 
-  @BeforeRemove()
+  /*@BeforeRemove()
   @BeforeSoftRemove()
   preventIfHasMember() {
     if (this.members.length > 0) {
@@ -61,5 +58,5 @@ export class MinistryModel extends BaseModel {
         `해당 사역을 가진 교인이 존재합니다.\n${memberNames}`,
       );
     }
-  }
+  }*/
 }

--- a/backend/src/management/ministries/ministries-domain/interface/ministries-domain.service.interface.ts
+++ b/backend/src/management/ministries/ministries-domain/interface/ministries-domain.service.interface.ts
@@ -40,7 +40,7 @@ export interface IMinistriesDomainService {
     targetMinistry: MinistryModel,
     dto: UpdateMinistryDto,
     qr: QueryRunner,
-    newMinistryGroup?: MinistryGroupModel,
+    newMinistryGroup?: MinistryGroupModel | null,
   ): Promise<MinistryModel>;
 
   deleteMinistry(ministry: MinistryModel, qr?: QueryRunner): Promise<string>;

--- a/backend/src/management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface.ts
+++ b/backend/src/management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface.ts
@@ -1,4 +1,8 @@
 import { MinistryGroupModel } from '../../entity/ministry-group.entity';
+import { ChurchModel } from '../../../../churches/entity/church.entity';
+import { FindOptionsRelations, QueryRunner } from 'typeorm';
+import { CreateMinistryGroupDto } from '../../dto/create-ministry-group.dto';
+import { UpdateMinistryGroupDto } from '../../dto/update-ministry-group.dto';
 
 export const IMINISTRY_GROUPS_DOMAIN_SERVICE = Symbol(
   'IMINISTRY_GROUPS_DOMAIN_SERVICE',
@@ -15,4 +19,53 @@ export interface MinistryGroupWithParentGroups extends MinistryGroupModel {
   parentMinistryGroups: ParentMinistryGroup[];
 }
 
-export interface IMinistryGroupsDomainService {}
+export interface IMinistryGroupsDomainService {
+  findMinistryGroups(
+    church: ChurchModel,
+    qr?: QueryRunner,
+  ): Promise<MinistryGroupModel[]>;
+
+  findMinistryGroupModelById(
+    church: ChurchModel,
+    ministryGroupId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<MinistryGroupModel>,
+  ): Promise<MinistryGroupModel>;
+
+  findMinistryGroupById(
+    church: ChurchModel,
+    ministryGroupId: number,
+    qr?: QueryRunner,
+  ): Promise<MinistryGroupWithParentGroups>;
+
+  findParentMinistryGroups(
+    church: ChurchModel,
+    ministryGroupId: number,
+    qr?: QueryRunner,
+  ): Promise<ParentMinistryGroup[]>;
+
+  findChildMinistryGroupIds(
+    church: ChurchModel,
+    ministryGroupId: number,
+    qr?: QueryRunner,
+  ): Promise<number[]>;
+
+  createMinistryGroup(
+    church: ChurchModel,
+    dto: CreateMinistryGroupDto,
+    qr: QueryRunner,
+  ): Promise<MinistryGroupModel>;
+
+  updateMinistryGroup(
+    church: ChurchModel,
+    ministryGroupId: number,
+    dto: UpdateMinistryGroupDto,
+    qr: QueryRunner,
+  ): Promise<MinistryGroupWithParentGroups>;
+
+  deleteMinistryGroup(
+    church: ChurchModel,
+    ministryGroupId: number,
+    qr: QueryRunner,
+  ): Promise<string>;
+}

--- a/backend/src/management/ministries/ministries-domain/ministries-domain.service.ts
+++ b/backend/src/management/ministries/ministries-domain/ministries-domain.service.ts
@@ -145,7 +145,7 @@ export class MinistriesDomainService implements IMinistriesDomainService {
     targetMinistry: MinistryModel,
     dto: UpdateMinistryDto,
     qr: QueryRunner,
-    newMinistryGroup?: MinistryGroupModel,
+    newMinistryGroup?: MinistryGroupModel | null,
   ) {
     const ministriesRepository = this.getMinistriesRepository(qr);
 
@@ -170,7 +170,7 @@ export class MinistriesDomainService implements IMinistriesDomainService {
       },
       {
         name: dto.name,
-        ministryGroupId: newMinistryGroupId ? newMinistryGroupId : undefined,
+        ministryGroupId: dto.ministryGroupId === 0 ? null : dto.ministryGroupId,
       },
     );
 

--- a/backend/src/management/ministries/ministries-domain/ministry-groups-domain.service.ts
+++ b/backend/src/management/ministries/ministries-domain/ministry-groups-domain.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import {
   IMinistryGroupsDomainService,
   MinistryGroupWithParentGroups,
@@ -10,6 +14,7 @@ import { FindOptionsRelations, IsNull, QueryRunner, Repository } from 'typeorm';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { MinistryGroupException } from '../const/ministry-group.exception';
 import { CreateMinistryGroupDto } from '../dto/create-ministry-group.dto';
+import { UpdateMinistryGroupDto } from '../dto/update-ministry-group.dto';
 
 @Injectable()
 export class MinistryGroupsDomainService
@@ -29,7 +34,7 @@ export class MinistryGroupsDomainService
   private async isExistMinistryGroup(
     church: ChurchModel,
     name: string,
-    parentMinistryGroup?: MinistryGroupModel,
+    parentMinistryGroup?: MinistryGroupModel | null,
     qr?: QueryRunner,
   ) {
     const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
@@ -47,7 +52,7 @@ export class MinistryGroupsDomainService
     return !!group;
   }
 
-  async getMinistryGroups(church: ChurchModel, qr?: QueryRunner) {
+  async findMinistryGroups(church: ChurchModel, qr?: QueryRunner) {
     const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
 
     return ministryGroupsRepository.find({
@@ -109,6 +114,7 @@ export class MinistryGroupsDomainService
       parentMinistryGroups: await this.findParentMinistryGroups(
         church,
         ministryGroup.id,
+        qr,
       ),
     };
   }
@@ -157,11 +163,297 @@ export class MinistryGroupsDomainService
     return result;
   }
 
+  async findChildMinistryGroupIds(
+    church: ChurchModel,
+    ministryGroupId: number,
+    qr?: QueryRunner,
+  ) {
+    const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
+
+    const ministryGroup = await this.findMinistryGroupModelById(
+      church,
+      ministryGroupId,
+      qr,
+    );
+
+    const subGroupsQuery = await ministryGroupsRepository.query(
+      `
+        WITH RECURSIVE group_tree AS (
+      -- 초기 그룹의 직계 그룹들
+      SELECT id, "parentMinistryGroupId", 1 as level, name
+    FROM ministry_group_model
+    WHERE "parentMinistryGroupId" = $1 AND "deletedAt" IS NULL 
+    
+    UNION ALL 
+    
+    SELECT g.id, g."parentMinistryGroupId", gt.level + 1, g.name
+    FROM ministry_group_model g
+    INNER JOIN group_tree gt ON g."parentMinistryGroupId" = gt.id
+    WHERE g."deletedAt" IS NULL
+    )
+    SELECT id, level, name FROM group_tree
+        `,
+      [ministryGroup.id],
+    );
+
+    return subGroupsQuery.map((row: any) => row.id);
+  }
+
   async createMinistryGroup(
     church: ChurchModel,
     dto: CreateMinistryGroupDto,
     qr: QueryRunner,
   ) {
+    const parentMinistryGroup = dto.parentMinistryGroupId
+      ? await this.findMinistryGroupModelById(
+          church,
+          dto.parentMinistryGroupId,
+          qr,
+        )
+      : undefined;
+
+    const isExist = await this.isExistMinistryGroup(
+      church,
+      dto.name,
+      parentMinistryGroup,
+      qr,
+    );
+
+    if (isExist) {
+      throw new BadRequestException(MinistryGroupException.ALREADY_EXIST);
+    }
+
+    return parentMinistryGroup
+      ? this.handleLeafMinistryGroup(church, parentMinistryGroup, dto, qr)
+      : this.handleNodeMinistryGroup(church, dto, qr);
+  }
+
+  private async handleLeafMinistryGroup(
+    church: ChurchModel,
+    parentGroup: MinistryGroupModel,
+    dto: CreateMinistryGroupDto,
+    qr: QueryRunner,
+  ) {
     const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
+
+    const grandParentGroups = await this.findParentMinistryGroups(
+      church,
+      parentGroup.id,
+      qr,
+    );
+
+    if (grandParentGroups.length + 1 >= 5) {
+      throw new BadRequestException(MinistryGroupException.LIMIT_DEPTH_REACHED);
+    }
+
+    const newGroup = await ministryGroupsRepository.save({
+      churchId: church.id,
+      name: dto.name,
+      parentMinistryGroupId: parentGroup.id,
+    });
+
+    await this.appendChildMinistryGroupId(parentGroup, newGroup, qr);
+
+    return newGroup;
+  }
+
+  private async handleNodeMinistryGroup(
+    church: ChurchModel,
+    dto: CreateMinistryGroupDto,
+    qr: QueryRunner,
+  ) {
+    const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
+
+    return ministryGroupsRepository.save({
+      churchId: church.id,
+      ...dto,
+    });
+  }
+
+  async updateMinistryGroup(
+    church: ChurchModel,
+    ministryGroupId: number,
+    dto: UpdateMinistryGroupDto,
+    qr: QueryRunner,
+  ) {
+    const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
+
+    const ministryGroup = await this.findMinistryGroupModelById(
+      church,
+      ministryGroupId,
+      qr,
+      { parentMinistryGroup: true },
+    );
+
+    // 이름 중복 체크 시작
+    // 부모 변경 시 새로운 부모 그룹 || 기존 부모 그룹 (노드 그룹일 경우 null)
+    let newParentGroup: MinistryGroupModel | null = dto.parentMinistryGroupId
+      ? await this.findMinistryGroupModelById(
+          church,
+          dto.parentMinistryGroupId,
+          qr,
+        )
+      : ministryGroup.parentMinistryGroup;
+
+    // 업데이트 대상을 최상위 그룹으로 옮기는 경우
+    if (dto.parentMinistryGroupId === 0) {
+      newParentGroup = null;
+    }
+
+    // 변경하려는 이름 || 기존 이름
+    const newName = dto.name ? dto.name : ministryGroup.name;
+
+    const isExist = await this.isExistMinistryGroup(
+      church,
+      newName,
+      newParentGroup,
+      qr,
+    );
+
+    if (isExist) {
+      throw new BadRequestException(MinistryGroupException.ALREADY_EXIST);
+    }
+    // 이름 중복 체크 종료
+
+    // 부모 변경 시 체크
+    if (
+      (dto.parentMinistryGroupId && newParentGroup) ||
+      dto.parentMinistryGroupId === 0
+    ) {
+      // 1. 의존 관계 역전인지
+      if (
+        ministryGroup.childMinistryGroupIds.includes(dto.parentMinistryGroupId)
+      ) {
+        throw new BadRequestException(
+          MinistryGroupException.CANNOT_SET_SUBGROUP_AS_PARENT,
+        );
+      }
+
+      // 2. 그룹의 depth 확인
+      const newGrandParentGroups = await this.findParentMinistryGroups(
+        church,
+        dto.parentMinistryGroupId,
+        qr,
+      );
+
+      if (newGrandParentGroups.length + 1 >= 5) {
+        throw new BadRequestException(
+          MinistryGroupException.LIMIT_DEPTH_REACHED,
+        );
+      }
+
+      // 이전 상위 그룹, 새로운 상위 그룹의 childGroupId 수정
+      await Promise.all([
+        this.appendChildMinistryGroupId(newParentGroup, ministryGroup, qr),
+        this.removeChildMinistryGroupId(
+          ministryGroup.parentMinistryGroup,
+          ministryGroup,
+          qr,
+        ),
+      ]);
+    }
+
+    // 업데이트 수행
+    const result = await ministryGroupsRepository.update(
+      {
+        id: ministryGroupId,
+        deletedAt: IsNull(),
+      },
+      {
+        ...dto,
+        parentMinistryGroupId:
+          dto.parentMinistryGroupId === 0 ? null : dto.parentMinistryGroupId,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException(MinistryGroupException.NOT_FOUND);
+    }
+
+    return this.findMinistryGroupById(church, ministryGroupId, qr);
+  }
+
+  async deleteMinistryGroup(
+    church: ChurchModel,
+    ministryGroupId: number,
+    qr: QueryRunner,
+  ) {
+    const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
+
+    const ministryGroup = await this.findMinistryGroupModelById(
+      church,
+      ministryGroupId,
+      qr,
+      { parentMinistryGroup: true, ministries: true },
+    );
+
+    // 하위 그룹 or 사역 체크
+    if (
+      ministryGroup.childMinistryGroupIds.length > 0 ||
+      ministryGroup.ministries.length > 0
+    ) {
+      throw new BadRequestException(
+        MinistryGroupException.GROUP_HAS_DEPENDENCIES,
+      );
+    }
+
+    await ministryGroupsRepository.softDelete({
+      id: ministryGroupId,
+      deletedAt: IsNull(),
+    });
+
+    await this.removeChildMinistryGroupId(
+      ministryGroup.parentMinistryGroup,
+      ministryGroup,
+      qr,
+    );
+
+    return `ministryGroupId ${ministryGroupId} deleted`;
+  }
+
+  private async appendChildMinistryGroupId(
+    parentMinistryGroup: MinistryGroupModel | null,
+    childMinistryGroup: MinistryGroupModel,
+    qr: QueryRunner,
+  ) {
+    if (!parentMinistryGroup) {
+      return;
+    }
+
+    const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
+
+    await ministryGroupsRepository
+      .createQueryBuilder(undefined, qr)
+      .update()
+      .set({
+        childMinistryGroupIds: () =>
+          `array_append("childMinistryGroupIds", :childMinistryGroupId)`,
+      })
+      .where('id= :id', { id: parentMinistryGroup.id })
+      .setParameters({ childMinistryGroupId: childMinistryGroup.id })
+      .execute();
+  }
+
+  private async removeChildMinistryGroupId(
+    parentMinistryGroup: MinistryGroupModel | null,
+    childMinistryGroup: MinistryGroupModel,
+    qr: QueryRunner,
+  ) {
+    if (!parentMinistryGroup) {
+      return;
+    }
+
+    const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
+
+    await ministryGroupsRepository
+      .createQueryBuilder(undefined, qr)
+      .update()
+      .set({
+        childMinistryGroupIds: () =>
+          `array_remove("childMinistryGroupIds", :childMinistryGroupId)`,
+      })
+      .where('id= :id', { id: parentMinistryGroup.id })
+      .setParameters({ childMinistryGroupId: childMinistryGroup.id })
+      .execute();
   }
 }

--- a/backend/src/management/ministries/ministries.module.ts
+++ b/backend/src/management/ministries/ministries.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { MinistryModel } from './entity/ministry.entity';
-import { MinistryGroupModel } from './entity/ministry-group.entity';
 import { MinistriesController } from './controller/ministries.controller';
 import { MinistryGroupsController } from './controller/ministry-groups.controller';
 import { MinistryService } from './service/ministry.service';
@@ -18,12 +17,12 @@ import { MinistriesDomainModule } from './ministries-domain/ministries-domain.mo
         module: MinistriesModule,
       },
     ]),
-    TypeOrmModule.forFeature([MinistryModel, MinistryGroupModel]),
+    TypeOrmModule.forFeature([MinistryModel]),
     ChurchesDomainModule,
     MinistriesDomainModule,
   ],
   controllers: [MinistriesController, MinistryGroupsController],
   providers: [MinistryService, MinistryGroupService],
-  exports: [MinistryGroupService],
+  exports: [],
 })
 export class MinistriesModule {}

--- a/backend/src/management/ministries/service/ministry-group.service.ts
+++ b/backend/src/management/ministries/service/ministry-group.service.ts
@@ -1,12 +1,6 @@
-import {
-  BadRequestException,
-  Inject,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { Inject, Injectable } from '@nestjs/common';
 import { MinistryGroupModel } from '../entity/ministry-group.entity';
-import { FindOptionsRelations, IsNull, QueryRunner, Repository } from 'typeorm';
+import { FindOptionsRelations, QueryRunner } from 'typeorm';
 import { CreateMinistryGroupDto } from '../dto/create-ministry-group.dto';
 import { UpdateMinistryGroupDto } from '../dto/update-ministry-group.dto';
 import {
@@ -21,61 +15,17 @@ import {
 @Injectable()
 export class MinistryGroupService {
   constructor(
-    @InjectRepository(MinistryGroupModel)
-    private readonly ministryGroupRepository: Repository<MinistryGroupModel>,
-
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,
     @Inject(IMINISTRY_GROUPS_DOMAIN_SERVICE)
     private readonly ministryGroupsDomainService: IMinistryGroupsDomainService,
   ) {}
 
-  private getMinistryGroupRepository(qr?: QueryRunner) {
-    return qr
-      ? qr.manager.getRepository(MinistryGroupModel)
-      : this.ministryGroupRepository;
-  }
-
-  private async checkChurchExist(churchId: number, qr?: QueryRunner) {
-    const isExistChurch = await this.churchesDomainService.isExistChurch(
-      churchId,
-      qr,
-    );
-
-    if (!isExistChurch) {
-      throw new NotFoundException('해당 교회를 찾을 수 없습니다.');
-    }
-  }
-
-  private async isExistMinistryGroup(
-    churchId: number,
-    parentMinistryGroupId: number | undefined,
-    name: string,
-    qr?: QueryRunner,
-  ) {
-    const ministryGroupsRepository = this.getMinistryGroupRepository(qr);
-
-    const group = await ministryGroupsRepository.findOne({
-      where: {
-        churchId,
-        parentMinistryGroupId: parentMinistryGroupId
-          ? parentMinistryGroupId
-          : IsNull(),
-        name,
-      },
-    });
-
-    return !!group;
-  }
-
   async getMinistryGroups(churchId: number) {
-    return this.ministryGroupRepository.find({
-      where: { churchId },
-      relations: {
-        //ministries: true,
-      },
-      order: { createdAt: 'ASC' },
-    });
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    return this.ministryGroupsDomainService.findMinistryGroups(church);
   }
 
   async getMinistryGroupModelById(
@@ -84,23 +34,17 @@ export class MinistryGroupService {
     qr?: QueryRunner,
     relationOptions?: FindOptionsRelations<MinistryGroupModel>,
   ) {
-    const ministryGroupRepository = this.getMinistryGroupRepository(qr);
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
 
-    const ministryGroup = await ministryGroupRepository.findOne({
-      where: {
-        id: ministryGroupId,
-        churchId,
-      },
-      relations: {
-        ...relationOptions,
-      },
-    });
-
-    if (!ministryGroup) {
-      throw new NotFoundException('해당 사역 그룹을 찾을 수 없습니다.');
-    }
-
-    return ministryGroup;
+    return this.ministryGroupsDomainService.findMinistryGroupModelById(
+      church,
+      ministryGroupId,
+      qr,
+      relationOptions,
+    );
   }
 
   async getMinistryGroupById(
@@ -108,79 +52,16 @@ export class MinistryGroupService {
     ministryGroupId: number,
     qr?: QueryRunner,
   ) {
-    const ministryGroupRepository = this.getMinistryGroupRepository(qr);
-
-    const ministryGroup = await ministryGroupRepository.findOne({
-      where: {
-        churchId,
-        id: ministryGroupId,
-      },
-      relations: {
-        ministries: true,
-      },
-    });
-
-    if (!ministryGroup) {
-      throw new NotFoundException('해당 사역 그룹을 찾을 수 없습니다.');
-    }
-
-    return {
-      ...ministryGroup,
-      parentMinistryGroups: await this.getParentMinistryGroups(
-        churchId,
-        ministryGroupId,
-        qr,
-      ),
-    };
-  }
-
-  async getParentMinistryGroups(
-    churchId: number,
-    ministryGroupId: number,
-    qr?: QueryRunner,
-  ) {
-    const ministryGroupRepository = this.getMinistryGroupRepository(qr);
-
-    const parents = await ministryGroupRepository.query(
-      `
-    WITH RECURSIVE parent_groups AS (
-      -- 초기 그룹의 부모
-      SELECT g.* 
-      FROM ministry_group_model g
-      JOIN ministry_group_model child 
-      ON g.id = child."parentMinistryGroupId"
-      WHERE child.id = $1 AND child."churchId" = $2
-      
-      UNION ALL
-      
-      -- 재귀적으로 부모의 부모 찾기
-      SELECT g.*
-      FROM ministry_group_model g
-      JOIN parent_groups pg 
-      ON g.id = pg."parentMinistryGroupId"
-    )
-    SELECT * FROM parent_groups;
-    `,
-      [ministryGroupId, churchId],
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
     );
 
-    let result: {
-      id: number;
-      name: string;
-      parentMinistryGroupId: number | null;
-      depth: number;
-    }[] = [];
-
-    parents.forEach((parent: MinistryGroupModel, i: number) => {
-      result.unshift({
-        id: parent.id,
-        name: parent.name,
-        parentMinistryGroupId: parent.parentMinistryGroupId,
-        depth: parents.length - i,
-      });
-    });
-
-    return result;
+    return this.ministryGroupsDomainService.findMinistryGroupById(
+      church,
+      ministryGroupId,
+      qr,
+    );
   }
 
   async createMinistryGroup(
@@ -188,92 +69,16 @@ export class MinistryGroupService {
     dto: CreateMinistryGroupDto,
     qr: QueryRunner,
   ) {
-    await this.checkChurchExist(churchId, qr);
-
-    const ministryGroupRepository = this.getMinistryGroupRepository(qr);
-
-    const existingMinistryGroup = await ministryGroupRepository.findOne({
-      where: {
-        churchId,
-        parentMinistryGroupId: dto.parentMinistryGroupId
-          ? dto.parentMinistryGroupId
-          : IsNull(),
-        name: dto.name,
-      },
-      relations: {
-        childMinistryGroups: true,
-        ministries: true,
-      },
-      withDeleted: true,
-    });
-
-    if (existingMinistryGroup) {
-      if (!existingMinistryGroup.deletedAt) {
-        throw new BadRequestException('이미 존재하는 사역 그룹 이름입니다.');
-      }
-
-      await ministryGroupRepository.remove(existingMinistryGroup);
-    }
-
-    // 상위 그룹 지정 시
-    if (dto.parentMinistryGroupId) {
-      const parentMinistryGroup = await this.getMinistryGroupModelById(
-        churchId,
-        dto.parentMinistryGroupId,
-        qr,
-      );
-
-      /**
-       * 그룹 depth 확인 후 5 넘을 경우 BadRequestException
-       */
-
-      const newGroup = await ministryGroupRepository.save({
-        churchId,
-        name: dto.name,
-        parentMinistryGroupId: dto.parentMinistryGroupId,
-      });
-
-      await this.appendChildMinistryGroupId(
-        parentMinistryGroup.id,
-        newGroup.id,
-        ministryGroupRepository,
-        qr,
-      );
-
-      return newGroup;
-    }
-
-    // 루트 그룹 생성 시
-    return ministryGroupRepository.save({
+    const church = await this.churchesDomainService.findChurchModelById(
       churchId,
-      ...dto,
-    });
-  }
-
-  private async isValidParentMinistryGroup(
-    churchId: number,
-    targetMinistryGroup: MinistryGroupModel,
-    newParentGroupId: number,
-    qr: QueryRunner,
-  ) {
-    // 새 부모 그룹 조회, 없다면 NotFoundException
-    const newParentMinistryGroup = await this.getMinistryGroupModelById(
-      churchId,
-      newParentGroupId,
       qr,
     );
 
-    if (
-      targetMinistryGroup.childMinistryGroupIds.includes(
-        newParentMinistryGroup.id,
-      )
-    ) {
-      throw new BadRequestException(
-        '현재 하위 그룹을 새로운 상위 그룹으로 지정할 수 없습니다.',
-      );
-    }
-
-    return true;
+    return this.ministryGroupsDomainService.createMinistryGroup(
+      church,
+      dto,
+      qr,
+    );
   }
 
   async updateMinistryGroup(
@@ -282,78 +87,17 @@ export class MinistryGroupService {
     dto: UpdateMinistryGroupDto,
     qr: QueryRunner,
   ) {
-    await this.checkChurchExist(churchId, qr);
-
-    const ministryGroupRepository = this.getMinistryGroupRepository(qr);
-
-    // 변경 전 사역 그룹
-    const targetGroup = await this.getMinistryGroupModelById(
+    const church = await this.churchesDomainService.findChurchModelById(
       churchId,
-      ministryGroupId,
       qr,
     );
 
-    const newParentMinistryGroupId =
-      dto.parentMinistryGroupId !== undefined
-        ? dto.parentMinistryGroupId
-        : targetGroup.parentMinistryGroupId;
-
-    // 이름 변경하는 경우 중복 확인
-    if (
-      dto.name &&
-      (await this.isExistMinistryGroup(
-        churchId,
-        newParentMinistryGroupId,
-        dto.name,
-        qr,
-      ))
-    ) {
-      throw new BadRequestException('이미 존재하는 사역 그룹 이름입니다.');
-    }
-
-    // 상위 그룹을 변경하려는 경우
-    if (dto.parentMinistryGroupId !== undefined) {
-      if (dto.parentMinistryGroupId !== null) {
-        await this.isValidParentMinistryGroup(
-          churchId,
-          targetGroup,
-          newParentMinistryGroupId,
-          qr,
-        );
-      }
-
-      // childGroupIds 업데이트
-      await Promise.all([
-        this.removeChildMinistryGroupId(
-          targetGroup.parentMinistryGroupId,
-          targetGroup.id,
-          ministryGroupRepository,
-          qr,
-        ),
-        this.appendChildMinistryGroupId(
-          dto.parentMinistryGroupId,
-          targetGroup.id,
-          ministryGroupRepository,
-          qr,
-        ),
-      ]);
-
-      await ministryGroupRepository.update({ id: ministryGroupId }, { ...dto });
-
-      return this.getMinistryGroupById(churchId, ministryGroupId, qr);
-
-      /*return ministryGroupRepository.findOne({
-        where: { id: ministryGroupId, churchId },
-      });*/
-    }
-
-    // 이름만 변경하는 경우
-    await ministryGroupRepository.update({ id: ministryGroupId }, { ...dto });
-
-    return this.getMinistryGroupById(churchId, ministryGroupId, qr);
-    /*return ministryGroupRepository.findOne({
-      where: { id: ministryGroupId, churchId },
-    });*/
+    return this.ministryGroupsDomainService.updateMinistryGroup(
+      church,
+      ministryGroupId,
+      dto,
+      qr,
+    );
   }
 
   async deleteMinistryGroup(
@@ -361,41 +105,16 @@ export class MinistryGroupService {
     ministryGroupId: number,
     qr: QueryRunner,
   ) {
-    const ministryGroupRepository = this.getMinistryGroupRepository(qr);
-
-    const deleteTarget = await this.getMinistryGroupModelById(
+    const church = await this.churchesDomainService.findChurchModelById(
       churchId,
+      qr,
+    );
+
+    return this.ministryGroupsDomainService.deleteMinistryGroup(
+      church,
       ministryGroupId,
       qr,
-      { ministries: true },
     );
-
-    /*// 하위 그룹 or 사역이 있을 경우 Exception
-    if (
-      deleteTarget.childMinistryGroupIds.length > 0 ||
-      deleteTarget.ministries.length > 0
-    ) {
-      throw new BadRequestException(
-        '해당 사역 그룹에 속한 하위 사역 그룹 또는 사역이 존재합니다.',
-      );
-    }
-
-    await ministryGroupRepository.softDelete({
-      id: ministryGroupId,
-      churchId,
-    });
-    */
-
-    await ministryGroupRepository.softRemove(deleteTarget);
-
-    await this.removeChildMinistryGroupId(
-      deleteTarget.parentMinistryGroupId,
-      deleteTarget.id,
-      ministryGroupRepository,
-      qr,
-    );
-
-    return `ministryGroupId ${ministryGroupId} deleted`;
   }
 
   async getMinistryGroupsCascade(
@@ -403,70 +122,15 @@ export class MinistryGroupService {
     ministryGroupId: number,
     qr?: QueryRunner,
   ) {
-    const ministryGroupsRepository = this.getMinistryGroupRepository(qr);
-
-    const ministryGroup = await this.getMinistryGroupModelById(
+    const church = await this.churchesDomainService.findChurchModelById(
       churchId,
-      ministryGroupId,
       qr,
     );
 
-    const subGroupsQuery = await ministryGroupsRepository.query(
-      `
-        WITH RECURSIVE group_tree AS (
-      -- 초기 그룹의 직계 그룹들
-      SELECT id, "parentMinistryGroupId", 1 as level, name
-    FROM ministry_group_model
-    WHERE "parentMinistryGroupId" = $1 AND "deletedAt" IS NULL 
-    
-    UNION ALL 
-    
-    SELECT g.id, g."parentMinistryGroupId", gt.level + 1, g.name
-    FROM ministry_group_model g
-    INNER JOIN group_tree gt ON g."parentMinistryGroupId" = gt.id
-    WHERE g."deletedAt" IS NULL
-    )
-    SELECT id, level, name FROM group_tree
-        `,
-      [ministryGroup.id],
+    return this.ministryGroupsDomainService.findChildMinistryGroupIds(
+      church,
+      ministryGroupId,
+      qr,
     );
-
-    return subGroupsQuery.map((row: any) => row.id);
-  }
-
-  private async appendChildMinistryGroupId(
-    parentMinistryGroupId: number,
-    childMinistryGroupId: number,
-    ministryGroupRepository: Repository<MinistryGroupModel>,
-    qr: QueryRunner,
-  ) {
-    await ministryGroupRepository
-      .createQueryBuilder(undefined, qr)
-      .update()
-      .set({
-        childMinistryGroupIds: () =>
-          `array_append("childMinistryGroupIds", :childMinistryGroupId)`,
-      })
-      .where('id= :id', { id: parentMinistryGroupId })
-      .setParameters({ childMinistryGroupId: childMinistryGroupId })
-      .execute();
-  }
-
-  private async removeChildMinistryGroupId(
-    parentMinistryGroupId: number,
-    childMinistryGroupId: number,
-    ministryGroupRepository: Repository<MinistryGroupModel>,
-    qr: QueryRunner,
-  ) {
-    await ministryGroupRepository
-      .createQueryBuilder(undefined, qr)
-      .update()
-      .set({
-        childMinistryGroupIds: () =>
-          `array_remove("childMinistryGroupIds", :childMinistryGroupId)`,
-      })
-      .where('id= :id', { id: parentMinistryGroupId })
-      .setParameters({ childMinistryGroupId })
-      .execute();
   }
 }


### PR DESCRIPTION
## 주요 내용
`MinistryGroupsDomainService`의 인터페이스를 선언 및 구현하고, 기존 `MinistryGroupsService`를 의존하던 코드들을 `MinistryGroupsDomainService`를 사용하도록 변경하였습니다. 또한, `MinistryGroup` 및 `Ministry`의 계층 변경 시 특정 ID 값을 `0`으로 설정하면 최상위 계층(노드)으로 이동하도록 기능을 추가하였습니다.

## 세부 내용
- `MinistryGroupsDomainService` 인터페이스 선언 및 구현
- 기존 `MinistryGroupsService`를 의존하던 코드에서 `MinistryGroupsDomainService`를 사용하도록 변경
- `MinistryGroup` 및 `Ministry` 계층 변경 시
  - `parentMinistryGroupId = 0` 또는 `ministryGroupId = 0`일 경우 최상위 계층으로 이동
- 인터페이스 기반 DI 적용으로 결합도 감소 및 확장성 향상

이번 변경을 통해 `MinistryGroup` 관련 도메인 로직이 보다 명확하게 분리되었으며, 인터페이스를 활용한 구조 개선으로 유지보수성과 확장성이 향상되었습니다.
또한, 계층 변경 기능을 추가하여 보다 직관적인 구조 관리를 가능하게 하였습니다. 🚀