### PR TITLE
feat: 심방 CRUD 기능 완성

### DIFF
--- a/backend/src/visitation/const/exception/visitation-meta.exception.ts
+++ b/backend/src/visitation/const/exception/visitation-meta.exception.ts
@@ -1,6 +1,0 @@
-export const VisitationMetaException = {
-  NOT_FOUND: '심방 데이터를 찾을 수 없습니다.',
-  INVALID_INSTRUCTOR: '심방 진행자로 등록할 수 없습니다.',
-  UPDATE_ERROR: '심방 데이터 업데이트 도중 에러 발생',
-  DELETE_ERROR: '심방 데이터 삭제 도중 에러 발생',
-};

--- a/backend/src/visitation/const/exception/visitation.exception.ts
+++ b/backend/src/visitation/const/exception/visitation.exception.ts
@@ -1,0 +1,18 @@
+export const VisitationException = {
+  NOT_FOUND: '심방 데이터를 찾을 수 없습니다.',
+  INVALID_INSTRUCTOR: '심방 진행자로 등록할 수 없는 교인입니다.',
+  UPDATE_ERROR: '심방 데이터 업데이트 도중 에러 발생',
+  DELETE_ERROR: '심방 데이터 삭제 도중 에러 발생',
+
+  ALREADY_EXIST_TARGET_MEMBER: (alreadyExistMember: number | number[]) =>
+    `이미 존재하는 심방 대상자입니다. 존재하는 교인 id: [${alreadyExistMember}]`,
+  NOT_EXIST_DELETE_TARGET_MEMBER: (notExistMemberId: number | number[]) =>
+    `삭제 대상자가 심방 대상자에 포함되어 있지 않습니다. 존재하지 않는 교인 id: [${notExistMemberId}]`,
+};
+
+export const VisitationDetailException = {
+  NOT_FOUND: '해당 심방 세부 데이터를 찾을 수 없습니다.',
+  ALREADY_EXIST: '이미 존재하는 심방 세부 데이터입니다.',
+  UPDATE_ERROR: '심방 세부 데이터 업데이트 도중 에러 발생',
+  DELETE_ERROR: '심방 세부 데이터 삭제 도중 에러 발생',
+};

--- a/backend/src/visitation/const/visitation-find-options.const.ts
+++ b/backend/src/visitation/const/visitation-find-options.const.ts
@@ -4,7 +4,11 @@ import { VisitationDetailModel } from '../entity/visitation-detail.entity';
 
 export const VisitationRelationOptions: FindOptionsRelations<VisitationMetaModel> =
   {
-    members: true,
+    members: {
+      officer: true,
+      group: true,
+      groupRole: true,
+    },
     instructor: {
       officer: true,
       group: true,
@@ -53,6 +57,18 @@ export const VisitationSelectOptions: FindOptionsSelect<VisitationMetaModel> = {
   members: {
     id: true,
     name: true,
+    officer: {
+      id: true,
+      name: true,
+    },
+    group: {
+      id: true,
+      name: true,
+    },
+    groupRole: {
+      id: true,
+      role: true,
+    },
   },
 };
 

--- a/backend/src/visitation/controller/visitation-detail.controller.ts
+++ b/backend/src/visitation/controller/visitation-detail.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  UseInterceptors,
+} from '@nestjs/common';
+import { VisitationService } from '../visitation.service';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { UpdateVisitationDetailDto } from '../dto/detail/update-visitation-detail.dto';
+import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
+import { QueryRunner } from '../../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm/query-runner/QueryRunner';
+import { CreateVisitationDetailDto } from '../dto/detail/create-visitation-detail.dto';
+
+@ApiTags('Visitations:Details')
+@Controller('visitations/:visitationId/details')
+export class VisitationDetailController {
+  constructor(private readonly visitationService: VisitationService) {}
+
+  @ApiOperation({
+    summary: '심방 대상자 추가',
+    description: '심방 메타 데이터 수정에서 대상자를 추가',
+    deprecated: true,
+  })
+  @Post()
+  @UseInterceptors(TransactionInterceptor)
+  postVisitationDetail(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('visitationId', ParseIntPipe) visitationId: number,
+    @Body() dto: CreateVisitationDetailDto,
+    @QueryRunner() qr: QR,
+  ) {
+    /*return this.visitationService.createVisitationDetail(
+      churchId,
+      visitationId,
+      dto,
+      qr,
+    );*/
+  }
+
+  @ApiOperation({
+    summary: '심방 세부 내용 작성',
+    description: '심방 세부 내용 작성, 심방 대상자 삭제 불가능',
+  })
+  @Patch(':detailId')
+  patchVisitationDetail(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('visitationId', ParseIntPipe) visitationId: number,
+    @Param('detailId', ParseIntPipe) detailId: number,
+    @Body() dto: UpdateVisitationDetailDto,
+  ) {
+    return this.visitationService.updateVisitationDetail(
+      churchId,
+      visitationId,
+      detailId,
+      dto,
+    );
+  }
+
+  @ApiOperation({
+    summary: '심방 세부 내용 삭제',
+    description:
+      '심방 메타 데이터 수정에서 심방 대상자를 삭제하여 세부 내용을 삭제',
+    deprecated: true,
+  })
+  @UseInterceptors(TransactionInterceptor)
+  @Delete(':detailId')
+  deleteVisitationDetail(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('visitationId', ParseIntPipe) visitationId: number,
+    @Param('detailId', ParseIntPipe) detailId: number,
+    @QueryRunner() qr: QR,
+  ) {}
+}

--- a/backend/src/visitation/decorator/visitation.swagger.ts
+++ b/backend/src/visitation/decorator/visitation.swagger.ts
@@ -1,0 +1,37 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+export const ApiGetVisitations = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교회의 심방 목록 조회',
+      description:
+        '<h2>교회의 심방 목록을 조회합니다.</h2>' +
+        '<p>take: 요청 데이터 개수 (기본값: 20)</p>' +
+        '<p>page: 요청 페이지 (기본값: 1)</p>' +
+        '<p>order: 정렬 기준 (기본값: 심방 날짜)</p>' +
+        '<p>orderDirection: 정렬 차순 (기본값: 내림차순)</p>' +
+        '<h3>필터링 조건</h3>' +
+        '<p>fromVisitationDate: 심방 날짜 ~ 부터</p>' +
+        '<p>toVisitationDate: 심방 날짜 ~ 까지</p>' +
+        '<p>visitationStatus: 심방 상태 (예약 / 완료 / 지연)</p>' +
+        '<p>visitationMethod: 심방 방식 (대면 / 비대면)</p>' +
+        '<p>visitationType: 심방 종류 (개인 / 그룹)</p>' +
+        '<p>visitationTitle: 심방 제목 (부분 일치 포함)</p>' +
+        '<p>instructorId: 심방 진행자의 교인 ID</p>',
+    }),
+  );
+
+export const ApiPostVisitation = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '심방 생성 (인증 필요)',
+      description:
+        '<p>심방을 생성합니다.</p>' +
+        '<p>심방의 예약과 기록은 <b>VisitationStatus</b> 로 구분합니다.</p>' +
+        '<p>예약 생성 시 --> VisitationStatus: RESERVE</p>' +
+        '<p>기록 생성 시 --> VisitationStatus: DONE</p>' +
+        '<p>예약 생성이더라도 VisitationDetail 의 내용을 기재할 수 있습니다.</p>' +
+        '<p>VisitationDetail 의 개수에 따라 개인 / 그룹 심방이 결정됩니다.</p>',
+    }),
+  );

--- a/backend/src/visitation/dto/detail/update-visitation-detail.dto.ts
+++ b/backend/src/visitation/dto/detail/update-visitation-detail.dto.ts
@@ -1,0 +1,6 @@
+import { OmitType, PartialType } from '@nestjs/swagger';
+import { CreateVisitationDetailDto } from './create-visitation-detail.dto';
+
+export class UpdateVisitationDetailDto extends PartialType(
+  OmitType(CreateVisitationDetailDto, ['memberId']),
+) {}

--- a/backend/src/visitation/dto/get-visitation.dto.ts
+++ b/backend/src/visitation/dto/get-visitation.dto.ts
@@ -79,7 +79,7 @@ export class GetVisitationDto {
   @IsOptional()
   @TransformStringArray()
   @IsEnum(VisitationStatus, { each: true })
-  where__visitationStatus?: VisitationStatus[];
+  visitationStatus?: VisitationStatus[];
 
   @ApiProperty({
     description: '심방 방식 (대면 / 비대면)',
@@ -90,7 +90,7 @@ export class GetVisitationDto {
   @IsOptional()
   @TransformStringArray()
   @IsEnum(VisitationMethod, { each: true })
-  where__visitationMethod?: VisitationMethod[];
+  visitationMethod?: VisitationMethod[];
 
   @ApiProperty({
     description: '심방 종류 (개인 / 그룹)',
@@ -101,7 +101,7 @@ export class GetVisitationDto {
   @IsOptional()
   @TransformStringArray()
   @IsEnum(VisitationType, { each: true })
-  where__visitationType?: VisitationType[];
+  visitationType?: VisitationType[];
 
   @ApiProperty({
     description: '심방 제목',
@@ -109,7 +109,7 @@ export class GetVisitationDto {
   })
   @IsOptional()
   @IsString()
-  where__visitationTitle?: string;
+  visitationTitle?: string;
 
   @ApiProperty({
     description: '심방 진행자의 교인 ID',
@@ -118,5 +118,5 @@ export class GetVisitationDto {
   @IsOptional()
   @IsNumber()
   @Min(1)
-  where__instructorId?: number;
+  instructorId?: number;
 }

--- a/backend/src/visitation/dto/meta/update-visitation-meta.dto.ts
+++ b/backend/src/visitation/dto/meta/update-visitation-meta.dto.ts
@@ -1,6 +1,6 @@
-import { PartialType } from '@nestjs/swagger';
+import { OmitType, PartialType } from '@nestjs/swagger';
 import { CreateVisitationMetaDto } from './create-visitation-meta.dto';
 
 export class UpdateVisitationMetaDto extends PartialType(
-  CreateVisitationMetaDto,
+  OmitType(CreateVisitationMetaDto, ['creator']),
 ) {}

--- a/backend/src/visitation/dto/update-visitation.dto.ts
+++ b/backend/src/visitation/dto/update-visitation.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty, OmitType, PartialType } from '@nestjs/swagger';
+
+import { IsArray, IsOptional } from 'class-validator';
+import { CreateVisitationMetaDto } from './meta/create-visitation-meta.dto';
+import { TransformNumberArray } from '../../common/decorator/transformer/transform-array';
+
+export class UpdateVisitationDto extends PartialType(
+  OmitType(CreateVisitationMetaDto, ['creator', 'visitationType']),
+) {
+  @ApiProperty({
+    description: '심방 대상자 추가할 교인 ID 들',
+    isArray: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsArray()
+  @TransformNumberArray()
+  addMemberIds?: number[];
+
+  @ApiProperty({
+    description: '심방 대상자 제거할 교인 ID 들',
+    isArray: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsArray()
+  @TransformNumberArray()
+  deleteMemberIds?: number[];
+}

--- a/backend/src/visitation/visitation-domain/service/interface/visitation-detail-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/service/interface/visitation-detail-domain.service.interface.ts
@@ -3,6 +3,7 @@ import { QueryRunner, UpdateResult } from 'typeorm';
 import { VisitationDetailModel } from '../../../entity/visitation-detail.entity';
 import { MemberModel } from '../../../../members/entity/member.entity';
 import { VisitationDetailDto } from '../../../dto/visitation-detail.dto';
+import { UpdateVisitationDetailDto } from '../../../dto/detail/update-visitation-detail.dto';
 
 export const IVISITATION_DETAIL_DOMAIN_SERVICE = Symbol(
   'IVISITATION_DETAIL_DOMAIN_SERVICE',
@@ -16,13 +17,43 @@ export interface IVisitationDetailDomainService {
     qr: QueryRunner,
   ): Promise<VisitationDetailModel>;
 
+  findVisitationDetailByMetaAndMemberId(
+    metaData: VisitationMetaModel,
+    member: MemberModel,
+    qr?: QueryRunner,
+  ): Promise<VisitationDetailModel>;
+
   findVisitationDetailsByMetaId(
     metaData: VisitationMetaModel,
     qr?: QueryRunner,
   ): Promise<VisitationDetailModel[]>;
 
+  findVisitationDetailById(
+    visitationMeta: VisitationMetaModel,
+    visitationDetailId: number,
+    qr?: QueryRunner,
+  ): Promise<VisitationDetailModel>;
+
+  findVisitationDetailModelById(
+    visitationMeta: VisitationMetaModel,
+    visitationDetailId: number,
+    qr?: QueryRunner,
+  ): Promise<VisitationDetailModel>;
+
+  updateVisitationDetail(
+    visitationMeta: VisitationMetaModel,
+    visitationDetail: VisitationDetailModel,
+    dto: UpdateVisitationDetailDto,
+    qr?: QueryRunner,
+  ): Promise<VisitationDetailModel>;
+
   deleteVisitationDetailsCascade(
     metaData: VisitationMetaModel,
     qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  deleteVisitationDetail(
+    visitationDetail: VisitationDetailModel,
+    qr?: QueryRunner,
   ): Promise<UpdateResult>;
 }

--- a/backend/src/visitation/visitation-domain/service/interface/visitation-meta-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/service/interface/visitation-meta-domain.service.interface.ts
@@ -4,6 +4,7 @@ import { CreateVisitationMetaDto } from '../../../dto/meta/create-visitation-met
 import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { VisitationMetaModel } from '../../../entity/visitation-meta.entity';
 import { GetVisitationDto } from '../../../dto/get-visitation.dto';
+import { UpdateVisitationMetaDto } from '../../../dto/meta/update-visitation-meta.dto';
 
 export const IVISITATION_META_DOMAIN_SERVICE = Symbol(
   'IVISITATION_META_DOMAIN_SERVICE',
@@ -38,8 +39,15 @@ export interface IVisitationMetaDomainService {
 
   updateVisitationMetaData(
     visitationMetaData: VisitationMetaModel,
-    dto: any,
+    dto: UpdateVisitationMetaDto,
+    newInstructor?: MemberModel,
     qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  updateVisitationMember(
+    visitationMetaData: VisitationMetaModel,
+    members: MemberModel[],
+    qr: QueryRunner,
   ): Promise<VisitationMetaModel>;
 
   deleteVisitationMeta(

--- a/backend/src/visitation/visitation.module.ts
+++ b/backend/src/visitation/visitation.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { RouterModule } from '@nestjs/core';
-import { VisitationController } from './visitation.controller';
+import { VisitationController } from './controller/visitation.controller';
 import { VisitationService } from './visitation.service';
 import { VisitationDomainModule } from './visitation-domain/visitation-domain.module';
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
 import { UserDomainModule } from '../user/user-domain/user-domain.module';
 import { MembersDomainModule } from '../members/member-domain/members-domain.module';
+import { VisitationDetailController } from './controller/visitation-detail.controller';
 
 @Module({
   imports: [
@@ -19,7 +20,7 @@ import { MembersDomainModule } from '../members/member-domain/members-domain.mod
 
     VisitationDomainModule,
   ],
-  controllers: [VisitationController],
+  controllers: [VisitationController, VisitationDetailController],
   providers: [VisitationService],
 })
 export class VisitationModule {}

--- a/backend/src/visitation/visitation.service.ts
+++ b/backend/src/visitation/visitation.service.ts
@@ -1,4 +1,10 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import {
   IVISITATION_META_DOMAIN_SERVICE,
   IVisitationMetaDomainService,
@@ -12,10 +18,6 @@ import {
   IChurchesDomainService,
 } from '../churches/churches-domain/interface/churches-domain.service.interface';
 import {
-  IUSER_DOMAIN_SERVICE,
-  IUserDomainService,
-} from '../user/user-domain/interface/user-domain.service.interface';
-import {
   IMEMBERS_DOMAIN_SERVICE,
   IMembersDomainService,
 } from '../members/member-domain/service/interface/members-domain.service.interface';
@@ -26,18 +28,21 @@ import { VisitationDetailModel } from './entity/visitation-detail.entity';
 import { VisitationMetaModel } from './entity/visitation-meta.entity';
 import { CreateVisitationDto } from './dto/create-visitation.dto';
 import { JwtAccessPayload } from '../auth/type/jwt';
-import { VisitationMetaException } from './const/exception/visitation-meta.exception';
+import { VisitationException } from './const/exception/visitation.exception';
 import { CreateVisitationMetaDto } from './dto/meta/create-visitation-meta.dto';
 import { GetVisitationDto } from './dto/get-visitation.dto';
 import { VisitationType } from './const/visitation-type.enum';
+import { UpdateVisitationDetailDto } from './dto/detail/update-visitation-detail.dto';
+import { UpdateVisitationDto } from './dto/update-visitation.dto';
+import { VisitationDetailDto } from './dto/visitation-detail.dto';
+import { ChurchModel } from '../churches/entity/church.entity';
+import { MemberModel } from '../members/entity/member.entity';
 
 @Injectable()
 export class VisitationService {
   constructor(
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,
-    @Inject(IUSER_DOMAIN_SERVICE)
-    private readonly userDomainService: IUserDomainService,
     @Inject(IMEMBERS_DOMAIN_SERVICE)
     private readonly membersDomainService: IMembersDomainService,
 
@@ -56,6 +61,9 @@ export class VisitationService {
 
     return {
       data: visitations,
+      take: dto.take,
+      page: dto.page,
+      totalPage: Math.ceil(totalCount / dto.take),
       totalCount,
     };
   }
@@ -115,13 +123,7 @@ export class VisitationService {
     );
 
     // 심방 진행자 검증
-    if (
-      !instructor.user.role ||
-      (instructor.user.role !== UserRole.mainAdmin &&
-        instructor.user.role !== UserRole.manager)
-    ) {
-      throw new BadRequestException(VisitationMetaException.INVALID_INSTRUCTOR);
-    }
+    this.checkInstructorAuthorization(instructor);
 
     const memberIds = dto.visitationDetails.map((detail) => detail.memberId);
 
@@ -131,27 +133,35 @@ export class VisitationService {
       qr,
     );
 
-    const createVisitationMetaDto: CreateVisitationMetaDto = {
-      instructorId: dto.instructorId,
-      visitationStatus: dto.visitationStatus,
-      visitationMethod: dto.visitationMethod,
-      visitationType:
-        memberIds.length > 1 ? VisitationType.GROUP : VisitationType.SINGLE,
-      visitationTitle: dto.visitationTitle,
-      visitationDate: dto.visitationDate,
-      creator: creatorMember,
-    };
+    const visitationMeta = await this.createVisitationMeta(
+      church,
+      creatorMember,
+      instructor,
+      members,
+      dto,
+      qr,
+    );
 
-    const metaData =
-      await this.visitationMetaDomainService.createVisitationMetaData(
-        church,
-        instructor,
-        createVisitationMetaDto,
-        members,
-        qr,
-      );
+    await this.createVisitationDetails(church, visitationMeta, dto, qr);
 
-    const detailData = await Promise.all(
+    return this.getVisitationById(churchId, visitationMeta.id, qr);
+  }
+
+  /**
+   * 심방 생성 시 대상자들의 심방 세부 데이터 생성
+   * @param church 교회 엔티티
+   * @param visitationMeta 사전에 생성된 심방 메타 데이터
+   * @param dto 심방 생성 DTO
+   * @param qr 트랜잭션을 위한 QueryRunner
+   * @private
+   */
+  private async createVisitationDetails(
+    church: ChurchModel,
+    visitationMeta: VisitationMetaModel,
+    dto: CreateVisitationDto,
+    qr: QueryRunner,
+  ) {
+    return Promise.all(
       dto.visitationDetails.map(async (visitationDetailDto) => {
         const member = await this.membersDomainService.findMemberModelById(
           church,
@@ -165,29 +175,192 @@ export class VisitationService {
         );
 
         return this.visitationDetailDomainService.createVisitationDetail(
-          metaData,
+          visitationMeta,
           member,
           visitationDetailDto,
           qr,
         );
       }),
     );
+  }
 
-    const { user, ...instructorMember } = instructor;
-
-    const reservedVisitation = {
-      ...metaData,
-      instructor: instructorMember,
-      visitationDetails: detailData,
+  /**
+   * 심방 생성 시 심방의 메타 데이터 생성
+   * @param church 교회 엔티티
+   * @param creatorMember 심방 생성 교인
+   * @param instructor 심방 진행자
+   * @param members 심방 대상자 (교인 엔티티 배열)
+   * @param dto 심방 생성 DTO
+   * @param qr 트랜잭션을 위한 QueryRunner
+   * @private
+   */
+  private async createVisitationMeta(
+    church: ChurchModel,
+    creatorMember: MemberModel,
+    instructor: MemberModel,
+    members: MemberModel[],
+    dto: CreateVisitationDto,
+    qr: QueryRunner,
+  ) {
+    const createVisitationMetaDto: CreateVisitationMetaDto = {
+      instructorId: dto.instructorId,
+      visitationStatus: dto.visitationStatus,
+      visitationMethod: dto.visitationMethod,
+      visitationType:
+        members.length > 1 ? VisitationType.GROUP : VisitationType.SINGLE,
+      visitationTitle: dto.visitationTitle,
+      visitationDate: dto.visitationDate,
+      creator: creatorMember,
     };
 
-    return reservedVisitation;
+    return this.visitationMetaDomainService.createVisitationMetaData(
+      church,
+      instructor,
+      createVisitationMetaDto,
+      members,
+      qr,
+    );
+  }
+
+  private checkInstructorAuthorization(instructor?: MemberModel) {
+    if (!instructor) {
+      return;
+    }
+
+    if (
+      !instructor.user ||
+      (instructor.user.role !== UserRole.mainAdmin &&
+        instructor.user.role !== UserRole.manager)
+    ) {
+      throw new BadRequestException(VisitationException.INVALID_INSTRUCTOR);
+    }
+  }
+
+  private async updateVisitationMembers(
+    church: ChurchModel,
+    visitationMeta: VisitationMetaModel,
+    dto: UpdateVisitationDto,
+    qr: QueryRunner,
+  ) {
+    if (!visitationMeta.members) {
+      throw new InternalServerErrorException('심방 대상자 불러오기 실패');
+    }
+
+    let visitationMembers = [...visitationMeta.members];
+
+    // 교인이 추가되는 경우 추가할 수 있는지 확인
+    if (dto.addMemberIds) {
+      const visitationMemberIds = visitationMeta.members.map(
+        (member) => member.id,
+      );
+
+      const alreadyExistMember: number[] = [];
+
+      dto.addMemberIds.forEach((memberId) => {
+        if (visitationMemberIds.includes(memberId)) {
+          alreadyExistMember.push(memberId);
+        }
+      });
+
+      if (alreadyExistMember.length > 0) {
+        throw new ConflictException(
+          VisitationException.ALREADY_EXIST_TARGET_MEMBER(alreadyExistMember),
+        );
+      }
+
+      const newMembers = await this.membersDomainService.findMembersById(
+        church,
+        dto.addMemberIds,
+        qr,
+      );
+
+      // 새 심방 대상자 추가
+      visitationMembers.push(...newMembers);
+
+      await Promise.all(
+        dto.addMemberIds.map(async (memberId) => {
+          const member = await this.membersDomainService.findMemberModelById(
+            church,
+            memberId,
+            qr,
+          );
+
+          const detailDto: VisitationDetailDto = {
+            memberId: memberId,
+          };
+
+          return this.visitationDetailDomainService.createVisitationDetail(
+            visitationMeta,
+            member,
+            detailDto,
+            qr,
+          );
+        }),
+      );
+    }
+
+    // 교인이 삭제되는 경우 삭제할 수 있는지 확인
+    if (dto.deleteMemberIds) {
+      const visitationMemberIds = visitationMeta.members.map(
+        (member) => member.id,
+      );
+
+      const notExistMember: number[] = [];
+
+      // 심방 대상자에 존재하지 않는 id 값 필터링
+      dto.deleteMemberIds.forEach((memberId) => {
+        if (!visitationMemberIds.includes(memberId)) {
+          notExistMember.push(memberId);
+        }
+      });
+
+      if (notExistMember.length > 0) {
+        throw new ConflictException(
+          VisitationException.NOT_EXIST_DELETE_TARGET_MEMBER(notExistMember),
+        );
+      }
+
+      visitationMembers = visitationMembers.filter(
+        (member) => !dto.deleteMemberIds?.includes(member.id),
+      );
+
+      await Promise.all(
+        dto.deleteMemberIds.map(async (memberId) => {
+          const member = await this.membersDomainService.findMemberModelById(
+            church,
+            memberId,
+            qr,
+          );
+
+          const deleteTarget =
+            await this.visitationDetailDomainService.findVisitationDetailByMetaAndMemberId(
+              visitationMeta,
+              member,
+              qr,
+            );
+
+          await this.visitationDetailDomainService.deleteVisitationDetail(
+            deleteTarget,
+            qr,
+          );
+        }),
+      );
+    }
+
+    await this.visitationMetaDomainService.updateVisitationMember(
+      visitationMeta,
+      visitationMembers,
+      qr,
+    );
+
+    return visitationMembers;
   }
 
   async updateVisitationMetaData(
     churchId: number,
     visitationMetaDataId: number,
-    dto: UpdateVisitationMetaDto,
+    dto: UpdateVisitationDto,
+    qr: QueryRunner,
   ) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
@@ -196,11 +369,61 @@ export class VisitationService {
       await this.visitationMetaDomainService.findVisitationMetaModelById(
         church,
         visitationMetaDataId,
+        qr,
+        { members: true },
       );
 
-    return this.visitationMetaDomainService.updateVisitationMetaData(
+    // 심방 진행자 변경 시
+    const newInstructor =
+      dto.instructorId && dto.instructorId !== targetMetaData.instructorId
+        ? await this.membersDomainService.findMemberModelById(
+            church,
+            dto.instructorId,
+            qr,
+            { user: true },
+          )
+        : undefined;
+
+    // 새로운 심방 진행자의 권한 확인
+    this.checkInstructorAuthorization(newInstructor);
+
+    // 심방 대상자 변경
+    let visitationType: VisitationType = targetMetaData.visitationType;
+
+    if (dto.addMemberIds || dto.deleteMemberIds) {
+      const newVisitationMembers = await this.updateVisitationMembers(
+        church,
+        targetMetaData,
+        dto,
+        qr,
+      );
+
+      visitationType =
+        newVisitationMembers.length > 1
+          ? VisitationType.GROUP
+          : VisitationType.SINGLE;
+    }
+
+    const updateVisitationMetaDto: UpdateVisitationMetaDto = {
+      visitationDate: dto.visitationDate,
+      visitationMethod: dto.visitationMethod,
+      visitationType,
+      visitationStatus: dto.visitationStatus,
+      visitationTitle: dto.visitationTitle,
+      instructorId: dto.instructorId,
+    };
+
+    await this.visitationMetaDomainService.updateVisitationMetaData(
       targetMetaData,
-      dto,
+      updateVisitationMetaDto,
+      newInstructor,
+      qr,
+    );
+
+    return this.visitationMetaDomainService.findVisitationMetaById(
+      church,
+      visitationMetaDataId,
+      qr,
     );
   }
 
@@ -226,6 +449,34 @@ export class VisitationService {
     await this.visitationDetailDomainService.deleteVisitationDetailsCascade(
       metaData,
       qr,
+    );
+  }
+
+  async updateVisitationDetail(
+    churchId: number,
+    visitationId: number,
+    detailId: number,
+    dto: UpdateVisitationDetailDto,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const metaData =
+      await this.visitationMetaDomainService.findVisitationMetaModelById(
+        church,
+        visitationId,
+      );
+
+    const detailData =
+      await this.visitationDetailDomainService.findVisitationDetailModelById(
+        metaData,
+        detailId,
+      );
+
+    return this.visitationDetailDomainService.updateVisitationDetail(
+      metaData,
+      detailData,
+      dto,
     );
   }
 }


### PR DESCRIPTION
## 주요 내용
심방(Visitation) 도메인의 전체 CRUD 기능을 구현하였으며,
메타데이터와 세부데이터를 기반으로 하는 구조로 설계되었습니다.
심방 생성, 수정, 조회, 삭제 및 목록 페이지네이션까지 전반적인 기능을 완성했습니다.

## 세부 내용

### 심방 목록
- 페이지네이션 기반 심방 목록 조회
- 필터 및 정렬(진행일, 생성일, 수정일), 검색(제목, 날짜 범위, 상태, 방식, 종류, 진행자 등) 지원

### 심방 조회
- 개별 심방 메타데이터 및 세부데이터 조회 기능

### 심방 생성
- 메타데이터 + 세부데이터를 함께 생성
- 메타데이터: 상태, 날짜, 방식, 종류(자동 지정), 진행자, 제목, 대상자
- 세부데이터: 대상자별 심방 내용 및 기도제목
- 대상자 수에 따라 **개인/그룹 심방** 자동 분류

### 심방 메타데이터 수정
- `addMemberIds`: 대상자 추가 시 자동으로 세부데이터 생성
- `deleteMemberIds`: 대상자 삭제 시 해당 세부데이터 제거
- 대상자 수 변경에 따른 개인/그룹 심방 자동 재분류
- 날짜, 방식, 상태, 진행자, 제목 수정 지원

### 심방 세부데이터 수정
- 심방 완료 이후 내용 및 기도제목 수정 가능

### 심방 삭제
- 메타데이터 삭제 시 연관된 모든 세부데이터 함께 삭제

이번 기능 구현을 통해 심방 생성부터 관리, 종료까지의 전체 흐름을 일관되게 처리할 수 있으며, 관리자가 손쉽게 심방 일정을 계획하고 기록을 관리할 수 있도록 고도화된 구조로 완성되었습니다. 📋✨