### PR TITLE
fix: 교육 업데이트 시 description이 사라지는 버그 수정

### DIFF
--- a/backend/src/management/educations/dto/education/create-education.dto.ts
+++ b/backend/src/management/educations/dto/education/create-education.dto.ts
@@ -36,5 +36,5 @@ export class CreateEducationDto extends PickType(EducationModel, [
   @MaxLength(300)
   @Transform(({ value }) => value?.trim() ?? '')
   @IsOptional()
-  override description: string = '';
+  override description: string;
 }


### PR DESCRIPTION
## 주요 내용
교육 정보를 업데이트할 때 `description` 값을 명시하지 않으면 기존 내용이 사라지는 버그를 수정하였습니다.

## 세부 내용
- 업데이트 요청에서 `description` 값이 명시되지 않은 경우 기존 값을 유지하도록 로직 수정
- 부분 업데이트 시 기존 데이터 보존을 위한 처리 로직 보완
- 관련 테스트 및 예외 케이스 검증

이번 수정으로 인해 `description` 입력이 누락되더라도 기존 값이 유지되며,
안정적인 데이터 업데이트가 가능해졌습니다. 🚀