### PR TITLE
refactor: EducationEnrollment 도메인 로직 분리 및 인터페이스 기반 의존성 적용

### DIFF
--- a/backend/src/management/educations/const/exception/education.exception.ts
+++ b/backend/src/management/educations/const/exception/education.exception.ts
@@ -11,3 +11,10 @@ export const EducationTermException = {
   UPDATE_ERROR: '교육 기수 업데이트 도중 에러 발생',
   DELETE_ERROR: '교육 기수 삭제 도중 에러 발생',
 };
+
+export const EducationEnrollmentException = {
+  ALREADY_EXIST: '이미 교육 대상자로 등록된 교인입니다.',
+  NOT_FOUND: '해당 교육 대상자 내역을 찾을 수 없습니다.',
+  UPDATE_ERROR: '교육 대상자 업데이트 도중 에러 발생',
+  DELETE_ERROR: '교육 대상자 삭제 도중 에러 발생',
+};

--- a/backend/src/management/educations/controller/education-terms.controller.ts
+++ b/backend/src/management/educations/controller/education-terms.controller.ts
@@ -22,10 +22,7 @@ import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 @ApiTags('Management:Educations:Terms')
 @Controller('educations/:educationId/terms')
 export class EducationTermsController {
-  constructor(
-    //private readonly educationService: EducationsService,
-    private readonly educationTermService: EducationTermService,
-  ) {}
+  constructor(private readonly educationTermService: EducationTermService) {}
 
   @ApiOperation({
     summary: '교육 기수 조회',
@@ -36,7 +33,6 @@ export class EducationTermsController {
     @Param('educationId', ParseIntPipe) educationId: number,
     @Query() dto: GetEducationTermDto,
   ) {
-    //return this.educationService.getEducationTerms(churchId, educationId, dto);
     return this.educationTermService.getEducationTerms(
       churchId,
       educationId,
@@ -61,12 +57,6 @@ export class EducationTermsController {
       dto,
       qr,
     );
-    /*return this.educationService.createEducationTerm(
-      churchId,
-      educationId,
-      dto,
-      qr,
-    );*/
   }
 
   @ApiOperation({
@@ -83,11 +73,6 @@ export class EducationTermsController {
       educationId,
       educationTermId,
     );
-    /*return this.educationService.getEducationTermById(
-      churchId,
-      educationId,
-      educationTermId,
-    );*/
   }
 
   @ApiOperation({
@@ -109,14 +94,6 @@ export class EducationTermsController {
       dto,
       qr,
     );
-
-    /*return this.educationService.updateEducationTerm(
-      churchId,
-      educationId,
-      educationTermId,
-      dto,
-      qr,
-    );*/
   }
 
   @ApiOperation({ summary: '교육 기수 삭제' })
@@ -131,11 +108,6 @@ export class EducationTermsController {
       educationId,
       educationTermId,
     );
-
-    /*return this.educationService.deleteEducationTerm(
-      educationId,
-      educationTermId,
-    );*/
   }
 
   @ApiOperation({
@@ -158,12 +130,5 @@ export class EducationTermsController {
       educationTermId,
       qr,
     );
-
-    /*return this.educationService.syncSessionAttendances(
-      churchId,
-      educationId,
-      educationTermId,
-      qr,
-    );*/
   }
 }

--- a/backend/src/management/educations/dto/education-enrollment-pagination-result.dto.ts
+++ b/backend/src/management/educations/dto/education-enrollment-pagination-result.dto.ts
@@ -1,0 +1,5 @@
+import { BasePaginationResultDto } from '../../../common/dto/base-pagination-result.dto';
+import { EducationEnrollmentModel } from '../../entity/education/education-enrollment.entity';
+
+export interface EducationEnrollmentPaginationResultDto
+  extends BasePaginationResultDto<EducationEnrollmentModel> {}

--- a/backend/src/management/educations/service/education-domain/education-domain.module.ts
+++ b/backend/src/management/educations/service/education-domain/education-domain.module.ts
@@ -6,9 +6,22 @@ import { EducationDomainService } from './service/education-domain.service';
 import { IEDUCATION_TERM_DOMAIN_SERVICE } from './interface/education-term-domain.service.interface';
 import { EducationTermDomainService } from './service/educaiton-term-domain.service';
 import { EducationTermModel } from '../../../entity/education/education-term.entity';
+import { IEDUCATION_ENROLLMENT_DOMAIN_SERVICE } from './interface/education-enrollment-domain.service.interface';
+import { EducationEnrollmentsDomainService } from './service/education-enrollments-domain.service';
+import { EducationEnrollmentModel } from '../../../entity/education/education-enrollment.entity';
+import { EducationSessionModel } from '../../../entity/education/education-session.entity';
+import { SessionAttendanceModel } from '../../../entity/education/session-attendance.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([EducationModel, EducationTermModel])],
+  imports: [
+    TypeOrmModule.forFeature([
+      EducationModel,
+      EducationTermModel,
+      EducationEnrollmentModel,
+      EducationSessionModel,
+      SessionAttendanceModel,
+    ]),
+  ],
   providers: [
     {
       provide: IEDUCATION_DOMAIN_SERVICE,
@@ -18,7 +31,15 @@ import { EducationTermModel } from '../../../entity/education/education-term.ent
       provide: IEDUCATION_TERM_DOMAIN_SERVICE,
       useClass: EducationTermDomainService,
     },
+    {
+      provide: IEDUCATION_ENROLLMENT_DOMAIN_SERVICE,
+      useClass: EducationEnrollmentsDomainService,
+    },
   ],
-  exports: [IEDUCATION_DOMAIN_SERVICE, IEDUCATION_TERM_DOMAIN_SERVICE],
+  exports: [
+    IEDUCATION_DOMAIN_SERVICE,
+    IEDUCATION_TERM_DOMAIN_SERVICE,
+    IEDUCATION_ENROLLMENT_DOMAIN_SERVICE,
+  ],
 })
 export class EducationDomainModule {}

--- a/backend/src/management/educations/service/education-domain/interface/education-enrollment-domain.service.interface.ts
+++ b/backend/src/management/educations/service/education-domain/interface/education-enrollment-domain.service.interface.ts
@@ -1,0 +1,43 @@
+import { EducationEnrollmentPaginationResultDto } from '../../../dto/education-enrollment-pagination-result.dto';
+import { EducationTermModel } from '../../../../entity/education/education-term.entity';
+import { GetEducationEnrollmentDto } from '../../../dto/enrollments/get-education-enrollment.dto';
+import { QueryRunner } from 'typeorm';
+import { MemberModel } from '../../../../../churches/members/entity/member.entity';
+import { EducationEnrollmentModel } from '../../../../entity/education/education-enrollment.entity';
+import { CreateEducationEnrollmentDto } from '../../../dto/enrollments/create-education-enrollment.dto';
+import { UpdateEducationEnrollmentDto } from '../../../dto/enrollments/update-education-enrollment.dto';
+
+export const IEDUCATION_ENROLLMENT_DOMAIN_SERVICE = Symbol(
+  'IEDUCATION_ENROLLMENT_DOMAIN_SERVICE',
+);
+
+export interface IEducationEnrollmentsDomainService {
+  findEducationEnrollments(
+    educationTerm: EducationTermModel,
+    dto: GetEducationEnrollmentDto,
+    qr?: QueryRunner,
+  ): Promise<EducationEnrollmentPaginationResultDto>;
+
+  findMemberEducationEnrollments(
+    member: MemberModel,
+    qr?: QueryRunner,
+  ): Promise<EducationEnrollmentModel[]>;
+
+  createEducationEnrollment(
+    educationTerm: EducationTermModel,
+    member: MemberModel,
+    dto: CreateEducationEnrollmentDto,
+    qr: QueryRunner,
+  ): Promise<EducationEnrollmentModel>;
+
+  updateEducationEnrollment(
+    educationEnrollment: EducationEnrollmentModel,
+    dto: UpdateEducationEnrollmentDto,
+    qr: QueryRunner,
+  ): Promise<EducationEnrollmentModel>;
+
+  deleteEducationEnrollment(
+    educationEnrollment: EducationEnrollmentModel,
+    qr: QueryRunner,
+  ): Promise<string>;
+}

--- a/backend/src/management/educations/service/education-domain/service/education-enrollments-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/education-enrollments-domain.service.ts
@@ -1,0 +1,212 @@
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { IEducationEnrollmentsDomainService } from '../interface/education-enrollment-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EducationEnrollmentModel } from '../../../../entity/education/education-enrollment.entity';
+import { FindOptionsRelations, QueryRunner, Repository } from 'typeorm';
+import { EducationTermModel } from '../../../../entity/education/education-term.entity';
+import { GetEducationEnrollmentDto } from '../../../dto/enrollments/get-education-enrollment.dto';
+import { EducationEnrollmentOrderEnum } from '../../../const/order.enum';
+import { MemberModel } from '../../../../../churches/members/entity/member.entity';
+import { EducationEnrollmentException } from '../../../const/exception/education.exception';
+import { CreateEducationEnrollmentDto } from '../../../dto/enrollments/create-education-enrollment.dto';
+import { UpdateEducationEnrollmentDto } from '../../../dto/enrollments/update-education-enrollment.dto';
+
+@Injectable()
+export class EducationEnrollmentsDomainService
+  implements IEducationEnrollmentsDomainService
+{
+  constructor(
+    @InjectRepository(EducationEnrollmentModel)
+    private readonly educationEnrollmentsRepository: Repository<EducationEnrollmentModel>,
+  ) {}
+
+  private getEducationEnrollmentsRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(EducationEnrollmentModel)
+      : this.educationEnrollmentsRepository;
+  }
+
+  private async isExistEnrollment(
+    educationTerm: EducationTermModel,
+    member: MemberModel,
+    qr?: QueryRunner,
+  ) {
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    const enrollment = await educationEnrollmentsRepository.findOne({
+      where: {
+        educationTermId: educationTerm.id,
+        memberId: member.id,
+      },
+    });
+
+    return !!enrollment;
+  }
+
+  async findEducationEnrollments(
+    educationTerm: EducationTermModel,
+    dto: GetEducationEnrollmentDto,
+    qr?: QueryRunner,
+  ) {
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    const [result, totalCount] = await Promise.all([
+      educationEnrollmentsRepository.find({
+        where: {
+          educationTermId: educationTerm.id,
+        },
+        relations: {
+          member: {
+            group: true,
+            groupRole: true,
+            officer: true,
+          },
+        },
+        order: {
+          [dto.order]: dto.orderDirection,
+          createdAt:
+            dto.order === EducationEnrollmentOrderEnum.createdAt
+              ? undefined
+              : 'desc',
+        },
+        take: dto.take,
+        skip: dto.take * (dto.page - 1),
+      }),
+      educationEnrollmentsRepository.count({
+        where: {
+          educationTermId: educationTerm.id,
+        },
+      }),
+    ]);
+
+    return {
+      data: result,
+      totalCount,
+      count: result.length,
+      page: dto.page,
+    };
+  }
+
+  async findMemberEducationEnrollments(member: MemberModel, qr?: QueryRunner) {
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    return await educationEnrollmentsRepository.find({
+      where: {
+        memberId: member.id,
+      },
+      relations: {
+        educationTerm: true,
+      },
+    });
+  }
+
+  private async getEducationEnrollmentModelById(
+    educationEnrollmentId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<EducationEnrollmentModel>,
+  ) {
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    const enrollment = await educationEnrollmentsRepository.findOne({
+      where: {
+        id: educationEnrollmentId,
+      },
+      relations: relationOptions,
+    });
+
+    if (!enrollment) {
+      throw new NotFoundException(EducationEnrollmentException.NOT_FOUND);
+    }
+
+    return enrollment;
+  }
+
+  async createEducationEnrollment(
+    educationTerm: EducationTermModel,
+    member: MemberModel,
+    dto: CreateEducationEnrollmentDto,
+    qr: QueryRunner,
+  ): Promise<EducationEnrollmentModel> {
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    const isExistEnrollment = await this.isExistEnrollment(
+      educationTerm,
+      member,
+      qr,
+    );
+    if (isExistEnrollment) {
+      throw new BadRequestException(EducationEnrollmentException.ALREADY_EXIST);
+    }
+
+    return educationEnrollmentsRepository.save({
+      member,
+      educationTerm,
+      status: dto.status,
+      note: dto.note,
+    });
+  }
+
+  async updateEducationEnrollment(
+    educationEnrollment: EducationEnrollmentModel,
+    dto: UpdateEducationEnrollmentDto,
+    qr: QueryRunner,
+  ) {
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    await educationEnrollmentsRepository.update(
+      {
+        id: educationEnrollment.id,
+      },
+      {
+        status: dto.status,
+        note: dto.note,
+      },
+    );
+
+    const updated = await educationEnrollmentsRepository.findOne({
+      where: {
+        id: educationEnrollment.id,
+      },
+      relations: {
+        member: {
+          group: true,
+          groupRole: true,
+          officer: true,
+        },
+      },
+    });
+
+    if (!updated) {
+      throw new InternalServerErrorException(
+        EducationEnrollmentException.UPDATE_ERROR,
+      );
+    }
+
+    return updated;
+  }
+
+  async deleteEducationEnrollment(
+    educationEnrollment: EducationEnrollmentModel,
+    qr: QueryRunner,
+  ) {
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    await educationEnrollmentsRepository.softDelete({
+      id: educationEnrollment.id,
+    });
+
+    return `educationEnrollment: ${educationEnrollment.id} deleted`;
+  }
+}

--- a/backend/src/management/educations/service/education-enrollment.service.ts
+++ b/backend/src/management/educations/service/education-enrollment.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  Inject,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -13,6 +14,10 @@ import { UpdateEducationEnrollmentDto } from '../dto/enrollments/update-educatio
 import { EducationTermEnrollmentSyncService } from './sync/education-term-enrollment-sync.service';
 import { EducationEnrollmentAttendanceSyncService } from './sync/education-enrollment-attendance-sync.service';
 import { MembersService } from '../../../churches/members/service/members.service';
+import {
+  IEDUCATION_ENROLLMENT_DOMAIN_SERVICE,
+  IEducationEnrollmentsDomainService,
+} from './education-domain/interface/education-enrollment-domain.service.interface';
 
 @Injectable()
 export class EducationEnrollmentService {
@@ -23,6 +28,9 @@ export class EducationEnrollmentService {
     private readonly membersService: MembersService,
     private readonly educationTermEnrollmentSyncService: EducationTermEnrollmentSyncService,
     private readonly educationEnrollmentAttendanceSyncService: EducationEnrollmentAttendanceSyncService,
+
+    @Inject(IEDUCATION_ENROLLMENT_DOMAIN_SERVICE)
+    private readonly educationEnrollmentsDomain: IEducationEnrollmentsDomainService,
   ) {}
 
   private getEducationEnrollmentsRepository(qr?: QueryRunner) {


### PR DESCRIPTION
## 주요 내용
`EducationEnrollmentService`의 도메인 로직을 `EducationEnrollmentDomainService`로 분리하고, 도메인 서비스는 인터페이스를 통해 의존하도록 구조를 개선하였습니다.

## 세부 내용
- `EducationEnrollmentDomainService` 인터페이스 선언 및 구현
- 도메인 관련 로직을 기존 `EducationEnrollmentService`에서 분리하여 도메인 서비스로 이동
- 인터페이스 기반 DI 적용으로 결합도 감소 및 테스트 용이성 향상

이번 변경을 통해 서비스 계층과 도메인 계층의 책임이 명확히 분리되었으며,
모듈 간 유연성과 유지보수성이 크게 향상되었습니다. 🚀