### PR TITLE
feat: 심방 목록 조회 고도화 및 생성/삭제 로직 개선  

### DIFF
--- a/backend/src/common/entity/base.entity.ts
+++ b/backend/src/common/entity/base.entity.ts
@@ -5,6 +5,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { Exclude } from 'class-transformer';
 
 export abstract class BaseModel {
   @PrimaryGeneratedColumn()
@@ -19,5 +20,6 @@ export abstract class BaseModel {
   updatedAt: Date;
 
   @DeleteDateColumn()
+  @Exclude()
   deletedAt: Date;
 }

--- a/backend/src/members/const/exception/member.exception.ts
+++ b/backend/src/members/const/exception/member.exception.ts
@@ -1,6 +1,7 @@
 export const MemberException = {
   NOT_FOUND: '해당 교인을 찾을 수 없습니다.',
   NOT_FOUND_GUIDE: '인도자로 지정한 교인을 찾을 수 없습니다.',
+  NOT_FOUND_PARTIAL: '교인 중 존재하지 않는 교인이 있습니다.',
   ALREADY_EXIST: '이미 동일한 이름과 전화번호를 가진 교인이 존재합니다.',
   UPDATE_ERROR: '교인 업데이트 도중 에러 발생',
   DELETE_ERROR: '교인 삭제 도중 에러 발생',

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -196,24 +196,35 @@ export class MemberModel extends BaseModel {
   @OneToMany(() => GroupHistoryModel, (groupHistory) => groupHistory.member)
   groupHistory: GroupHistoryModel[];
 
+  // 진행하는 심방
   @OneToMany(
     () => VisitationMetaModel,
     (visitationMeta) => visitationMeta.instructor,
   )
-  visitationInstructor: VisitationMetaModel[];
+  instructingVisitations: VisitationMetaModel[];
 
+  // 생성한 심방
+  @OneToMany(
+    () => VisitationMetaModel,
+    (visitationMeta) => visitationMeta.creator,
+  )
+  createdVisitations: VisitationMetaModel[];
+
+  // 보고 받을 심방
   @ManyToMany(
     () => VisitationMetaModel,
     (visitationMeta) => visitationMeta.reportTo,
   )
   visitationReports: VisitationMetaModel[];
 
+  // 참여한 심방
   @ManyToMany(
     () => VisitationMetaModel,
     (visitationMeta) => visitationMeta.members,
   )
   visitationMetas: VisitationMetaModel[];
 
+  // 나의 심방 세부 내용
   @OneToMany(
     () => VisitationDetailModel,
     (visitingDetail) => visitingDetail.member,

--- a/backend/src/members/member-domain/service/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/service/interface/members-domain.service.interface.ts
@@ -29,6 +29,12 @@ export interface IMembersDomainService {
     qr?: QueryRunner,
   ): Promise<MemberPaginationResultDto>;
 
+  findMembersById(
+    church: ChurchModel,
+    ids: number[],
+    qr?: QueryRunner,
+  ): Promise<MemberModel[]>;
+
   findMemberById(
     church: ChurchModel,
     memberId: number,
@@ -38,6 +44,13 @@ export interface IMembersDomainService {
   findMemberModelById(
     church: ChurchModel,
     memberId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<MemberModel>,
+  ): Promise<MemberModel>;
+
+  findMemberModelByUserId(
+    church: ChurchModel,
+    userId: number,
     qr?: QueryRunner,
     relationOptions?: FindOptionsRelations<MemberModel>,
   ): Promise<MemberModel>;

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -12,6 +12,7 @@ import {
   FindOptionsRelations,
   FindOptionsSelect,
   FindOptionsWhere,
+  In,
   IsNull,
   QueryRunner,
   Repository,
@@ -79,6 +80,27 @@ export class MembersDomainService implements IMembersDomainService {
     return resultDto;
   }
 
+  async findMembersById(
+    church: ChurchModel,
+    ids: number[],
+    qr?: QueryRunner,
+  ): Promise<MemberModel[]> {
+    const repository = this.getMembersRepository(qr);
+
+    const members = await repository.find({
+      where: {
+        churchId: church.id,
+        id: In(ids),
+      },
+    });
+
+    if (members.length !== ids.length) {
+      throw new NotFoundException(MemberException.NOT_FOUND_PARTIAL);
+    }
+
+    return members;
+  }
+
   async findMemberById(
     church: ChurchModel,
     memberId: number,
@@ -114,6 +136,29 @@ export class MembersDomainService implements IMembersDomainService {
       where: {
         id: memberId,
         churchId: church.id,
+      },
+      relations: relationOptions,
+    });
+
+    if (!member) {
+      throw new NotFoundException(MemberException.NOT_FOUND);
+    }
+
+    return member;
+  }
+
+  async findMemberModelByUserId(
+    church: ChurchModel,
+    userId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<MemberModel>,
+  ) {
+    const membersRepository = this.getMembersRepository(qr);
+
+    const member = await membersRepository.findOne({
+      where: {
+        churchId: church.id,
+        userId,
       },
       relations: relationOptions,
     });

--- a/backend/src/visitation/const/order.enum.ts
+++ b/backend/src/visitation/const/order.enum.ts
@@ -1,0 +1,5 @@
+export enum VisitationOrderEnum {
+  visitationDate = 'visitationDate',
+  createdAt = 'createdAt',
+  updatedAt = 'updatedAt',
+}

--- a/backend/src/visitation/const/visitation-find-options.const.ts
+++ b/backend/src/visitation/const/visitation-find-options.const.ts
@@ -1,0 +1,86 @@
+import { FindOptionsRelations, FindOptionsSelect } from 'typeorm';
+import { VisitationMetaModel } from '../entity/visitation-meta.entity';
+import { VisitationDetailModel } from '../entity/visitation-detail.entity';
+
+export const VisitationRelationOptions: FindOptionsRelations<VisitationMetaModel> =
+  {
+    members: true,
+    instructor: {
+      officer: true,
+      group: true,
+      groupRole: true,
+    },
+    creator: {
+      officer: true,
+      group: true,
+      groupRole: true,
+    },
+  };
+
+export const VisitationSelectOptions: FindOptionsSelect<VisitationMetaModel> = {
+  creator: {
+    id: true,
+    name: true,
+    officer: {
+      id: true,
+      name: true,
+    },
+    group: {
+      id: true,
+      name: true,
+    },
+    groupRole: {
+      id: true,
+      role: true,
+    },
+  },
+  instructor: {
+    id: true,
+    name: true,
+    officer: {
+      id: true,
+      name: true,
+    },
+    group: {
+      id: true,
+      name: true,
+    },
+    groupRole: {
+      id: true,
+      role: true,
+    },
+  },
+  members: {
+    id: true,
+    name: true,
+  },
+};
+
+export const VisitationDetailRelationOptions: FindOptionsRelations<VisitationDetailModel> =
+  {
+    member: {
+      officer: true,
+      group: true,
+      groupRole: true,
+    },
+  };
+
+export const VisitationDetailSelectOptions: FindOptionsSelect<VisitationDetailModel> =
+  {
+    member: {
+      id: true,
+      name: true,
+      officer: {
+        id: true,
+        name: true,
+      },
+      group: {
+        id: true,
+        name: true,
+      },
+      groupRole: {
+        id: true,
+        role: true,
+      },
+    },
+  };

--- a/backend/src/visitation/decorator/visitation-detail.validator.ts
+++ b/backend/src/visitation/decorator/visitation-detail.validator.ts
@@ -1,0 +1,42 @@
+import { ValidationOptions } from 'joi';
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { VisitationDetailDto } from '../dto/visitation-detail.dto';
+
+@ValidatorConstraint({ name: 'VisitationDetailValidator', async: false })
+export class VisitationDetailConstraint
+  implements ValidatorConstraintInterface
+{
+  defaultMessage(validationArguments?: ValidationArguments): string {
+    return '중복된 심방 대상자가 존재합니다.';
+  }
+
+  validate(
+    value: VisitationDetailDto[],
+    validationArguments?: ValidationArguments,
+  ): Promise<boolean> | boolean {
+    const memberIds = value.map((detail) => detail.memberId);
+
+    const memberIdsSet = new Set(memberIds);
+
+    return memberIds.length === memberIdsSet.size;
+  }
+}
+
+export function VisitationDetailValidator(
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: VisitationDetailConstraint,
+    });
+  };
+}

--- a/backend/src/visitation/dto/create-visitation.dto.ts
+++ b/backend/src/visitation/dto/create-visitation.dto.ts
@@ -7,12 +7,12 @@ import {
   Min,
   ValidateNested,
 } from 'class-validator';
-import { VisitationType } from '../const/visitation-type.enum';
 import { VisitationMethod } from '../const/visitation-method.enum';
 import { ApiProperty } from '@nestjs/swagger';
 import { VisitationDetailDto } from './visitation-detail.dto';
 import { Type } from 'class-transformer';
 import { VisitationStatus } from '../const/visitation-status.enum';
+import { VisitationDetailValidator } from '../decorator/visitation-detail.validator';
 
 export class CreateVisitationDto {
   @ApiProperty({
@@ -23,12 +23,13 @@ export class CreateVisitationDto {
   @IsEnum(VisitationStatus)
   visitationStatus: VisitationStatus;
 
-  @ApiProperty({
+  /*@ApiProperty({
     description: '심방 종류 (개인 / 그룹)',
     enum: VisitationType,
+    deprecated: true,
   })
   @IsEnum(VisitationType)
-  visitationType: VisitationType;
+  visitationType: VisitationType;*/
 
   @ApiProperty({
     description: '심방 방식 (대면 / 비대면)',
@@ -65,5 +66,6 @@ export class CreateVisitationDto {
   })
   @ValidateNested({ each: true })
   @Type(() => VisitationDetailDto)
+  @VisitationDetailValidator()
   visitationDetails: VisitationDetailDto[];
 }

--- a/backend/src/visitation/dto/get-visitation.dto.ts
+++ b/backend/src/visitation/dto/get-visitation.dto.ts
@@ -1,0 +1,122 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsDate,
+  IsEnum,
+  IsIn,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+import { VisitationStatus } from '../const/visitation-status.enum';
+import { TransformStringArray } from '../../common/decorator/transformer/transform-array';
+import { VisitationOrderEnum } from '../const/order.enum';
+import { VisitationMethod } from '../const/visitation-method.enum';
+import { VisitationType } from '../const/visitation-type.enum';
+
+export class GetVisitationDto {
+  @ApiProperty({
+    description: '요청 데이터 개수',
+    default: 20,
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  take: number = 20;
+
+  @ApiProperty({
+    description: '요청 페이지',
+    default: 1,
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  page: number = 1;
+
+  @ApiProperty({
+    description: '정렬 기준',
+    enum: VisitationOrderEnum,
+    default: VisitationOrderEnum.visitationDate,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(VisitationOrderEnum)
+  order: VisitationOrderEnum = VisitationOrderEnum.visitationDate;
+
+  @ApiProperty({
+    description: '정렬 오름차순 / 내림차순',
+    default: 'desc',
+    required: false,
+  })
+  @IsOptional()
+  @IsIn(['asc', 'desc', 'ASC', 'DESC'])
+  orderDirection: 'asc' | 'desc' | 'ASC' | 'DESC' = 'desc';
+
+  @ApiProperty({
+    description: '심방 날짜 ~ 부터',
+    required: false,
+  })
+  @IsOptional()
+  @IsDate()
+  fromVisitationDate?: Date;
+
+  @ApiProperty({
+    description: '심방 날짜 ~ 까지',
+    required: false,
+  })
+  @IsOptional()
+  @IsDate()
+  toVisitationDate?: Date;
+
+  @ApiProperty({
+    description: '심방 상태 (예약 / 완료 / 지연)',
+    enum: VisitationStatus,
+    isArray: true,
+    required: false,
+  })
+  @IsOptional()
+  @TransformStringArray()
+  @IsEnum(VisitationStatus, { each: true })
+  where__visitationStatus?: VisitationStatus[];
+
+  @ApiProperty({
+    description: '심방 방식 (대면 / 비대면)',
+    enum: VisitationMethod,
+    isArray: true,
+    required: false,
+  })
+  @IsOptional()
+  @TransformStringArray()
+  @IsEnum(VisitationMethod, { each: true })
+  where__visitationMethod?: VisitationMethod[];
+
+  @ApiProperty({
+    description: '심방 종류 (개인 / 그룹)',
+    enum: VisitationType,
+    isArray: true,
+    required: false,
+  })
+  @IsOptional()
+  @TransformStringArray()
+  @IsEnum(VisitationType, { each: true })
+  where__visitationType?: VisitationType[];
+
+  @ApiProperty({
+    description: '심방 제목',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  where__visitationTitle?: string;
+
+  @ApiProperty({
+    description: '심방 진행자의 교인 ID',
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  where__instructorId?: number;
+}

--- a/backend/src/visitation/dto/meta/create-visitation-meta.dto.ts
+++ b/backend/src/visitation/dto/meta/create-visitation-meta.dto.ts
@@ -4,6 +4,7 @@ import { IsDate, IsEnum, IsNumber, IsString, Length } from 'class-validator';
 import { VisitationType } from '../../const/visitation-type.enum';
 import { TransformStartDate } from '../../../member-history/decorator/transform-start-date.decorator';
 import { VisitationStatus } from '../../const/visitation-status.enum';
+import { MemberModel } from '../../../members/entity/member.entity';
 
 export class CreateVisitationMetaDto {
   @ApiProperty({
@@ -52,4 +53,6 @@ export class CreateVisitationMetaDto {
   @IsDate()
   @TransformStartDate()
   visitationDate: Date;
+
+  creator: MemberModel;
 }

--- a/backend/src/visitation/entity/visitation-meta.entity.ts
+++ b/backend/src/visitation/entity/visitation-meta.entity.ts
@@ -4,6 +4,7 @@ import {
   Entity,
   Index,
   JoinColumn,
+  JoinTable,
   ManyToMany,
   ManyToOne,
   OneToMany,
@@ -49,16 +50,24 @@ export class VisitationMetaModel extends BaseModel {
   @Column({ comment: '심방 진행자 ID' })
   instructorId: number;
 
-  @ManyToOne(() => MemberModel)
+  @ManyToOne(() => MemberModel, (member) => member.instructingVisitations)
   @JoinColumn({ name: 'instructorId' })
   instructor: MemberModel;
 
+  @Index()
+  @Column({ comment: '심방 생성자 ID' })
+  creatorId: number;
+
+  @ManyToOne(() => MemberModel, (member) => member.createdVisitations)
+  @JoinColumn({ name: 'creatorId' })
+  creator: MemberModel;
+
   @ManyToMany(() => MemberModel, (member) => member.visitationReports)
-  @JoinColumn()
+  @JoinTable()
   reportTo: MemberModel[];
 
   @ManyToMany(() => MemberModel, (member) => member.visitationMetas)
-  @JoinColumn()
+  @JoinTable()
   members: MemberModel[];
 
   @OneToMany(

--- a/backend/src/visitation/visitation-domain/service/interface/visitation-detail-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/service/interface/visitation-detail-domain.service.interface.ts
@@ -1,5 +1,5 @@
 import { VisitationMetaModel } from '../../../entity/visitation-meta.entity';
-import { QueryRunner } from 'typeorm';
+import { QueryRunner, UpdateResult } from 'typeorm';
 import { VisitationDetailModel } from '../../../entity/visitation-detail.entity';
 import { MemberModel } from '../../../../members/entity/member.entity';
 import { VisitationDetailDto } from '../../../dto/visitation-detail.dto';
@@ -15,4 +15,14 @@ export interface IVisitationDetailDomainService {
     dto: VisitationDetailDto,
     qr: QueryRunner,
   ): Promise<VisitationDetailModel>;
+
+  findVisitationDetailsByMetaId(
+    metaData: VisitationMetaModel,
+    qr?: QueryRunner,
+  ): Promise<VisitationDetailModel[]>;
+
+  deleteVisitationDetailsCascade(
+    metaData: VisitationMetaModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
 }

--- a/backend/src/visitation/visitation-domain/service/interface/visitation-meta-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/service/interface/visitation-meta-domain.service.interface.ts
@@ -1,8 +1,9 @@
 import { ChurchModel } from '../../../../churches/entity/church.entity';
 import { MemberModel } from '../../../../members/entity/member.entity';
 import { CreateVisitationMetaDto } from '../../../dto/meta/create-visitation-meta.dto';
-import { FindOptionsRelations, QueryRunner } from 'typeorm';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { VisitationMetaModel } from '../../../entity/visitation-meta.entity';
+import { GetVisitationDto } from '../../../dto/get-visitation.dto';
 
 export const IVISITATION_META_DOMAIN_SERVICE = Symbol(
   'IVISITATION_META_DOMAIN_SERVICE',
@@ -11,6 +12,7 @@ export const IVISITATION_META_DOMAIN_SERVICE = Symbol(
 export interface IVisitationMetaDomainService {
   paginateVisitations(
     church: ChurchModel,
+    dto: GetVisitationDto,
   ): Promise<{ visitations: VisitationMetaModel[]; totalCount: number }>;
 
   findVisitationMetaById(
@@ -30,6 +32,7 @@ export interface IVisitationMetaDomainService {
     church: ChurchModel,
     instructor: MemberModel,
     dto: CreateVisitationMetaDto,
+    members: MemberModel[],
     qr: QueryRunner,
   ): Promise<VisitationMetaModel>;
 
@@ -38,4 +41,9 @@ export interface IVisitationMetaDomainService {
     dto: any,
     qr?: QueryRunner,
   ): Promise<VisitationMetaModel>;
+
+  deleteVisitationMeta(
+    metaData: VisitationMetaModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
 }

--- a/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
@@ -2,10 +2,14 @@ import { Injectable } from '@nestjs/common';
 import { IVisitationDetailDomainService } from './interface/visitation-detail-domain.service.interface';
 import { InjectRepository } from '@nestjs/typeorm';
 import { VisitationDetailModel } from '../../entity/visitation-detail.entity';
-import { QueryRunner, Repository } from 'typeorm';
+import { QueryRunner, Repository, UpdateResult } from 'typeorm';
 import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { VisitationDetailDto } from '../../dto/visitation-detail.dto';
+import {
+  VisitationDetailRelationOptions,
+  VisitationDetailSelectOptions,
+} from '../../const/visitation-find-options.const';
 
 @Injectable()
 export class VisitationDetailDomainService
@@ -35,6 +39,32 @@ export class VisitationDetailDomainService
       member,
       visitationContent: dto.visitationContent,
       visitationPray: dto.visitationPray,
+    });
+  }
+
+  async findVisitationDetailsByMetaId(
+    metaData: VisitationMetaModel,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    return repository.find({
+      where: {
+        visitationMetaId: metaData.id,
+      },
+      relations: VisitationDetailRelationOptions,
+      select: VisitationDetailSelectOptions,
+    });
+  }
+
+  async deleteVisitationDetailsCascade(
+    metaData: VisitationMetaModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    return repository.softDelete({
+      visitationMetaId: metaData.id,
     });
   }
 }


### PR DESCRIPTION
## 주요 내용  
심방 목록 조회 기능에 정렬, 검색, 필터링 기능을 고도화하고,  
심방 생성 및 삭제 시 동작을 개선하였습니다. 또한, 심방 종류는 클라이언트가 지정하지 않아도  
대상 교인 수에 따라 자동으로 결정되도록 변경하였습니다.  

## 세부 내용  

### 목록 조회 기능 고도화  
- 정렬 기준: 진행일, 생성일, 수정일 순 정렬  
- 날짜 범위 검색 기능 추가 (심방 진행일 기준)  
- 필터링 기능 추가  
  - 심방 상태  
  - 심방 방식  
  - 심방 종류  
  - 심방 진행자  
- 심방 제목 검색 기능 추가 (부분 일치)

### 생성/삭제 로직 개선  
- 심방 생성 시 생성자 교인 정보(`createdBy`) 저장  
- 심방 삭제 시 관련된 `VisitationDetail` 데이터도 함께 삭제되도록 처리  

### 심방 종류 자동 설정  
- 클라이언트가 심방 종류를 입력하지 않아도 됨  
- 대상 교인이 2명 이상일 경우 → **그룹 심방**  
- 대상 교인이 1명일 경우 → **개인 심방**  
- 서버에서 자동 분류하여 일관된 데이터 입력 보장  

이번 개선을 통해 조회 기능은 더욱 유연하고 실용적으로,  
생성/삭제는 안전하게, 입력은 간결하면서도 자동화된 방식으로 심방 관리가 한층 고도화되었습니다. 🗂️📆⚙️  
