### PR TITLE
refactor: EducationEnrollmentService 도메인 접근 방식 개선 및 구조 정리

### DIFF
--- a/backend/src/management/educations/educations.module.ts
+++ b/backend/src/management/educations/educations.module.ts
@@ -16,7 +16,6 @@ import { EducationTermService } from './service/education-term.service';
 import { SessionAttendanceService } from './service/session-attendance.service';
 import { EducationTermSessionSyncService } from './service/sync/education-term-session-sync.service';
 import { EducationTermAttendanceSyncService } from './service/sync/education-term-attendance-sync.service';
-import { EducationTermEnrollmentSyncService } from './service/sync/education-term-enrollment-sync.service';
 import { EducationEnrollmentAttendanceSyncService } from './service/sync/education-enrollment-attendance-sync.service';
 import { EducationEnrollmentSessionSyncService } from './service/sync/education-enrollment-session-sync.service';
 import { RouterModule } from '@nestjs/core';
@@ -63,7 +62,7 @@ import { ChurchesDomainModule } from '../../churches/churches-domain/churches-do
     //EducationTermSyncService,
     EducationTermSessionSyncService,
     EducationTermAttendanceSyncService,
-    EducationTermEnrollmentSyncService,
+    //EducationTermEnrollmentSyncService,
     EducationEnrollmentAttendanceSyncService,
     EducationEnrollmentSessionSyncService,
   ],

--- a/backend/src/management/educations/service/education-domain/interface/education-enrollment-domain.service.interface.ts
+++ b/backend/src/management/educations/service/education-domain/interface/education-enrollment-domain.service.interface.ts
@@ -1,7 +1,7 @@
 import { EducationEnrollmentPaginationResultDto } from '../../../dto/education-enrollment-pagination-result.dto';
 import { EducationTermModel } from '../../../../entity/education/education-term.entity';
 import { GetEducationEnrollmentDto } from '../../../dto/enrollments/get-education-enrollment.dto';
-import { QueryRunner } from 'typeorm';
+import { FindOptionsRelations, QueryRunner } from 'typeorm';
 import { MemberModel } from '../../../../../churches/members/entity/member.entity';
 import { EducationEnrollmentModel } from '../../../../entity/education/education-enrollment.entity';
 import { CreateEducationEnrollmentDto } from '../../../dto/enrollments/create-education-enrollment.dto';
@@ -22,6 +22,18 @@ export interface IEducationEnrollmentsDomainService {
     member: MemberModel,
     qr?: QueryRunner,
   ): Promise<EducationEnrollmentModel[]>;
+
+  findEducationEnrollmentById(
+    educationTerm: EducationTermModel,
+    educationEnrollmentId: number,
+    qr?: QueryRunner,
+  ): Promise<EducationEnrollmentModel>;
+
+  findEducationEnrollmentModelById(
+    educationEnrollmentId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<EducationEnrollmentModel>,
+  ): Promise<EducationEnrollmentModel>;
 
   createEducationEnrollment(
     educationTerm: EducationTermModel,

--- a/backend/src/management/educations/service/education-domain/interface/education-term-domain.service.interface.ts
+++ b/backend/src/management/educations/service/education-domain/interface/education-term-domain.service.interface.ts
@@ -1,13 +1,14 @@
 import { ChurchModel } from '../../../../../churches/entity/church.entity';
 import { EducationModel } from '../../../../entity/education/education.entity';
 import { GetEducationTermDto } from '../../../dto/terms/get-education-term.dto';
-import { FindOptionsRelations, QueryRunner } from 'typeorm';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { EducationTermPaginationResultDto } from '../../../dto/education-term-pagination-result.dto';
 import { EducationTermModel } from '../../../../entity/education/education-term.entity';
 import { MemberModel } from '../../../../../churches/members/entity/member.entity';
 import { CreateEducationTermDto } from '../../../dto/terms/create-education-term.dto';
 import { EducationEnrollmentModel } from '../../../../entity/education/education-enrollment.entity';
 import { UpdateEducationTermDto } from '../../../dto/terms/update-education-term.dto';
+import { EducationStatus } from '../../../const/education-status.enum';
 
 export const IEDUCATION_TERM_DOMAIN_SERVICE = Symbol(
   'IEDUCATION_TERM_DOMAIN_SERVICE',
@@ -64,4 +65,26 @@ export interface IEducationTermDomainService {
     educationName: string,
     qr: QueryRunner,
   ): Promise<void>;
+
+  increaseEnrollmentCount(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  decrementEnrollmentCount(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  incrementEducationStatusCount(
+    educationTerm: EducationTermModel,
+    status: EducationStatus,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  decrementEducationStatusCount(
+    educationTerm: EducationTermModel,
+    status: EducationStatus,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
 }

--- a/backend/src/management/educations/service/education-domain/service/educaiton-term-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/educaiton-term-domain.service.ts
@@ -18,6 +18,7 @@ import { CreateEducationTermDto } from '../../../dto/terms/create-education-term
 import { MemberModel } from '../../../../../churches/members/entity/member.entity';
 import { UpdateEducationTermDto } from '../../../dto/terms/update-education-term.dto';
 import { EducationEnrollmentModel } from '../../../../entity/education/education-enrollment.entity';
+import { EducationStatus } from '../../../const/education-status.enum';
 
 @Injectable()
 export class EducationTermDomainService implements IEducationTermDomainService {
@@ -25,6 +26,12 @@ export class EducationTermDomainService implements IEducationTermDomainService {
     @InjectRepository(EducationTermModel)
     private readonly educationTermsRepository: Repository<EducationTermModel>,
   ) {}
+
+  private CountColumnMap = {
+    [EducationStatus.IN_PROGRESS]: 'inProgressCount',
+    [EducationStatus.COMPLETED]: 'completedCount',
+    [EducationStatus.INCOMPLETE]: 'incompleteCount',
+  };
 
   private getEducationTermsRepository(qr?: QueryRunner) {
     return qr
@@ -322,5 +329,87 @@ export class EducationTermDomainService implements IEducationTermDomainService {
         educationName,
       },
     );
+  }
+
+  async increaseEnrollmentCount(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ) {
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+
+    const result = await educationTermsRepository.increment(
+      { id: educationTerm.id },
+      'enrollmentCount',
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+    }
+
+    return result;
+  }
+
+  async decrementEnrollmentCount(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ) {
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+
+    const result = await educationTermsRepository.decrement(
+      { id: educationTerm.id },
+      'enrollmentCount',
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+    }
+
+    return result;
+  }
+
+  async incrementEducationStatusCount(
+    educationTerm: EducationTermModel,
+    status: EducationStatus,
+    qr: QueryRunner,
+  ) {
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+
+    const result = await educationTermsRepository.increment(
+      {
+        id: educationTerm.id,
+      },
+      this.CountColumnMap[status],
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+    }
+
+    return result;
+  }
+
+  async decrementEducationStatusCount(
+    educationTerm: EducationTermModel,
+    status: EducationStatus,
+    qr: QueryRunner,
+  ) {
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+
+    const result = await educationTermsRepository.decrement(
+      {
+        id: educationTerm.id,
+      },
+      this.CountColumnMap[status],
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+    }
+
+    return result;
   }
 }

--- a/backend/src/management/educations/service/education-domain/service/education-enrollments-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/education-enrollments-domain.service.ts
@@ -108,7 +108,36 @@ export class EducationEnrollmentsDomainService
     });
   }
 
-  private async getEducationEnrollmentModelById(
+  async findEducationEnrollmentById(
+    educationTerm: EducationTermModel,
+    educationEnrollmentId: number,
+    qr?: QueryRunner,
+  ) {
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    const enrollment = await educationEnrollmentsRepository.findOne({
+      where: {
+        educationTermId: educationTerm.id,
+        id: educationEnrollmentId,
+      },
+      relations: {
+        member: {
+          group: true,
+          groupRole: true,
+          officer: true,
+        },
+      },
+    });
+
+    if (!enrollment) {
+      throw new NotFoundException(EducationEnrollmentException.NOT_FOUND);
+    }
+
+    return enrollment;
+  }
+
+  async findEducationEnrollmentModelById(
     educationEnrollmentId: number,
     qr?: QueryRunner,
     relationOptions?: FindOptionsRelations<EducationEnrollmentModel>,

--- a/backend/src/management/educations/service/education-enrollment.service.ts
+++ b/backend/src/management/educations/service/education-enrollment.service.ts
@@ -1,43 +1,42 @@
-import {
-  BadRequestException,
-  Inject,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { EducationEnrollmentModel } from '../../entity/education/education-enrollment.entity';
-import { QueryRunner, Repository } from 'typeorm';
+import { Inject, Injectable } from '@nestjs/common';
+import { QueryRunner } from 'typeorm';
 import { GetEducationEnrollmentDto } from '../dto/enrollments/get-education-enrollment.dto';
-import { EducationEnrollmentOrderEnum } from '../const/order.enum';
 import { CreateEducationEnrollmentDto } from '../dto/enrollments/create-education-enrollment.dto';
 import { UpdateEducationEnrollmentDto } from '../dto/enrollments/update-education-enrollment.dto';
-import { EducationTermEnrollmentSyncService } from './sync/education-term-enrollment-sync.service';
 import { EducationEnrollmentAttendanceSyncService } from './sync/education-enrollment-attendance-sync.service';
 import { MembersService } from '../../../churches/members/service/members.service';
 import {
   IEDUCATION_ENROLLMENT_DOMAIN_SERVICE,
   IEducationEnrollmentsDomainService,
 } from './education-domain/interface/education-enrollment-domain.service.interface';
+import {
+  IEDUCATION_TERM_DOMAIN_SERVICE,
+  IEducationTermDomainService,
+} from './education-domain/interface/education-term-domain.service.interface';
+import {
+  IEDUCATION_DOMAIN_SERVICE,
+  IEducationDomainService,
+} from './education-domain/interface/education-domain.service.interface';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../../churches/churches-domain/interface/churches-domain.service.interface';
 
 @Injectable()
 export class EducationEnrollmentService {
   constructor(
-    @InjectRepository(EducationEnrollmentModel)
-    private readonly educationEnrollmentsRepository: Repository<EducationEnrollmentModel>,
-
     private readonly membersService: MembersService,
-    private readonly educationTermEnrollmentSyncService: EducationTermEnrollmentSyncService,
     private readonly educationEnrollmentAttendanceSyncService: EducationEnrollmentAttendanceSyncService,
 
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IEDUCATION_DOMAIN_SERVICE)
+    private readonly educationDomainService: IEducationDomainService,
+    @Inject(IEDUCATION_TERM_DOMAIN_SERVICE)
+    private readonly educationTermDomainService: IEducationTermDomainService,
     @Inject(IEDUCATION_ENROLLMENT_DOMAIN_SERVICE)
-    private readonly educationEnrollmentsDomain: IEducationEnrollmentsDomainService,
+    private readonly educationEnrollmentsDomainService: IEducationEnrollmentsDomainService,
   ) {}
-
-  private getEducationEnrollmentsRepository(qr?: QueryRunner) {
-    return qr
-      ? qr.manager.getRepository(EducationEnrollmentModel)
-      : this.educationEnrollmentsRepository;
-  }
 
   async getEducationEnrollments(
     churchId: number,
@@ -46,7 +45,31 @@ export class EducationEnrollmentService {
     dto: GetEducationEnrollmentDto,
     qr?: QueryRunner,
   ) {
-    const educationEnrollmentsRepository =
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+    const education = await this.educationDomainService.findEducationModelById(
+      church,
+      educationId,
+      qr,
+    );
+
+    const educationTerm =
+      await this.educationTermDomainService.findEducationTermModelById(
+        church,
+        education,
+        educationTermId,
+        qr,
+      );
+
+    return this.educationEnrollmentsDomainService.findEducationEnrollments(
+      educationTerm,
+      dto,
+      qr,
+    );
+
+    /*const educationEnrollmentsRepository =
       this.getEducationEnrollmentsRepository(qr);
 
     const [result, totalCount] = await Promise.all([
@@ -95,7 +118,7 @@ export class EducationEnrollmentService {
       totalCount,
       count: result.length,
       page: dto.page,
-    };
+    };*/
   }
 
   async getMemberEducationEnrollments(
@@ -103,7 +126,19 @@ export class EducationEnrollmentService {
     churchId: number,
     qr?: QueryRunner,
   ) {
-    const educationEnrollmentsRepository =
+    const member = await this.membersService.getMemberModelById(
+      churchId,
+      memberId,
+      {},
+      qr,
+    );
+
+    return this.educationEnrollmentsDomainService.findMemberEducationEnrollments(
+      member,
+      qr,
+    );
+
+    /*const educationEnrollmentsRepository =
       this.getEducationEnrollmentsRepository(qr);
 
     const enrollments = await educationEnrollmentsRepository.find({
@@ -120,10 +155,10 @@ export class EducationEnrollmentService {
       },
     });
 
-    return enrollments;
+    return enrollments;*/
   }
 
-  async getEducationEnrollmentModelById(
+  /*async getEducationEnrollmentModelById(
     educationEnrollmentId: number,
     qr?: QueryRunner,
   ) {
@@ -141,9 +176,9 @@ export class EducationEnrollmentService {
     }
 
     return enrollment;
-  }
+  }*/
 
-  async getEducationEnrollmentById(
+  /*async getEducationEnrollmentById(
     churchId: number,
     educationId: number,
     educationTermId: number,
@@ -171,9 +206,9 @@ export class EducationEnrollmentService {
     }
 
     return enrollment;
-  }
+  }*/
 
-  async isExistEnrollment(
+  /*async isExistEnrollment(
     educationTermId: number,
     memberId: number,
     qr?: QueryRunner,
@@ -189,7 +224,7 @@ export class EducationEnrollmentService {
     });
 
     return !!enrollment;
-  }
+  }*/
 
   async createEducationEnrollment(
     churchId: number,
@@ -198,8 +233,15 @@ export class EducationEnrollmentService {
     dto: CreateEducationEnrollmentDto,
     qr: QueryRunner,
   ) {
-    const educationEnrollmentsRepository =
-      this.getEducationEnrollmentsRepository();
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+    const education = await this.educationDomainService.findEducationModelById(
+      church,
+      educationId,
+      qr,
+    );
 
     const member = await this.membersService.getMemberModelById(
       churchId,
@@ -208,7 +250,15 @@ export class EducationEnrollmentService {
       qr,
     );
 
-    const [educationTerm, isExistEnrollment] = await Promise.all([
+    const educationTerm =
+      await this.educationTermDomainService.findEducationTermModelById(
+        church,
+        education,
+        educationTermId,
+        qr,
+      );
+
+    /*const [educationTerm, isExistEnrollment] = await Promise.all([
       this.educationTermEnrollmentSyncService.getEducationTermModelById(
         churchId,
         educationId,
@@ -221,15 +271,23 @@ export class EducationEnrollmentService {
 
     if (isExistEnrollment) {
       throw new BadRequestException('이미 교육 대상자로 등록된 교인입니다.');
-    }
+    }*/
 
-    // enrollment 생성
+    /*// enrollment 생성
     const enrollment = await educationEnrollmentsRepository.save({
       member,
       educationTerm,
       status: dto.status,
       note: dto.note,
-    });
+    });*/
+
+    const enrollment =
+      await this.educationEnrollmentsDomainService.createEducationEnrollment(
+        educationTerm,
+        member,
+        dto,
+        qr,
+      );
 
     // 교육 등록 생성 후속 작업
     const educationSessionIds = educationTerm.educationSessions.map(
@@ -239,16 +297,25 @@ export class EducationEnrollmentService {
     // 수강 대상 교인 수 증가 + 세션의 출석 정보 생성
     await Promise.all([
       // 교육 수강자 수 증가
-      this.educationTermEnrollmentSyncService.incrementEnrollmentCount(
-        educationTermId,
+      this.educationTermDomainService.increaseEnrollmentCount(
+        educationTerm,
         qr,
       ),
-      // 교육 수강자 상태 통계값 업데이트
-      this.educationTermEnrollmentSyncService.incrementEducationStatusCount(
+      /*this.educationTermEnrollmentSyncService.incrementEnrollmentCount(
         educationTermId,
+        qr,
+      ),*/
+      // 교육 수강자 상태 통계값 업데이트
+      this.educationTermDomainService.incrementEducationStatusCount(
+        educationTerm,
         dto.status,
         qr,
       ),
+      /*this.educationTermEnrollmentSyncService.incrementEducationStatusCount(
+        educationTermId,
+        dto.status,
+        qr,
+      ),*/
       // 수강자의 출석 정보 생성
       this.educationEnrollmentAttendanceSyncService.createSessionAttendanceForNewEnrollment(
         enrollment,
@@ -257,18 +324,11 @@ export class EducationEnrollmentService {
       ),
     ]);
 
-    return educationEnrollmentsRepository.findOne({
-      where: {
-        id: enrollment.id,
-      },
-      relations: {
-        member: {
-          group: true,
-          groupRole: true,
-          officer: true,
-        },
-      },
-    });
+    return this.educationEnrollmentsDomainService.findEducationEnrollmentById(
+      educationTerm,
+      educationTermId,
+      qr,
+    );
   }
 
   async updateEducationEnrollment(
@@ -279,37 +339,72 @@ export class EducationEnrollmentService {
     dto: UpdateEducationEnrollmentDto,
     qr: QueryRunner,
   ) {
-    const educationEnrollmentsRepository =
-      this.getEducationEnrollmentsRepository(qr);
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+    const education = await this.educationDomainService.findEducationModelById(
+      church,
+      educationId,
+      qr,
+    );
+    const educationTerm =
+      await this.educationTermDomainService.findEducationTermModelById(
+        church,
+        education,
+        educationTermId,
+        qr,
+      );
 
-    const targetEducationEnrollment = await this.getEducationEnrollmentById(
+    const targetEducationEnrollment =
+      await this.educationEnrollmentsDomainService.findEducationEnrollmentModelById(
+        educationEnrollmentId,
+        qr,
+      );
+
+    /*const targetEducationEnrollment = await this.getEducationEnrollmentById(
       churchId,
       educationId,
       educationTermId,
       educationEnrollmentId,
       qr,
-    );
+    );*/
 
     // 교육 이수 상태 변경 시 해당 기수의 이수자 통계 업데이트
     // 교육 이수 상태를 변경 && 기존 이수 상태와 다를 경우
     if (dto.status && dto.status !== targetEducationEnrollment.status) {
       await Promise.all([
         // 기존 status 감소
-        this.educationTermEnrollmentSyncService.decrementEducationStatusCount(
-          educationTermId,
+        this.educationTermDomainService.decrementEducationStatusCount(
+          educationTerm,
           targetEducationEnrollment.status,
           qr,
         ),
-        // 새 status 증가
-        this.educationTermEnrollmentSyncService.incrementEducationStatusCount(
+        /*this.educationTermEnrollmentSyncService.decrementEducationStatusCount(
           educationTermId,
+          targetEducationEnrollment.status,
+          qr,
+        ),*/
+        // 새 status 증가
+        this.educationTermDomainService.incrementEducationStatusCount(
+          educationTerm,
           dto.status,
           qr,
         ),
+        /*this.educationTermEnrollmentSyncService.incrementEducationStatusCount(
+          educationTermId,
+          dto.status,
+          qr,
+        ),*/
       ]);
     }
 
-    // 교육등록 업데이트
+    await this.educationEnrollmentsDomainService.updateEducationEnrollment(
+      targetEducationEnrollment,
+      dto,
+      qr,
+    );
+    /*// 교육등록 업데이트
     await educationEnrollmentsRepository.update(
       {
         id: educationEnrollmentId,
@@ -319,20 +414,13 @@ export class EducationEnrollmentService {
         status: dto.status,
         note: dto.note,
       },
-    );
+    );*/
 
-    return educationEnrollmentsRepository.findOne({
-      where: {
-        id: targetEducationEnrollment.id,
-      },
-      relations: {
-        member: {
-          group: true,
-          groupRole: true,
-          officer: true,
-        },
-      },
-    });
+    return this.educationEnrollmentsDomainService.findEducationEnrollmentById(
+      educationTerm,
+      educationEnrollmentId,
+      qr,
+    );
   }
 
   async deleteEducationEnrollment(
@@ -343,16 +431,36 @@ export class EducationEnrollmentService {
     qr: QueryRunner,
     memberDeleted: boolean = false,
   ) {
-    const educationEnrollmentsRepository =
-      this.getEducationEnrollmentsRepository(qr);
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+    const education = await this.educationDomainService.findEducationModelById(
+      church,
+      educationId,
+      qr,
+    );
+    const educationTerm =
+      await this.educationTermDomainService.findEducationTermModelById(
+        church,
+        education,
+        educationTermId,
+        qr,
+      );
 
-    const targetEnrollment = await this.getEducationEnrollmentById(
+    const targetEnrollment =
+      await this.educationEnrollmentsDomainService.findEducationEnrollmentModelById(
+        educationEnrollmentId,
+        qr,
+      );
+
+    /*const targetEnrollment = await this.getEducationEnrollmentById(
       churchId,
       educationId,
       educationTermId,
       educationEnrollmentId,
       qr,
-    );
+    );*/
 
     const member = memberDeleted
       ? await this.membersService.getDeleteMemberModelById(
@@ -372,21 +480,34 @@ export class EducationEnrollmentService {
       // 교인 - 교육 관계 해제
       this.membersService.endMemberEducation(member, educationEnrollmentId, qr),
       // 등록 인원 감소
-      this.educationTermEnrollmentSyncService.decrementEnrollmentCount(
-        educationTermId,
+      this.educationTermDomainService.decrementEnrollmentCount(
+        educationTerm,
         qr,
       ),
-      // 상태별 카운트 감소
-      this.educationTermEnrollmentSyncService.decrementEducationStatusCount(
+      /*this.educationTermEnrollmentSyncService.decrementEnrollmentCount(
         educationTermId,
+        qr,
+      ),*/
+      // 상태별 카운트 감소
+      this.educationTermDomainService.decrementEducationStatusCount(
+        educationTerm,
         targetEnrollment.status,
         qr,
       ),
+      /*this.educationTermEnrollmentSyncService.decrementEducationStatusCount(
+        educationTermId,
+        targetEnrollment.status,
+        qr,
+      ),*/
       // 교육 등록 삭제
-      educationEnrollmentsRepository.softDelete({
+      this.educationEnrollmentsDomainService.deleteEducationEnrollment(
+        targetEnrollment,
+        qr,
+      ),
+      /*educationEnrollmentsRepository.softDelete({
         id: educationEnrollmentId,
         educationTermId,
-      }),
+      }),*/
       // 출석 정보 삭제
       this.educationEnrollmentAttendanceSyncService.deleteSessionAttendanceByEnrollmentDeletion(
         educationEnrollmentId,


### PR DESCRIPTION
## 주요 내용
`EducationEnrollmentService`의 데이터 접근 방식을 도메인 서비스 기반으로 개선하고, 교육 기수(`EducationTerm`) 접근 시 기존 `EducationTermEnrollmentSyncService`를 제거하고 `EducationTermDomainService`를 통해 접근하도록 구조를 변경하였습니다.

## 세부 내용
- `EducationEnrollmentService`에서 직접 `EducationEnrollmentRepository`를 조회하던 로직 제거
- 대신 `EducationEnrollmentDomainService`를 통해 데이터 조회 및 처리
- `EducationTermEnrollmentSyncService` 제거
- 교육 기수 정보는 `EducationTermDomainService`를 통해 접근하도록 변경
- 도메인 계층과 서비스 계층의 역할 분리 및 일관성 있는 구조 정비

이번 변경을 통해 `EducationEnrollmentService`가 도메인 중심 설계 방식에 맞게 개선되었으며, 서비스 간 결합도를 줄이고 유지보수성과 확장성을 강화하였습니다. 🚀