### PR TITLE
feat: 모바일 로그인 엔드포인트 및 테스트 로그인 옵션 추가

### DIFF
--- a/backend/src/auth/const/swagger/auth/controller.swagger.ts
+++ b/backend/src/auth/const/swagger/auth/controller.swagger.ts
@@ -1,14 +1,35 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation } from '@nestjs/swagger';
+import { ApiOperation, ApiQuery } from '@nestjs/swagger';
 
 export const ApiTestAuth = () =>
   applyDecorators(
+    ApiQuery({
+      name: 'loginOption',
+      required: false,
+      type: String,
+      description: '로그인 옵션 (기본값: test, 가능한값: test | mobile)',
+    }),
     ApiOperation({
       summary: '테스트 유저 생성/로그인',
       description:
-        '<p><h2>테스트 유저를 생성 또는 로그인합니다.</h2></p>' +
+        '<p><h2>provider, providerId 로 직접 유저를 생성 또는 로그인합니다.</h2></p>' +
+        '<p>모바일 로그인일 경우 loginOption = "mobile"</p>' +
+        '<p>테스트 로그인일 경우 loginOption = "test"</p>' +
+        '<p>기본값 loginOptions = "test"</p>' +
         '<p>기존 생성한 테스트 유저로 로그인할 경우 AccessToken, RefreshToken 반환</p>' +
         '<p>존재하지 않는 테스트 유저일 경우 TemporalToken 반환</p>' +
+        '<p>TemporalToken 으로 이후 회원가입 절차 진행 가능</p>',
+    }),
+  );
+
+export const ApiMobileLoginAuth = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '모바일 유저 생성/로그인',
+      description:
+        '<p><h2>provider, providerId 로 직접 유저를 생성 또는 로그인합니다.</h2></p>' +
+        '<p>기존 생성한 유저로 로그인할 경우 AccessToken, RefreshToken 반환</p>' +
+        '<p>존재하지 않는 유저일 경우 TemporalToken 반환</p>' +
         '<p>TemporalToken 으로 이후 회원가입 절차 진행 가능</p>',
     }),
   );

--- a/backend/src/auth/dto/mobile-login.dto.ts
+++ b/backend/src/auth/dto/mobile-login.dto.ts
@@ -1,0 +1,20 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MobileLoginDto {
+  @ApiProperty({
+    description: 'OAuth 제공사',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  provider: string;
+
+  @ApiProperty({
+    description: 'OAuth id',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  providerId: string;
+}


### PR DESCRIPTION
## 주요 내용
모바일 환경에서의 로그인을 지원하기 위해 전용 엔드포인트를 추가하였으며,
기존 테스트 로그인 엔드포인트에 `loginOption` 파라미터를 도입하여 응답 방식을 분기 처리할 수 있도록 개선하였습니다.

## 세부 내용
### 모바일 로그인 기능 추가
- `POST /auth/mobile-login`
  - 클라이언트에서 소셜 로그인 후 받은 `providerId`와 `provider`를 전달하여 로그인 처리
  - 모바일 앱에서의 인증 플로우를 지원

### 테스트 로그인 개선
- 기존 테스트 로그인 엔드포인트에 `loginOption` 파라미터 추가
  - `mobile`: 모바일 로그인에 맞는 JSON 응답 반환
  - `test`: 기존과 동일하게 쿠키를 통해 인증 정보 전달
- 하나의 테스트 로그인 엔드포인트에서 다양한 환경을 테스트할 수 있도록 확장

이번 변경을 통해 모바일 환경에서도 안정적인 로그인 처리가 가능해졌으며,
개발 및 테스트 환경에서도 유연하게 대응할 수 있도록 개선하였습니다. 📱🚀