### PR TITLE
feat: 교인 사역 이력 도메인 서비스 추가

### DIFF
--- a/backend/src/member-history/const/exception/ministry-history.exception.ts
+++ b/backend/src/member-history/const/exception/ministry-history.exception.ts
@@ -1,0 +1,8 @@
+export const MinistryHistoryException = {
+  NOT_FOUND: '',
+  ALREADY_EXIST: '이미 부여된 사역입니다.',
+  CANNOT_DELETE: '종료되지 않은 이력을 삭제할 수 없습니다.',
+  RELATION_OPTIONS_ERROR: '사역 정보 불러오기 실패',
+  UPDATE_ERROR: '사역 이력 업데이트 도중 에러 발생',
+  DELETE_ERROR: '사역 이력 삭제 도중 에러 발생',
+};

--- a/backend/src/member-history/const/exception/officer-history.exception.ts
+++ b/backend/src/member-history/const/exception/officer-history.exception.ts
@@ -1,6 +1,7 @@
 export const OfficerHistoryException = {
   NOT_FOUND: '직분 이력을 찾을 수 없습니다.',
   ALREADY_EXIST: '직분이 있는 교인입니다.',
+  CANNOT_DELETE: '종료되지 않은 이력을 삭제할 수 없습니다.',
   UPDATE_ERROR: '직분 이력 업데이트 도중 에러 발생',
   DELETE_ERROR: '직분 이력 삭제 도중 에러 발생',
 

--- a/backend/src/member-history/controller/member-ministry.controller.ts
+++ b/backend/src/member-history/controller/member-ministry.controller.ts
@@ -21,7 +21,6 @@ import {
   ApiDeleteMemberMinistry,
   ApiDeleteMinistryHistory,
   ApiGetMemberMinistry,
-  ApiGetMinistryHistory,
   ApiPatchMinistryHistory,
   ApiPostMemberMinistry,
 } from '../const/swagger/ministry/controller.swagger';
@@ -41,7 +40,7 @@ export class MemberMinistryController {
     @Param('memberId', ParseIntPipe) memberId: number,
     @Query() dto: GetMinistryHistoryDto,
   ) {
-    return this.memberMinistryService.getCurrentMemberMinistry(
+    return this.memberMinistryService.getMinistryHistories(
       churchId,
       memberId,
       dto,
@@ -80,49 +79,10 @@ export class MemberMinistryController {
     return 'patch ministry';
   }
 
-  // 교인의 현재 사역 삭제 + 종료
-  // N:N relation 삭제
-  // 현재 ministryHistory 삭제 + 해당 MinistryHistoryModel 에 endDate 추가
-  @ApiDeleteMemberMinistry()
-  @Delete(':ministryId')
-  @UseInterceptors(TransactionInterceptor)
-  deleteMemberMinistry(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
-    @Param('ministryId', ParseIntPipe) ministryId: number,
-    @Body() dto: EndMemberMinistryDto,
-    @QueryRunner() qr: QR,
-  ) {
-    //return 'delete Ministry';
-    return this.memberMinistryService.endMemberMinistry(
-      churchId,
-      memberId,
-      ministryId,
-      dto,
-      qr,
-    );
-  }
-
-  // 교인의 사역 이력 조회
-  @ApiGetMinistryHistory()
-  //@Get('history')
-  getMinistryHistory(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
-    @Query() dto: GetMinistryHistoryDto,
-  ) {
-    /*return this.memberMinistryService.getMinistryHistory(
-      churchId,
-      memberId,
-      dto,
-    );*/
-    //return 'get history';
-  }
-
   // 교인의 사역 이력 수정
   // 사역의 시작 날짜, 종료 날짜만 수정 가능
   @ApiPatchMinistryHistory()
-  @Patch('history/:ministryHistoryId')
+  @Patch(':ministryHistoryId')
   patchMinistryHistory(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
@@ -138,9 +98,31 @@ export class MemberMinistryController {
     );
   }
 
+  // 교인의 현재 사역  종료
+  // N:N relation 삭제
+  // 해당 MinistryHistoryModel 에 endDate 추가
+  @ApiDeleteMemberMinistry()
+  @Patch(':ministryHistoryId/end')
+  @UseInterceptors(TransactionInterceptor)
+  deleteMemberMinistry(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Param('ministryHistoryId', ParseIntPipe) ministryHistoryId: number,
+    @Body() dto: EndMemberMinistryDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.memberMinistryService.endMemberMinistry(
+      churchId,
+      memberId,
+      ministryHistoryId,
+      dto,
+      qr,
+    );
+  }
+
   // 교인의 사역 이력 삭제
   @ApiDeleteMinistryHistory()
-  @Delete('history/:ministryHistoryId')
+  @Delete(':ministryHistoryId')
   deleteMinistryHistory(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,

--- a/backend/src/member-history/dto/ministry/ministry-history-pagination-result.dto.ts
+++ b/backend/src/member-history/dto/ministry/ministry-history-pagination-result.dto.ts
@@ -1,0 +1,7 @@
+import { BasePaginationResultDto } from '../../../common/dto/base-pagination-result.dto';
+import { MinistryHistoryModel } from '../../entity/ministry-history.entity';
+
+export interface MinistryHistoryPaginationResult
+  extends BasePaginationResultDto<MinistryHistoryModel> {
+  totalPage: number;
+}

--- a/backend/src/member-history/entity/ministry-history.entity.ts
+++ b/backend/src/member-history/entity/ministry-history.entity.ts
@@ -21,7 +21,7 @@ export class MinistryHistoryModel extends BaseModel {
   ministryId: number | null;
 
   @ManyToOne(() => MinistryModel, (ministry) => ministry.ministryHistory)
-  ministry: MinistryModel;
+  ministry: MinistryModel | null;
 
   @Column({ comment: '사역 종료일 시점의 사역 이름', nullable: true })
   ministrySnapShot: string;

--- a/backend/src/member-history/member-history-domain/member-history-domain.module.ts
+++ b/backend/src/member-history/member-history-domain/member-history-domain.module.ts
@@ -3,15 +3,24 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { IOFFICER_HISTORY_DOMAIN_SERVICE } from './service/interface/officer-history-domain.service.interface';
 import { OfficerHistoryDomainService } from './service/officer-history-domain.service';
 import { OfficerHistoryModel } from '../entity/officer-history.entity';
+import { IMINISTRY_HISTORY_DOMAIN_SERVICE } from './service/interface/ministry-history-domain.service.interface';
+import { MinistryHistoryDomainService } from './service/ministry-history-domain.service';
+import { MinistryHistoryModel } from '../entity/ministry-history.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([OfficerHistoryModel])],
+  imports: [
+    TypeOrmModule.forFeature([OfficerHistoryModel, MinistryHistoryModel]),
+  ],
   providers: [
     {
       provide: IOFFICER_HISTORY_DOMAIN_SERVICE,
       useClass: OfficerHistoryDomainService,
     },
+    {
+      provide: IMINISTRY_HISTORY_DOMAIN_SERVICE,
+      useClass: MinistryHistoryDomainService,
+    },
   ],
-  exports: [IOFFICER_HISTORY_DOMAIN_SERVICE],
+  exports: [IOFFICER_HISTORY_DOMAIN_SERVICE, IMINISTRY_HISTORY_DOMAIN_SERVICE],
 })
 export class MemberHistoryDomainModule {}

--- a/backend/src/member-history/member-history-domain/service/interface/ministry-history-domain.service.interface.ts
+++ b/backend/src/member-history/member-history-domain/service/interface/ministry-history-domain.service.interface.ts
@@ -1,0 +1,53 @@
+import { MemberModel } from '../../../../members/entity/member.entity';
+import { GetMinistryHistoryDto } from '../../../dto/ministry/get-ministry-history.dto';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
+import { MinistryHistoryModel } from '../../../entity/ministry-history.entity';
+import { MinistryModel } from '../../../../management/ministries/entity/ministry.entity';
+import { UpdateMinistryHistoryDto } from '../../../dto/ministry/update-ministry-history.dto';
+
+export const IMINISTRY_HISTORY_DOMAIN_SERVICE = Symbol(
+  'IMINISTRY_HISTORY_DOMAIN_SERVICE',
+);
+
+export interface IMinistryHistoryDomainService {
+  paginateMinistryHistory(
+    member: MemberModel,
+    dto: GetMinistryHistoryDto,
+    qr?: QueryRunner,
+  ): Promise<{ ministryHistories: MinistryHistoryModel[]; totalCount: number }>;
+
+  findMinistryHistoryModelById(
+    member: MemberModel,
+    ministryHistoryId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<MinistryHistoryModel>,
+  ): Promise<MinistryHistoryModel>;
+
+  createMinistryHistory(
+    member: MemberModel,
+    ministry: MinistryModel,
+    startDate: Date,
+    qr: QueryRunner,
+  ): Promise<MinistryHistoryModel>;
+
+  endMinistryHistory(
+    ministryHistory: MinistryHistoryModel,
+    snapShot: {
+      ministrySnapShot: string;
+      ministryGroupSnapShot: string | null;
+    },
+    endDate: Date,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  updateMinistryHistory(
+    ministryHistory: MinistryHistoryModel,
+    dto: UpdateMinistryHistoryDto,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  deleteMinistryHistory(
+    ministryHistory: MinistryHistoryModel,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+}

--- a/backend/src/member-history/member-history-domain/service/ministry-history-domain.service.ts
+++ b/backend/src/member-history/member-history-domain/service/ministry-history-domain.service.ts
@@ -1,0 +1,247 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { IMinistryHistoryDomainService } from './interface/ministry-history-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { MinistryHistoryModel } from '../../entity/ministry-history.entity';
+import { FindOptionsRelations, IsNull, QueryRunner, Repository } from 'typeorm';
+import { MemberModel } from '../../../members/entity/member.entity';
+import { GetMinistryHistoryDto } from '../../dto/ministry/get-ministry-history.dto';
+import { MinistryModel } from '../../../management/ministries/entity/ministry.entity';
+import { MinistryHistoryException } from '../../const/exception/ministry-history.exception';
+import { UpdateMinistryHistoryDto } from '../../dto/ministry/update-ministry-history.dto';
+
+@Injectable()
+export class MinistryHistoryDomainService
+  implements IMinistryHistoryDomainService
+{
+  constructor(
+    @InjectRepository(MinistryHistoryModel)
+    private ministryHistoryRepository: Repository<MinistryHistoryModel>,
+  ) {}
+
+  private getMinistryHistoryRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(MinistryHistoryModel)
+      : this.ministryHistoryRepository;
+  }
+
+  async paginateMinistryHistory(
+    member: MemberModel,
+    dto: GetMinistryHistoryDto,
+    qr?: QueryRunner,
+  ) {
+    const ministryHistoryRepository = this.getMinistryHistoryRepository(qr);
+
+    const [ministryHistories, totalCount] = await Promise.all([
+      ministryHistoryRepository.find({
+        where: {
+          memberId: member.id,
+        },
+        relations: {
+          ministry: {
+            ministryGroup: true,
+          },
+        },
+        order: {
+          endDate: dto.orderDirection,
+          startDate: dto.orderDirection,
+          id: dto.orderDirection,
+        },
+        take: dto.take,
+        skip: dto.take * (dto.page - 1),
+      }),
+      ministryHistoryRepository.count({
+        where: {
+          memberId: member.id,
+        },
+      }),
+    ]);
+
+    return { ministryHistories, totalCount };
+  }
+
+  async findMinistryHistoryModelById(
+    member: MemberModel,
+    ministryHistoryId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<MinistryHistoryModel>,
+  ) {
+    const ministryHistoryRepository = this.getMinistryHistoryRepository(qr);
+
+    const ministryHistory = await ministryHistoryRepository.findOne({
+      where: {
+        id: ministryHistoryId,
+        memberId: member.id,
+      },
+      relations: relationOptions,
+    });
+
+    if (!ministryHistory) {
+      throw new NotFoundException(MinistryHistoryException.NOT_FOUND);
+    }
+
+    return ministryHistory;
+  }
+
+  private async isExistMinistryHistory(
+    member: MemberModel,
+    ministry: MinistryModel,
+    qr?: QueryRunner,
+  ) {
+    const ministryHistoryRepository = this.getMinistryHistoryRepository(qr);
+
+    const ministryHistory = await ministryHistoryRepository.findOne({
+      where: {
+        memberId: member.id,
+        ministryId: ministry.id,
+        endDate: IsNull(),
+      },
+    });
+
+    return !!ministryHistory;
+  }
+
+  async createMinistryHistory(
+    member: MemberModel,
+    ministry: MinistryModel,
+    startDate: Date,
+    qr: QueryRunner,
+  ) {
+    const ministryHistoryRepository = this.getMinistryHistoryRepository(qr);
+
+    const isExistMinistryHistory = await this.isExistMinistryHistory(
+      member,
+      ministry,
+      qr,
+    );
+
+    if (isExistMinistryHistory) {
+      throw new ConflictException(MinistryHistoryException.ALREADY_EXIST);
+    }
+
+    return ministryHistoryRepository.save({
+      //memberId: member.id,
+      //ministryId: ministry.id,
+      member,
+      ministry,
+      startDate,
+    });
+  }
+
+  async endMinistryHistory(
+    ministryHistory: MinistryHistoryModel,
+    snapShot: {
+      ministrySnapShot: string;
+      ministryGroupSnapShot: string | null;
+    },
+    endDate: Date,
+    qr: QueryRunner,
+  ) {
+    const ministryHistoryRepository = this.getMinistryHistoryRepository(qr);
+
+    const result = await ministryHistoryRepository.update(
+      { id: ministryHistory.id },
+      {
+        ministryId: null,
+        ministrySnapShot: snapShot.ministrySnapShot,
+        ministryGroupSnapShot: snapShot.ministryGroupSnapShot,
+        endDate,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        MinistryHistoryException.UPDATE_ERROR,
+      );
+    }
+
+    return result;
+  }
+
+  private isValidUpdateDate(
+    targetHistory: MinistryHistoryModel,
+    dto: UpdateMinistryHistoryDto,
+  ) {
+    if (targetHistory.endDate === null && dto.endDate) {
+      throw new BadRequestException(
+        '종료되지 않은 사역의 종료 날짜를 수정할 수 없습니다.',
+      );
+    }
+
+    // 시작일 변경하는 경우 --> 새로운 시작일이 종료일보다 앞에 있어야함
+    // 종료일 변경하는 경우 --> 새로운 종료일이 시작일보다 뒤에 있어야함
+    // 시작일,종료일 변경하는 경우 --> DTO 에서 검증
+
+    if (dto.startDate && !dto.endDate) {
+      if (targetHistory.endDate && dto.startDate > targetHistory.endDate) {
+        throw new BadRequestException(
+          '이력 시작일은 종료일보다 늦을 수 없습니다.',
+        );
+      }
+    }
+
+    if (dto.endDate && !dto.startDate) {
+      if (dto.endDate < targetHistory.startDate) {
+        throw new BadRequestException(
+          '이력 종료일은 시작일보다 빠를 수 없습니다.',
+        );
+      }
+    }
+  }
+
+  async updateMinistryHistory(
+    ministryHistory: MinistryHistoryModel,
+    dto: UpdateMinistryHistoryDto,
+    qr?: QueryRunner,
+  ) {
+    const ministryHistoryRepository = this.getMinistryHistoryRepository(qr);
+
+    this.isValidUpdateDate(ministryHistory, dto);
+
+    const result = await ministryHistoryRepository.update(
+      {
+        id: ministryHistory.id,
+      },
+      {
+        startDate: dto.startDate,
+        endDate: dto.endDate,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        MinistryHistoryException.UPDATE_ERROR,
+      );
+    }
+
+    return result;
+  }
+
+  async deleteMinistryHistory(
+    ministryHistory: MinistryHistoryModel,
+    qr?: QueryRunner,
+  ) {
+    if (ministryHistory.endDate === null) {
+      throw new BadRequestException(MinistryHistoryException.CANNOT_DELETE);
+    }
+
+    const ministryHistoryRepository = this.getMinistryHistoryRepository(qr);
+
+    const result = await ministryHistoryRepository.softDelete(
+      ministryHistory.id,
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        MinistryHistoryException.DELETE_ERROR,
+      );
+    }
+
+    return result;
+  }
+}

--- a/backend/src/member-history/member-history-domain/service/officer-history-domain.service.ts
+++ b/backend/src/member-history/member-history-domain/service/officer-history-domain.service.ts
@@ -238,7 +238,7 @@ export class OfficerHistoryDomainService
     qr?: QueryRunner,
   ) {
     if (officerHistory.endDate === null) {
-      throw new BadRequestException('종료되지 않은 이력을 삭제할 수 없습니다.');
+      throw new BadRequestException(OfficerHistoryException.CANNOT_DELETE);
     }
 
     const officerHistoryRepository = this.getOfficerHistoryRepository(qr);


### PR DESCRIPTION
## 주요 내용
교인의 사역 이력 관리를 위한 도메인 로직을 `MinistryHistoryDomainService`로 분리하여 비즈니스 로직과 도메인 로직의 책임을 명확히 하였습니다.

## 세부 내용
- `MinistryHistoryDomainService` 인터페이스 선언 및 구현
- 사역 이력 생성, 수정, 상태 검증 등 도메인 규칙을 도메인 서비스에서 처리
- 기존 서비스 계층은 유스케이스 흐름 제어에 집중하도록 구조 분리
- 도메인 중심 설계를 기반으로 역할 분리 및 테스트 용이성 확보

이번 변경을 통해 교인의 사역 이력 로직이 구조적으로 정리되었으며,
유지보수성과 확장성이 향상되었습니다. 🛠️🚀