### PR TITLE
refactor: Ministry, MinistryGroup, Group의 계층 이동 로직 정리 및 제한 추가

### DIFF
--- a/backend/src/management/const/group-depth.const.ts
+++ b/backend/src/management/const/group-depth.const.ts
@@ -1,0 +1,1 @@
+export const GROUP_MAX_DEPTH = 5;

--- a/backend/src/management/groups/const/exception/group.exception.ts
+++ b/backend/src/management/groups/const/exception/group.exception.ts
@@ -5,4 +5,5 @@ export const GroupException = {
   CANNOT_SET_SUBGROUP_AS_PARENT:
     '현재 하위 그룹을 새로운 상위 그룹으로 지정할 수 없습니다.',
   GROUP_HAS_DEPENDENCIES: '해당 그룹에 속한 하위 그룹 또는 교인이 존재합니다.',
+  UPDATE_ERROR: '업데이트 도중 에러 발생',
 };

--- a/backend/src/management/groups/controller/groups.controller.ts
+++ b/backend/src/management/groups/controller/groups.controller.ts
@@ -9,7 +9,7 @@ import {
   Post,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { GroupsService } from '../service/groups.service';
 import { CreateGroupDto } from '../dto/create-group.dto';
 import { UpdateGroupDto } from '../dto/update-group.dto';
@@ -45,6 +45,10 @@ export class GroupsController {
     return this.groupsService.getGroupByIdWithParents(churchId, groupId);
   }
 
+  @ApiOperation({
+    summary: '그룹 수정',
+    description: '상위 그룹을 없애려는 경우 ministryGroupId 를 null 로 설정',
+  })
   @Patch(':groupId')
   @UseInterceptors(TransactionInterceptor)
   patchGroup(

--- a/backend/src/management/groups/dto/create-group.dto.ts
+++ b/backend/src/management/groups/dto/create-group.dto.ts
@@ -24,5 +24,5 @@ export class CreateGroupDto extends PickType(GroupModel, [
   })
   @IsNumber()
   @IsOptional()
-  override parentGroupId: number;
+  override parentGroupId: number | null;
 }

--- a/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
+++ b/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
@@ -52,10 +52,11 @@ export interface IGroupsDomainService {
   ): Promise<GroupModel>;
 
   updateGroup(
-    churchId: number,
-    groupId: number,
+    church: ChurchModel,
+    targetGroup: GroupModel,
     dto: UpdateGroupDto,
     qr: QueryRunner,
+    newParentGroup: GroupModel | null,
   ): Promise<GroupModel>;
 
   deleteGroup(

--- a/backend/src/management/ministries/const/ministry-group.exception.ts
+++ b/backend/src/management/ministries/const/ministry-group.exception.ts
@@ -5,4 +5,5 @@ export const MinistryGroupException = {
   CANNOT_SET_SUBGROUP_AS_PARENT:
     '현재 하위 그룹을 새로운 상위 그룹으로 지정할 수 없습니다.',
   GROUP_HAS_DEPENDENCIES: '해당 그룹에 속한 사역이 존재합니다.',
+  UPDATE_ERROR: '업데이트 도중 에러 발생',
 };

--- a/backend/src/management/ministries/controller/ministries.controller.ts
+++ b/backend/src/management/ministries/controller/ministries.controller.ts
@@ -53,7 +53,7 @@ export class MinistriesController {
   @ApiOperation({
     summary: '사역 수정',
     description:
-      '소속 사역 그룹을 없애려는 경우 ministryGroupId 를 0 으로 설정',
+      '소속 사역 그룹을 없애려는 경우 ministryGroupId 를 null 로 설정',
   })
   @Patch(':ministryId')
   @UseInterceptors(TransactionInterceptor)

--- a/backend/src/management/ministries/controller/ministry-groups.controller.ts
+++ b/backend/src/management/ministries/controller/ministry-groups.controller.ts
@@ -51,7 +51,7 @@ export class MinistryGroupsController {
   @ApiOperation({
     summary: '사역 그룹 수정',
     description:
-      '최상위 그룹으로 설정하려는 경우 parentMinistryGroupId 를 0 으로 설정',
+      '최상위 그룹으로 설정하려는 경우 parentMinistryGroupId 를 null 로 설정',
   })
   @Patch(':ministryGroupId')
   @UseInterceptors(TransactionInterceptor)

--- a/backend/src/management/ministries/dto/create-ministry-group.dto.ts
+++ b/backend/src/management/ministries/dto/create-ministry-group.dto.ts
@@ -33,5 +33,5 @@ export class CreateMinistryGroupDto extends PickType(MinistryGroupModel, [
   })
   @IsNumber()
   @IsOptional()
-  override parentMinistryGroupId: number;
+  override parentMinistryGroupId: number | null;
 }

--- a/backend/src/management/ministries/dto/create-ministry.dto.ts
+++ b/backend/src/management/ministries/dto/create-ministry.dto.ts
@@ -38,5 +38,5 @@ export class CreateMinistryDto /*extends PickType(MinistryModel, [
   @Min(0)
   @IsNumber()
   @IsOptional()
-  ministryGroupId: number;
+  ministryGroupId: number | null;
 }

--- a/backend/src/management/ministries/ministries-domain/interface/ministries-domain.service.interface.ts
+++ b/backend/src/management/ministries/ministries-domain/interface/ministries-domain.service.interface.ts
@@ -31,8 +31,8 @@ export interface IMinistriesDomainService {
   createMinistry(
     church: ChurchModel,
     dto: CreateMinistryDto,
+    ministryGroup: MinistryGroupModel | null,
     qr?: QueryRunner,
-    ministryGroup?: MinistryGroupModel,
   ): Promise<MinistryModel>;
 
   updateMinistry(

--- a/backend/src/management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface.ts
+++ b/backend/src/management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface.ts
@@ -58,9 +58,10 @@ export interface IMinistryGroupsDomainService {
 
   updateMinistryGroup(
     church: ChurchModel,
-    ministryGroupId: number,
+    targetMinistryGroup: MinistryGroupModel,
     dto: UpdateMinistryGroupDto,
     qr: QueryRunner,
+    newParentMinistryGroup: MinistryGroupModel | null,
   ): Promise<MinistryGroupWithParentGroups>;
 
   deleteMinistryGroup(

--- a/backend/src/management/ministries/ministries-domain/ministries-domain.service.ts
+++ b/backend/src/management/ministries/ministries-domain/ministries-domain.service.ts
@@ -30,7 +30,7 @@ export class MinistriesDomainService implements IMinistriesDomainService {
 
   private async isExistMinistry(
     churchId: number,
-    ministryGroupId: number,
+    ministryGroup: MinistryGroupModel | null,
     name: string,
     qr?: QueryRunner,
   ) {
@@ -39,7 +39,7 @@ export class MinistriesDomainService implements IMinistriesDomainService {
     const ministry = await ministriesRepository.findOne({
       where: {
         churchId,
-        ministryGroupId: ministryGroupId ? ministryGroupId : IsNull(),
+        ministryGroupId: ministryGroup === null ? IsNull() : ministryGroup.id,
         name,
       },
     });
@@ -117,14 +117,14 @@ export class MinistriesDomainService implements IMinistriesDomainService {
   async createMinistry(
     church: ChurchModel,
     dto: CreateMinistryDto,
+    ministryGroup: MinistryGroupModel | null,
     qr?: QueryRunner,
-    ministryGroup?: MinistryGroupModel,
   ) {
     const ministriesRepository = this.getMinistriesRepository(qr);
 
     const isExistMinistry = await this.isExistMinistry(
       church.id,
-      dto.ministryGroupId,
+      ministryGroup,
       dto.name,
       qr,
     );
@@ -136,7 +136,7 @@ export class MinistriesDomainService implements IMinistriesDomainService {
     return ministriesRepository.save({
       name: dto.name,
       churchId: church.id,
-      ministryGroup,
+      ministryGroup: ministryGroup ? ministryGroup : undefined,
     });
   }
 
@@ -145,16 +145,15 @@ export class MinistriesDomainService implements IMinistriesDomainService {
     targetMinistry: MinistryModel,
     dto: UpdateMinistryDto,
     qr: QueryRunner,
-    newMinistryGroup?: MinistryGroupModel | null,
+    newMinistryGroup: MinistryGroupModel | null,
   ) {
     const ministriesRepository = this.getMinistriesRepository(qr);
 
-    const newMinistryGroupId = newMinistryGroup ? newMinistryGroup.id : 0;
     const newName = dto.name ? dto.name : targetMinistry.name;
 
     const isExist = await this.isExistMinistry(
       church.id,
-      newMinistryGroupId,
+      newMinistryGroup,
       newName,
       qr,
     );
@@ -170,7 +169,7 @@ export class MinistriesDomainService implements IMinistriesDomainService {
       },
       {
         name: dto.name,
-        ministryGroupId: dto.ministryGroupId === 0 ? null : dto.ministryGroupId,
+        ministryGroupId: newMinistryGroup === null ? null : newMinistryGroup.id,
       },
     );
 

--- a/backend/src/management/ministries/service/ministry-group.service.ts
+++ b/backend/src/management/ministries/service/ministry-group.service.ts
@@ -92,11 +92,31 @@ export class MinistryGroupService {
       qr,
     );
 
+    const targetMinistryGroup =
+      await this.ministryGroupsDomainService.findMinistryGroupModelById(
+        church,
+        ministryGroupId,
+        qr,
+        { parentMinistryGroup: true },
+      );
+
+    const newParentMinistryGroup: MinistryGroupModel | null =
+      dto.parentMinistryGroupId === undefined
+        ? targetMinistryGroup.parentMinistryGroup // 변경하지 않는 경우 (기존 값 유지) nullable
+        : dto.parentMinistryGroupId === null
+          ? null // 상위 사역 그룹을 없애는 경우 (최상위 계층으로 이동)
+          : await this.ministryGroupsDomainService.findMinistryGroupModelById(
+              church,
+              dto.parentMinistryGroupId,
+              qr,
+            ); // 새 상위 사역 그룹으로 변경
+
     return this.ministryGroupsDomainService.updateMinistryGroup(
       church,
-      ministryGroupId,
+      targetMinistryGroup,
       dto,
       qr,
+      newParentMinistryGroup,
     );
   }
 

--- a/backend/src/management/ministries/service/ministry.service.ts
+++ b/backend/src/management/ministries/service/ministry.service.ts
@@ -84,19 +84,21 @@ export class MinistryService {
       qr,
     );
 
+    // 소속 사역 그룹을 설정할 경우 해당 그룹 조회
+    // 설정하지 않을 경우 null
     const ministryGroup = dto.ministryGroupId
       ? await this.ministryGroupsDomainService.findMinistryGroupModelById(
           church,
           dto.ministryGroupId,
           qr,
         )
-      : undefined;
+      : null;
 
     return this.ministriesDomainService.createMinistry(
       church,
       dto,
-      qr,
       ministryGroup,
+      qr,
     );
   }
 
@@ -134,15 +136,16 @@ export class MinistryService {
         },
       );
 
-    let newMinistryGroup: MinistryGroupModel | null = dto.ministryGroupId
-      ? await this.ministryGroupsDomainService.findMinistryGroupModelById(
-          church,
-          dto.ministryGroupId,
-          qr,
-        )
-      : targetMinistry.ministryGroup;
-
-    if (dto.ministryGroupId === 0) newMinistryGroup = null;
+    const newMinistryGroup: MinistryGroupModel | null =
+      dto.ministryGroupId === undefined
+        ? targetMinistry.ministryGroup // 변경하지 않는 경우 (기존 값 유지)
+        : dto.ministryGroupId === null
+          ? null // 소속 사역 그룹을 없애는 경우
+          : await this.ministryGroupsDomainService.findMinistryGroupModelById(
+              church,
+              dto.ministryGroupId,
+              qr,
+            ); // 새 사역 그룹으로 변경
 
     return this.ministriesDomainService.updateMinistry(
       church,


### PR DESCRIPTION
## 주요 내용
`Ministry`, `MinistryGroup`, `Group`의 업데이트 로직에서 계층 이동에 대한 처리를 명확하게 정리하였으며, 그룹 이동 시 깊이 제한을 추가하여 구조적 일관성을 유지하도록 개선하였습니다.

## 세부 내용
- 계층 이동 시 입력 값 처리 방식 정리
  - 소속 그룹을 없애거나 최상위 계층으로 변경할 경우 `parentGroupId = null` 설정
  - 이름만 변경할 경우 `parentGroupId = undefined` 유지
  - 특정 그룹의 하위 계층으로 이동할 경우 해당 그룹의 ID를 입력하도록 변경
- 그룹 이동 시 깊이 제한 추가
  - 상위 그룹과 이동 대상의 `depth` 합이 `5`를 초과할 경우 `BadRequestException` 응답

이번 변경을 통해 계층 이동 로직이 보다 명확하고 일관되게 정리되었으며,
비정상적인 계층 이동을 방지하여 데이터 구조의 안정성을 강화하였습니다. 🚀