### PR TITLE
chore: Swagger 문서의 ApiTags 수정 (Settings → Management)

### DIFF
--- a/backend/src/management/groups/controller/groups-roles.controller.ts
+++ b/backend/src/management/groups/controller/groups-roles.controller.ts
@@ -18,7 +18,7 @@ import { QueryRunner as QR } from 'typeorm';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 
-@ApiTags('Settings:Groups:Roles')
+@ApiTags('Management:Groups:Roles')
 @Controller('groups')
 export class GroupsRolesController {
   constructor(private readonly groupsRolesService: GroupRolesService) {}

--- a/backend/src/management/officers/controller/officers.controller.ts
+++ b/backend/src/management/officers/controller/officers.controller.ts
@@ -17,7 +17,7 @@ import { QueryRunner as QR } from 'typeorm';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 
-@ApiTags('Settings:Officers')
+@ApiTags('Management:Officers')
 @Controller('officers')
 export class OfficersController {
   constructor(private readonly officersService: OfficersService) {}


### PR DESCRIPTION
## 주요 내용
Swagger 문서의 `ApiTags`를 기존 `Settings`에서 `Management`로 변경하여 도메인 구조에 맞게 문서 태그를 정리하였습니다.

## 세부 내용
- `@ApiTags('Settings')` → `@ApiTags('Management')`로 변경
- Swagger UI 상에서 API 분류가 보다 명확하게 표현되도록 개선

이번 변경을 통해 문서 구조가 실제 모듈 구조와 일치하게 되며,
API 명세의 가독성과 일관성이 향상되었습니다. 📚