### PR TITLE
refactor: 심방 생성 시 메타데이터 및 세부데이터 동시 생성 방식으로 변경

### DIFF
--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -28,6 +28,7 @@ import { MinistryHistoryModel } from '../../member-history/entity/ministry-histo
 import { OfficerHistoryModel } from '../../member-history/entity/officer-history.entity';
 import { GroupHistoryModel } from '../../member-history/entity/group-history.entity';
 import { VisitationDetailModel } from '../../visitation/entity/visitation-detail.entity';
+import { VisitationMetaModel } from '../../visitation/entity/visitation-meta.entity';
 
 @Entity()
 export class MemberModel extends BaseModel {
@@ -194,6 +195,24 @@ export class MemberModel extends BaseModel {
 
   @OneToMany(() => GroupHistoryModel, (groupHistory) => groupHistory.member)
   groupHistory: GroupHistoryModel[];
+
+  @OneToMany(
+    () => VisitationMetaModel,
+    (visitationMeta) => visitationMeta.instructor,
+  )
+  visitationInstructor: VisitationMetaModel[];
+
+  @ManyToMany(
+    () => VisitationMetaModel,
+    (visitationMeta) => visitationMeta.reportTo,
+  )
+  visitationReports: VisitationMetaModel[];
+
+  @ManyToMany(
+    () => VisitationMetaModel,
+    (visitationMeta) => visitationMeta.members,
+  )
+  visitationMetas: VisitationMetaModel[];
 
   @OneToMany(
     () => VisitationDetailModel,

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -6,13 +6,7 @@ import { MembersDomainModule } from '../members/member-domain/members-domain.mod
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
 
 @Module({
-  imports: [
-    //TypeOrmModule.forFeature([UserModel /*, MemberModel, ChurchModel*/]),
-    //JwtModule.register({}),
-    UserDomainModule,
-    ChurchesDomainModule,
-    MembersDomainModule,
-  ],
+  imports: [UserDomainModule, ChurchesDomainModule, MembersDomainModule],
   controllers: [UserController],
   providers: [UserService],
   exports: [],

--- a/backend/src/visitation/const/visitation-status.enum.ts
+++ b/backend/src/visitation/const/visitation-status.enum.ts
@@ -1,0 +1,5 @@
+export enum VisitationStatus {
+  RESERVE = 'RESERVE',
+  DONE = 'DONE',
+  PENDING = 'PENDING',
+}

--- a/backend/src/visitation/dto/create-visitation.dto.ts
+++ b/backend/src/visitation/dto/create-visitation.dto.ts
@@ -1,0 +1,69 @@
+import {
+  IsDate,
+  IsEnum,
+  IsNumber,
+  IsString,
+  Length,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { VisitationType } from '../const/visitation-type.enum';
+import { VisitationMethod } from '../const/visitation-method.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { VisitationDetailDto } from './visitation-detail.dto';
+import { Type } from 'class-transformer';
+import { VisitationStatus } from '../const/visitation-status.enum';
+
+export class CreateVisitationDto {
+  @ApiProperty({
+    description: '심방 상태 (예약 / 완료 / 지연)',
+    enum: VisitationStatus,
+    default: VisitationStatus.RESERVE,
+  })
+  @IsEnum(VisitationStatus)
+  visitationStatus: VisitationStatus;
+
+  @ApiProperty({
+    description: '심방 종류 (개인 / 그룹)',
+    enum: VisitationType,
+  })
+  @IsEnum(VisitationType)
+  visitationType: VisitationType;
+
+  @ApiProperty({
+    description: '심방 방식 (대면 / 비대면)',
+    enum: VisitationMethod,
+  })
+  @IsEnum(VisitationMethod)
+  visitationMethod: VisitationMethod;
+
+  @ApiProperty({
+    description: '심방 제목',
+    maxLength: 50,
+  })
+  @IsString()
+  @Length(2, 50)
+  visitationTitle: string;
+
+  @ApiProperty({
+    description: '심방 진행자 ID',
+  })
+  @IsNumber()
+  @Min(1)
+  instructorId: number;
+
+  @ApiProperty({
+    description: '심방 날짜',
+  })
+  @IsDate()
+  visitationDate: Date;
+
+  @ApiProperty({
+    description: '심방 세부 정보',
+    type: VisitationDetailDto,
+    isArray: true,
+  })
+  @ValidateNested({ each: true })
+  @Type(() => VisitationDetailDto)
+  visitationDetails: VisitationDetailDto[];
+}

--- a/backend/src/visitation/dto/meta/create-visitation-meta.dto.ts
+++ b/backend/src/visitation/dto/meta/create-visitation-meta.dto.ts
@@ -3,8 +3,16 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsDate, IsEnum, IsNumber, IsString, Length } from 'class-validator';
 import { VisitationType } from '../../const/visitation-type.enum';
 import { TransformStartDate } from '../../../member-history/decorator/transform-start-date.decorator';
+import { VisitationStatus } from '../../const/visitation-status.enum';
 
 export class CreateVisitationMetaDto {
+  @ApiProperty({
+    description: '심방 상태 (예약 / 완료 / 지연)',
+    enum: VisitationStatus,
+  })
+  @IsEnum(VisitationStatus)
+  visitationStatus: VisitationStatus;
+
   @ApiProperty({
     description: '심방 방식 (대면 / 비대면)',
     enum: VisitationMethod,

--- a/backend/src/visitation/dto/visitation-detail.dto.ts
+++ b/backend/src/visitation/dto/visitation-detail.dto.ts
@@ -1,0 +1,25 @@
+import { IsNumber, IsOptional, IsString, Min } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class VisitationDetailDto {
+  @ApiProperty({
+    description: '심방 대상자 ID',
+  })
+  @IsNumber()
+  @Min(1)
+  memberId: number;
+
+  @ApiProperty({
+    description: '심방 내용 (예약 시 생략)',
+  })
+  @IsString()
+  @IsOptional()
+  visitationContent?: string;
+
+  @ApiProperty({
+    description: '기도 제목 (예약 시 생략)',
+  })
+  @IsString()
+  @IsOptional()
+  visitationPray?: string;
+}

--- a/backend/src/visitation/entity/visitation-detail.entity.ts
+++ b/backend/src/visitation/entity/visitation-detail.entity.ts
@@ -24,9 +24,9 @@ export class VisitationDetailModel extends BaseModel {
   @JoinColumn({ name: 'memberId' })
   member: MemberModel;
 
-  @Column()
+  @Column({ nullable: true })
   visitationContent: string;
 
-  @Column()
+  @Column({ nullable: true })
   visitationPray: string;
 }

--- a/backend/src/visitation/entity/visitation-meta.entity.ts
+++ b/backend/src/visitation/entity/visitation-meta.entity.ts
@@ -4,14 +4,16 @@ import {
   Entity,
   Index,
   JoinColumn,
+  ManyToMany,
   ManyToOne,
   OneToMany,
 } from 'typeorm';
 import { VisitationDetailModel } from './visitation-detail.entity';
-import { UserModel } from '../../user/entity/user.entity';
 import { VisitationMethod } from '../const/visitation-method.enum';
 import { VisitationType } from '../const/visitation-type.enum';
 import { ChurchModel } from '../../churches/entity/church.entity';
+import { MemberModel } from '../../members/entity/member.entity';
+import { VisitationStatus } from '../const/visitation-status.enum';
 
 @Entity()
 export class VisitationMetaModel extends BaseModel {
@@ -22,6 +24,13 @@ export class VisitationMetaModel extends BaseModel {
   @ManyToOne(() => ChurchModel, (church) => church.visitations)
   @JoinColumn({ name: 'churchId' })
   church: ChurchModel;
+
+  @Column({
+    enum: VisitationStatus,
+    comment: '심방 상태 (예약 / 완료 / 지연)',
+    default: VisitationStatus.RESERVE,
+  })
+  visitationStatus: VisitationStatus;
 
   @Column({ enum: VisitationMethod, comment: '심방 방식 (대면 / 비대면)' })
   visitationMethod: VisitationMethod;
@@ -40,9 +49,17 @@ export class VisitationMetaModel extends BaseModel {
   @Column({ comment: '심방 진행자 ID' })
   instructorId: number;
 
-  @ManyToOne(() => UserModel)
+  @ManyToOne(() => MemberModel)
   @JoinColumn({ name: 'instructorId' })
-  instructor: UserModel;
+  instructor: MemberModel;
+
+  @ManyToMany(() => MemberModel, (member) => member.visitationReports)
+  @JoinColumn()
+  reportTo: MemberModel[];
+
+  @ManyToMany(() => MemberModel, (member) => member.visitationMetas)
+  @JoinColumn()
+  members: MemberModel[];
 
   @OneToMany(
     () => VisitationDetailModel,

--- a/backend/src/visitation/visitation-domain/service/interface/visitation-detail-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/service/interface/visitation-detail-domain.service.interface.ts
@@ -1,5 +1,18 @@
+import { VisitationMetaModel } from '../../../entity/visitation-meta.entity';
+import { QueryRunner } from 'typeorm';
+import { VisitationDetailModel } from '../../../entity/visitation-detail.entity';
+import { MemberModel } from '../../../../members/entity/member.entity';
+import { VisitationDetailDto } from '../../../dto/visitation-detail.dto';
+
 export const IVISITATION_DETAIL_DOMAIN_SERVICE = Symbol(
   'IVISITATION_DETAIL_DOMAIN_SERVICE',
 );
 
-export interface IVisitationDetailDomainService {}
+export interface IVisitationDetailDomainService {
+  createVisitationDetail(
+    metaData: VisitationMetaModel,
+    memberModel: MemberModel,
+    dto: VisitationDetailDto,
+    qr: QueryRunner,
+  ): Promise<VisitationDetailModel>;
+}

--- a/backend/src/visitation/visitation-domain/service/interface/visitation-meta-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/service/interface/visitation-meta-domain.service.interface.ts
@@ -30,7 +30,7 @@ export interface IVisitationMetaDomainService {
     church: ChurchModel,
     instructor: MemberModel,
     dto: CreateVisitationMetaDto,
-    qr?: QueryRunner,
+    qr: QueryRunner,
   ): Promise<VisitationMetaModel>;
 
   updateVisitationMetaData(

--- a/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
@@ -1,9 +1,40 @@
 import { Injectable } from '@nestjs/common';
 import { IVisitationDetailDomainService } from './interface/visitation-detail-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { VisitationDetailModel } from '../../entity/visitation-detail.entity';
+import { QueryRunner, Repository } from 'typeorm';
+import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
+import { MemberModel } from '../../../members/entity/member.entity';
+import { VisitationDetailDto } from '../../dto/visitation-detail.dto';
 
 @Injectable()
 export class VisitationDetailDomainService
   implements IVisitationDetailDomainService
 {
-  constructor() {}
+  constructor(
+    @InjectRepository(VisitationDetailModel)
+    private readonly repository: Repository<VisitationDetailModel>,
+  ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(VisitationDetailModel)
+      : this.repository;
+  }
+
+  async createVisitationDetail(
+    metaData: VisitationMetaModel,
+    member: MemberModel,
+    dto: VisitationDetailDto,
+    qr: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    return repository.save({
+      visitationMeta: metaData,
+      member,
+      visitationContent: dto.visitationContent,
+      visitationPray: dto.visitationPray,
+    });
+  }
 }

--- a/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
@@ -102,13 +102,15 @@ export class VisitationMetaDomainService
     church: ChurchModel,
     instructor: MemberModel,
     dto: CreateVisitationMetaDto,
-    qr?: QueryRunner,
+    qr: QueryRunner,
+    reportTo?: MemberModel,
   ) {
     const visitationMetaRepository = this.getVisitationMetaRepository(qr);
 
     return visitationMetaRepository.save({
-      church,
+      churchId: church.id,
       instructor,
+      visitationStatus: dto.visitationStatus,
       visitationMethod: dto.visitationMethod,
       visitationType: dto.visitationType,
       visitationTitle: dto.visitationTitle,

--- a/backend/src/visitation/visitation.controller.ts
+++ b/backend/src/visitation/visitation.controller.ts
@@ -7,15 +7,21 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { VisitationService } from './visitation.service';
-import { CreateVisitationMetaDto } from './dto/meta/create-visitation-meta.dto';
 import { UpdateVisitationMetaDto } from './dto/meta/update-visitation-meta.dto';
 import { TransactionInterceptor } from '../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
+import { CreateVisitationDto } from './dto/create-visitation.dto';
+import { ChurchManagerGuard } from '../churches/guard/church-manager-guard.service';
+import { AccessTokenGuard } from '../auth/guard/jwt.guard';
+import { Token } from '../auth/decorator/jwt.decorator';
+import { AuthType } from '../auth/const/enum/auth-type.enum';
+import { JwtAccessPayload } from '../auth/type/jwt';
 
 @ApiTags('Visitations')
 @Controller('visitations')
@@ -27,19 +33,23 @@ export class VisitationController {
     return this.visitationService.getVisitations(churchId);
   }
 
-  @Post('meta')
-  postVisitationMetaData(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Body() dto: CreateVisitationMetaDto,
+  @Post()
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
+  @UseInterceptors(TransactionInterceptor)
+  postVisitationReservation(
+    @Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
+    @Param('churchId', ParseIntPipe)
+    churchId: number,
+    @Body() dto: CreateVisitationDto,
+    @QueryRunner() qr: QR,
   ) {
-    return this.visitationService.createVisitingMetaData(churchId, dto);
+    return this.visitationService.createVisitation(
+      accessPayload,
+      churchId,
+      dto,
+      qr,
+    );
   }
-
-  @Post(':metaId/details')
-  postVisitationDetail(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('metaId', ParseIntPipe) metaId: number,
-  ) {}
 
   @Patch(':metaId/details/:detailId')
   patchVisitationDetail() {}


### PR DESCRIPTION
## 주요 내용
기존에는 클라이언트가 심방 메타데이터(`VisitationMetaModel`)와 세부데이터(`VisitationDetailModel`)를 개별적으로 생성 및 수정했지만, 이번 변경에서는 서버가 하나의 요청으로 메타데이터와 세부데이터를 함께 생성하도록 구조를 변경하였습니다.

## 세부 내용
- 클라이언트 → 서버 요청 단순화: 이제 하나의 요청으로 전체 심방 데이터 생성
- 서버에서 메타데이터 생성 후, 포함된 `visitationDetails`를 기반으로 세부데이터도 함께 생성
- 생성 책임을 서버에서 일괄적으로 처리하여 데이터 일관성 확보
- 관련 서비스 로직 통합 및 `createVisitation` 흐름 정비
- 클라이언트는 더 이상 메타/세부 데이터를 분리 관리하지 않아도 됨

이번 변경을 통해 클라이언트는 보다 간단하게 심방을 생성할 수 있게 되었으며,
서버는 일관성 있는 데이터 생성을 보장할 수 있게 되었습니다. 🗂️✅