### PR TITLE
refactor: 모듈 의존성 정리 및 JwtModule 전역 설정 적용

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -36,6 +36,8 @@ import { MembersModule } from './members/members.module';
 import { MembersDomainModule } from './members/member-domain/members-domain.module';
 import { ChurchesDomainModule } from './churches/churches-domain/churches-domain.module';
 import { FamilyRelationModule } from './family-relation/family-relation.module';
+import { JwtModule } from '@nestjs/jwt';
+import { ENV_VARIABLE_KEY } from './common/const/env.const';
 
 @Module({
   imports: [
@@ -131,6 +133,13 @@ import { FamilyRelationModule } from './family-relation/family-relation.module';
           GroupHistoryModel,
         ],
         synchronize: true,
+      }),
+      inject: [ConfigService],
+    }),
+    JwtModule.registerAsync({
+      global: true,
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.getOrThrow(ENV_VARIABLE_KEY.JWT_SECRET),
       }),
       inject: [ConfigService],
     }),

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -2,9 +2,6 @@ import { Module } from '@nestjs/common';
 import { AuthService } from './service/auth.service';
 import { AuthController } from './controller/auth.controller';
 import { GoogleStrategy } from './strategy/google.strategy';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { TempUserModel } from './entity/temp-user.entity';
-import { JwtModule } from '@nestjs/jwt';
 import { TokenService } from './service/token.service';
 import { NaverStrategy } from './strategy/naver.strategy';
 import { KakaoStrategy } from './strategy/kakao.strategy';
@@ -15,8 +12,8 @@ import { TempUserDomainModule } from './temp-user-domain/temp-user-domain.module
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([TempUserModel]),
-    JwtModule.register({}),
+    //TypeOrmModule.forFeature([TempUserModel]),
+    //JwtModule.register({}),
     CommonModule,
     UserDomainModule,
     TempUserDomainModule,
@@ -30,6 +27,8 @@ import { TempUserDomainModule } from './temp-user-domain/temp-user-domain.module
     KakaoStrategy,
     AuthCookieHelper,
   ],
-  exports: [JwtModule],
+  exports: [
+    /*JwtModule*/
+  ],
 })
 export class AuthModule {}

--- a/backend/src/auth/guard/jwt.guard.ts
+++ b/backend/src/auth/guard/jwt.guard.ts
@@ -43,13 +43,13 @@ abstract class JwtTokenGuard implements CanActivate {
 
     const token = this.extractTokenFromCookie(req);
 
-    const jwtSecret = this.configService.getOrThrow(
+    /*const jwtSecret = this.configService.getOrThrow(
       ENV_VARIABLE_KEY.JWT_SECRET,
-    );
+    );*/
 
     try {
       req.tokenPayload = await this.jwtService.verifyAsync(token, {
-        secret: jwtSecret,
+        //secret: jwtSecret,
       });
 
       return true;

--- a/backend/src/auth/service/token.service.ts
+++ b/backend/src/auth/service/token.service.ts
@@ -32,9 +32,9 @@ export class TokenService {
     );
 
     return this.jwtService.sign(payload, {
-      secret: this.configService.getOrThrow<string>(
+      /*secret: this.configService.getOrThrow<string>(
         ENV_VARIABLE_KEY.JWT_SECRET,
-      ),
+      ),*/
       expiresIn,
     });
   }
@@ -61,9 +61,9 @@ export class TokenService {
   verifyToken(token: string) {
     try {
       return this.jwtService.verify(token, {
-        secret: this.configService.getOrThrow<string>(
+        /*secret: this.configService.getOrThrow<string>(
           ENV_VARIABLE_KEY.JWT_SECRET,
-        ),
+        ),*/
       });
     } catch (error) {
       if (error instanceof TokenExpiredError) {

--- a/backend/src/user/dto/link-member-to-user.dto.ts
+++ b/backend/src/user/dto/link-member-to-user.dto.ts
@@ -3,6 +3,12 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class LinkMemberToUserDto {
   @ApiProperty({
+    description: '연결하려는 교인이 속한 교회의 ID',
+  })
+  @IsNumber()
+  churchId: number;
+
+  @ApiProperty({
     description: '연결하려는 교인 데이터의 ID',
   })
   @IsNumber()

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -48,6 +48,11 @@ export class UserController {
     @Body() dto: LinkMemberToUserDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.userService.linkMemberToUser(accessToken.id, dto.memberId, qr);
+    return this.userService.linkMemberToUser(
+      accessToken.id,
+      dto.churchId,
+      dto.memberId,
+      qr,
+    );
   }
 }

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,20 +1,19 @@
 import { Module } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
-import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserModel } from './entity/user.entity';
 import { UserDomainModule } from './user-domain/user-domain.module';
-import { ChurchModel } from '../churches/entity/church.entity';
-import { MemberModel } from '../members/entity/member.entity';
-import { MembersModule } from '../members/members.module';
+import { MembersDomainModule } from '../members/member-domain/members-domain.module';
+import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([UserModel, MemberModel, ChurchModel]),
-    JwtModule.register({}),
-    MembersModule,
+    TypeOrmModule.forFeature([UserModel /*, MemberModel, ChurchModel*/]),
+    //JwtModule.register({}),
     UserDomainModule,
+    ChurchesDomainModule,
+    MembersDomainModule,
   ],
   controllers: [UserController],
   providers: [UserService],

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,37 +1,42 @@
-import {
-  BadRequestException,
-  Inject,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { QueryRunner, Repository } from 'typeorm';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { QueryRunner } from 'typeorm';
 import {
   IUSER_DOMAIN_SERVICE,
   IUserDomainService,
 } from './user-domain/interface/user-domain.service.interface';
-import { ChurchModel } from '../churches/entity/church.entity';
 import { UserRole } from './const/user-role.enum';
-import { MemberModel } from '../members/entity/member.entity';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IMEMBERS_DOMAIN_SERVICE,
+  IMembersDomainService,
+} from '../members/member-domain/service/interface/members-domain.service.interface';
 
 @Injectable()
 export class UserService {
   constructor(
     @Inject(IUSER_DOMAIN_SERVICE)
     private readonly userDomainService: IUserDomainService,
-    @InjectRepository(MemberModel)
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,
+
+    /*@InjectRepository(MemberModel)
     private readonly memberRepository: Repository<MemberModel>,
     @InjectRepository(ChurchModel)
-    private readonly churchRepository: Repository<ChurchModel>,
+    private readonly churchRepository: Repository<ChurchModel>,*/
   ) {}
 
-  private getMemberRepository(qr?: QueryRunner) {
+  /*private getMemberRepository(qr?: QueryRunner) {
     return qr ? qr.manager.getRepository(MemberModel) : this.memberRepository;
-  }
+  }*/
 
-  private getChurchRepository(qr?: QueryRunner) {
+  /*private getChurchRepository(qr?: QueryRunner) {
     return qr ? qr.manager.getRepository(ChurchModel) : this.churchRepository;
-  }
+  }*/
 
   async getUserById(id: number) {
     return this.userDomainService.findUserById(id);
@@ -44,8 +49,11 @@ export class UserService {
       throw new BadRequestException('이미 소속된 교회가 있습니다.');
     }
 
-    // TODO ChurchDomainService 로 변경
-    const church = await this.getChurchRepository(qr).findOne({
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+    /*const church = await this.getChurchRepository(qr).findOne({
       where: {
         id: churchId,
       },
@@ -53,7 +61,7 @@ export class UserService {
 
     if (!church) {
       throw new NotFoundException('해당 교회를 찾을 수 없습니다.');
-    }
+    }*/
 
     // 사용자 정보 업데이트
     await this.userDomainService.updateUser(
@@ -66,10 +74,26 @@ export class UserService {
     await this.userDomainService.signInChurch(user, church, qr);
   }
 
-  async linkMemberToUser(userId: number, memberId: number, qr?: QueryRunner) {
+  async linkMemberToUser(
+    userId: number,
+    churchId: number,
+    memberId: number,
+    qr?: QueryRunner,
+  ) {
     const user = await this.userDomainService.findUserById(userId);
 
-    const member = await this.getMemberRepository(qr).findOne({
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const member = await this.membersDomainService.findMemberModelById(
+      church,
+      memberId,
+      qr,
+    );
+
+    /*const member = await this.getMemberRepository(qr).findOne({
       where: {
         churchId: user.adminChurch.id,
         id: memberId,
@@ -78,7 +102,7 @@ export class UserService {
 
     if (!member) {
       throw new NotFoundException('관리 교회에 해당 교인이 존재하지 않습니다.');
-    }
+    }*/
 
     if (user.mobilePhone !== member.mobilePhone) {
       throw new BadRequestException(


### PR DESCRIPTION
## 주요 내용
기존에 `MemberModule`, `ChurchModule`을 참조하던 모듈들이 도메인 레이어만 의존하도록 `MemberDomainModule`, `ChurchDomainModule`을 참조하도록 수정하였으며, `JwtModule`을 전역으로 설정하고 secret 키도 전역 설정으로 통일하였습니다.

## 세부 내용
- 다른 모듈에서 `MemberModule`, `ChurchModule` 대신 `MemberDomainModule`, `ChurchDomainModule`을 import 하도록 변경
  - 도메인 서비스만 필요한 경우 전체 모듈 의존 제거
- `JwtModule`을 전역 등록하여 반복 설정 제거
- JWT secret 키도 전역 설정 파일에서 불러오도록 통일
- 모듈 간 결합도 완화 및 공통 설정 일관성 확보

이번 변경을 통해 도메인 중심 설계에 맞춘 모듈 참조 방식이 정비되었으며,
JWT 설정의 일관성과 재사용성이 향상되었습니다. 🔐🚀