### PR TITLE
feat: 심방 메타데이터 생성 및 조회 기능 추가

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -38,6 +38,9 @@ import { OfficerHistoryModel } from './member-history/entity/officer-history.ent
 import { MinistryHistoryModel } from './member-history/entity/ministry-history.entity';
 import { GroupHistoryModel } from './member-history/entity/group-history.entity';
 import { MemberHistoryModule } from './member-history/member-history.module';
+import { VisitationModule } from './visitation/visitation.module';
+import { VisitationMetaModel } from './visitation/entity/visitation-meta.entity';
+import { VisitationDetailModel } from './visitation/entity/visitation-detail.entity';
 
 @Module({
   imports: [
@@ -131,6 +134,9 @@ import { MemberHistoryModule } from './member-history/member-history.module';
           GroupModel,
           GroupRoleModel,
           GroupHistoryModel,
+          // 심방 관련 엔티티
+          VisitationMetaModel,
+          VisitationDetailModel,
         ],
         synchronize: true,
       }),
@@ -152,6 +158,7 @@ import { MemberHistoryModule } from './member-history/member-history.module';
     FamilyRelationModule,
     MemberHistoryModule,
     ManagementModule,
+    VisitationModule,
 
     ChurchesDomainModule,
     MembersDomainModule,

--- a/backend/src/churches/entity/church.entity.ts
+++ b/backend/src/churches/entity/church.entity.ts
@@ -10,6 +10,7 @@ import { MinistryGroupModel } from '../../management/ministries/entity/ministry-
 import { MinistryModel } from '../../management/ministries/entity/ministry.entity';
 import { MemberModel } from '../../members/entity/member.entity';
 import { RequestInfoModel } from '../../request-info/entity/request-info.entity';
+import { VisitationMetaModel } from '../../visitation/entity/visitation-meta.entity';
 
 @Entity()
 export class ChurchModel extends BaseModel {
@@ -66,4 +67,7 @@ export class ChurchModel extends BaseModel {
 
   @OneToMany(() => MemberModel, (member) => member.church)
   members: MemberModel[];
+
+  @OneToMany(() => VisitationMetaModel, (visitingMeta) => visitingMeta.church)
+  visitations: VisitationMetaModel[];
 }

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -27,6 +27,7 @@ import { RequestInfoModel } from '../../request-info/entity/request-info.entity'
 import { MinistryHistoryModel } from '../../member-history/entity/ministry-history.entity';
 import { OfficerHistoryModel } from '../../member-history/entity/officer-history.entity';
 import { GroupHistoryModel } from '../../member-history/entity/group-history.entity';
+import { VisitationDetailModel } from '../../visitation/entity/visitation-detail.entity';
 
 @Entity()
 export class MemberModel extends BaseModel {
@@ -193,4 +194,10 @@ export class MemberModel extends BaseModel {
 
   @OneToMany(() => GroupHistoryModel, (groupHistory) => groupHistory.member)
   groupHistory: GroupHistoryModel[];
+
+  @OneToMany(
+    () => VisitationDetailModel,
+    (visitingDetail) => visitingDetail.member,
+  )
+  visitationDetails: VisitationDetailModel[];
 }

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,15 +1,13 @@
 import { Module } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { UserModel } from './entity/user.entity';
 import { UserDomainModule } from './user-domain/user-domain.module';
 import { MembersDomainModule } from '../members/member-domain/members-domain.module';
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([UserModel /*, MemberModel, ChurchModel*/]),
+    //TypeOrmModule.forFeature([UserModel /*, MemberModel, ChurchModel*/]),
     //JwtModule.register({}),
     UserDomainModule,
     ChurchesDomainModule,

--- a/backend/src/visitation/const/exception/visitation-meta.exception.ts
+++ b/backend/src/visitation/const/exception/visitation-meta.exception.ts
@@ -1,0 +1,6 @@
+export const VisitationMetaException = {
+  NOT_FOUND: '심방 데이터를 찾을 수 없습니다.',
+  INVALID_INSTRUCTOR: '심방 진행자로 등록할 수 없습니다.',
+  UPDATE_ERROR: '심방 데이터 업데이트 도중 에러 발생',
+  DELETE_ERROR: '심방 데이터 삭제 도중 에러 발생',
+};

--- a/backend/src/visitation/const/visitation-method.enum.ts
+++ b/backend/src/visitation/const/visitation-method.enum.ts
@@ -1,0 +1,4 @@
+export enum VisitationMethod {
+  IN_PERSON = 'IN_PERSON',
+  REMOTE = 'REMOTE',
+}

--- a/backend/src/visitation/const/visitation-type.enum.ts
+++ b/backend/src/visitation/const/visitation-type.enum.ts
@@ -1,0 +1,4 @@
+export enum VisitationType {
+  SINGLE = 'SINGLE',
+  GROUP = 'GROUP',
+}

--- a/backend/src/visitation/dto/detail/create-visitation-detail.dto.ts
+++ b/backend/src/visitation/dto/detail/create-visitation-detail.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class CreateVisitationDetailDto {
+  @ApiProperty({
+    description: '심방 대상자 교인 ID',
+  })
+  @IsNumber()
+  memberId: number;
+
+  @ApiProperty({
+    description: '심방 내용',
+  })
+  @IsString()
+  @IsOptional()
+  visitationContent: string;
+
+  @ApiProperty({
+    description: '기도 제목',
+  })
+  @IsString()
+  @IsOptional()
+  visitationPray: string;
+}

--- a/backend/src/visitation/dto/meta/create-visitation-meta.dto.ts
+++ b/backend/src/visitation/dto/meta/create-visitation-meta.dto.ts
@@ -1,0 +1,47 @@
+import { VisitationMethod } from '../../const/visitation-method.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDate, IsEnum, IsNumber, IsString, Length } from 'class-validator';
+import { VisitationType } from '../../const/visitation-type.enum';
+import { TransformStartDate } from '../../../member-history/decorator/transform-start-date.decorator';
+
+export class CreateVisitationMetaDto {
+  @ApiProperty({
+    description: '심방 방식 (대면 / 비대면)',
+    enum: VisitationMethod,
+    required: true,
+  })
+  @IsEnum(VisitationMethod)
+  visitationMethod: VisitationMethod;
+
+  @ApiProperty({
+    description: '심방 종류 (개인 / 그룹)',
+    enum: VisitationType,
+    required: true,
+  })
+  @IsEnum(VisitationType)
+  visitationType: VisitationType;
+
+  @ApiProperty({
+    description: '심방 제목',
+    maxLength: 50,
+    required: true,
+  })
+  @IsString()
+  @Length(2, 50)
+  visitationTitle: string;
+
+  @ApiProperty({
+    description: '진행자 ID',
+    required: true,
+  })
+  @IsNumber()
+  instructorId: number;
+
+  @ApiProperty({
+    description: '심방 날짜',
+    required: true,
+  })
+  @IsDate()
+  @TransformStartDate()
+  visitationDate: Date;
+}

--- a/backend/src/visitation/dto/meta/update-visitation-meta.dto.ts
+++ b/backend/src/visitation/dto/meta/update-visitation-meta.dto.ts
@@ -1,0 +1,6 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateVisitationMetaDto } from './create-visitation-meta.dto';
+
+export class UpdateVisitationMetaDto extends PartialType(
+  CreateVisitationMetaDto,
+) {}

--- a/backend/src/visitation/entity/visitation-detail.entity.ts
+++ b/backend/src/visitation/entity/visitation-detail.entity.ts
@@ -1,0 +1,32 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseModel } from '../../common/entity/base.entity';
+import { VisitationMetaModel } from './visitation-meta.entity';
+import { MemberModel } from '../../members/entity/member.entity';
+
+@Entity()
+export class VisitationDetailModel extends BaseModel {
+  @Index()
+  @Column()
+  visitationMetaId: number;
+
+  @ManyToOne(
+    () => VisitationMetaModel,
+    (visitingMeta) => visitingMeta.visitationDetails,
+  )
+  @JoinColumn({ name: 'visitationMetaId' })
+  visitationMeta: VisitationMetaModel;
+
+  @Index()
+  @Column()
+  memberId: number;
+
+  @ManyToOne(() => MemberModel, (member) => member.visitationDetails)
+  @JoinColumn({ name: 'memberId' })
+  member: MemberModel;
+
+  @Column()
+  visitationContent: string;
+
+  @Column()
+  visitationPray: string;
+}

--- a/backend/src/visitation/entity/visitation-meta.entity.ts
+++ b/backend/src/visitation/entity/visitation-meta.entity.ts
@@ -1,0 +1,52 @@
+import { BaseModel } from '../../common/entity/base.entity';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+} from 'typeorm';
+import { VisitationDetailModel } from './visitation-detail.entity';
+import { UserModel } from '../../user/entity/user.entity';
+import { VisitationMethod } from '../const/visitation-method.enum';
+import { VisitationType } from '../const/visitation-type.enum';
+import { ChurchModel } from '../../churches/entity/church.entity';
+
+@Entity()
+export class VisitationMetaModel extends BaseModel {
+  @Index()
+  @Column()
+  churchId: number;
+
+  @ManyToOne(() => ChurchModel, (church) => church.visitations)
+  @JoinColumn({ name: 'churchId' })
+  church: ChurchModel;
+
+  @Column({ enum: VisitationMethod, comment: '심방 방식 (대면 / 비대면)' })
+  visitationMethod: VisitationMethod;
+
+  @Column({ enum: VisitationType, comment: '심방 종류 (개인 / 그룹)' })
+  visitationType: VisitationType;
+
+  @Index()
+  @Column({ type: 'timestamptz', comment: '심방 일자' })
+  visitationDate: Date;
+
+  @Column({ length: 50, comment: '심방 제목' })
+  visitationTitle: string;
+
+  @Index()
+  @Column({ comment: '심방 진행자 ID' })
+  instructorId: number;
+
+  @ManyToOne(() => UserModel)
+  @JoinColumn({ name: 'instructorId' })
+  instructor: UserModel;
+
+  @OneToMany(
+    () => VisitationDetailModel,
+    (visitingDetail) => visitingDetail.visitationMeta,
+  )
+  visitationDetails: VisitationDetailModel[];
+}

--- a/backend/src/visitation/visitation-domain/service/interface/visitation-detail-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/service/interface/visitation-detail-domain.service.interface.ts
@@ -1,0 +1,5 @@
+export const IVISITATION_DETAIL_DOMAIN_SERVICE = Symbol(
+  'IVISITATION_DETAIL_DOMAIN_SERVICE',
+);
+
+export interface IVisitationDetailDomainService {}

--- a/backend/src/visitation/visitation-domain/service/interface/visitation-meta-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/service/interface/visitation-meta-domain.service.interface.ts
@@ -1,0 +1,41 @@
+import { ChurchModel } from '../../../../churches/entity/church.entity';
+import { MemberModel } from '../../../../members/entity/member.entity';
+import { CreateVisitationMetaDto } from '../../../dto/meta/create-visitation-meta.dto';
+import { FindOptionsRelations, QueryRunner } from 'typeorm';
+import { VisitationMetaModel } from '../../../entity/visitation-meta.entity';
+
+export const IVISITATION_META_DOMAIN_SERVICE = Symbol(
+  'IVISITATION_META_DOMAIN_SERVICE',
+);
+
+export interface IVisitationMetaDomainService {
+  paginateVisitations(
+    church: ChurchModel,
+  ): Promise<{ visitations: VisitationMetaModel[]; totalCount: number }>;
+
+  findVisitationMetaById(
+    church: ChurchModel,
+    visitationMetaId: number,
+    qr?: QueryRunner,
+  ): Promise<VisitationMetaModel>;
+
+  findVisitationMetaModelById(
+    church: ChurchModel,
+    visitationMetaId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<VisitationMetaModel>,
+  ): Promise<VisitationMetaModel>;
+
+  createVisitationMetaData(
+    church: ChurchModel,
+    instructor: MemberModel,
+    dto: CreateVisitationMetaDto,
+    qr?: QueryRunner,
+  ): Promise<VisitationMetaModel>;
+
+  updateVisitationMetaData(
+    visitationMetaData: VisitationMetaModel,
+    dto: any,
+    qr?: QueryRunner,
+  ): Promise<VisitationMetaModel>;
+}

--- a/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import { IVisitationDetailDomainService } from './interface/visitation-detail-domain.service.interface';
+
+@Injectable()
+export class VisitationDetailDomainService
+  implements IVisitationDetailDomainService
+{
+  constructor() {}
+}

--- a/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
@@ -1,0 +1,153 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { IVisitationMetaDomainService } from './interface/visitation-meta-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
+import { QueryRunner, Repository } from 'typeorm';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { CreateVisitationMetaDto } from '../../dto/meta/create-visitation-meta.dto';
+import { MemberModel } from '../../../members/entity/member.entity';
+import { VisitationMetaException } from '../../const/exception/visitation-meta.exception';
+
+@Injectable()
+export class VisitationMetaDomainService
+  implements IVisitationMetaDomainService
+{
+  constructor(
+    @InjectRepository(VisitationMetaModel)
+    private readonly visitationMetaRepository: Repository<VisitationMetaModel>,
+  ) {}
+
+  private getVisitationMetaRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(VisitationMetaModel)
+      : this.visitationMetaRepository;
+  }
+
+  async paginateVisitations(
+    church: ChurchModel,
+  ): Promise<{ visitations: VisitationMetaModel[]; totalCount: number }> {
+    const repository = this.getVisitationMetaRepository();
+
+    const [visitations, totalCount] = await Promise.all([
+      repository.find({
+        where: {
+          churchId: church.id,
+        },
+        relations: {
+          visitationDetails: {
+            member: true,
+          },
+        },
+      }),
+      repository.count({
+        where: {
+          churchId: church.id,
+        },
+      }),
+    ]);
+
+    return { visitations, totalCount };
+  }
+
+  async findVisitationMetaById(
+    church: ChurchModel,
+    visitationMetaId: number,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getVisitationMetaRepository(qr);
+
+    const visitation = await repository.findOne({
+      where: {
+        churchId: church.id,
+        id: visitationMetaId,
+      },
+      relations: {
+        instructor: true,
+      },
+    });
+
+    if (!visitation) {
+      throw new NotFoundException(VisitationMetaException.NOT_FOUND);
+    }
+
+    return visitation;
+  }
+
+  async findVisitationMetaModelById(
+    church: ChurchModel,
+    visitationMetaId: number,
+    qr?: QueryRunner,
+  ): Promise<VisitationMetaModel> {
+    const repository = this.getVisitationMetaRepository(qr);
+
+    const metaData = await repository.findOne({
+      where: {
+        id: visitationMetaId,
+        churchId: church.id,
+      },
+    });
+
+    if (!metaData) {
+      throw new NotFoundException(VisitationMetaException.NOT_FOUND);
+    }
+
+    return metaData;
+  }
+
+  async createVisitationMetaData(
+    church: ChurchModel,
+    instructor: MemberModel,
+    dto: CreateVisitationMetaDto,
+    qr?: QueryRunner,
+  ) {
+    const visitationMetaRepository = this.getVisitationMetaRepository(qr);
+
+    return visitationMetaRepository.save({
+      church,
+      instructor,
+      visitationMethod: dto.visitationMethod,
+      visitationType: dto.visitationType,
+      visitationTitle: dto.visitationTitle,
+      visitationDate: dto.visitationDate,
+    });
+  }
+
+  async updateVisitationMetaData(
+    visitationMetaData: VisitationMetaModel,
+    dto: any,
+    qr?: QueryRunner,
+  ): Promise<VisitationMetaModel> {
+    const visitationMetaRepository = this.getVisitationMetaRepository(qr);
+
+    const result = await visitationMetaRepository.update(
+      {
+        id: visitationMetaData.id,
+      },
+      {
+        ...dto,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException();
+    }
+
+    const meta = await this.visitationMetaRepository.findOne({
+      where: {
+        id: visitationMetaData.id,
+      },
+    });
+
+    if (!meta) {
+      throw new InternalServerErrorException(
+        VisitationMetaException.UPDATE_ERROR,
+      );
+    }
+
+    return meta;
+  }
+}

--- a/backend/src/visitation/visitation-domain/visitation-domain.module.ts
+++ b/backend/src/visitation/visitation-domain/visitation-domain.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { VisitationMetaModel } from '../entity/visitation-meta.entity';
+import { VisitationDetailModel } from '../entity/visitation-detail.entity';
+import { IVISITATION_META_DOMAIN_SERVICE } from './service/interface/visitation-meta-domain.service.interface';
+import { VisitationMetaDomainService } from './service/visitation-meta-domain.service';
+import { IVISITATION_DETAIL_DOMAIN_SERVICE } from './service/interface/visitation-detail-domain.service.interface';
+import { VisitationDetailDomainService } from './service/visitation-detail-domain.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([VisitationMetaModel, VisitationDetailModel]),
+  ],
+  providers: [
+    {
+      provide: IVISITATION_META_DOMAIN_SERVICE,
+      useClass: VisitationMetaDomainService,
+    },
+    {
+      provide: IVISITATION_DETAIL_DOMAIN_SERVICE,
+      useClass: VisitationDetailDomainService,
+    },
+  ],
+  exports: [IVISITATION_DETAIL_DOMAIN_SERVICE, IVISITATION_META_DOMAIN_SERVICE],
+})
+export class VisitationDomainModule {}

--- a/backend/src/visitation/visitation.controller.ts
+++ b/backend/src/visitation/visitation.controller.ts
@@ -1,0 +1,76 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { VisitationService } from './visitation.service';
+import { CreateVisitationMetaDto } from './dto/meta/create-visitation-meta.dto';
+import { UpdateVisitationMetaDto } from './dto/meta/update-visitation-meta.dto';
+import { TransactionInterceptor } from '../common/interceptor/transaction.interceptor';
+import { QueryRunner } from '../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm';
+
+@ApiTags('Visitations')
+@Controller('visitations')
+export class VisitationController {
+  constructor(private readonly visitationService: VisitationService) {}
+
+  @Get()
+  getVisitations(@Param('churchId', ParseIntPipe) churchId: number) {
+    return this.visitationService.getVisitations(churchId);
+  }
+
+  @Post('meta')
+  postVisitationMetaData(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Body() dto: CreateVisitationMetaDto,
+  ) {
+    return this.visitationService.createVisitingMetaData(churchId, dto);
+  }
+
+  @Post(':metaId/details')
+  postVisitationDetail(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('metaId', ParseIntPipe) metaId: number,
+  ) {}
+
+  @Patch(':metaId/details/:detailId')
+  patchVisitationDetail() {}
+
+  @Get(':visitingId')
+  @UseInterceptors(TransactionInterceptor)
+  getVisitingById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('visitingId', ParseIntPipe) visitingMetaDataId: number,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.visitationService.getVisitationById(
+      churchId,
+      visitingMetaDataId,
+      qr,
+    );
+  }
+
+  @Patch(':visitationId')
+  patchVisitationMetaData(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('visitationId', ParseIntPipe) visitationMetaDataId: number,
+    @Body() dto: UpdateVisitationMetaDto,
+  ) {
+    return this.visitationService.updateVisitingMetaData(
+      churchId,
+      visitationMetaDataId,
+      dto,
+    );
+  }
+
+  @Delete(':visitingId')
+  deleteVisiting(@Param('visitingId', ParseIntPipe) visitingId) {}
+}

--- a/backend/src/visitation/visitation.module.ts
+++ b/backend/src/visitation/visitation.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { RouterModule } from '@nestjs/core';
+import { VisitationController } from './visitation.controller';
+import { VisitationService } from './visitation.service';
+import { VisitationDomainModule } from './visitation-domain/visitation-domain.module';
+import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
+import { UserDomainModule } from '../user/user-domain/user-domain.module';
+import { MembersDomainModule } from '../members/member-domain/members-domain.module';
+
+@Module({
+  imports: [
+    RouterModule.register([
+      { path: 'churches/:churchId', module: VisitationModule },
+    ]),
+
+    ChurchesDomainModule,
+    UserDomainModule,
+    MembersDomainModule,
+
+    VisitationDomainModule,
+  ],
+  controllers: [VisitationController],
+  providers: [VisitationService],
+})
+export class VisitationModule {}

--- a/backend/src/visitation/visitation.service.ts
+++ b/backend/src/visitation/visitation.service.ts
@@ -1,0 +1,129 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import {
+  IVISITATION_META_DOMAIN_SERVICE,
+  IVisitationMetaDomainService,
+} from './visitation-domain/service/interface/visitation-meta-domain.service.interface';
+import {
+  IVISITATION_DETAIL_DOMAIN_SERVICE,
+  IVisitationDetailDomainService,
+} from './visitation-domain/service/interface/visitation-detail-domain.service.interface';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../churches/churches-domain/interface/churches-domain.service.interface';
+import { CreateVisitationMetaDto } from './dto/meta/create-visitation-meta.dto';
+import {
+  IUSER_DOMAIN_SERVICE,
+  IUserDomainService,
+} from '../user/user-domain/interface/user-domain.service.interface';
+import {
+  IMEMBERS_DOMAIN_SERVICE,
+  IMembersDomainService,
+} from '../members/member-domain/service/interface/members-domain.service.interface';
+import { UserRole } from '../user/const/user-role.enum';
+import { VisitationMetaException } from './const/exception/visitation-meta.exception';
+import { UpdateVisitationMetaDto } from './dto/meta/update-visitation-meta.dto';
+import { QueryRunner } from 'typeorm';
+import { VisitationDetailModel } from './entity/visitation-detail.entity';
+import { VisitationMetaModel } from './entity/visitation-meta.entity';
+
+@Injectable()
+export class VisitationService {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IUSER_DOMAIN_SERVICE)
+    private readonly userDomainService: IUserDomainService,
+    @Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,
+
+    @Inject(IVISITATION_META_DOMAIN_SERVICE)
+    private readonly visitationMetaDomainService: IVisitationMetaDomainService,
+    @Inject(IVISITATION_DETAIL_DOMAIN_SERVICE)
+    private readonly visitationDetailDomainService: IVisitationDetailDomainService,
+  ) {}
+
+  async getVisitations(churchId: number) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const { visitations, totalCount } =
+      await this.visitationMetaDomainService.paginateVisitations(church);
+
+    return {
+      data: visitations,
+      totalCount,
+    };
+  }
+
+  async getVisitationById(
+    churchId: number,
+    visitingMetaDataId: number,
+    qr: QueryRunner,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const visitationMeta =
+      await this.visitationMetaDomainService.findVisitationMetaById(
+        church,
+        visitingMetaDataId,
+        qr,
+      );
+
+    const visitationDetails: VisitationDetailModel[] = [];
+
+    const visitation: VisitationMetaModel = {
+      ...visitationMeta,
+      visitationDetails,
+    };
+
+    return visitation;
+  }
+
+  async createVisitingMetaData(churchId: number, dto: CreateVisitationMetaDto) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const instructor = await this.membersDomainService.findMemberModelById(
+      church,
+      dto.instructorId,
+      undefined,
+      { user: true },
+    );
+
+    if (
+      !instructor.user ||
+      (instructor.user.role !== UserRole.mainAdmin &&
+        instructor.user.role !== UserRole.manager)
+    ) {
+      throw new BadRequestException(VisitationMetaException.INVALID_INSTRUCTOR);
+    }
+
+    return this.visitationMetaDomainService.createVisitationMetaData(
+      church,
+      instructor,
+      dto,
+    );
+  }
+
+  async updateVisitingMetaData(
+    churchId: number,
+    visitationMetaDataId: number,
+    dto: UpdateVisitationMetaDto,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const targetMetaData =
+      await this.visitationMetaDomainService.findVisitationMetaModelById(
+        church,
+        visitationMetaDataId,
+      );
+
+    return this.visitationMetaDomainService.updateVisitationMetaData(
+      targetMetaData,
+      dto,
+    );
+  }
+}


### PR DESCRIPTION
## 주요 내용
심방에 대한 메타데이터를 생성하고 조회할 수 있는 기능을 추가하였습니다.

## 세부 내용
- 심방 메타데이터 생성 API 추가
- 교회 기준으로 심방 메타데이터 조회 가능하도록 구현
- 메타데이터 저장 구조 설계 및 필요한 관계 설정
- 향후 심방 기록 및 통계 기능 확장을 위한 기반 마련

이번 기능 추가를 통해 심방 관련 데이터를 보다 체계적으로 관리할 수 있게 되었으며,
추후 심방 일정, 기록, 통계 기능으로 확장할 수 있는 기반을 마련하였습니다. 📋🚀