### PR TITLE
refactor: OAuth 로그인 쿠키 저장 방식 및 Guard 디코딩 로직 수정

### DIFF
--- a/backend/src/auth/guard/jwt.guard.ts
+++ b/backend/src/auth/guard/jwt.guard.ts
@@ -35,7 +35,7 @@ abstract class JwtTokenGuard implements CanActivate {
       throw new UnauthorizedException(AuthException.TOKEN_REQUIRED);
     }
 
-    return Buffer.from(rawToken, 'base64').toString('utf-8');
+    return rawToken;
   }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {

--- a/backend/src/auth/helper/auth-cookie.helper.ts
+++ b/backend/src/auth/helper/auth-cookie.helper.ts
@@ -15,10 +15,6 @@ export class AuthCookieHelper {
   private readonly REFRESH_TOKEN: 'refreshToken' = 'refreshToken';
   private readonly TEMPORAL_TOKEN: 'temporal' = 'temporal';
 
-  private encodeBase64(token: string) {
-    return Buffer.from(token).toString('base64');
-  }
-
   public setTokenCookie(
     loginResult:
       | { accessToken: string; refreshToken: string }
@@ -27,34 +23,27 @@ export class AuthCookieHelper {
     res: Response,
   ) {
     if (this.ACCESS_TOKEN in loginResult && this.REFRESH_TOKEN in loginResult) {
-      const encodedAccessToken = this.encodeBase64(loginResult.accessToken);
-      const encodedRefreshToken = this.encodeBase64(loginResult.refreshToken);
-
       res.cookie(
         this.configService.getOrThrow(ENV_VARIABLE_KEY.ACCESS_TOKEN_KEY),
-        encodedAccessToken,
+        loginResult.accessToken,
         TOKEN_COOKIE_OPTIONS(this.NODE_ENV, AuthType.ACCESS),
       );
 
       res.cookie(
         this.configService.getOrThrow(ENV_VARIABLE_KEY.REFRESH_TOKEN_KEY),
-        encodedRefreshToken,
+        loginResult.refreshToken,
         TOKEN_COOKIE_OPTIONS(this.NODE_ENV, AuthType.REFRESH),
       );
     } else if (this.ACCESS_TOKEN in loginResult) {
-      const encodedAccessToken = this.encodeBase64(loginResult.accessToken);
-
       res.cookie(
         this.configService.getOrThrow(ENV_VARIABLE_KEY.ACCESS_TOKEN_KEY),
-        encodedAccessToken,
+        loginResult.accessToken,
         TOKEN_COOKIE_OPTIONS(this.NODE_ENV, AuthType.ACCESS),
       );
     } else if (this.TEMPORAL_TOKEN in loginResult) {
-      const encodedTemporalToken = this.encodeBase64(loginResult.temporal);
-
       res.cookie(
         this.configService.getOrThrow(ENV_VARIABLE_KEY.TEMPORAL_TOKEN_KEY),
-        encodedTemporalToken,
+        loginResult.temporal,
         TOKEN_COOKIE_OPTIONS(this.NODE_ENV, AuthType.TEMP),
       );
     }


### PR DESCRIPTION
## 주요 내용
기존 OAuth 로그인 후 JWT를 base64로 인코딩하여 쿠키에 저장하던 방식을 변경하여, JWT를 인코딩 없이 그대로 쿠키에 저장하도록 수정하였고,
이에 따라 Guard에서도 base64 디코딩 로직을 제거하였습니다.

## 세부 내용
- OAuth 로그인 성공 시 JWT를 base64 인코딩 없이 쿠키에 그대로 저장하도록 변경
- 인증 Guard에서 JWT 쿠키를 디코딩하지 않고 직접 검증하도록 로직 수정
- 불필요한 변환 제거로 로직 단순화 및 오류 가능성 감소
- 기존 쿠키 파싱 및 토큰 검증 테스트 케이스 점검 및 보완

이번 변경을 통해 인증 로직이 보다 직관적이고 안정적으로 개선되었으며,
JWT 처리 방식의 일관성과 성능이 향상되었습니다. 🚀