### PR TITLE
fix: EducationEnrollment 생성 및 조회 버그 수정 및 도메인 접근 방식 개선

### DIFF
--- a/backend/src/management/educations/educations.module.ts
+++ b/backend/src/management/educations/educations.module.ts
@@ -16,7 +16,7 @@ import { EducationTermService } from './service/education-term.service';
 import { SessionAttendanceService } from './service/session-attendance.service';
 import { EducationTermAttendanceSyncService } from './service/sync/education-term-attendance-sync.service';
 import { EducationEnrollmentAttendanceSyncService } from './service/sync/education-enrollment-attendance-sync.service';
-import { EducationEnrollmentSessionSyncService } from './service/sync/education-enrollment-session-sync.service';
+//import { EducationEnrollmentSessionSyncService } from './service/sync/education-enrollment-session-sync.service';
 import { RouterModule } from '@nestjs/core';
 import { MembersModule } from '../../churches/members/members.module';
 import { MemberEducationEventHandler } from './service/member-education-event-handler.service';
@@ -63,7 +63,7 @@ import { ChurchesDomainModule } from '../../churches/churches-domain/churches-do
     EducationTermAttendanceSyncService,
     //EducationTermEnrollmentSyncService,
     EducationEnrollmentAttendanceSyncService,
-    EducationEnrollmentSessionSyncService,
+    //EducationEnrollmentSessionSyncService,
   ],
   exports: [/*EducationsService,*/ EducationEnrollmentService],
 })

--- a/backend/src/management/educations/service/educaiton-session.service.ts
+++ b/backend/src/management/educations/service/educaiton-session.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { QueryRunner, Repository } from 'typeorm';
 import { SessionAttendanceModel } from '../../entity/education/session-attendance.entity';
 import { UpdateEducationSessionDto } from '../dto/sessions/update-education-session.dto';
-import { EducationEnrollmentSessionSyncService } from './sync/education-enrollment-session-sync.service';
+//import { EducationEnrollmentSessionSyncService } from './sync/education-enrollment-session-sync.service';
 import {
   IEDUCATION_SESSION_DOMAIN_SERVICE,
   IEducationSessionDomainService,
@@ -20,18 +20,18 @@ import {
   IEDUCATION_TERM_DOMAIN_SERVICE,
   IEducationTermDomainService,
 } from './education-domain/interface/education-term-domain.service.interface';
+import {
+  IEDUCATION_ENROLLMENT_DOMAIN_SERVICE,
+  IEducationEnrollmentsDomainService,
+} from './education-domain/interface/education-enrollment-domain.service.interface';
 
 @Injectable()
 export class EducationSessionService {
   constructor(
-    /*@InjectRepository(EducationSessionModel)
-    private readonly educationSessionsRepository: Repository<EducationSessionModel>,*/
-
     @InjectRepository(SessionAttendanceModel)
     private readonly sessionAttendanceRepository: Repository<SessionAttendanceModel>,
 
-    //private readonly educationTermSessionSyncService: EducationTermSessionSyncService,
-    private readonly educationEnrollmentSessionSyncService: EducationEnrollmentSessionSyncService,
+    //private readonly educationEnrollmentSessionSyncService: EducationEnrollmentSessionSyncService,
 
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,
@@ -41,13 +41,9 @@ export class EducationSessionService {
     private readonly educationTermDomainService: IEducationTermDomainService,
     @Inject(IEDUCATION_SESSION_DOMAIN_SERVICE)
     private readonly educationSessionDomainService: IEducationSessionDomainService,
+    @Inject(IEDUCATION_ENROLLMENT_DOMAIN_SERVICE)
+    private readonly educationEnrollmentsDomainService: IEducationEnrollmentsDomainService,
   ) {}
-
-  /*private getEducationSessionsRepository(qr?: QueryRunner) {
-    return qr
-      ? qr.manager.getRepository(EducationSessionModel)
-      : this.educationSessionsRepository;
-  }*/
 
   private getSessionAttendanceRepository(qr?: QueryRunner) {
     return qr
@@ -131,26 +127,6 @@ export class EducationSessionService {
       educationSessionId,
       qr,
     );
-    /*const educationSessionsRepository = this.getEducationSessionsRepository(qr);
-
-    const session = await educationSessionsRepository.findOne({
-      where: {
-        id: educationSessionId,
-        educationTermId,
-        educationTerm: {
-          educationId,
-          education: {
-            churchId,
-          },
-        },
-      },
-    });
-
-    if (!session) {
-      throw new NotFoundException('해당 교육 세션을 찾을 수 없습니다.');
-    }
-
-    return session;*/
   }
 
   async createSingleEducationSession(
@@ -173,30 +149,6 @@ export class EducationSessionService {
         { educationEnrollments: true },
       );
 
-    /*const educationTerm =
-      await this.educationTermSessionSyncService.getEducationTermModelById(
-        educationId,
-        educationTermId,
-        qr,
-      );*/
-
-    /*const lastSession = await educationSessionsRepository.findOne({
-      where: {
-        educationTermId: educationTermId,
-      },
-      order: {
-        session: 'desc',
-      },
-    });*/
-
-    //const newSessionNumber = lastSession ? lastSession.session + 1 : 1;
-
-    // 교육 세션 생성
-    /*const newSession = await educationSessionsRepository.save({
-      session: newSessionNumber,
-      educationTermId,
-    });*/
-
     const newSession =
       await this.educationSessionDomainService.createSingleEducationSession(
         educationTerm,
@@ -209,10 +161,6 @@ export class EducationSessionService {
         educationTerm,
         qr,
       ),
-      /*this.educationTermSessionSyncService.incrementNumberOfSessions(
-        educationTermId,
-        qr,
-      ),*/
 
       // 세션 출석 정보 생성
       this.getSessionAttendanceRepository(qr).save(
@@ -228,13 +176,6 @@ export class EducationSessionService {
       newSession.id,
       qr,
     );
-    /*return this.getEducationSessionById(
-      churchId,
-      educationId,
-      educationTermId,
-      newSession.id,
-      qr,
-    );*/
   }
 
   async updateEducationSession(
@@ -245,16 +186,6 @@ export class EducationSessionService {
     dto: UpdateEducationSessionDto,
     qr: QueryRunner,
   ) {
-    /*const educationSessionsRepository = this.getEducationSessionsRepository(qr);
-
-    const targetSession = await this.getEducationSessionById(
-      churchId,
-      educationId,
-      educationTermId,
-      educationSessionId,
-      qr,
-    );*/
-
     const educationTerm = await this.getEducationTerm(
       churchId,
       educationId,
@@ -280,19 +211,11 @@ export class EducationSessionService {
           educationTerm,
           qr,
         );
-        /*await this.educationTermSessionSyncService.increaseDoneCount(
-          educationTermId,
-          qr,
-        );*/
       } else if (!dto.isDone) {
         await this.educationTermDomainService.decrementDoneCount(
           educationTerm,
           qr,
         );
-        /*await this.educationTermSessionSyncService.decreaseDoneCount(
-          educationTermId,
-          qr,
-        );*/
       }
     }
 
@@ -301,25 +224,6 @@ export class EducationSessionService {
       dto,
       qr,
     );
-
-    /*const result = await educationSessionsRepository.update(
-      {
-        id: targetSession.id,
-      },
-      {
-        content: dto.content,
-        sessionDate: dto.sessionDate,
-        isDone: dto.isDone,
-      },
-    );
-
-    if (result.affected === 0) {
-      throw new NotFoundException('해당 교육 회차를 찾을 수 없습니다.');
-    }
-
-    return educationSessionsRepository.findOne({
-      where: { id: educationSessionId },
-    });*/
   }
 
   async deleteEducationSessions(
@@ -329,16 +233,6 @@ export class EducationSessionService {
     educationSessionId: number,
     qr: QueryRunner,
   ) {
-    /*const educationSessionsRepository = this.getEducationSessionsRepository(qr);
-
-    const targetSession = await this.getEducationSessionById(
-      churchId,
-      educationId,
-      educationTermId,
-      educationSessionId,
-      qr,
-    );*/
-
     const educationTerm = await this.getEducationTerm(
       churchId,
       educationId,
@@ -365,31 +259,18 @@ export class EducationSessionService {
       targetSession,
       qr,
     );
-    /*await educationSessionsRepository.decrement(
-      { educationTermId, session: MoreThan(targetSession.session) },
-      'session',
-      1,
-    );*/
 
     // 해당 기수의 세션 개수 업데이트
     await this.educationTermDomainService.decrementNumberOfSessions(
       educationTerm,
       qr,
     );
-    /*await this.educationTermSessionSyncService.decreaseSessionCount(
-      educationTermId,
-      qr,
-    );*/
 
     if (targetSession.isDone) {
       await this.educationTermDomainService.decrementDoneCount(
         educationTerm,
         qr,
       );
-      /*await this.educationTermSessionSyncService.decreaseDoneCount(
-        educationTermId,
-        qr,
-      );*/
     }
 
     // 해당 세션 하위의 출석 정보 삭제
@@ -411,10 +292,15 @@ export class EducationSessionService {
       educationSessionId: educationSessionId,
     });
 
-    await this.educationEnrollmentSessionSyncService.decreaseAttendanceCount(
+    await this.educationEnrollmentsDomainService.decrementAttendanceCountBySessionDeletion(
       attendedEnrollmentIds,
       qr,
     );
+
+    /*await this.educationEnrollmentSessionSyncService.decreaseAttendanceCount(
+      attendedEnrollmentIds,
+      qr,
+    );*/
 
     return `educationSessionId: ${educationSessionId} deleted`;
   }

--- a/backend/src/management/educations/service/education-domain/interface/education-enrollment-domain.service.interface.ts
+++ b/backend/src/management/educations/service/education-domain/interface/education-enrollment-domain.service.interface.ts
@@ -19,7 +19,8 @@ export interface IEducationEnrollmentsDomainService {
   ): Promise<EducationEnrollmentPaginationResultDto>;
 
   findMemberEducationEnrollments(
-    member: MemberModel,
+    //member: MemberModel,
+    memberId: number,
     qr?: QueryRunner,
   ): Promise<EducationEnrollmentModel[]>;
 
@@ -52,4 +53,9 @@ export interface IEducationEnrollmentsDomainService {
     educationEnrollment: EducationEnrollmentModel,
     qr: QueryRunner,
   ): Promise<string>;
+
+  decrementAttendanceCountBySessionDeletion(
+    attendedEnrollmentIds: number[],
+    qr: QueryRunner,
+  ): Promise<void>;
 }

--- a/backend/src/management/educations/service/education-domain/service/education-enrollments-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/education-enrollments-domain.service.ts
@@ -7,7 +7,7 @@ import {
 import { IEducationEnrollmentsDomainService } from '../interface/education-enrollment-domain.service.interface';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EducationEnrollmentModel } from '../../../../entity/education/education-enrollment.entity';
-import { FindOptionsRelations, QueryRunner, Repository } from 'typeorm';
+import { FindOptionsRelations, In, QueryRunner, Repository } from 'typeorm';
 import { EducationTermModel } from '../../../../entity/education/education-term.entity';
 import { GetEducationEnrollmentDto } from '../../../dto/enrollments/get-education-enrollment.dto';
 import { EducationEnrollmentOrderEnum } from '../../../const/order.enum';
@@ -104,13 +104,13 @@ export class EducationEnrollmentsDomainService
     };
   }
 
-  async findMemberEducationEnrollments(member: MemberModel, qr?: QueryRunner) {
+  async findMemberEducationEnrollments(memberId: number, qr?: QueryRunner) {
     const educationEnrollmentsRepository =
       this.getEducationEnrollmentsRepository(qr);
 
     return await educationEnrollmentsRepository.find({
       where: {
-        memberId: member.id,
+        memberId: memberId,
       },
       relations: {
         educationTerm: true,
@@ -247,5 +247,19 @@ export class EducationEnrollmentsDomainService
     });
 
     return `educationEnrollment: ${educationEnrollment.id} deleted`;
+  }
+
+  async decrementAttendanceCountBySessionDeletion(
+    attendedEnrollmentIds: number[],
+    qr: QueryRunner,
+  ) {
+    const educationEnrollmentsRepository =
+      this.getEducationEnrollmentsRepository(qr);
+
+    await educationEnrollmentsRepository.decrement(
+      { id: In(attendedEnrollmentIds) },
+      'attendanceCount',
+      1,
+    );
   }
 }

--- a/backend/src/management/educations/service/education-enrollment.service.ts
+++ b/backend/src/management/educations/service/education-enrollment.service.ts
@@ -68,163 +68,7 @@ export class EducationEnrollmentService {
       dto,
       qr,
     );
-
-    /*const educationEnrollmentsRepository =
-      this.getEducationEnrollmentsRepository(qr);
-
-    const [result, totalCount] = await Promise.all([
-      educationEnrollmentsRepository.find({
-        where: {
-          educationTermId,
-          educationTerm: {
-            educationId,
-            education: {
-              churchId,
-            },
-          },
-        },
-        relations: {
-          member: {
-            group: true,
-            groupRole: true,
-            officer: true,
-          },
-        },
-        order: {
-          [dto.order]: dto.orderDirection,
-          createdAt:
-            dto.order === EducationEnrollmentOrderEnum.createdAt
-              ? undefined
-              : 'desc',
-        },
-        take: dto.take,
-        skip: dto.take * (dto.page - 1),
-      }),
-      educationEnrollmentsRepository.count({
-        where: {
-          educationTermId,
-          educationTerm: {
-            educationId,
-            education: {
-              churchId,
-            },
-          },
-        },
-      }),
-    ]);
-
-    return {
-      data: result,
-      totalCount,
-      count: result.length,
-      page: dto.page,
-    };*/
   }
-
-  async getMemberEducationEnrollments(
-    memberId: number,
-    churchId: number,
-    qr?: QueryRunner,
-  ) {
-    const member = await this.membersService.getMemberModelById(
-      churchId,
-      memberId,
-      {},
-      qr,
-    );
-
-    return this.educationEnrollmentsDomainService.findMemberEducationEnrollments(
-      member,
-      qr,
-    );
-
-    /*const educationEnrollmentsRepository =
-      this.getEducationEnrollmentsRepository(qr);
-
-    const enrollments = await educationEnrollmentsRepository.find({
-      where: {
-        memberId,
-        educationTerm: {
-          education: {
-            churchId,
-          },
-        },
-      },
-      relations: {
-        educationTerm: true,
-      },
-    });
-
-    return enrollments;*/
-  }
-
-  /*async getEducationEnrollmentModelById(
-    educationEnrollmentId: number,
-    qr?: QueryRunner,
-  ) {
-    const educationEnrollmentsRepository =
-      this.getEducationEnrollmentsRepository(qr);
-
-    const enrollment = await educationEnrollmentsRepository.findOne({
-      where: {
-        id: educationEnrollmentId,
-      },
-    });
-
-    if (!enrollment) {
-      throw new NotFoundException('해당 교육 대상자 내역을 찾을 수 없습니다.');
-    }
-
-    return enrollment;
-  }*/
-
-  /*async getEducationEnrollmentById(
-    churchId: number,
-    educationId: number,
-    educationTermId: number,
-    educationEnrollmentId: number,
-    qr?: QueryRunner,
-  ) {
-    const educationEnrollmentsRepository =
-      this.getEducationEnrollmentsRepository(qr);
-
-    const enrollment = await educationEnrollmentsRepository.findOne({
-      where: {
-        educationTerm: {
-          educationId,
-          education: {
-            churchId,
-          },
-        },
-        educationTermId,
-        id: educationEnrollmentId,
-      },
-    });
-
-    if (!enrollment) {
-      throw new NotFoundException('해당 교육 대상자 내역을 찾을 수 없습니다.');
-    }
-
-    return enrollment;
-  }*/
-
-  /*async isExistEnrollment(
-    educationTermId: number,
-    memberId: number,
-    qr?: QueryRunner,
-  ) {
-    const educationEnrollmentsRepository =
-      this.getEducationEnrollmentsRepository(qr);
-
-    const enrollment = await educationEnrollmentsRepository.findOne({
-      where: {
-        educationTermId,
-        memberId,
-      },
-    });
-
-    return !!enrollment;
-  }*/
 
   async createEducationEnrollment(
     churchId: number,
@@ -256,30 +100,8 @@ export class EducationEnrollmentService {
         education,
         educationTermId,
         qr,
+        { educationSessions: true },
       );
-
-    /*const [educationTerm, isExistEnrollment] = await Promise.all([
-      this.educationTermEnrollmentSyncService.getEducationTermModelById(
-        churchId,
-        educationId,
-        educationTermId,
-        qr,
-      ),
-
-      this.isExistEnrollment(educationTermId, member.id, qr),
-    ]);
-
-    if (isExistEnrollment) {
-      throw new BadRequestException('이미 교육 대상자로 등록된 교인입니다.');
-    }*/
-
-    /*// enrollment 생성
-    const enrollment = await educationEnrollmentsRepository.save({
-      member,
-      educationTerm,
-      status: dto.status,
-      note: dto.note,
-    });*/
 
     const enrollment =
       await this.educationEnrollmentsDomainService.createEducationEnrollment(
@@ -301,21 +123,14 @@ export class EducationEnrollmentService {
         educationTerm,
         qr,
       ),
-      /*this.educationTermEnrollmentSyncService.incrementEnrollmentCount(
-        educationTermId,
-        qr,
-      ),*/
+
       // 교육 수강자 상태 통계값 업데이트
       this.educationTermDomainService.incrementEducationStatusCount(
         educationTerm,
         dto.status,
         qr,
       ),
-      /*this.educationTermEnrollmentSyncService.incrementEducationStatusCount(
-        educationTermId,
-        dto.status,
-        qr,
-      ),*/
+
       // 수강자의 출석 정보 생성
       this.educationEnrollmentAttendanceSyncService.createSessionAttendanceForNewEnrollment(
         enrollment,
@@ -326,7 +141,7 @@ export class EducationEnrollmentService {
 
     return this.educationEnrollmentsDomainService.findEducationEnrollmentById(
       educationTerm,
-      educationTermId,
+      enrollment.id,
       qr,
     );
   }
@@ -362,14 +177,6 @@ export class EducationEnrollmentService {
         qr,
       );
 
-    /*const targetEducationEnrollment = await this.getEducationEnrollmentById(
-      churchId,
-      educationId,
-      educationTermId,
-      educationEnrollmentId,
-      qr,
-    );*/
-
     // 교육 이수 상태 변경 시 해당 기수의 이수자 통계 업데이트
     // 교육 이수 상태를 변경 && 기존 이수 상태와 다를 경우
     if (dto.status && dto.status !== targetEducationEnrollment.status) {
@@ -380,22 +187,13 @@ export class EducationEnrollmentService {
           targetEducationEnrollment.status,
           qr,
         ),
-        /*this.educationTermEnrollmentSyncService.decrementEducationStatusCount(
-          educationTermId,
-          targetEducationEnrollment.status,
-          qr,
-        ),*/
+
         // 새 status 증가
         this.educationTermDomainService.incrementEducationStatusCount(
           educationTerm,
           dto.status,
           qr,
         ),
-        /*this.educationTermEnrollmentSyncService.incrementEducationStatusCount(
-          educationTermId,
-          dto.status,
-          qr,
-        ),*/
       ]);
     }
 
@@ -404,17 +202,6 @@ export class EducationEnrollmentService {
       dto,
       qr,
     );
-    /*// 교육등록 업데이트
-    await educationEnrollmentsRepository.update(
-      {
-        id: educationEnrollmentId,
-        educationTermId,
-      },
-      {
-        status: dto.status,
-        note: dto.note,
-      },
-    );*/
 
     return this.educationEnrollmentsDomainService.findEducationEnrollmentById(
       educationTerm,
@@ -454,14 +241,6 @@ export class EducationEnrollmentService {
         qr,
       );
 
-    /*const targetEnrollment = await this.getEducationEnrollmentById(
-      churchId,
-      educationId,
-      educationTermId,
-      educationEnrollmentId,
-      qr,
-    );*/
-
     const member = memberDeleted
       ? await this.membersService.getDeleteMemberModelById(
           churchId,
@@ -484,30 +263,20 @@ export class EducationEnrollmentService {
         educationTerm,
         qr,
       ),
-      /*this.educationTermEnrollmentSyncService.decrementEnrollmentCount(
-        educationTermId,
-        qr,
-      ),*/
+
       // 상태별 카운트 감소
       this.educationTermDomainService.decrementEducationStatusCount(
         educationTerm,
         targetEnrollment.status,
         qr,
       ),
-      /*this.educationTermEnrollmentSyncService.decrementEducationStatusCount(
-        educationTermId,
-        targetEnrollment.status,
-        qr,
-      ),*/
+
       // 교육 등록 삭제
       this.educationEnrollmentsDomainService.deleteEducationEnrollment(
         targetEnrollment,
         qr,
       ),
-      /*educationEnrollmentsRepository.softDelete({
-        id: educationEnrollmentId,
-        educationTermId,
-      }),*/
+
       // 출석 정보 삭제
       this.educationEnrollmentAttendanceSyncService.deleteSessionAttendanceByEnrollmentDeletion(
         educationEnrollmentId,

--- a/backend/src/management/educations/service/education-term.service.ts
+++ b/backend/src/management/educations/service/education-term.service.ts
@@ -26,7 +26,7 @@ import {
 export class EducationTermService {
   constructor(
     private readonly membersService: MembersService,
-    //private readonly educationTermSessionSyncService: EducationTermSessionSyncService,
+
     private readonly educationTermAttendanceSyncService: EducationTermAttendanceSyncService,
 
     @Inject(ICHURCHES_DOMAIN_SERVICE)
@@ -61,47 +61,6 @@ export class EducationTermService {
       dto,
       qr,
     );
-    /*const educationTermsRepository = this.getEducationTermsRepository(qr);
-
-    const [result, totalCount] = await Promise.all([
-      educationTermsRepository.find({
-        where: {
-          education: {
-            churchId,
-          },
-          educationId: educationId,
-        },
-        order: {
-          [dto.order]: dto.orderDirection,
-          createdAt:
-            dto.order === EducationTermOrderEnum.createdAt ? undefined : 'desc',
-        },
-        relations: {
-          instructor: {
-            officer: true,
-            group: true,
-            groupRole: true,
-          },
-        },
-        take: dto.take,
-        skip: dto.take * (dto.page - 1),
-      }),
-      educationTermsRepository.count({
-        where: {
-          education: {
-            churchId,
-          },
-          educationId,
-        },
-      }),
-    ]);
-
-    return {
-      data: result,
-      totalCount,
-      count: result.length,
-      page: dto.page,
-    };*/
   }
 
   async getEducationTermById(
@@ -126,88 +85,7 @@ export class EducationTermService {
       educationTermId,
       qr,
     );
-
-    /*const educationTermsRepository = this.getEducationTermsRepository(qr);
-
-    const educationTerm = await educationTermsRepository.findOne({
-      where: {
-        id: educationTermId,
-        educationId,
-        education: {
-          churchId,
-        },
-      },
-      relations: {
-        instructor: {
-          group: true,
-          groupRole: true,
-          officer: true,
-        },
-        /!*educationEnrollments: {
-          member: {
-            group: true,
-            groupRole: true,
-            officer: true,
-          },
-        },*!/
-        educationSessions: true,
-      },
-    });
-
-    if (!educationTerm) {
-      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
-    }
-
-    return educationTerm;*/
   }
-
-  /*async getEducationTermModelById(
-    churchId: number,
-    educationId: number,
-    educationTermId: number,
-    qr?: QueryRunner,
-    relations?: FindOptionsRelations<EducationTermModel>,
-  ) {
-    const educationTermsRepository = this.getEducationTermsRepository(qr);
-
-    const educationTerm = await educationTermsRepository.findOne({
-      where: {
-        id: educationTermId,
-        educationId,
-        education: {
-          churchId,
-        },
-      },
-      relations: {
-        //instructor: true,
-        educationSessions: true,
-        ...relations,
-      },
-    });
-
-    if (!educationTerm) {
-      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
-    }
-
-    return educationTerm;
-  }*/
-
-  /*async isExistEducationTerm(
-    educationId: number,
-    term: number,
-    qr?: QueryRunner,
-  ) {
-    const educationTermsRepository = this.getEducationTermsRepository(qr);
-
-    const educationTerm = await educationTermsRepository.findOne({
-      where: {
-        educationId,
-        term,
-      },
-    });
-
-    return !!educationTerm;
-  }*/
 
   async createEducationTerm(
     churchId: number,
@@ -215,44 +93,6 @@ export class EducationTermService {
     dto: CreateEducationTermDto,
     qr: QueryRunner,
   ) {
-    /*const educationTermsRepository = this.getEducationTermsRepository(qr);
-
-    const education = await this.educationTermSyncService.getEducationModelById(
-      churchId,
-      educationId,
-      qr,
-    );
-
-    const instructor = dto.instructorId
-      ? await this.membersService.getMemberModelById(
-          churchId,
-          dto.instructorId,
-          {},
-          qr,
-        )
-      : undefined;
-
-    const isExistEducationTerm = await this.isExistEducationTerm(
-      educationId,
-      dto.term,
-      qr,
-    );
-
-    if (isExistEducationTerm) {
-      throw new BadRequestException('이미 존재하는 교육 기수입니다.');
-    }
-
-    const educationTerm = await educationTermsRepository.save({
-      educationId,
-      educationName: education.name,
-      term: dto.term, //newTerm,
-      numberOfSessions: dto.numberOfSessions,
-      completionCriteria: dto.completionCriteria,
-      startDate: dto.startDate,
-      endDate: dto.endDate,
-      instructor,
-    });*/
-
     const church = await this.churchesDomainService.findChurchModelById(
       churchId,
       qr,
@@ -288,58 +128,9 @@ export class EducationTermService {
       educationTerm.numberOfSessions,
       qr,
     );
-    /*await this.educationTermSessionSyncService.createEducationSessions(
-      educationTerm.id,
-      educationTerm.numberOfSessions,
-      qr,
-    );*/
 
     return educationTerm;
   }
-
-  /*private validateUpdateEducationTerm(
-    dto: UpdateEducationTermDto,
-    educationTerm: EducationTermModel,
-  ) {
-    // 회자만 수정
-    if (dto.numberOfSessions && !dto.completionCriteria) {
-      if (
-        educationTerm.completionCriteria &&
-        dto.numberOfSessions < educationTerm.completionCriteria
-      ) {
-        throw new BadRequestException(
-          '교육 회차는 이수 조건보다 크거나 같아야합니다.',
-        );
-      }
-    }
-
-    // 이수 조건만 수정
-    if (dto.completionCriteria && !dto.numberOfSessions) {
-      if (dto.completionCriteria > educationTerm.numberOfSessions) {
-        throw new BadRequestException(
-          '이수 조건은 교육 회차보다 작거나 같아야합니다.',
-        );
-      }
-    }
-
-    // 시작일만 수정
-    if (dto.startDate && !dto.endDate) {
-      if (dto.startDate > educationTerm.endDate) {
-        throw new BadRequestException(
-          '교육 시작일은 종료일보다 뒤일 수 없습니다.',
-        );
-      }
-    }
-
-    // 종료일만 수정
-    if (dto.endDate && !dto.startDate) {
-      if (educationTerm.startDate > dto.endDate) {
-        throw new BadRequestException(
-          '교육 종료일은 시작일보다 앞설 수 없습니다.',
-        );
-      }
-    }
-  }*/
 
   async updateEducationTerm(
     churchId: number,
@@ -375,53 +166,6 @@ export class EducationTermService {
       7-1. 진행자가 해당 교회에 소속 --> 정상 업데이트
       7-2. 진행자가 해당 교회에 소속X --> 해당 교인을 찾을 수 없음. NotFoundException
      */
-
-    /*const educationTermsRepository = this.getEducationTermsRepository(qr);
-
-    const educationTerm = await this.getEducationTermModelById(
-        churchId,
-        educationId,
-        educationTermId,
-        qr,
-        { educationEnrollments: true },
-    );
-
-    this.validateUpdateEducationTerm(dto, educationTerm);
-
-    const instructor = dto.instructorId
-      ? await this.membersService.getMemberModelById(
-          churchId,
-          dto.instructorId,
-          {},
-          qr,
-        )
-      : undefined;
-
-    if (dto.term) {
-      const isExistEducationTerm = await this.isExistEducationTerm(
-        educationId,
-        dto.term,
-        qr,
-      );
-
-      if (isExistEducationTerm) {
-        throw new BadRequestException('이미 존재하는 교육 기수입니다.');
-      }
-    }
-
-
-
-    await educationTermsRepository.update(
-      {
-        id: educationTermId,
-      },
-      {
-        ...dto,
-        instructor: instructor,
-      },
-    );
-
-    return educationTermsRepository.findOne({ where: { id: educationTermId } });*/
 
     const church = await this.churchesDomainService.findChurchModelById(
       churchId,
@@ -472,11 +216,6 @@ export class EducationTermService {
           dto.numberOfSessions,
           qr,
         );
-      /*await this.educationTermSessionSyncService.createAdditionalSessions(
-          educationTerm,
-          dto,
-          qr,
-        );*/
 
       // 증가된 세션에 대한 출석 정보 생성
       const newSessionIds = newSessions.map((newSession) => newSession.id);
@@ -529,19 +268,6 @@ export class EducationTermService {
       educationTerm,
       qr,
     );
-
-    /*const educationTermsRepository = this.getEducationTermsRepository(qr);
-
-    const result = await educationTermsRepository.softDelete({
-      educationId,
-      id: educationTermId,
-    });
-
-    if (result.affected === 0) {
-      throw new NotFoundException('해당 교육 기수를 찾을 수 없습니다.');
-    }
-
-    return `educationTermId: ${educationTermId} deleted`;*/
   }
 
   async syncSessionAttendances(

--- a/backend/src/management/educations/service/educations.service.ts
+++ b/backend/src/management/educations/service/educations.service.ts
@@ -38,35 +38,6 @@ export class EducationsService {
     );
 
     return this.educationDomainService.findEducations(church, dto, qr);
-
-    /*const educationsRepository = this.getEducationsRepository(qr);
-
-    const [result, totalCount] = await Promise.all([
-      educationsRepository.find({
-        where: {
-          churchId,
-        },
-        order: {
-          [dto.order]: dto.orderDirection,
-          createdAt:
-            dto.order === EducationOrderEnum.createdAt ? undefined : 'desc',
-        },
-        take: dto.take,
-        skip: dto.take * (dto.page - 1),
-      }),
-      educationsRepository.count({
-        where: {
-          churchId,
-        },
-      }),
-    ]);
-
-    return {
-      data: result,
-      totalCount,
-      count: result.length,
-      page: dto.page,
-    };*/
   }
 
   async getEducationById(
@@ -84,31 +55,6 @@ export class EducationsService {
       educationId,
       qr,
     );
-
-    /*const educationsRepository = this.getEducationsRepository(qr);
-
-    const education = await educationsRepository.findOne({
-      where: {
-        churchId,
-        id: educationId,
-      },
-      relations: {
-        educationTerms: {
-          instructor: true,
-        },
-      },
-      order: {
-        educationTerms: {
-          term: 'asc',
-        },
-      },
-    });
-
-    if (!education) {
-      throw new BadRequestException(EducationException.NOT_FOUND);
-    }
-
-    return education;*/
   }
 
   async createEducation(
@@ -122,26 +68,6 @@ export class EducationsService {
     );
 
     return this.educationDomainService.createEducation(church, dto, qr);
-
-    /*const educationsRepository = this.getEducationsRepository(qr);
-
-    // 교육 이름 중복 체크
-    const existEducationName = await this.isExistEducationName(
-      churchId,
-      dto.name,
-      false,
-      qr,
-    );
-
-    if (existEducationName) {
-      throw new BadRequestException(EducationException.ALREADY_EXIST);
-    }
-
-    return educationsRepository.save({
-      name: dto.name,
-      description: dto.description,
-      churchId,
-    });*/
   }
 
   async updateEducation(
@@ -176,38 +102,6 @@ export class EducationsService {
       dto,
       qr,
     );
-
-    /*const educationsRepository = this.getEducationsRepository(qr);
-
-    const education = await educationsRepository.findOne({
-      where: {
-        churchId,
-        id: educationId,
-      },
-    });
-
-    if (!education) {
-      throw new NotFoundException(EducationException.NOT_FOUND);
-    }
-
-    // 바꾸려는 이름이 존재하는 지 확인
-    const existEducationName = dto.name
-      ? await this.isExistEducationName(churchId, dto.name, false, qr)
-      : false;
-
-    if (existEducationName) {
-      throw new BadRequestException(EducationException.ALREADY_EXIST);
-    }
-
-    await educationsRepository.update(
-      {
-        id: educationId,
-      },
-      {
-        name: dto.name,
-        description: dto.description,
-      },
-    );*/
   }
 
   async deleteEducation(
@@ -228,18 +122,5 @@ export class EducationsService {
       );
 
     return this.educationDomainService.deleteEducation(targetEducation, qr);
-
-    /*const educationsRepository = this.getEducationsRepository(qr);
-
-    const result = await educationsRepository.softDelete({
-      id: educationId,
-      churchId,
-    });
-
-    if (result.affected === 0) {
-      throw new NotFoundException(EducationException.NOT_FOUND);
-    }
-
-    return `educationId: ${educationId} deleted`;*/
   }
 }

--- a/backend/src/management/educations/service/member-education-event-handler.service.ts
+++ b/backend/src/management/educations/service/member-education-event-handler.service.ts
@@ -1,8 +1,12 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 import { MemberDeletedEvent } from '../../../churches/members/events/member.event';
 import { DataSource } from 'typeorm';
 import { EducationEnrollmentService } from './education-enrollment.service';
+import {
+  IEDUCATION_ENROLLMENT_DOMAIN_SERVICE,
+  IEducationEnrollmentsDomainService,
+} from './education-domain/interface/education-enrollment-domain.service.interface';
 
 @Injectable()
 export class MemberEducationEventHandler {
@@ -10,6 +14,9 @@ export class MemberEducationEventHandler {
     private readonly educationEnrollmentService: EducationEnrollmentService,
     private readonly eventEmitter: EventEmitter2,
     private readonly dataSource: DataSource,
+
+    @Inject(IEDUCATION_ENROLLMENT_DOMAIN_SERVICE)
+    private readonly educationEnrollmentDomainService: IEducationEnrollmentsDomainService,
   ) {}
 
   // 재시도 간격을 지수적으로 증가 (exponential backoff)
@@ -28,11 +35,15 @@ export class MemberEducationEventHandler {
 
     try {
       const enrollments =
-        await this.educationEnrollmentService.getMemberEducationEnrollments(
+        await this.educationEnrollmentDomainService.findMemberEducationEnrollments(
+          memberId,
+          qr,
+        );
+      /*await this.educationEnrollmentService.getMemberEducationEnrollments(
           event.memberId,
           event.churchId,
           qr,
-        );
+        );*/
 
       await Promise.all(
         enrollments.map((enrollment) =>

--- a/backend/src/management/educations/service/sync/deprecated/education-enrollment-session-sync.service.ts
+++ b/backend/src/management/educations/service/sync/deprecated/education-enrollment-session-sync.service.ts
@@ -1,11 +1,10 @@
-import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { EducationEnrollmentModel } from '../../../entity/education/education-enrollment.entity';
+import { EducationEnrollmentModel } from '../../../../entity/education/education-enrollment.entity';
 import { In, QueryRunner, Repository } from 'typeorm';
-import { SessionAttendanceModel } from '../../../entity/education/session-attendance.entity';
+import { SessionAttendanceModel } from '../../../../entity/education/session-attendance.entity';
 
-@Injectable()
-export class EducationEnrollmentSessionSyncService {
+//@Injectable()
+/*export*/ class EducationEnrollmentSessionSyncService {
   constructor(
     @InjectRepository(EducationEnrollmentModel)
     private readonly educationEnrollmentRepository: Repository<EducationEnrollmentModel>,

--- a/backend/src/management/educations/service/sync/deprecated/education-term-enrollment-sync.service.ts
+++ b/backend/src/management/educations/service/sync/deprecated/education-term-enrollment-sync.service.ts
@@ -1,12 +1,12 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { EducationTermModel } from '../../../entity/education/education-term.entity';
+import { EducationTermModel } from '../../../../entity/education/education-term.entity';
 import { QueryRunner, Repository } from 'typeorm';
-import { EducationEnrollmentModel } from '../../../entity/education/education-enrollment.entity';
-import { EducationStatus } from '../../const/education-status.enum';
+import { EducationEnrollmentModel } from '../../../../entity/education/education-enrollment.entity';
+import { EducationStatus } from '../../../const/education-status.enum';
 
-@Injectable()
-export class EducationTermEnrollmentSyncService {
+//@Injectable()
+/*export */ class EducationTermEnrollmentSyncService {
   constructor(
     @InjectRepository(EducationTermModel)
     private readonly educationTermRepository: Repository<EducationTermModel>,

--- a/backend/src/management/educations/service/sync/deprecated/education-term-session-sync.service.ts
+++ b/backend/src/management/educations/service/sync/deprecated/education-term-session-sync.service.ts
@@ -1,12 +1,12 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { EducationTermModel } from '../../../entity/education/education-term.entity';
+import { EducationTermModel } from '../../../../entity/education/education-term.entity';
 import { QueryRunner, Repository } from 'typeorm';
-import { EducationSessionModel } from '../../../entity/education/education-session.entity';
-import { UpdateEducationTermDto } from '../../dto/terms/update-education-term.dto';
+import { EducationSessionModel } from '../../../../entity/education/education-session.entity';
+import { UpdateEducationTermDto } from '../../../dto/terms/update-education-term.dto';
 
-@Injectable()
-export class EducationTermSessionSyncService {
+//@Injectable()
+/*export*/ class EducationTermSessionSyncService {
   constructor(
     @InjectRepository(EducationTermModel)
     private readonly educationTermRepository: Repository<EducationTermModel>,


### PR DESCRIPTION
## 주요 내용
`EducationEnrollmentService`와 `EducationEnrollmentDomainService`에서 발생하던 Enrollment 생성 및 반환 관련 버그를 수정하였고, `EducationTermEnrollmentSyncService`를 제거하고 `EducationEnrollmentDomainService`를 통해 Enrollment 정보를 조회하도록 구조를 개선하였습니다.

## 세부 내용
### 버그 수정
1. Enrollment 생성 시 해당 세션의 `SessionAttendance`가 자동으로 생성되지 않던 문제 해결
2. Enrollment 생성 후, 생성된 객체가 아닌 잘못된 다른 Enrollment가 반환되던 문제 해결

### 구조 개선
- `EducationTermEnrollmentSyncService` 제거
- `EducationTerm`에서 `Enrollment` 정보를 조회할 때 `EducationEnrollmentDomainService`를 사용하도록 변경
- 도메인 계층을 통한 일관된 접근 방식으로 서비스 간 결합도 완화

이번 수정으로 교육 등록 로직의 안정성과 정확성이 향상되었으며,
도메인 중심 구조 개선을 통해 유지보수성과 확장성을 강화하였습니다. 🚀