### PR TITLE
fix: 초대 메시지 전송 시 교회 이름 누락 문제 해결 및 문자 발송 비동화 처리

### DIFF
--- a/backend/src/common/provider/coolsms.provider.ts
+++ b/backend/src/common/provider/coolsms.provider.ts
@@ -3,7 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import coolsms from 'coolsms-node-sdk';
 import { ENV_VARIABLE_KEY } from '../const/env.const';
 
-export const COOLSMS_CLIENT = 'COOLSMS_CLIENT';
+export const COOLSMS_CLIENT = Symbol('COOLSMS_CLIENT');
 
 export const CoolSMSProvider: Provider = {
   provide: COOLSMS_CLIENT,

--- a/backend/src/common/service/message.service.ts
+++ b/backend/src/common/service/message.service.ts
@@ -1,10 +1,8 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-
 import { ENV_VARIABLE_KEY } from '../const/env.const';
 import { COOLSMS_CLIENT } from '../provider/coolsms.provider';
 import { ICoolSMS } from '../provider/coolsms.interface';
-//import { MESSAGE_SERVICE } from '../const/env.const';
 
 @Injectable()
 export class MessageService {

--- a/backend/src/request-info/request-info-domain/service/interface/request-info-domain.service.interface.ts
+++ b/backend/src/request-info/request-info-domain/service/interface/request-info-domain.service.interface.ts
@@ -1,5 +1,10 @@
 import { ChurchModel } from '../../../../churches/entity/church.entity';
-import { DeleteResult, QueryRunner, UpdateResult } from 'typeorm';
+import {
+  DeleteResult,
+  FindOptionsRelations,
+  QueryRunner,
+  UpdateResult,
+} from 'typeorm';
 import { RequestInfoModel } from '../../../entity/request-info.entity';
 import { GetRequestInfoDto } from '../../../dto/get-request-info.dto';
 import { MemberModel } from '../../../../members/entity/member.entity';
@@ -28,6 +33,13 @@ export interface IRequestInfoDomainService {
     church: ChurchModel,
     requestInfoId: number,
     qr?: QueryRunner,
+  ): Promise<RequestInfoModel>;
+
+  findRequestInfoModelById(
+    church: ChurchModel,
+    requestInfoId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<RequestInfoModel>,
   ): Promise<RequestInfoModel>;
 
   createRequestInfo(

--- a/backend/src/request-info/request-info.controller.ts
+++ b/backend/src/request-info/request-info.controller.ts
@@ -49,14 +49,16 @@ export class RequestInfoController {
       qr,
     );
 
-    /*if (!requestInfo) {
-      throw new InternalServerErrorException('입력 요청 생성 중 문제 발생');
-    }*/
-
-    return this.requestInfoService.sendRequestInfoUrlMessage(
+    const message = this.requestInfoService.sendRequestInfoUrlMessage(
       requestInfo,
       isTest,
     );
+
+    if (isTest) {
+      return message;
+    } else {
+      return '초대 메시지 전송 완료';
+    }
   }
 
   @Delete(':requestInfoId')

--- a/backend/src/request-info/request-info.module.ts
+++ b/backend/src/request-info/request-info.module.ts
@@ -1,8 +1,6 @@
 import { Module } from '@nestjs/common';
 import { RequestInfoService } from './service/request-info.service';
 import { RequestInfoController } from './request-info.controller';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { RequestInfoModel } from './entity/request-info.entity';
 import { RequestLimitValidatorService } from './service/request-limit-validator.service';
 import { CommonModule } from '../common/common.module';
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
@@ -12,7 +10,6 @@ import { RequestInfoDomainModule } from './request-info-domain/request-info-doma
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([RequestInfoModel]),
     CommonModule,
     RequestInfoDomainModule,
     ChurchesDomainModule,


### PR DESCRIPTION
## 주요 내용
교인 초대 메시지 전송 시 교회 이름이 누락되어 메시지 내용이 올바르게 출력되지 않던 문제를 수정하였고, 문자 메시지 전송을 비동기로 처리하여 응답 지연을 최소화하였습니다.

## 세부 내용
- 초대 메시지 구성 시 교회 이름이 정상적으로 포함되도록 데이터 조회 로직 수정
- 문자 전송 로직을 비동기 방식으로 변경하여 요청 응답 속도 개선

이번 수정으로 초대 메시지의 정확도가 향상되었으며,
문자 전송 비동화로 전체 응답 속도 및 사용자 경험이 개선되었습니다. 📩⚡️