### PR TITLE
feat: 회원의 교회 생성 기능 추가

### DIFF
--- a/backend/src/churches/churches-domain/churhes-domain.service.ts
+++ b/backend/src/churches/churches-domain/churhes-domain.service.ts
@@ -1,17 +1,24 @@
 import {
-  BadRequestException,
+  ConflictException,
   Injectable,
+  InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
 import { IChurchesDomainService } from './interface/churches-domain.service.interface';
-import { UserModel } from '../../user/entity/user.entity';
 import { CreateChurchDto } from '../dto/create-church.dto';
-import { IsNull, QueryRunner, Repository, UpdateResult } from 'typeorm';
+import {
+  FindOptionsRelations,
+  IsNull,
+  QueryRunner,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
 import { ChurchModel } from '../entity/church.entity';
 import { UpdateChurchDto } from '../dto/update-church.dto';
 import { RequestLimitValidationType } from '../request-info/types/request-limit-validation-result';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserRole } from '../../user/const/user-role.enum';
+import { ChurchException } from '../const/exception/church.exception';
 
 @Injectable()
 export class ChurchesDomainService implements IChurchesDomainService {
@@ -24,16 +31,15 @@ export class ChurchesDomainService implements IChurchesDomainService {
     return qr ? qr.manager.getRepository(ChurchModel) : this.churchRepository;
   }
 
-  findAllChurches(): Promise<ChurchModel[]> {
+  async findAllChurches(): Promise<ChurchModel[]> {
     const churchRepository = this.getChurchRepository();
 
     return churchRepository.find();
   }
 
   async createChurch(
-    user: UserModel,
     dto: CreateChurchDto,
-    qr?: QueryRunner,
+    qr: QueryRunner,
   ): Promise<ChurchModel> {
     const churchRepository = this.getChurchRepository(qr);
 
@@ -45,31 +51,29 @@ export class ChurchesDomainService implements IChurchesDomainService {
     });
 
     if (isDuplicated) {
-      throw new BadRequestException('이미 존재하는 교회입니다.');
+      throw new ConflictException(ChurchException.ALREADY_EXIST);
     }
 
     const newChurch = churchRepository.create({
       ...dto,
     });
 
-    newChurch.users.push(user);
-
     return churchRepository.save(newChurch);
   }
 
-  async deleteChurchById(id: number, qr?: QueryRunner): Promise<string> {
+  async deleteChurch(church: ChurchModel, qr?: QueryRunner): Promise<string> {
     const churchRepository = this.getChurchRepository(qr);
 
     const result = await churchRepository.softDelete({
-      id,
+      id: church.id,
       deletedAt: IsNull(),
     });
 
     if (result.affected === 0) {
-      throw new NotFoundException('해당 교회를 찾을 수 없습니다.');
+      throw new InternalServerErrorException(ChurchException.DELETE_ERROR);
     }
 
-    return `churchId: ${id} deleted`;
+    return `churchId: ${church.id} deleted`;
   }
 
   async findChurchById(id: number, qr?: QueryRunner): Promise<ChurchModel> {
@@ -80,12 +84,12 @@ export class ChurchesDomainService implements IChurchesDomainService {
         id,
       },
       relations: {
-        users: true,
+        //users: true,
       },
     });
 
     if (!church) {
-      throw new NotFoundException('해당 교회를 찾을 수 없습니다.');
+      throw new NotFoundException(ChurchException.NOT_FOUND);
     }
 
     return church;
@@ -94,6 +98,7 @@ export class ChurchesDomainService implements IChurchesDomainService {
   async findChurchModelById(
     id: number,
     qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<ChurchModel>,
   ): Promise<ChurchModel> {
     const churchRepository = this.getChurchRepository(qr);
 
@@ -101,10 +106,11 @@ export class ChurchesDomainService implements IChurchesDomainService {
       where: {
         id,
       },
+      relations: relationOptions,
     });
 
     if (!church) {
-      throw new NotFoundException('해당 교회를 찾을 수 없습니다.');
+      throw new NotFoundException(ChurchException.NOT_FOUND);
     }
 
     return church;
@@ -119,14 +125,14 @@ export class ChurchesDomainService implements IChurchesDomainService {
   }
 
   async updateChurch(
-    churchId: number,
+    church: ChurchModel,
     dto: UpdateChurchDto,
   ): Promise<ChurchModel> {
     const churchRepository = this.getChurchRepository();
 
     const result = await churchRepository.update(
       {
-        id: churchId,
+        id: church.id,
       },
       {
         ...dto,
@@ -134,10 +140,10 @@ export class ChurchesDomainService implements IChurchesDomainService {
     );
 
     if (result.affected === 0) {
-      throw new NotFoundException('');
+      throw new InternalServerErrorException(ChurchException.UPDATE_ERROR);
     }
 
-    return this.findChurchById(churchId);
+    return this.findChurchById(church.id);
   }
 
   updateRequestAttempts(
@@ -177,7 +183,7 @@ export class ChurchesDomainService implements IChurchesDomainService {
     });
 
     if (!church) {
-      throw new NotFoundException('해당 교회를 찾을 수 없습니다.');
+      throw new NotFoundException(ChurchException.NOT_FOUND);
     }
 
     return church.users
@@ -201,7 +207,7 @@ export class ChurchesDomainService implements IChurchesDomainService {
     });
 
     if (!church) {
-      throw new NotFoundException('해당 교회를 찾을 수 없습니다.');
+      throw new NotFoundException(ChurchException.NOT_FOUND);
     }
 
     return church.users

--- a/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
+++ b/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
@@ -1,8 +1,7 @@
 import { ChurchModel } from '../../entity/church.entity';
-import { QueryRunner, UpdateResult } from 'typeorm';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { CreateChurchDto } from '../../dto/create-church.dto';
 import { UpdateChurchDto } from '../../dto/update-church.dto';
-import { UserModel } from '../../../user/entity/user.entity';
 import { RequestLimitValidationType } from '../../request-info/types/request-limit-validation-result';
 
 export const ICHURCHES_DOMAIN_SERVICE = Symbol('ICHURCHES_DOMAIN_SERVICE');
@@ -12,19 +11,19 @@ export interface IChurchesDomainService {
 
   findChurchById(id: number, qr?: QueryRunner): Promise<ChurchModel>;
 
-  findChurchModelById(id: number, qr?: QueryRunner): Promise<ChurchModel>;
+  findChurchModelById(
+    id: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<ChurchModel>,
+  ): Promise<ChurchModel>;
 
   isExistChurch(id: number, qr?: QueryRunner): Promise<boolean>;
 
-  createChurch(
-    user: UserModel,
-    dto: CreateChurchDto,
-    qr?: QueryRunner,
-  ): Promise<ChurchModel>;
+  createChurch(dto: CreateChurchDto, qr?: QueryRunner): Promise<ChurchModel>;
 
-  updateChurch(churchId: number, dto: UpdateChurchDto): Promise<ChurchModel>;
+  updateChurch(church: ChurchModel, dto: UpdateChurchDto): Promise<ChurchModel>;
 
-  deleteChurchById(id: number, qr?: QueryRunner): Promise<string>;
+  deleteChurch(church: ChurchModel, qr?: QueryRunner): Promise<string>;
 
   updateRequestAttempts(
     church: ChurchModel,

--- a/backend/src/churches/churches.controller.ts
+++ b/backend/src/churches/churches.controller.ts
@@ -8,6 +8,7 @@ import {
   Patch,
   Post,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import { ChurchesService } from './churches.service';
 import { CreateChurchDto } from './dto/create-church.dto';
@@ -28,6 +29,9 @@ import {
   ApiPostChurch,
 } from './const/swagger/churches/controller.swagger';
 import { AuthType } from '../auth/const/enum/auth-type.enum';
+import { TransactionInterceptor } from '../common/interceptor/transaction.interceptor';
+import { QueryRunner } from '../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm';
 
 @Controller('churches')
 export class ChurchesController {
@@ -43,11 +47,13 @@ export class ChurchesController {
   @Post()
   @ApiBearerAuth()
   @UseGuards(AccessTokenGuard)
+  @UseInterceptors(TransactionInterceptor)
   postChurch(
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
     @Body() dto: CreateChurchDto,
+    @QueryRunner() qr: QR,
   ) {
-    return this.churchesService.createChurch(accessToken, dto);
+    return this.churchesService.createChurch(accessPayload, dto, qr);
   }
 
   @ApiGetChurchById()

--- a/backend/src/churches/churches.module.ts
+++ b/backend/src/churches/churches.module.ts
@@ -1,19 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ChurchesService } from './churches.service';
 import { ChurchesController } from './churches.controller';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { ChurchModel } from './entity/church.entity';
 import { JwtModule } from '@nestjs/jwt';
 import { UserDomainModule } from '../user/user-domain/user-domain.module';
 import { ChurchesDomainModule } from './churches-domain/churches-domain.module';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([ChurchModel]),
-    JwtModule.register({}),
-    UserDomainModule,
-    ChurchesDomainModule,
-  ],
+  imports: [JwtModule.register({}), UserDomainModule, ChurchesDomainModule],
   controllers: [ChurchesController],
   providers: [ChurchesService],
 })

--- a/backend/src/churches/const/exception/church.exception.ts
+++ b/backend/src/churches/const/exception/church.exception.ts
@@ -1,0 +1,7 @@
+export const ChurchException = {
+  NOT_ALLOWED_TO_CREATE: '소속된 교회가 있을 경우, 교회를 생성할 수 없습니다.',
+  ALREADY_EXIST: '이미 존재하는 교회입니다.',
+  UPDATE_ERROR: '교회 업데이트 도중 에러 발생',
+  DELETE_ERROR: '교회 삭제 도중 에러 발생',
+  NOT_FOUND: '해당 교회를 찾을 수 없습니다.',
+};

--- a/backend/src/churches/entity/church.entity.ts
+++ b/backend/src/churches/entity/church.entity.ts
@@ -35,7 +35,7 @@ export class ChurchModel extends BaseModel {
   @Column({ enum: MemberSize, nullable: true })
   memberSize: MemberSize;
 
-  @OneToMany(() => UserModel, (user) => user.adminChurch)
+  @OneToMany(() => UserModel, (user) => user.church)
   users: UserModel[];
 
   @OneToMany(() => GroupModel, (group) => group.church)

--- a/backend/src/user/entity/user.entity.ts
+++ b/backend/src/user/entity/user.entity.ts
@@ -33,7 +33,7 @@ export class UserModel extends BaseModel {
   privacyPolicyAgreed: boolean;
 
   @ManyToOne(() => ChurchModel, (church) => church.users)
-  adminChurch: ChurchModel;
+  church: ChurchModel;
 
   @Column({ enum: UserRole, default: UserRole.none })
   role: UserRole;

--- a/backend/src/user/user-domain/interface/user-domain.service.interface.ts
+++ b/backend/src/user/user-domain/interface/user-domain.service.interface.ts
@@ -4,6 +4,7 @@ import { CreateUserDto } from '../../dto/create-user.dto';
 import { MemberModel } from '../../../churches/members/entity/member.entity';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { UpdateUserDto } from '../../dto/update-user.dto';
+import { UserRole } from '../../const/user-role.enum';
 
 export const IUSER_DOMAIN_SERVICE = Symbol('IUserDomainService');
 
@@ -35,6 +36,7 @@ export interface IUserDomainService {
   signInChurch(
     user: UserModel,
     church: ChurchModel,
+    role: UserRole,
     qr?: QueryRunner,
   ): Promise<UpdateResult>;
 

--- a/backend/src/user/user-domain/user-domain.service.ts
+++ b/backend/src/user/user-domain/user-domain.service.ts
@@ -33,7 +33,7 @@ export class UserDomainService implements IUserDomainService {
         id,
       },
       relations: {
-        adminChurch: true,
+        church: true,
         member: true,
       },
     });
@@ -109,6 +109,7 @@ export class UserDomainService implements IUserDomainService {
   async signInChurch(
     user: UserModel,
     church: ChurchModel,
+    role: UserRole,
     qr?: QueryRunner,
   ): Promise<UpdateResult> {
     const userRepository = this.getUserRepository(qr);
@@ -118,7 +119,8 @@ export class UserDomainService implements IUserDomainService {
         id: user.id,
       },
       {
-        adminChurch: church,
+        church: church,
+        role,
       },
     );
   }
@@ -143,7 +145,7 @@ export class UserDomainService implements IUserDomainService {
         id: user.id,
       },
       relations: {
-        adminChurch: true,
+        church: true,
         member: true,
       },
     });

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -7,13 +7,14 @@ import { UserModel } from './entity/user.entity';
 import { MemberModel } from '../churches/members/entity/member.entity';
 import { MembersModule } from '../churches/members/members.module';
 import { UserDomainModule } from './user-domain/user-domain.module';
-import { ChurchModel } from '../churches/entity/church.entity';
+import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([UserModel, MemberModel, ChurchModel]),
+    TypeOrmModule.forFeature([UserModel, MemberModel]),
     JwtModule.register({}),
     MembersModule,
+    ChurchesDomainModule,
     UserDomainModule,
   ],
   controllers: [UserController],


### PR DESCRIPTION
## 주요 내용
회원이 새로운 교회를 생성할 수 있는 기능을 추가하였으며,
해당 회원은 생성한 교회의 `mainAdmin`으로 자동 등록되도록 처리하였습니다.

## 세부 내용
- 교회에 소속되지 않은 회원만 교회 생성 가능
- 교회 생성 시 해당 회원을 생성한 교회의 `mainAdmin`으로 설정
- 권한 및 상태 검증 로직 추가

이번 기능 추가로 인해 회원이 직접 교회를 생성하고 주 관리자 역할을 맡을 수 있게 되었으며, 교회-회원 간 역할 기반 관계 형성의 기반을 마련하였습니다. 🏛️🚀