### PR TITLE
refactor: EducationSession 도메인 서비스 분리 및 정렬 버그 수정

### DIFF
--- a/backend/src/management/educations/const/exception/education.exception.ts
+++ b/backend/src/management/educations/const/exception/education.exception.ts
@@ -18,3 +18,10 @@ export const EducationEnrollmentException = {
   UPDATE_ERROR: '교육 대상자 업데이트 도중 에러 발생',
   DELETE_ERROR: '교육 대상자 삭제 도중 에러 발생',
 };
+
+export const EducationSessionException = {
+  ALREADY_EXIST: '',
+  NOT_FOUND: '해당 교육 세션을 찾을 수 없습니다.',
+  UPDATE_ERROR: '교육 세션 업데이트 도중 에러 발생',
+  DELETE_ERROR: '교육 세션 삭제 도중 에러 발생',
+};

--- a/backend/src/management/educations/controller/education-terms.controller.ts
+++ b/backend/src/management/educations/controller/education-terms.controller.ts
@@ -97,16 +97,19 @@ export class EducationTermsController {
   }
 
   @ApiOperation({ summary: '교육 기수 삭제' })
+  @UseInterceptors(TransactionInterceptor)
   @Delete(':educationTermId')
   deleteEducationTerm(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('educationId', ParseIntPipe) educationId: number,
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
+    @QueryRunner() qr: QR,
   ) {
     return this.educationTermService.deleteEducationTerm(
       churchId,
       educationId,
       educationTermId,
+      qr,
     );
   }
 

--- a/backend/src/management/educations/dto/sessions/update-education-session.dto.ts
+++ b/backend/src/management/educations/dto/sessions/update-education-session.dto.ts
@@ -19,12 +19,12 @@ export class UpdateEducationSessionDto {
 
   @ApiProperty({
     description: '교육 일시',
-    default: new Date(),
+    //default: new Date(),
     required: false,
   })
   @IsOptional()
   @IsDate()
-  sessionDate: Date = new Date();
+  sessionDate: Date;
 
   @ApiProperty({
     description: '교육 진행 내용 (최대 300자, 빈 문자열 허용)',

--- a/backend/src/management/educations/educations.module.ts
+++ b/backend/src/management/educations/educations.module.ts
@@ -14,7 +14,6 @@ import { EducationSessionService } from './service/educaiton-session.service';
 import { EducationEnrollmentService } from './service/education-enrollment.service';
 import { EducationTermService } from './service/education-term.service';
 import { SessionAttendanceService } from './service/session-attendance.service';
-import { EducationTermSessionSyncService } from './service/sync/education-term-session-sync.service';
 import { EducationTermAttendanceSyncService } from './service/sync/education-term-attendance-sync.service';
 import { EducationEnrollmentAttendanceSyncService } from './service/sync/education-enrollment-attendance-sync.service';
 import { EducationEnrollmentSessionSyncService } from './service/sync/education-enrollment-session-sync.service';
@@ -60,7 +59,7 @@ import { ChurchesDomainModule } from '../../churches/churches-domain/churches-do
     EducationTermService,
     SessionAttendanceService,
     //EducationTermSyncService,
-    EducationTermSessionSyncService,
+    //EducationTermSessionSyncService,
     EducationTermAttendanceSyncService,
     //EducationTermEnrollmentSyncService,
     EducationEnrollmentAttendanceSyncService,

--- a/backend/src/management/educations/service/educaiton-session.service.ts
+++ b/backend/src/management/educations/service/educaiton-session.service.ts
@@ -1,44 +1,52 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { EducationSessionModel } from '../../entity/education/education-session.entity';
-import { MoreThan, QueryRunner, Repository } from 'typeorm';
+import { QueryRunner, Repository } from 'typeorm';
 import { SessionAttendanceModel } from '../../entity/education/session-attendance.entity';
 import { UpdateEducationSessionDto } from '../dto/sessions/update-education-session.dto';
-import { EducationTermSessionSyncService } from './sync/education-term-session-sync.service';
 import { EducationEnrollmentSessionSyncService } from './sync/education-enrollment-session-sync.service';
+import {
+  IEDUCATION_SESSION_DOMAIN_SERVICE,
+  IEducationSessionDomainService,
+} from './education-domain/interface/education-session-domain.service.interface';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IEDUCATION_DOMAIN_SERVICE,
+  IEducationDomainService,
+} from './education-domain/interface/education-domain.service.interface';
+import {
+  IEDUCATION_TERM_DOMAIN_SERVICE,
+  IEducationTermDomainService,
+} from './education-domain/interface/education-term-domain.service.interface';
 
 @Injectable()
 export class EducationSessionService {
   constructor(
-    @InjectRepository(EducationSessionModel)
-    private readonly educationSessionsRepository: Repository<EducationSessionModel>,
-    /*@InjectRepository(EducationTermModel)
-    private readonly educationTermsRepository: Repository<EducationTermModel>,*/
-    /*@InjectRepository(EducationEnrollmentModel)
-    private readonly educationEnrollmentsRepository: Repository<EducationEnrollmentModel>,*/
+    /*@InjectRepository(EducationSessionModel)
+    private readonly educationSessionsRepository: Repository<EducationSessionModel>,*/
+
     @InjectRepository(SessionAttendanceModel)
     private readonly sessionAttendanceRepository: Repository<SessionAttendanceModel>,
 
-    private readonly educationTermSessionSyncService: EducationTermSessionSyncService,
+    //private readonly educationTermSessionSyncService: EducationTermSessionSyncService,
     private readonly educationEnrollmentSessionSyncService: EducationEnrollmentSessionSyncService,
+
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IEDUCATION_DOMAIN_SERVICE)
+    private readonly educationDomainService: IEducationDomainService,
+    @Inject(IEDUCATION_TERM_DOMAIN_SERVICE)
+    private readonly educationTermDomainService: IEducationTermDomainService,
+    @Inject(IEDUCATION_SESSION_DOMAIN_SERVICE)
+    private readonly educationSessionDomainService: IEducationSessionDomainService,
   ) {}
 
-  private getEducationSessionsRepository(qr?: QueryRunner) {
+  /*private getEducationSessionsRepository(qr?: QueryRunner) {
     return qr
       ? qr.manager.getRepository(EducationSessionModel)
       : this.educationSessionsRepository;
-  }
-
-  /*private getEducationTermsRepository(qr?: QueryRunner) {
-    return qr
-      ? qr.manager.getRepository(EducationTermModel)
-      : this.educationTermsRepository;
-  }*/
-
-  /*private getEducationEnrollmentsRepository(qr?: QueryRunner) {
-    return qr
-      ? qr.manager.getRepository(EducationEnrollmentModel)
-      : this.educationEnrollmentsRepository;
   }*/
 
   private getSessionAttendanceRepository(qr?: QueryRunner) {
@@ -47,27 +55,61 @@ export class EducationSessionService {
       : this.sessionAttendanceRepository;
   }
 
+  private async getEducationTerm(
+    churchId: number,
+    educationId: number,
+    educationTermId: number,
+    qr?: QueryRunner,
+  ) {
+    const { church, education } = await this.getEducationInfo(
+      churchId,
+      educationId,
+      qr,
+    );
+
+    return this.educationTermDomainService.findEducationTermModelById(
+      church,
+      education,
+      educationTermId,
+      qr,
+    );
+  }
+
+  private async getEducationInfo(
+    churchId: number,
+    educationId: number,
+    qr?: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+    const education = await this.educationDomainService.findEducationModelById(
+      church,
+      educationId,
+      qr,
+    );
+
+    return {
+      church,
+      education,
+    };
+  }
+
   async getEducationSessions(
     churchId: number,
     educationId: number,
     educationTermId: number,
   ) {
-    const educationSessionsRepository = this.getEducationSessionsRepository();
+    const educationTerm = await this.getEducationTerm(
+      churchId,
+      educationId,
+      educationTermId,
+    );
 
-    return educationSessionsRepository.find({
-      where: {
-        educationTerm: {
-          educationId,
-          education: {
-            churchId,
-          },
-        },
-        educationTermId,
-      },
-      order: {
-        session: 'asc',
-      },
-    });
+    return this.educationSessionDomainService.findEducationSessions(
+      educationTerm,
+    );
   }
 
   async getEducationSessionById(
@@ -77,7 +119,19 @@ export class EducationSessionService {
     educationSessionId: number,
     qr?: QueryRunner,
   ) {
-    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
+    const educationTerm = await this.getEducationTerm(
+      churchId,
+      educationId,
+      educationTermId,
+      qr,
+    );
+
+    return this.educationSessionDomainService.findEducationSessionById(
+      educationTerm,
+      educationSessionId,
+      qr,
+    );
+    /*const educationSessionsRepository = this.getEducationSessionsRepository(qr);
 
     const session = await educationSessionsRepository.findOne({
       where: {
@@ -96,7 +150,7 @@ export class EducationSessionService {
       throw new NotFoundException('해당 교육 세션을 찾을 수 없습니다.');
     }
 
-    return session;
+    return session;*/
   }
 
   async createSingleEducationSession(
@@ -105,58 +159,61 @@ export class EducationSessionService {
     educationTermId: number,
     qr: QueryRunner,
   ) {
-    //const educationTermsRepository = this.getEducationTermsRepository(qr);
-    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
+    const { church, education } = await this.getEducationInfo(
+      churchId,
+      educationId,
+    );
 
     const educationTerm =
+      await this.educationTermDomainService.findEducationTermModelById(
+        church,
+        education,
+        educationTermId,
+        qr,
+        { educationEnrollments: true },
+      );
+
+    /*const educationTerm =
       await this.educationTermSessionSyncService.getEducationTermModelById(
         educationId,
         educationTermId,
         qr,
-      );
+      );*/
 
-    /*const educationTerm = await educationTermsRepository.findOne({
-      where: {
-        id: educationTermId,
-        educationId,
-      },
-      relations: {
-        educationEnrollments: true,
-      },
-    });
-
-    if (!educationTerm) {
-      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
-    }*/
-
-    const lastSession = await educationSessionsRepository.findOne({
+    /*const lastSession = await educationSessionsRepository.findOne({
       where: {
         educationTermId: educationTermId,
       },
       order: {
         session: 'desc',
       },
-    });
+    });*/
 
-    const newSessionNumber = lastSession ? lastSession.session + 1 : 1;
+    //const newSessionNumber = lastSession ? lastSession.session + 1 : 1;
 
     // 교육 세션 생성
-    const newSession = await educationSessionsRepository.save({
+    /*const newSession = await educationSessionsRepository.save({
       session: newSessionNumber,
       educationTermId,
-    });
+    });*/
+
+    const newSession =
+      await this.educationSessionDomainService.createSingleEducationSession(
+        educationTerm,
+        qr,
+      );
 
     await Promise.all([
       // 교육 세션 개수 업데이트
-      this.educationTermSessionSyncService.incrementNumberOfSessions(
-        educationTermId,
+      this.educationTermDomainService.incrementNumberOfSessions(
+        educationTerm,
         qr,
       ),
-      /*educationTermsRepository.increment(
-        { id: educationTermId },
-        'numberOfSessions',
-        1,
+      /*this.educationTermSessionSyncService.incrementNumberOfSessions(
+        educationTermId,
+        qr,
       ),*/
+
       // 세션 출석 정보 생성
       this.getSessionAttendanceRepository(qr).save(
         educationTerm.educationEnrollments.map((enrollment) => ({
@@ -166,13 +223,18 @@ export class EducationSessionService {
       ),
     ]);
 
-    return this.getEducationSessionById(
+    return this.educationSessionDomainService.findEducationSessionById(
+      educationTerm,
+      newSession.id,
+      qr,
+    );
+    /*return this.getEducationSessionById(
       churchId,
       educationId,
       educationTermId,
       newSession.id,
       qr,
-    );
+    );*/
   }
 
   async updateEducationSession(
@@ -183,8 +245,7 @@ export class EducationSessionService {
     dto: UpdateEducationSessionDto,
     qr: QueryRunner,
   ) {
-    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
-    //const educationTermsRepository = this.getEducationTermsRepository(qr);
+    /*const educationSessionsRepository = this.getEducationSessionsRepository(qr);
 
     const targetSession = await this.getEducationSessionById(
       churchId,
@@ -192,7 +253,21 @@ export class EducationSessionService {
       educationTermId,
       educationSessionId,
       qr,
+    );*/
+
+    const educationTerm = await this.getEducationTerm(
+      churchId,
+      educationId,
+      educationTermId,
+      qr,
     );
+
+    const targetSession =
+      await this.educationSessionDomainService.findEducationSessionById(
+        educationTerm,
+        educationSessionId,
+        qr,
+      );
 
     /*
     기존 session 의 isDone 이 true
@@ -201,39 +276,33 @@ export class EducationSessionService {
     */
     if (dto.isDone !== undefined && dto.isDone !== targetSession.isDone) {
       if (dto.isDone) {
-        //console.log('isDoneCount 증가');
-        //await this.incrementIsDoneCount(educationTermId, qr);
-        /*await educationTermsRepository.increment(
-          { id: educationTermId },
-          'isDoneCount',
-          1,
-        );*/
-        await this.educationTermSessionSyncService.increaseDoneCount(
-          educationTermId,
+        await this.educationTermDomainService.incrementDoneCount(
+          educationTerm,
           qr,
         );
+        /*await this.educationTermSessionSyncService.increaseDoneCount(
+          educationTermId,
+          qr,
+        );*/
       } else if (!dto.isDone) {
-        //console.log('isDoneCount 감소');
-        //await this.decrementIsDoneCount(educationTermId, qr);
-        /*await educationTermsRepository.decrement(
-          { id: educationTermId },
-          'isDoneCount',
-          1,
-        );*/
-        await this.educationTermSessionSyncService.decreaseDoneCount(
-          educationTermId,
+        await this.educationTermDomainService.decrementDoneCount(
+          educationTerm,
           qr,
         );
+        /*await this.educationTermSessionSyncService.decreaseDoneCount(
+          educationTermId,
+          qr,
+        );*/
       }
     }
 
-    /*
-    기존 session 의 isDone 이 false
-    --> dto.isDone = true -> isDoneCount 증가
-    --> dto.isDone = false --> isDoneCount 변화 X
-     */
+    return this.educationSessionDomainService.updateEducationSession(
+      targetSession,
+      dto,
+      qr,
+    );
 
-    const result = await educationSessionsRepository.update(
+    /*const result = await educationSessionsRepository.update(
       {
         id: targetSession.id,
       },
@@ -250,7 +319,7 @@ export class EducationSessionService {
 
     return educationSessionsRepository.findOne({
       where: { id: educationSessionId },
-    });
+    });*/
   }
 
   async deleteEducationSessions(
@@ -260,7 +329,7 @@ export class EducationSessionService {
     educationSessionId: number,
     qr: QueryRunner,
   ) {
-    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
+    /*const educationSessionsRepository = this.getEducationSessionsRepository(qr);
 
     const targetSession = await this.getEducationSessionById(
       churchId,
@@ -268,45 +337,59 @@ export class EducationSessionService {
       educationTermId,
       educationSessionId,
       qr,
-    );
+    );*/
 
-    // 세션 삭제
-    await educationSessionsRepository.softDelete({
-      id: educationSessionId,
-      educationTermId,
-    });
-
-    //const educationTermsRepository = this.getEducationTermsRepository(qr);
-
-    // 다른 회차들 session 번호 수정
-    await educationSessionsRepository.decrement(
-      { educationTermId, session: MoreThan(targetSession.session) },
-      'session',
-      1,
-    );
-
-    // 해당 기수의 세션 개수 업데이트
-    await this.educationTermSessionSyncService.decreaseSessionCount(
+    const educationTerm = await this.getEducationTerm(
+      churchId,
+      educationId,
       educationTermId,
       qr,
     );
-    /*await educationTermsRepository.decrement(
-      { id: educationTermId },
-      'numberOfSessions',
+
+    const targetSession =
+      await this.educationSessionDomainService.findEducationSessionById(
+        educationTerm,
+        educationSessionId,
+        qr,
+      );
+
+    // 세션 삭제
+    await this.educationSessionDomainService.deleteEducationSession(
+      targetSession,
+      qr,
+    );
+
+    // 다른 회차들 session 번호 수정
+    await this.educationSessionDomainService.reorderSessionsAfterDeletion(
+      educationTerm,
+      targetSession,
+      qr,
+    );
+    /*await educationSessionsRepository.decrement(
+      { educationTermId, session: MoreThan(targetSession.session) },
+      'session',
       1,
     );*/
 
+    // 해당 기수의 세션 개수 업데이트
+    await this.educationTermDomainService.decrementNumberOfSessions(
+      educationTerm,
+      qr,
+    );
+    /*await this.educationTermSessionSyncService.decreaseSessionCount(
+      educationTermId,
+      qr,
+    );*/
+
     if (targetSession.isDone) {
-      await this.educationTermSessionSyncService.decreaseDoneCount(
-        educationTermId,
+      await this.educationTermDomainService.decrementDoneCount(
+        educationTerm,
         qr,
       );
-      /*await educationTermsRepository.decrement(
-        { id: educationTermId },
-        'isDoneCount',
-        1,
+      /*await this.educationTermSessionSyncService.decreaseDoneCount(
+        educationTermId,
+        qr,
       );*/
-      //await this.decrementIsDoneCount(educationTermId, qr);
     }
 
     // 해당 세션 하위의 출석 정보 삭제
@@ -332,16 +415,6 @@ export class EducationSessionService {
       attendedEnrollmentIds,
       qr,
     );
-
-    /*
-    const educationEnrollmentsRepository =
-      this.getEducationEnrollmentsRepository(qr);
-
-    await educationEnrollmentsRepository.decrement(
-      { id: In(attendedEnrollmentIds) },
-      'attendanceCount',
-      1,
-    );*/
 
     return `educationSessionId: ${educationSessionId} deleted`;
   }

--- a/backend/src/management/educations/service/education-domain/education-domain.module.ts
+++ b/backend/src/management/educations/service/education-domain/education-domain.module.ts
@@ -11,6 +11,8 @@ import { EducationEnrollmentsDomainService } from './service/education-enrollmen
 import { EducationEnrollmentModel } from '../../../entity/education/education-enrollment.entity';
 import { EducationSessionModel } from '../../../entity/education/education-session.entity';
 import { SessionAttendanceModel } from '../../../entity/education/session-attendance.entity';
+import { IEDUCATION_SESSION_DOMAIN_SERVICE } from './interface/education-session-domain.service.interface';
+import { EducationSessionDomainService } from './service/education-session-domain.service';
 
 @Module({
   imports: [
@@ -35,11 +37,16 @@ import { SessionAttendanceModel } from '../../../entity/education/session-attend
       provide: IEDUCATION_ENROLLMENT_DOMAIN_SERVICE,
       useClass: EducationEnrollmentsDomainService,
     },
+    {
+      provide: IEDUCATION_SESSION_DOMAIN_SERVICE,
+      useClass: EducationSessionDomainService,
+    },
   ],
   exports: [
     IEDUCATION_DOMAIN_SERVICE,
     IEDUCATION_TERM_DOMAIN_SERVICE,
     IEDUCATION_ENROLLMENT_DOMAIN_SERVICE,
+    IEDUCATION_SESSION_DOMAIN_SERVICE,
   ],
 })
 export class EducationDomainModule {}

--- a/backend/src/management/educations/service/education-domain/interface/education-session-domain.service.interface.ts
+++ b/backend/src/management/educations/service/education-domain/interface/education-session-domain.service.interface.ts
@@ -1,0 +1,60 @@
+import { EducationTermModel } from '../../../../entity/education/education-term.entity';
+import { QueryRunner, UpdateResult } from 'typeorm';
+import { EducationSessionModel } from '../../../../entity/education/education-session.entity';
+import { UpdateEducationSessionDto } from '../../../dto/sessions/update-education-session.dto';
+
+export const IEDUCATION_SESSION_DOMAIN_SERVICE = Symbol(
+  'IEDUCATION_SESSION_DOMAIN_SERVICE',
+);
+
+export interface IEducationSessionDomainService {
+  findEducationSessions(
+    educationTerm: EducationTermModel,
+    qr?: QueryRunner,
+  ): Promise<EducationSessionModel[]>;
+
+  findEducationSessionById(
+    educationTerm: EducationTermModel,
+    educationSessionId: number,
+    qr?: QueryRunner,
+  ): Promise<EducationSessionModel>;
+
+  createEducationSessions(
+    educationTerm: EducationTermModel,
+    numberOfSessions: number,
+    qr: QueryRunner,
+  ): Promise<EducationSessionModel[]>;
+
+  createAdditionalSessions(
+    educationTerm: EducationTermModel,
+    numberOfSessions: number,
+    qr: QueryRunner,
+  ): Promise<EducationSessionModel[]>;
+
+  createSingleEducationSession(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ): Promise<EducationSessionModel>;
+
+  updateEducationSession(
+    educationSession: EducationSessionModel,
+    dto: UpdateEducationSessionDto,
+    qr: QueryRunner,
+  ): Promise<EducationSessionModel>;
+
+  deleteEducationSession(
+    educationSession: EducationSessionModel,
+    qr: QueryRunner,
+  ): Promise<string>;
+
+  deleteEducationSessionCasCade(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ): Promise<string>;
+
+  reorderSessionsAfterDeletion(
+    educationTerm: EducationTermModel,
+    deletedSession: EducationSessionModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+}

--- a/backend/src/management/educations/service/education-domain/interface/education-term-domain.service.interface.ts
+++ b/backend/src/management/educations/service/education-domain/interface/education-term-domain.service.interface.ts
@@ -66,7 +66,7 @@ export interface IEducationTermDomainService {
     qr: QueryRunner,
   ): Promise<void>;
 
-  increaseEnrollmentCount(
+  incrementEnrollmentCount(
     educationTerm: EducationTermModel,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
@@ -85,6 +85,26 @@ export interface IEducationTermDomainService {
   decrementEducationStatusCount(
     educationTerm: EducationTermModel,
     status: EducationStatus,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  incrementNumberOfSessions(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  decrementNumberOfSessions(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  incrementDoneCount(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  decrementDoneCount(
+    educationTerm: EducationTermModel,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 }

--- a/backend/src/management/educations/service/education-domain/service/educaiton-term-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/educaiton-term-domain.service.ts
@@ -7,7 +7,12 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EducationTermModel } from '../../../../entity/education/education-term.entity';
-import { FindOptionsRelations, QueryRunner, Repository } from 'typeorm';
+import {
+  FindOptionsRelations,
+  QueryRunner,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
 import { ChurchModel } from '../../../../../churches/entity/church.entity';
 import { EducationModel } from '../../../../entity/education/education.entity';
 import { GetEducationTermDto } from '../../../dto/terms/get-education-term.dto';
@@ -64,6 +69,16 @@ export class EducationTermDomainService implements IEducationTermDomainService {
   ): Promise<EducationTermPaginationResultDto> {
     const educationTermsRepository = this.getEducationTermsRepository(qr);
 
+    const order: Partial<
+      Record<EducationTermOrderEnum, 'asc' | 'desc' | 'ASC' | 'DESC'>
+    > = {
+      [dto.order]: dto.orderDirection,
+    };
+
+    if (dto.order !== EducationTermOrderEnum.createdAt) {
+      order.createdAt = 'desc';
+    }
+
     const [result, totalCount] = await Promise.all([
       educationTermsRepository.find({
         where: {
@@ -72,11 +87,11 @@ export class EducationTermDomainService implements IEducationTermDomainService {
           },
           educationId: education.id,
         },
-        order: {
+        order /*{
           [dto.order]: dto.orderDirection,
           createdAt:
             dto.order === EducationTermOrderEnum.createdAt ? undefined : 'desc',
-        },
+        }*/,
         relations: {
           instructor: {
             officer: true,
@@ -331,7 +346,7 @@ export class EducationTermDomainService implements IEducationTermDomainService {
     );
   }
 
-  async increaseEnrollmentCount(
+  async incrementEnrollmentCount(
     educationTerm: EducationTermModel,
     qr: QueryRunner,
   ) {
@@ -344,7 +359,9 @@ export class EducationTermDomainService implements IEducationTermDomainService {
     );
 
     if (result.affected === 0) {
-      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+      throw new InternalServerErrorException(
+        EducationTermException.UPDATE_ERROR,
+      );
     }
 
     return result;
@@ -363,7 +380,9 @@ export class EducationTermDomainService implements IEducationTermDomainService {
     );
 
     if (result.affected === 0) {
-      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+      throw new InternalServerErrorException(
+        EducationTermException.UPDATE_ERROR,
+      );
     }
 
     return result;
@@ -385,7 +404,9 @@ export class EducationTermDomainService implements IEducationTermDomainService {
     );
 
     if (result.affected === 0) {
-      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+      throw new InternalServerErrorException(
+        EducationTermException.UPDATE_ERROR,
+      );
     }
 
     return result;
@@ -407,7 +428,91 @@ export class EducationTermDomainService implements IEducationTermDomainService {
     );
 
     if (result.affected === 0) {
-      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
+      throw new InternalServerErrorException(
+        EducationTermException.UPDATE_ERROR,
+      );
+    }
+
+    return result;
+  }
+
+  async incrementNumberOfSessions(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+    const result = await educationTermsRepository.increment(
+      { id: educationTerm.id },
+      'numberOfSessions',
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        EducationTermException.UPDATE_ERROR,
+      );
+    }
+
+    return result;
+  }
+
+  async decrementNumberOfSessions(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+    const result = await educationTermsRepository.decrement(
+      { id: educationTerm.id },
+      'numberOfSessions',
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        EducationTermException.UPDATE_ERROR,
+      );
+    }
+
+    return result;
+  }
+
+  async incrementDoneCount(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const educationTermRepository = this.getEducationTermsRepository(qr);
+
+    const result = await educationTermRepository.increment(
+      { id: educationTerm.id },
+      'isDoneCount',
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        EducationTermException.UPDATE_ERROR,
+      );
+    }
+
+    return result;
+  }
+
+  async decrementDoneCount(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const educationTermRepository = this.getEducationTermsRepository(qr);
+
+    const result = await educationTermRepository.decrement(
+      { id: educationTerm.id },
+      'isDoneCount',
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        EducationTermException.UPDATE_ERROR,
+      );
     }
 
     return result;

--- a/backend/src/management/educations/service/education-domain/service/education-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/education-domain.service.ts
@@ -53,16 +53,22 @@ export class EducationDomainService implements IEducationDomainService {
   ): Promise<EducationPaginationResultDto> {
     const educationsRepository = this.getEducationsRepository(qr);
 
+    const order: Partial<
+      Record<EducationOrderEnum, 'asc' | 'desc' | 'ASC' | 'DESC'>
+    > = {
+      [dto.order]: dto.orderDirection,
+    };
+
+    if (dto.order !== EducationOrderEnum.createdAt) {
+      order.createdAt = 'desc';
+    }
+
     const [result, totalCount] = await Promise.all([
       educationsRepository.find({
         where: {
           churchId: church.id,
         },
-        order: {
-          [dto.order]: dto.orderDirection,
-          createdAt:
-            dto.order !== EducationOrderEnum.createdAt ? 'desc' : undefined,
-        },
+        order,
         take: dto.take,
         skip: dto.take * (dto.page - 1),
       }),

--- a/backend/src/management/educations/service/education-domain/service/education-enrollments-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/education-enrollments-domain.service.ts
@@ -57,6 +57,16 @@ export class EducationEnrollmentsDomainService
     const educationEnrollmentsRepository =
       this.getEducationEnrollmentsRepository(qr);
 
+    const order: Partial<
+      Record<EducationEnrollmentOrderEnum, 'asc' | 'desc' | 'ASC' | 'DESC'>
+    > = {
+      [dto.order]: dto.orderDirection,
+    };
+
+    if (dto.order !== EducationEnrollmentOrderEnum.createdAt) {
+      order.createdAt = 'desc';
+    }
+
     const [result, totalCount] = await Promise.all([
       educationEnrollmentsRepository.find({
         where: {

--- a/backend/src/management/educations/service/education-domain/service/education-session-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/education-session-domain.service.ts
@@ -1,0 +1,218 @@
+import { IEducationSessionDomainService } from '../interface/education-session-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EducationSessionModel } from '../../../../entity/education/education-session.entity';
+import { MoreThan, QueryRunner, Repository } from 'typeorm';
+import { EducationTermModel } from '../../../../entity/education/education-term.entity';
+import {
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { EducationSessionException } from '../../../const/exception/education.exception';
+import { UpdateEducationSessionDto } from '../../../dto/sessions/update-education-session.dto';
+import { session } from 'passport';
+
+export class EducationSessionDomainService
+  implements IEducationSessionDomainService
+{
+  constructor(
+    @InjectRepository(EducationSessionModel)
+    private readonly educationSessionsRepository: Repository<EducationSessionModel>,
+  ) {}
+
+  private getEducationSessionsRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(EducationSessionModel)
+      : this.educationSessionsRepository;
+  }
+
+  async findEducationSessions(
+    educationTerm: EducationTermModel,
+    qr?: QueryRunner,
+  ) {
+    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
+
+    return educationSessionsRepository.find({
+      where: {
+        educationTermId: educationTerm.id,
+      },
+      order: {
+        session: 'asc',
+      },
+    });
+  }
+
+  async findEducationSessionById(
+    educationTerm: EducationTermModel,
+    educationSessionId: number,
+    qr?: QueryRunner,
+  ) {
+    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
+
+    const session = await educationSessionsRepository.findOne({
+      where: {
+        educationTermId: educationTerm.id,
+        id: educationSessionId,
+      },
+    });
+
+    if (!session) {
+      throw new NotFoundException(EducationSessionException.NOT_FOUND);
+    }
+
+    return session;
+  }
+
+  createEducationSessions(
+    educationTerm: EducationTermModel,
+    numberOfSession: number,
+    qr: QueryRunner,
+  ): Promise<EducationSessionModel[]> {
+    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
+
+    return educationSessionsRepository.save(
+      Array.from({ length: numberOfSession }, (_, i) => ({
+        session: i + 1,
+        educationTerm,
+      })),
+    );
+  }
+
+  createAdditionalSessions(
+    educationTerm: EducationTermModel,
+    numberOfSessions: number,
+    qr: QueryRunner,
+  ): Promise<EducationSessionModel[]> {
+    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
+
+    return educationSessionsRepository.save(
+      Array.from(
+        {
+          length: numberOfSessions - educationTerm.educationSessions.length,
+        },
+        (_, index) => ({
+          educationTerm,
+          session: educationTerm.educationSessions.length + index + 1,
+        }),
+      ),
+    );
+  }
+
+  async createSingleEducationSession(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ) {
+    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
+
+    const lastSession = await educationSessionsRepository.findOne({
+      where: {
+        educationTermId: educationTerm.id,
+      },
+      order: {
+        session: 'desc',
+      },
+    });
+
+    const newSessionNumber = lastSession ? lastSession.session + 1 : 1;
+
+    return educationSessionsRepository.save({
+      session: newSessionNumber,
+      educationTerm,
+    });
+  }
+
+  async updateEducationSession(
+    educationSession: EducationSessionModel,
+    dto: UpdateEducationSessionDto,
+    qr: QueryRunner,
+  ) {
+    if (dto.isDone !== undefined && dto.isDone !== educationSession.isDone) {
+      if (dto.isDone) {
+        // EducationTerm 의 doneCount 증가
+      } else {
+        // EducationTerm 의 doneCount 감소
+      }
+    }
+
+    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
+
+    const result = await educationSessionsRepository.update(
+      {
+        id: educationSession.id,
+      },
+      {
+        content: dto.content,
+        sessionDate: dto.sessionDate,
+        isDone: dto.isDone,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        EducationSessionException.UPDATE_ERROR,
+      );
+    }
+
+    const updatedSession = await educationSessionsRepository.findOne({
+      where: {
+        id: educationSession.id,
+      },
+    });
+
+    if (!updatedSession) {
+      throw new InternalServerErrorException(
+        EducationSessionException.UPDATE_ERROR,
+      );
+    }
+
+    return updatedSession;
+  }
+
+  async deleteEducationSession(
+    educationSession: EducationSessionModel,
+    qr: QueryRunner,
+  ) {
+    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
+
+    const result = await educationSessionsRepository.softDelete({
+      id: educationSession.id,
+    });
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        EducationSessionException.DELETE_ERROR,
+      );
+    }
+
+    return `educationSessionId: ${educationSession.id} deleted`;
+  }
+
+  async deleteEducationSessionCasCade(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ): Promise<string> {
+    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
+
+    const result = await educationSessionsRepository.softDelete({
+      educationTermId: educationTerm.id,
+    });
+
+    return `${result.affected} sessions deleted`;
+  }
+
+  async reorderSessionsAfterDeletion(
+    educationTerm: EducationTermModel,
+    deletedSession: EducationSessionModel,
+    qr: QueryRunner,
+  ) {
+    const educationSessionsRepository = this.getEducationSessionsRepository(qr);
+
+    return educationSessionsRepository.decrement(
+      {
+        educationTermId: educationTerm.id,
+        session: MoreThan(deletedSession.session),
+      },
+      'session',
+      1,
+    );
+  }
+}

--- a/backend/src/management/educations/service/education-enrollment.service.ts
+++ b/backend/src/management/educations/service/education-enrollment.service.ts
@@ -297,7 +297,7 @@ export class EducationEnrollmentService {
     // 수강 대상 교인 수 증가 + 세션의 출석 정보 생성
     await Promise.all([
       // 교육 수강자 수 증가
-      this.educationTermDomainService.increaseEnrollmentCount(
+      this.educationTermDomainService.incrementEnrollmentCount(
         educationTerm,
         qr,
       ),

--- a/backend/src/management/educations/service/educations.service.ts
+++ b/backend/src/management/educations/service/educations.service.ts
@@ -161,7 +161,16 @@ export class EducationsService {
       qr,
     );
 
-    const updatedEducation = await this.educationDomainService.updateEducation(
+    // 이름 변경 시 하위 기수들의 교육명 업데이트
+    if (dto.name) {
+      await this.educationTermDomainService.updateEducationTermName(
+        education,
+        dto.name,
+        qr,
+      );
+    }
+
+    return this.educationDomainService.updateEducation(
       church,
       education,
       dto,
@@ -199,17 +208,6 @@ export class EducationsService {
         description: dto.description,
       },
     );*/
-
-    // 이름 변경 시 하위 기수들의 교육명 업데이트
-    if (dto.name) {
-      await this.educationTermDomainService.updateEducationTermName(
-        education,
-        dto.name,
-        qr,
-      );
-    }
-
-    return updatedEducation;
   }
 
   async deleteEducation(


### PR DESCRIPTION
## 주요 내용
`EducationSessionService`의 도메인 로직을 `EducationSessionDomainService`로 분리하고, `EducationDomainService` 및 `EducationTermDomainService`에서 생성일 기준 정렬이 누락되어 있던 문제를 수정하였습니다.

## 세부 내용
- `EducationSessionDomainService` 인터페이스 선언 및 구현
- 기존 도메인 로직을 `EducationSessionService`에서 분리하여 도메인 서비스로 이동
- `EducationSessionService`는 비즈니스 로직에 집중하도록 구조 개선
- `EducationDomainService`, `EducationTermDomainService`에서 목록 조회 시 생성일 기준 정렬 로직 누락된 부분 보완

이번 변경을 통해 교육 세션 관리 구조가 명확히 분리되었으며,
데이터 정렬 관련 버그 수정으로 조회 일관성과 사용자 경험이 향상되었습니다. 🚀