### PR TITLE
feat: 심방 CRUD 기능 완성

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -38,6 +38,9 @@ import { OfficerHistoryModel } from './member-history/entity/officer-history.ent
 import { MinistryHistoryModel } from './member-history/entity/ministry-history.entity';
 import { GroupHistoryModel } from './member-history/entity/group-history.entity';
 import { MemberHistoryModule } from './member-history/member-history.module';
+import { VisitationModule } from './visitation/visitation.module';
+import { VisitationMetaModel } from './visitation/entity/visitation-meta.entity';
+import { VisitationDetailModel } from './visitation/entity/visitation-detail.entity';
 
 @Module({
   imports: [
@@ -131,6 +134,9 @@ import { MemberHistoryModule } from './member-history/member-history.module';
           GroupModel,
           GroupRoleModel,
           GroupHistoryModel,
+          // 심방 관련 엔티티
+          VisitationMetaModel,
+          VisitationDetailModel,
         ],
         synchronize: true,
       }),
@@ -152,6 +158,7 @@ import { MemberHistoryModule } from './member-history/member-history.module';
     FamilyRelationModule,
     MemberHistoryModule,
     ManagementModule,
+    VisitationModule,
 
     ChurchesDomainModule,
     MembersDomainModule,

--- a/backend/src/churches/entity/church.entity.ts
+++ b/backend/src/churches/entity/church.entity.ts
@@ -10,6 +10,7 @@ import { MinistryGroupModel } from '../../management/ministries/entity/ministry-
 import { MinistryModel } from '../../management/ministries/entity/ministry.entity';
 import { MemberModel } from '../../members/entity/member.entity';
 import { RequestInfoModel } from '../../request-info/entity/request-info.entity';
+import { VisitationMetaModel } from '../../visitation/entity/visitation-meta.entity';
 
 @Entity()
 export class ChurchModel extends BaseModel {
@@ -66,4 +67,7 @@ export class ChurchModel extends BaseModel {
 
   @OneToMany(() => MemberModel, (member) => member.church)
   members: MemberModel[];
+
+  @OneToMany(() => VisitationMetaModel, (visitingMeta) => visitingMeta.church)
+  visitations: VisitationMetaModel[];
 }

--- a/backend/src/common/entity/base.entity.ts
+++ b/backend/src/common/entity/base.entity.ts
@@ -5,6 +5,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { Exclude } from 'class-transformer';
 
 export abstract class BaseModel {
   @PrimaryGeneratedColumn()
@@ -19,5 +20,6 @@ export abstract class BaseModel {
   updatedAt: Date;
 
   @DeleteDateColumn()
+  @Exclude()
   deletedAt: Date;
 }

--- a/backend/src/members/const/exception/member.exception.ts
+++ b/backend/src/members/const/exception/member.exception.ts
@@ -1,6 +1,7 @@
 export const MemberException = {
   NOT_FOUND: '해당 교인을 찾을 수 없습니다.',
   NOT_FOUND_GUIDE: '인도자로 지정한 교인을 찾을 수 없습니다.',
+  NOT_FOUND_PARTIAL: '교인 중 존재하지 않는 교인이 있습니다.',
   ALREADY_EXIST: '이미 동일한 이름과 전화번호를 가진 교인이 존재합니다.',
   UPDATE_ERROR: '교인 업데이트 도중 에러 발생',
   DELETE_ERROR: '교인 삭제 도중 에러 발생',

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -28,6 +28,7 @@ import { MinistryHistoryModel } from '../../member-history/entity/ministry-histo
 import { OfficerHistoryModel } from '../../member-history/entity/officer-history.entity';
 import { GroupHistoryModel } from '../../member-history/entity/group-history.entity';
 import { VisitationDetailModel } from '../../visitation/entity/visitation-detail.entity';
+import { VisitationMetaModel } from '../../visitation/entity/visitation-meta.entity';
 
 @Entity()
 export class MemberModel extends BaseModel {
@@ -194,6 +195,24 @@ export class MemberModel extends BaseModel {
 
   @OneToMany(() => GroupHistoryModel, (groupHistory) => groupHistory.member)
   groupHistory: GroupHistoryModel[];
+
+  @OneToMany(
+    () => VisitationMetaModel,
+    (visitationMeta) => visitationMeta.instructor,
+  )
+  visitationInstructor: VisitationMetaModel[];
+
+  @ManyToMany(
+    () => VisitationMetaModel,
+    (visitationMeta) => visitationMeta.reportTo,
+  )
+  visitationReports: VisitationMetaModel[];
+
+  @ManyToMany(
+    () => VisitationMetaModel,
+    (visitationMeta) => visitationMeta.members,
+  )
+  visitationMetas: VisitationMetaModel[];
 
   @OneToMany(
     () => VisitationDetailModel,

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -196,24 +196,35 @@ export class MemberModel extends BaseModel {
   @OneToMany(() => GroupHistoryModel, (groupHistory) => groupHistory.member)
   groupHistory: GroupHistoryModel[];
 
+  // 진행하는 심방
   @OneToMany(
     () => VisitationMetaModel,
     (visitationMeta) => visitationMeta.instructor,
   )
-  visitationInstructor: VisitationMetaModel[];
+  instructingVisitations: VisitationMetaModel[];
 
+  // 생성한 심방
+  @OneToMany(
+    () => VisitationMetaModel,
+    (visitationMeta) => visitationMeta.creator,
+  )
+  createdVisitations: VisitationMetaModel[];
+
+  // 보고 받을 심방
   @ManyToMany(
     () => VisitationMetaModel,
     (visitationMeta) => visitationMeta.reportTo,
   )
   visitationReports: VisitationMetaModel[];
 
+  // 참여한 심방
   @ManyToMany(
     () => VisitationMetaModel,
     (visitationMeta) => visitationMeta.members,
   )
   visitationMetas: VisitationMetaModel[];
 
+  // 나의 심방 세부 내용
   @OneToMany(
     () => VisitationDetailModel,
     (visitingDetail) => visitingDetail.member,

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -27,6 +27,7 @@ import { RequestInfoModel } from '../../request-info/entity/request-info.entity'
 import { MinistryHistoryModel } from '../../member-history/entity/ministry-history.entity';
 import { OfficerHistoryModel } from '../../member-history/entity/officer-history.entity';
 import { GroupHistoryModel } from '../../member-history/entity/group-history.entity';
+import { VisitationDetailModel } from '../../visitation/entity/visitation-detail.entity';
 
 @Entity()
 export class MemberModel extends BaseModel {
@@ -193,4 +194,10 @@ export class MemberModel extends BaseModel {
 
   @OneToMany(() => GroupHistoryModel, (groupHistory) => groupHistory.member)
   groupHistory: GroupHistoryModel[];
+
+  @OneToMany(
+    () => VisitationDetailModel,
+    (visitingDetail) => visitingDetail.member,
+  )
+  visitationDetails: VisitationDetailModel[];
 }

--- a/backend/src/members/member-domain/service/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/service/interface/members-domain.service.interface.ts
@@ -29,6 +29,12 @@ export interface IMembersDomainService {
     qr?: QueryRunner,
   ): Promise<MemberPaginationResultDto>;
 
+  findMembersById(
+    church: ChurchModel,
+    ids: number[],
+    qr?: QueryRunner,
+  ): Promise<MemberModel[]>;
+
   findMemberById(
     church: ChurchModel,
     memberId: number,
@@ -38,6 +44,13 @@ export interface IMembersDomainService {
   findMemberModelById(
     church: ChurchModel,
     memberId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<MemberModel>,
+  ): Promise<MemberModel>;
+
+  findMemberModelByUserId(
+    church: ChurchModel,
+    userId: number,
     qr?: QueryRunner,
     relationOptions?: FindOptionsRelations<MemberModel>,
   ): Promise<MemberModel>;

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -12,6 +12,7 @@ import {
   FindOptionsRelations,
   FindOptionsSelect,
   FindOptionsWhere,
+  In,
   IsNull,
   QueryRunner,
   Repository,
@@ -79,6 +80,27 @@ export class MembersDomainService implements IMembersDomainService {
     return resultDto;
   }
 
+  async findMembersById(
+    church: ChurchModel,
+    ids: number[],
+    qr?: QueryRunner,
+  ): Promise<MemberModel[]> {
+    const repository = this.getMembersRepository(qr);
+
+    const members = await repository.find({
+      where: {
+        churchId: church.id,
+        id: In(ids),
+      },
+    });
+
+    if (members.length !== ids.length) {
+      throw new NotFoundException(MemberException.NOT_FOUND_PARTIAL);
+    }
+
+    return members;
+  }
+
   async findMemberById(
     church: ChurchModel,
     memberId: number,
@@ -114,6 +136,29 @@ export class MembersDomainService implements IMembersDomainService {
       where: {
         id: memberId,
         churchId: church.id,
+      },
+      relations: relationOptions,
+    });
+
+    if (!member) {
+      throw new NotFoundException(MemberException.NOT_FOUND);
+    }
+
+    return member;
+  }
+
+  async findMemberModelByUserId(
+    church: ChurchModel,
+    userId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<MemberModel>,
+  ) {
+    const membersRepository = this.getMembersRepository(qr);
+
+    const member = await membersRepository.findOne({
+      where: {
+        churchId: church.id,
+        userId,
       },
       relations: relationOptions,
     });

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -6,13 +6,7 @@ import { MembersDomainModule } from '../members/member-domain/members-domain.mod
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
 
 @Module({
-  imports: [
-    //TypeOrmModule.forFeature([UserModel /*, MemberModel, ChurchModel*/]),
-    //JwtModule.register({}),
-    UserDomainModule,
-    ChurchesDomainModule,
-    MembersDomainModule,
-  ],
+  imports: [UserDomainModule, ChurchesDomainModule, MembersDomainModule],
   controllers: [UserController],
   providers: [UserService],
   exports: [],

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,15 +1,13 @@
 import { Module } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { UserModel } from './entity/user.entity';
 import { UserDomainModule } from './user-domain/user-domain.module';
 import { MembersDomainModule } from '../members/member-domain/members-domain.module';
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([UserModel /*, MemberModel, ChurchModel*/]),
+    //TypeOrmModule.forFeature([UserModel /*, MemberModel, ChurchModel*/]),
     //JwtModule.register({}),
     UserDomainModule,
     ChurchesDomainModule,

--- a/backend/src/visitation/const/exception/visitation-meta.exception.ts
+++ b/backend/src/visitation/const/exception/visitation-meta.exception.ts
@@ -1,6 +1,0 @@
-export const VisitationMetaException = {
-  NOT_FOUND: '심방 데이터를 찾을 수 없습니다.',
-  INVALID_INSTRUCTOR: '심방 진행자로 등록할 수 없습니다.',
-  UPDATE_ERROR: '심방 데이터 업데이트 도중 에러 발생',
-  DELETE_ERROR: '심방 데이터 삭제 도중 에러 발생',
-};

--- a/backend/src/visitation/const/exception/visitation-meta.exception.ts
+++ b/backend/src/visitation/const/exception/visitation-meta.exception.ts
@@ -1,0 +1,6 @@
+export const VisitationMetaException = {
+  NOT_FOUND: '심방 데이터를 찾을 수 없습니다.',
+  INVALID_INSTRUCTOR: '심방 진행자로 등록할 수 없습니다.',
+  UPDATE_ERROR: '심방 데이터 업데이트 도중 에러 발생',
+  DELETE_ERROR: '심방 데이터 삭제 도중 에러 발생',
+};

--- a/backend/src/visitation/const/exception/visitation.exception.ts
+++ b/backend/src/visitation/const/exception/visitation.exception.ts
@@ -1,0 +1,18 @@
+export const VisitationException = {
+  NOT_FOUND: '심방 데이터를 찾을 수 없습니다.',
+  INVALID_INSTRUCTOR: '심방 진행자로 등록할 수 없는 교인입니다.',
+  UPDATE_ERROR: '심방 데이터 업데이트 도중 에러 발생',
+  DELETE_ERROR: '심방 데이터 삭제 도중 에러 발생',
+
+  ALREADY_EXIST_TARGET_MEMBER: (alreadyExistMember: number | number[]) =>
+    `이미 존재하는 심방 대상자입니다. 존재하는 교인 id: [${alreadyExistMember}]`,
+  NOT_EXIST_DELETE_TARGET_MEMBER: (notExistMemberId: number | number[]) =>
+    `삭제 대상자가 심방 대상자에 포함되어 있지 않습니다. 존재하지 않는 교인 id: [${notExistMemberId}]`,
+};
+
+export const VisitationDetailException = {
+  NOT_FOUND: '해당 심방 세부 데이터를 찾을 수 없습니다.',
+  ALREADY_EXIST: '이미 존재하는 심방 세부 데이터입니다.',
+  UPDATE_ERROR: '심방 세부 데이터 업데이트 도중 에러 발생',
+  DELETE_ERROR: '심방 세부 데이터 삭제 도중 에러 발생',
+};

--- a/backend/src/visitation/const/order.enum.ts
+++ b/backend/src/visitation/const/order.enum.ts
@@ -1,0 +1,5 @@
+export enum VisitationOrderEnum {
+  visitationDate = 'visitationDate',
+  createdAt = 'createdAt',
+  updatedAt = 'updatedAt',
+}

--- a/backend/src/visitation/const/visitation-find-options.const.ts
+++ b/backend/src/visitation/const/visitation-find-options.const.ts
@@ -4,7 +4,11 @@ import { VisitationDetailModel } from '../entity/visitation-detail.entity';
 
 export const VisitationRelationOptions: FindOptionsRelations<VisitationMetaModel> =
   {
-    members: true,
+    members: {
+      officer: true,
+      group: true,
+      groupRole: true,
+    },
     instructor: {
       officer: true,
       group: true,
@@ -53,6 +57,18 @@ export const VisitationSelectOptions: FindOptionsSelect<VisitationMetaModel> = {
   members: {
     id: true,
     name: true,
+    officer: {
+      id: true,
+      name: true,
+    },
+    group: {
+      id: true,
+      name: true,
+    },
+    groupRole: {
+      id: true,
+      role: true,
+    },
   },
 };
 

--- a/backend/src/visitation/const/visitation-find-options.const.ts
+++ b/backend/src/visitation/const/visitation-find-options.const.ts
@@ -1,0 +1,86 @@
+import { FindOptionsRelations, FindOptionsSelect } from 'typeorm';
+import { VisitationMetaModel } from '../entity/visitation-meta.entity';
+import { VisitationDetailModel } from '../entity/visitation-detail.entity';
+
+export const VisitationRelationOptions: FindOptionsRelations<VisitationMetaModel> =
+  {
+    members: true,
+    instructor: {
+      officer: true,
+      group: true,
+      groupRole: true,
+    },
+    creator: {
+      officer: true,
+      group: true,
+      groupRole: true,
+    },
+  };
+
+export const VisitationSelectOptions: FindOptionsSelect<VisitationMetaModel> = {
+  creator: {
+    id: true,
+    name: true,
+    officer: {
+      id: true,
+      name: true,
+    },
+    group: {
+      id: true,
+      name: true,
+    },
+    groupRole: {
+      id: true,
+      role: true,
+    },
+  },
+  instructor: {
+    id: true,
+    name: true,
+    officer: {
+      id: true,
+      name: true,
+    },
+    group: {
+      id: true,
+      name: true,
+    },
+    groupRole: {
+      id: true,
+      role: true,
+    },
+  },
+  members: {
+    id: true,
+    name: true,
+  },
+};
+
+export const VisitationDetailRelationOptions: FindOptionsRelations<VisitationDetailModel> =
+  {
+    member: {
+      officer: true,
+      group: true,
+      groupRole: true,
+    },
+  };
+
+export const VisitationDetailSelectOptions: FindOptionsSelect<VisitationDetailModel> =
+  {
+    member: {
+      id: true,
+      name: true,
+      officer: {
+        id: true,
+        name: true,
+      },
+      group: {
+        id: true,
+        name: true,
+      },
+      groupRole: {
+        id: true,
+        role: true,
+      },
+    },
+  };

--- a/backend/src/visitation/const/visitation-method.enum.ts
+++ b/backend/src/visitation/const/visitation-method.enum.ts
@@ -1,0 +1,4 @@
+export enum VisitationMethod {
+  IN_PERSON = 'IN_PERSON',
+  REMOTE = 'REMOTE',
+}

--- a/backend/src/visitation/const/visitation-status.enum.ts
+++ b/backend/src/visitation/const/visitation-status.enum.ts
@@ -1,0 +1,5 @@
+export enum VisitationStatus {
+  RESERVE = 'RESERVE',
+  DONE = 'DONE',
+  PENDING = 'PENDING',
+}

--- a/backend/src/visitation/const/visitation-type.enum.ts
+++ b/backend/src/visitation/const/visitation-type.enum.ts
@@ -1,0 +1,4 @@
+export enum VisitationType {
+  SINGLE = 'SINGLE',
+  GROUP = 'GROUP',
+}

--- a/backend/src/visitation/controller/visitation-detail.controller.ts
+++ b/backend/src/visitation/controller/visitation-detail.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  UseInterceptors,
+} from '@nestjs/common';
+import { VisitationService } from '../visitation.service';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { UpdateVisitationDetailDto } from '../dto/detail/update-visitation-detail.dto';
+import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
+import { QueryRunner } from '../../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm/query-runner/QueryRunner';
+import { CreateVisitationDetailDto } from '../dto/detail/create-visitation-detail.dto';
+
+@ApiTags('Visitations:Details')
+@Controller('visitations/:visitationId/details')
+export class VisitationDetailController {
+  constructor(private readonly visitationService: VisitationService) {}
+
+  @ApiOperation({
+    summary: '심방 대상자 추가',
+    description: '심방 메타 데이터 수정에서 대상자를 추가',
+    deprecated: true,
+  })
+  @Post()
+  @UseInterceptors(TransactionInterceptor)
+  postVisitationDetail(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('visitationId', ParseIntPipe) visitationId: number,
+    @Body() dto: CreateVisitationDetailDto,
+    @QueryRunner() qr: QR,
+  ) {
+    /*return this.visitationService.createVisitationDetail(
+      churchId,
+      visitationId,
+      dto,
+      qr,
+    );*/
+  }
+
+  @ApiOperation({
+    summary: '심방 세부 내용 작성',
+    description: '심방 세부 내용 작성, 심방 대상자 삭제 불가능',
+  })
+  @Patch(':detailId')
+  patchVisitationDetail(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('visitationId', ParseIntPipe) visitationId: number,
+    @Param('detailId', ParseIntPipe) detailId: number,
+    @Body() dto: UpdateVisitationDetailDto,
+  ) {
+    return this.visitationService.updateVisitationDetail(
+      churchId,
+      visitationId,
+      detailId,
+      dto,
+    );
+  }
+
+  @ApiOperation({
+    summary: '심방 세부 내용 삭제',
+    description:
+      '심방 메타 데이터 수정에서 심방 대상자를 삭제하여 세부 내용을 삭제',
+    deprecated: true,
+  })
+  @UseInterceptors(TransactionInterceptor)
+  @Delete(':detailId')
+  deleteVisitationDetail(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('visitationId', ParseIntPipe) visitationId: number,
+    @Param('detailId', ParseIntPipe) detailId: number,
+    @QueryRunner() qr: QR,
+  ) {}
+}

--- a/backend/src/visitation/decorator/visitation-detail.validator.ts
+++ b/backend/src/visitation/decorator/visitation-detail.validator.ts
@@ -1,0 +1,42 @@
+import { ValidationOptions } from 'joi';
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { VisitationDetailDto } from '../dto/visitation-detail.dto';
+
+@ValidatorConstraint({ name: 'VisitationDetailValidator', async: false })
+export class VisitationDetailConstraint
+  implements ValidatorConstraintInterface
+{
+  defaultMessage(validationArguments?: ValidationArguments): string {
+    return '중복된 심방 대상자가 존재합니다.';
+  }
+
+  validate(
+    value: VisitationDetailDto[],
+    validationArguments?: ValidationArguments,
+  ): Promise<boolean> | boolean {
+    const memberIds = value.map((detail) => detail.memberId);
+
+    const memberIdsSet = new Set(memberIds);
+
+    return memberIds.length === memberIdsSet.size;
+  }
+}
+
+export function VisitationDetailValidator(
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: VisitationDetailConstraint,
+    });
+  };
+}

--- a/backend/src/visitation/decorator/visitation.swagger.ts
+++ b/backend/src/visitation/decorator/visitation.swagger.ts
@@ -1,0 +1,37 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+export const ApiGetVisitations = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교회의 심방 목록 조회',
+      description:
+        '<h2>교회의 심방 목록을 조회합니다.</h2>' +
+        '<p>take: 요청 데이터 개수 (기본값: 20)</p>' +
+        '<p>page: 요청 페이지 (기본값: 1)</p>' +
+        '<p>order: 정렬 기준 (기본값: 심방 날짜)</p>' +
+        '<p>orderDirection: 정렬 차순 (기본값: 내림차순)</p>' +
+        '<h3>필터링 조건</h3>' +
+        '<p>fromVisitationDate: 심방 날짜 ~ 부터</p>' +
+        '<p>toVisitationDate: 심방 날짜 ~ 까지</p>' +
+        '<p>visitationStatus: 심방 상태 (예약 / 완료 / 지연)</p>' +
+        '<p>visitationMethod: 심방 방식 (대면 / 비대면)</p>' +
+        '<p>visitationType: 심방 종류 (개인 / 그룹)</p>' +
+        '<p>visitationTitle: 심방 제목 (부분 일치 포함)</p>' +
+        '<p>instructorId: 심방 진행자의 교인 ID</p>',
+    }),
+  );
+
+export const ApiPostVisitation = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '심방 생성 (인증 필요)',
+      description:
+        '<p>심방을 생성합니다.</p>' +
+        '<p>심방의 예약과 기록은 <b>VisitationStatus</b> 로 구분합니다.</p>' +
+        '<p>예약 생성 시 --> VisitationStatus: RESERVE</p>' +
+        '<p>기록 생성 시 --> VisitationStatus: DONE</p>' +
+        '<p>예약 생성이더라도 VisitationDetail 의 내용을 기재할 수 있습니다.</p>' +
+        '<p>VisitationDetail 의 개수에 따라 개인 / 그룹 심방이 결정됩니다.</p>',
+    }),
+  );

--- a/backend/src/visitation/dto/create-visitation.dto.ts
+++ b/backend/src/visitation/dto/create-visitation.dto.ts
@@ -7,12 +7,12 @@ import {
   Min,
   ValidateNested,
 } from 'class-validator';
-import { VisitationType } from '../const/visitation-type.enum';
 import { VisitationMethod } from '../const/visitation-method.enum';
 import { ApiProperty } from '@nestjs/swagger';
 import { VisitationDetailDto } from './visitation-detail.dto';
 import { Type } from 'class-transformer';
 import { VisitationStatus } from '../const/visitation-status.enum';
+import { VisitationDetailValidator } from '../decorator/visitation-detail.validator';
 
 export class CreateVisitationDto {
   @ApiProperty({
@@ -23,12 +23,13 @@ export class CreateVisitationDto {
   @IsEnum(VisitationStatus)
   visitationStatus: VisitationStatus;
 
-  @ApiProperty({
+  /*@ApiProperty({
     description: '심방 종류 (개인 / 그룹)',
     enum: VisitationType,
+    deprecated: true,
   })
   @IsEnum(VisitationType)
-  visitationType: VisitationType;
+  visitationType: VisitationType;*/
 
   @ApiProperty({
     description: '심방 방식 (대면 / 비대면)',
@@ -65,5 +66,6 @@ export class CreateVisitationDto {
   })
   @ValidateNested({ each: true })
   @Type(() => VisitationDetailDto)
+  @VisitationDetailValidator()
   visitationDetails: VisitationDetailDto[];
 }

--- a/backend/src/visitation/dto/create-visitation.dto.ts
+++ b/backend/src/visitation/dto/create-visitation.dto.ts
@@ -1,0 +1,69 @@
+import {
+  IsDate,
+  IsEnum,
+  IsNumber,
+  IsString,
+  Length,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { VisitationType } from '../const/visitation-type.enum';
+import { VisitationMethod } from '../const/visitation-method.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { VisitationDetailDto } from './visitation-detail.dto';
+import { Type } from 'class-transformer';
+import { VisitationStatus } from '../const/visitation-status.enum';
+
+export class CreateVisitationDto {
+  @ApiProperty({
+    description: '심방 상태 (예약 / 완료 / 지연)',
+    enum: VisitationStatus,
+    default: VisitationStatus.RESERVE,
+  })
+  @IsEnum(VisitationStatus)
+  visitationStatus: VisitationStatus;
+
+  @ApiProperty({
+    description: '심방 종류 (개인 / 그룹)',
+    enum: VisitationType,
+  })
+  @IsEnum(VisitationType)
+  visitationType: VisitationType;
+
+  @ApiProperty({
+    description: '심방 방식 (대면 / 비대면)',
+    enum: VisitationMethod,
+  })
+  @IsEnum(VisitationMethod)
+  visitationMethod: VisitationMethod;
+
+  @ApiProperty({
+    description: '심방 제목',
+    maxLength: 50,
+  })
+  @IsString()
+  @Length(2, 50)
+  visitationTitle: string;
+
+  @ApiProperty({
+    description: '심방 진행자 ID',
+  })
+  @IsNumber()
+  @Min(1)
+  instructorId: number;
+
+  @ApiProperty({
+    description: '심방 날짜',
+  })
+  @IsDate()
+  visitationDate: Date;
+
+  @ApiProperty({
+    description: '심방 세부 정보',
+    type: VisitationDetailDto,
+    isArray: true,
+  })
+  @ValidateNested({ each: true })
+  @Type(() => VisitationDetailDto)
+  visitationDetails: VisitationDetailDto[];
+}

--- a/backend/src/visitation/dto/detail/create-visitation-detail.dto.ts
+++ b/backend/src/visitation/dto/detail/create-visitation-detail.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class CreateVisitationDetailDto {
+  @ApiProperty({
+    description: '심방 대상자 교인 ID',
+  })
+  @IsNumber()
+  memberId: number;
+
+  @ApiProperty({
+    description: '심방 내용',
+  })
+  @IsString()
+  @IsOptional()
+  visitationContent: string;
+
+  @ApiProperty({
+    description: '기도 제목',
+  })
+  @IsString()
+  @IsOptional()
+  visitationPray: string;
+}

--- a/backend/src/visitation/dto/detail/update-visitation-detail.dto.ts
+++ b/backend/src/visitation/dto/detail/update-visitation-detail.dto.ts
@@ -1,0 +1,6 @@
+import { OmitType, PartialType } from '@nestjs/swagger';
+import { CreateVisitationDetailDto } from './create-visitation-detail.dto';
+
+export class UpdateVisitationDetailDto extends PartialType(
+  OmitType(CreateVisitationDetailDto, ['memberId']),
+) {}

--- a/backend/src/visitation/dto/get-visitation.dto.ts
+++ b/backend/src/visitation/dto/get-visitation.dto.ts
@@ -1,0 +1,122 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsDate,
+  IsEnum,
+  IsIn,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+import { VisitationStatus } from '../const/visitation-status.enum';
+import { TransformStringArray } from '../../common/decorator/transformer/transform-array';
+import { VisitationOrderEnum } from '../const/order.enum';
+import { VisitationMethod } from '../const/visitation-method.enum';
+import { VisitationType } from '../const/visitation-type.enum';
+
+export class GetVisitationDto {
+  @ApiProperty({
+    description: '요청 데이터 개수',
+    default: 20,
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  take: number = 20;
+
+  @ApiProperty({
+    description: '요청 페이지',
+    default: 1,
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  page: number = 1;
+
+  @ApiProperty({
+    description: '정렬 기준',
+    enum: VisitationOrderEnum,
+    default: VisitationOrderEnum.visitationDate,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(VisitationOrderEnum)
+  order: VisitationOrderEnum = VisitationOrderEnum.visitationDate;
+
+  @ApiProperty({
+    description: '정렬 오름차순 / 내림차순',
+    default: 'desc',
+    required: false,
+  })
+  @IsOptional()
+  @IsIn(['asc', 'desc', 'ASC', 'DESC'])
+  orderDirection: 'asc' | 'desc' | 'ASC' | 'DESC' = 'desc';
+
+  @ApiProperty({
+    description: '심방 날짜 ~ 부터',
+    required: false,
+  })
+  @IsOptional()
+  @IsDate()
+  fromVisitationDate?: Date;
+
+  @ApiProperty({
+    description: '심방 날짜 ~ 까지',
+    required: false,
+  })
+  @IsOptional()
+  @IsDate()
+  toVisitationDate?: Date;
+
+  @ApiProperty({
+    description: '심방 상태 (예약 / 완료 / 지연)',
+    enum: VisitationStatus,
+    isArray: true,
+    required: false,
+  })
+  @IsOptional()
+  @TransformStringArray()
+  @IsEnum(VisitationStatus, { each: true })
+  where__visitationStatus?: VisitationStatus[];
+
+  @ApiProperty({
+    description: '심방 방식 (대면 / 비대면)',
+    enum: VisitationMethod,
+    isArray: true,
+    required: false,
+  })
+  @IsOptional()
+  @TransformStringArray()
+  @IsEnum(VisitationMethod, { each: true })
+  where__visitationMethod?: VisitationMethod[];
+
+  @ApiProperty({
+    description: '심방 종류 (개인 / 그룹)',
+    enum: VisitationType,
+    isArray: true,
+    required: false,
+  })
+  @IsOptional()
+  @TransformStringArray()
+  @IsEnum(VisitationType, { each: true })
+  where__visitationType?: VisitationType[];
+
+  @ApiProperty({
+    description: '심방 제목',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  where__visitationTitle?: string;
+
+  @ApiProperty({
+    description: '심방 진행자의 교인 ID',
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  where__instructorId?: number;
+}

--- a/backend/src/visitation/dto/get-visitation.dto.ts
+++ b/backend/src/visitation/dto/get-visitation.dto.ts
@@ -79,7 +79,7 @@ export class GetVisitationDto {
   @IsOptional()
   @TransformStringArray()
   @IsEnum(VisitationStatus, { each: true })
-  where__visitationStatus?: VisitationStatus[];
+  visitationStatus?: VisitationStatus[];
 
   @ApiProperty({
     description: '심방 방식 (대면 / 비대면)',
@@ -90,7 +90,7 @@ export class GetVisitationDto {
   @IsOptional()
   @TransformStringArray()
   @IsEnum(VisitationMethod, { each: true })
-  where__visitationMethod?: VisitationMethod[];
+  visitationMethod?: VisitationMethod[];
 
   @ApiProperty({
     description: '심방 종류 (개인 / 그룹)',
@@ -101,7 +101,7 @@ export class GetVisitationDto {
   @IsOptional()
   @TransformStringArray()
   @IsEnum(VisitationType, { each: true })
-  where__visitationType?: VisitationType[];
+  visitationType?: VisitationType[];
 
   @ApiProperty({
     description: '심방 제목',
@@ -109,7 +109,7 @@ export class GetVisitationDto {
   })
   @IsOptional()
   @IsString()
-  where__visitationTitle?: string;
+  visitationTitle?: string;
 
   @ApiProperty({
     description: '심방 진행자의 교인 ID',
@@ -118,5 +118,5 @@ export class GetVisitationDto {
   @IsOptional()
   @IsNumber()
   @Min(1)
-  where__instructorId?: number;
+  instructorId?: number;
 }

--- a/backend/src/visitation/dto/meta/create-visitation-meta.dto.ts
+++ b/backend/src/visitation/dto/meta/create-visitation-meta.dto.ts
@@ -1,0 +1,47 @@
+import { VisitationMethod } from '../../const/visitation-method.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDate, IsEnum, IsNumber, IsString, Length } from 'class-validator';
+import { VisitationType } from '../../const/visitation-type.enum';
+import { TransformStartDate } from '../../../member-history/decorator/transform-start-date.decorator';
+
+export class CreateVisitationMetaDto {
+  @ApiProperty({
+    description: '심방 방식 (대면 / 비대면)',
+    enum: VisitationMethod,
+    required: true,
+  })
+  @IsEnum(VisitationMethod)
+  visitationMethod: VisitationMethod;
+
+  @ApiProperty({
+    description: '심방 종류 (개인 / 그룹)',
+    enum: VisitationType,
+    required: true,
+  })
+  @IsEnum(VisitationType)
+  visitationType: VisitationType;
+
+  @ApiProperty({
+    description: '심방 제목',
+    maxLength: 50,
+    required: true,
+  })
+  @IsString()
+  @Length(2, 50)
+  visitationTitle: string;
+
+  @ApiProperty({
+    description: '진행자 ID',
+    required: true,
+  })
+  @IsNumber()
+  instructorId: number;
+
+  @ApiProperty({
+    description: '심방 날짜',
+    required: true,
+  })
+  @IsDate()
+  @TransformStartDate()
+  visitationDate: Date;
+}

--- a/backend/src/visitation/dto/meta/create-visitation-meta.dto.ts
+++ b/backend/src/visitation/dto/meta/create-visitation-meta.dto.ts
@@ -4,6 +4,7 @@ import { IsDate, IsEnum, IsNumber, IsString, Length } from 'class-validator';
 import { VisitationType } from '../../const/visitation-type.enum';
 import { TransformStartDate } from '../../../member-history/decorator/transform-start-date.decorator';
 import { VisitationStatus } from '../../const/visitation-status.enum';
+import { MemberModel } from '../../../members/entity/member.entity';
 
 export class CreateVisitationMetaDto {
   @ApiProperty({
@@ -52,4 +53,6 @@ export class CreateVisitationMetaDto {
   @IsDate()
   @TransformStartDate()
   visitationDate: Date;
+
+  creator: MemberModel;
 }

--- a/backend/src/visitation/dto/meta/create-visitation-meta.dto.ts
+++ b/backend/src/visitation/dto/meta/create-visitation-meta.dto.ts
@@ -3,8 +3,16 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsDate, IsEnum, IsNumber, IsString, Length } from 'class-validator';
 import { VisitationType } from '../../const/visitation-type.enum';
 import { TransformStartDate } from '../../../member-history/decorator/transform-start-date.decorator';
+import { VisitationStatus } from '../../const/visitation-status.enum';
 
 export class CreateVisitationMetaDto {
+  @ApiProperty({
+    description: '심방 상태 (예약 / 완료 / 지연)',
+    enum: VisitationStatus,
+  })
+  @IsEnum(VisitationStatus)
+  visitationStatus: VisitationStatus;
+
   @ApiProperty({
     description: '심방 방식 (대면 / 비대면)',
     enum: VisitationMethod,

--- a/backend/src/visitation/dto/meta/update-visitation-meta.dto.ts
+++ b/backend/src/visitation/dto/meta/update-visitation-meta.dto.ts
@@ -1,0 +1,6 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateVisitationMetaDto } from './create-visitation-meta.dto';
+
+export class UpdateVisitationMetaDto extends PartialType(
+  CreateVisitationMetaDto,
+) {}

--- a/backend/src/visitation/dto/meta/update-visitation-meta.dto.ts
+++ b/backend/src/visitation/dto/meta/update-visitation-meta.dto.ts
@@ -1,6 +1,6 @@
-import { PartialType } from '@nestjs/swagger';
+import { OmitType, PartialType } from '@nestjs/swagger';
 import { CreateVisitationMetaDto } from './create-visitation-meta.dto';
 
 export class UpdateVisitationMetaDto extends PartialType(
-  CreateVisitationMetaDto,
+  OmitType(CreateVisitationMetaDto, ['creator']),
 ) {}

--- a/backend/src/visitation/dto/update-visitation.dto.ts
+++ b/backend/src/visitation/dto/update-visitation.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty, OmitType, PartialType } from '@nestjs/swagger';
+
+import { IsArray, IsOptional } from 'class-validator';
+import { CreateVisitationMetaDto } from './meta/create-visitation-meta.dto';
+import { TransformNumberArray } from '../../common/decorator/transformer/transform-array';
+
+export class UpdateVisitationDto extends PartialType(
+  OmitType(CreateVisitationMetaDto, ['creator', 'visitationType']),
+) {
+  @ApiProperty({
+    description: '심방 대상자 추가할 교인 ID 들',
+    isArray: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsArray()
+  @TransformNumberArray()
+  addMemberIds?: number[];
+
+  @ApiProperty({
+    description: '심방 대상자 제거할 교인 ID 들',
+    isArray: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsArray()
+  @TransformNumberArray()
+  deleteMemberIds?: number[];
+}

--- a/backend/src/visitation/dto/visitation-detail.dto.ts
+++ b/backend/src/visitation/dto/visitation-detail.dto.ts
@@ -1,0 +1,25 @@
+import { IsNumber, IsOptional, IsString, Min } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class VisitationDetailDto {
+  @ApiProperty({
+    description: '심방 대상자 ID',
+  })
+  @IsNumber()
+  @Min(1)
+  memberId: number;
+
+  @ApiProperty({
+    description: '심방 내용 (예약 시 생략)',
+  })
+  @IsString()
+  @IsOptional()
+  visitationContent?: string;
+
+  @ApiProperty({
+    description: '기도 제목 (예약 시 생략)',
+  })
+  @IsString()
+  @IsOptional()
+  visitationPray?: string;
+}

--- a/backend/src/visitation/entity/visitation-detail.entity.ts
+++ b/backend/src/visitation/entity/visitation-detail.entity.ts
@@ -24,9 +24,9 @@ export class VisitationDetailModel extends BaseModel {
   @JoinColumn({ name: 'memberId' })
   member: MemberModel;
 
-  @Column()
+  @Column({ nullable: true })
   visitationContent: string;
 
-  @Column()
+  @Column({ nullable: true })
   visitationPray: string;
 }

--- a/backend/src/visitation/entity/visitation-detail.entity.ts
+++ b/backend/src/visitation/entity/visitation-detail.entity.ts
@@ -1,0 +1,32 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseModel } from '../../common/entity/base.entity';
+import { VisitationMetaModel } from './visitation-meta.entity';
+import { MemberModel } from '../../members/entity/member.entity';
+
+@Entity()
+export class VisitationDetailModel extends BaseModel {
+  @Index()
+  @Column()
+  visitationMetaId: number;
+
+  @ManyToOne(
+    () => VisitationMetaModel,
+    (visitingMeta) => visitingMeta.visitationDetails,
+  )
+  @JoinColumn({ name: 'visitationMetaId' })
+  visitationMeta: VisitationMetaModel;
+
+  @Index()
+  @Column()
+  memberId: number;
+
+  @ManyToOne(() => MemberModel, (member) => member.visitationDetails)
+  @JoinColumn({ name: 'memberId' })
+  member: MemberModel;
+
+  @Column()
+  visitationContent: string;
+
+  @Column()
+  visitationPray: string;
+}

--- a/backend/src/visitation/entity/visitation-meta.entity.ts
+++ b/backend/src/visitation/entity/visitation-meta.entity.ts
@@ -4,14 +4,16 @@ import {
   Entity,
   Index,
   JoinColumn,
+  ManyToMany,
   ManyToOne,
   OneToMany,
 } from 'typeorm';
 import { VisitationDetailModel } from './visitation-detail.entity';
-import { UserModel } from '../../user/entity/user.entity';
 import { VisitationMethod } from '../const/visitation-method.enum';
 import { VisitationType } from '../const/visitation-type.enum';
 import { ChurchModel } from '../../churches/entity/church.entity';
+import { MemberModel } from '../../members/entity/member.entity';
+import { VisitationStatus } from '../const/visitation-status.enum';
 
 @Entity()
 export class VisitationMetaModel extends BaseModel {
@@ -22,6 +24,13 @@ export class VisitationMetaModel extends BaseModel {
   @ManyToOne(() => ChurchModel, (church) => church.visitations)
   @JoinColumn({ name: 'churchId' })
   church: ChurchModel;
+
+  @Column({
+    enum: VisitationStatus,
+    comment: '심방 상태 (예약 / 완료 / 지연)',
+    default: VisitationStatus.RESERVE,
+  })
+  visitationStatus: VisitationStatus;
 
   @Column({ enum: VisitationMethod, comment: '심방 방식 (대면 / 비대면)' })
   visitationMethod: VisitationMethod;
@@ -40,9 +49,17 @@ export class VisitationMetaModel extends BaseModel {
   @Column({ comment: '심방 진행자 ID' })
   instructorId: number;
 
-  @ManyToOne(() => UserModel)
+  @ManyToOne(() => MemberModel)
   @JoinColumn({ name: 'instructorId' })
-  instructor: UserModel;
+  instructor: MemberModel;
+
+  @ManyToMany(() => MemberModel, (member) => member.visitationReports)
+  @JoinColumn()
+  reportTo: MemberModel[];
+
+  @ManyToMany(() => MemberModel, (member) => member.visitationMetas)
+  @JoinColumn()
+  members: MemberModel[];
 
   @OneToMany(
     () => VisitationDetailModel,

--- a/backend/src/visitation/entity/visitation-meta.entity.ts
+++ b/backend/src/visitation/entity/visitation-meta.entity.ts
@@ -1,0 +1,52 @@
+import { BaseModel } from '../../common/entity/base.entity';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+} from 'typeorm';
+import { VisitationDetailModel } from './visitation-detail.entity';
+import { UserModel } from '../../user/entity/user.entity';
+import { VisitationMethod } from '../const/visitation-method.enum';
+import { VisitationType } from '../const/visitation-type.enum';
+import { ChurchModel } from '../../churches/entity/church.entity';
+
+@Entity()
+export class VisitationMetaModel extends BaseModel {
+  @Index()
+  @Column()
+  churchId: number;
+
+  @ManyToOne(() => ChurchModel, (church) => church.visitations)
+  @JoinColumn({ name: 'churchId' })
+  church: ChurchModel;
+
+  @Column({ enum: VisitationMethod, comment: '심방 방식 (대면 / 비대면)' })
+  visitationMethod: VisitationMethod;
+
+  @Column({ enum: VisitationType, comment: '심방 종류 (개인 / 그룹)' })
+  visitationType: VisitationType;
+
+  @Index()
+  @Column({ type: 'timestamptz', comment: '심방 일자' })
+  visitationDate: Date;
+
+  @Column({ length: 50, comment: '심방 제목' })
+  visitationTitle: string;
+
+  @Index()
+  @Column({ comment: '심방 진행자 ID' })
+  instructorId: number;
+
+  @ManyToOne(() => UserModel)
+  @JoinColumn({ name: 'instructorId' })
+  instructor: UserModel;
+
+  @OneToMany(
+    () => VisitationDetailModel,
+    (visitingDetail) => visitingDetail.visitationMeta,
+  )
+  visitationDetails: VisitationDetailModel[];
+}

--- a/backend/src/visitation/entity/visitation-meta.entity.ts
+++ b/backend/src/visitation/entity/visitation-meta.entity.ts
@@ -4,6 +4,7 @@ import {
   Entity,
   Index,
   JoinColumn,
+  JoinTable,
   ManyToMany,
   ManyToOne,
   OneToMany,
@@ -49,16 +50,24 @@ export class VisitationMetaModel extends BaseModel {
   @Column({ comment: '심방 진행자 ID' })
   instructorId: number;
 
-  @ManyToOne(() => MemberModel)
+  @ManyToOne(() => MemberModel, (member) => member.instructingVisitations)
   @JoinColumn({ name: 'instructorId' })
   instructor: MemberModel;
 
+  @Index()
+  @Column({ comment: '심방 생성자 ID' })
+  creatorId: number;
+
+  @ManyToOne(() => MemberModel, (member) => member.createdVisitations)
+  @JoinColumn({ name: 'creatorId' })
+  creator: MemberModel;
+
   @ManyToMany(() => MemberModel, (member) => member.visitationReports)
-  @JoinColumn()
+  @JoinTable()
   reportTo: MemberModel[];
 
   @ManyToMany(() => MemberModel, (member) => member.visitationMetas)
-  @JoinColumn()
+  @JoinTable()
   members: MemberModel[];
 
   @OneToMany(

--- a/backend/src/visitation/visitation-domain/service/interface/visitation-detail-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/service/interface/visitation-detail-domain.service.interface.ts
@@ -1,5 +1,18 @@
+import { VisitationMetaModel } from '../../../entity/visitation-meta.entity';
+import { QueryRunner } from 'typeorm';
+import { VisitationDetailModel } from '../../../entity/visitation-detail.entity';
+import { MemberModel } from '../../../../members/entity/member.entity';
+import { VisitationDetailDto } from '../../../dto/visitation-detail.dto';
+
 export const IVISITATION_DETAIL_DOMAIN_SERVICE = Symbol(
   'IVISITATION_DETAIL_DOMAIN_SERVICE',
 );
 
-export interface IVisitationDetailDomainService {}
+export interface IVisitationDetailDomainService {
+  createVisitationDetail(
+    metaData: VisitationMetaModel,
+    memberModel: MemberModel,
+    dto: VisitationDetailDto,
+    qr: QueryRunner,
+  ): Promise<VisitationDetailModel>;
+}

--- a/backend/src/visitation/visitation-domain/service/interface/visitation-detail-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/service/interface/visitation-detail-domain.service.interface.ts
@@ -3,6 +3,7 @@ import { QueryRunner, UpdateResult } from 'typeorm';
 import { VisitationDetailModel } from '../../../entity/visitation-detail.entity';
 import { MemberModel } from '../../../../members/entity/member.entity';
 import { VisitationDetailDto } from '../../../dto/visitation-detail.dto';
+import { UpdateVisitationDetailDto } from '../../../dto/detail/update-visitation-detail.dto';
 
 export const IVISITATION_DETAIL_DOMAIN_SERVICE = Symbol(
   'IVISITATION_DETAIL_DOMAIN_SERVICE',
@@ -16,13 +17,43 @@ export interface IVisitationDetailDomainService {
     qr: QueryRunner,
   ): Promise<VisitationDetailModel>;
 
+  findVisitationDetailByMetaAndMemberId(
+    metaData: VisitationMetaModel,
+    member: MemberModel,
+    qr?: QueryRunner,
+  ): Promise<VisitationDetailModel>;
+
   findVisitationDetailsByMetaId(
     metaData: VisitationMetaModel,
     qr?: QueryRunner,
   ): Promise<VisitationDetailModel[]>;
 
+  findVisitationDetailById(
+    visitationMeta: VisitationMetaModel,
+    visitationDetailId: number,
+    qr?: QueryRunner,
+  ): Promise<VisitationDetailModel>;
+
+  findVisitationDetailModelById(
+    visitationMeta: VisitationMetaModel,
+    visitationDetailId: number,
+    qr?: QueryRunner,
+  ): Promise<VisitationDetailModel>;
+
+  updateVisitationDetail(
+    visitationMeta: VisitationMetaModel,
+    visitationDetail: VisitationDetailModel,
+    dto: UpdateVisitationDetailDto,
+    qr?: QueryRunner,
+  ): Promise<VisitationDetailModel>;
+
   deleteVisitationDetailsCascade(
     metaData: VisitationMetaModel,
     qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  deleteVisitationDetail(
+    visitationDetail: VisitationDetailModel,
+    qr?: QueryRunner,
   ): Promise<UpdateResult>;
 }

--- a/backend/src/visitation/visitation-domain/service/interface/visitation-detail-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/service/interface/visitation-detail-domain.service.interface.ts
@@ -1,0 +1,5 @@
+export const IVISITATION_DETAIL_DOMAIN_SERVICE = Symbol(
+  'IVISITATION_DETAIL_DOMAIN_SERVICE',
+);
+
+export interface IVisitationDetailDomainService {}

--- a/backend/src/visitation/visitation-domain/service/interface/visitation-detail-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/service/interface/visitation-detail-domain.service.interface.ts
@@ -1,5 +1,5 @@
 import { VisitationMetaModel } from '../../../entity/visitation-meta.entity';
-import { QueryRunner } from 'typeorm';
+import { QueryRunner, UpdateResult } from 'typeorm';
 import { VisitationDetailModel } from '../../../entity/visitation-detail.entity';
 import { MemberModel } from '../../../../members/entity/member.entity';
 import { VisitationDetailDto } from '../../../dto/visitation-detail.dto';
@@ -15,4 +15,14 @@ export interface IVisitationDetailDomainService {
     dto: VisitationDetailDto,
     qr: QueryRunner,
   ): Promise<VisitationDetailModel>;
+
+  findVisitationDetailsByMetaId(
+    metaData: VisitationMetaModel,
+    qr?: QueryRunner,
+  ): Promise<VisitationDetailModel[]>;
+
+  deleteVisitationDetailsCascade(
+    metaData: VisitationMetaModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
 }

--- a/backend/src/visitation/visitation-domain/service/interface/visitation-meta-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/service/interface/visitation-meta-domain.service.interface.ts
@@ -4,6 +4,7 @@ import { CreateVisitationMetaDto } from '../../../dto/meta/create-visitation-met
 import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { VisitationMetaModel } from '../../../entity/visitation-meta.entity';
 import { GetVisitationDto } from '../../../dto/get-visitation.dto';
+import { UpdateVisitationMetaDto } from '../../../dto/meta/update-visitation-meta.dto';
 
 export const IVISITATION_META_DOMAIN_SERVICE = Symbol(
   'IVISITATION_META_DOMAIN_SERVICE',
@@ -38,8 +39,15 @@ export interface IVisitationMetaDomainService {
 
   updateVisitationMetaData(
     visitationMetaData: VisitationMetaModel,
-    dto: any,
+    dto: UpdateVisitationMetaDto,
+    newInstructor?: MemberModel,
     qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  updateVisitationMember(
+    visitationMetaData: VisitationMetaModel,
+    members: MemberModel[],
+    qr: QueryRunner,
   ): Promise<VisitationMetaModel>;
 
   deleteVisitationMeta(

--- a/backend/src/visitation/visitation-domain/service/interface/visitation-meta-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/service/interface/visitation-meta-domain.service.interface.ts
@@ -30,7 +30,7 @@ export interface IVisitationMetaDomainService {
     church: ChurchModel,
     instructor: MemberModel,
     dto: CreateVisitationMetaDto,
-    qr?: QueryRunner,
+    qr: QueryRunner,
   ): Promise<VisitationMetaModel>;
 
   updateVisitationMetaData(

--- a/backend/src/visitation/visitation-domain/service/interface/visitation-meta-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/service/interface/visitation-meta-domain.service.interface.ts
@@ -1,0 +1,41 @@
+import { ChurchModel } from '../../../../churches/entity/church.entity';
+import { MemberModel } from '../../../../members/entity/member.entity';
+import { CreateVisitationMetaDto } from '../../../dto/meta/create-visitation-meta.dto';
+import { FindOptionsRelations, QueryRunner } from 'typeorm';
+import { VisitationMetaModel } from '../../../entity/visitation-meta.entity';
+
+export const IVISITATION_META_DOMAIN_SERVICE = Symbol(
+  'IVISITATION_META_DOMAIN_SERVICE',
+);
+
+export interface IVisitationMetaDomainService {
+  paginateVisitations(
+    church: ChurchModel,
+  ): Promise<{ visitations: VisitationMetaModel[]; totalCount: number }>;
+
+  findVisitationMetaById(
+    church: ChurchModel,
+    visitationMetaId: number,
+    qr?: QueryRunner,
+  ): Promise<VisitationMetaModel>;
+
+  findVisitationMetaModelById(
+    church: ChurchModel,
+    visitationMetaId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<VisitationMetaModel>,
+  ): Promise<VisitationMetaModel>;
+
+  createVisitationMetaData(
+    church: ChurchModel,
+    instructor: MemberModel,
+    dto: CreateVisitationMetaDto,
+    qr?: QueryRunner,
+  ): Promise<VisitationMetaModel>;
+
+  updateVisitationMetaData(
+    visitationMetaData: VisitationMetaModel,
+    dto: any,
+    qr?: QueryRunner,
+  ): Promise<VisitationMetaModel>;
+}

--- a/backend/src/visitation/visitation-domain/service/interface/visitation-meta-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/service/interface/visitation-meta-domain.service.interface.ts
@@ -1,8 +1,9 @@
 import { ChurchModel } from '../../../../churches/entity/church.entity';
 import { MemberModel } from '../../../../members/entity/member.entity';
 import { CreateVisitationMetaDto } from '../../../dto/meta/create-visitation-meta.dto';
-import { FindOptionsRelations, QueryRunner } from 'typeorm';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { VisitationMetaModel } from '../../../entity/visitation-meta.entity';
+import { GetVisitationDto } from '../../../dto/get-visitation.dto';
 
 export const IVISITATION_META_DOMAIN_SERVICE = Symbol(
   'IVISITATION_META_DOMAIN_SERVICE',
@@ -11,6 +12,7 @@ export const IVISITATION_META_DOMAIN_SERVICE = Symbol(
 export interface IVisitationMetaDomainService {
   paginateVisitations(
     church: ChurchModel,
+    dto: GetVisitationDto,
   ): Promise<{ visitations: VisitationMetaModel[]; totalCount: number }>;
 
   findVisitationMetaById(
@@ -30,6 +32,7 @@ export interface IVisitationMetaDomainService {
     church: ChurchModel,
     instructor: MemberModel,
     dto: CreateVisitationMetaDto,
+    members: MemberModel[],
     qr: QueryRunner,
   ): Promise<VisitationMetaModel>;
 
@@ -38,4 +41,9 @@ export interface IVisitationMetaDomainService {
     dto: any,
     qr?: QueryRunner,
   ): Promise<VisitationMetaModel>;
+
+  deleteVisitationMeta(
+    metaData: VisitationMetaModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
 }

--- a/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import { IVisitationDetailDomainService } from './interface/visitation-detail-domain.service.interface';
+
+@Injectable()
+export class VisitationDetailDomainService
+  implements IVisitationDetailDomainService
+{
+  constructor() {}
+}

--- a/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
@@ -2,10 +2,14 @@ import { Injectable } from '@nestjs/common';
 import { IVisitationDetailDomainService } from './interface/visitation-detail-domain.service.interface';
 import { InjectRepository } from '@nestjs/typeorm';
 import { VisitationDetailModel } from '../../entity/visitation-detail.entity';
-import { QueryRunner, Repository } from 'typeorm';
+import { QueryRunner, Repository, UpdateResult } from 'typeorm';
 import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { VisitationDetailDto } from '../../dto/visitation-detail.dto';
+import {
+  VisitationDetailRelationOptions,
+  VisitationDetailSelectOptions,
+} from '../../const/visitation-find-options.const';
 
 @Injectable()
 export class VisitationDetailDomainService
@@ -35,6 +39,32 @@ export class VisitationDetailDomainService
       member,
       visitationContent: dto.visitationContent,
       visitationPray: dto.visitationPray,
+    });
+  }
+
+  async findVisitationDetailsByMetaId(
+    metaData: VisitationMetaModel,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    return repository.find({
+      where: {
+        visitationMetaId: metaData.id,
+      },
+      relations: VisitationDetailRelationOptions,
+      select: VisitationDetailSelectOptions,
+    });
+  }
+
+  async deleteVisitationDetailsCascade(
+    metaData: VisitationMetaModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    return repository.softDelete({
+      visitationMetaId: metaData.id,
     });
   }
 }

--- a/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
@@ -1,9 +1,40 @@
 import { Injectable } from '@nestjs/common';
 import { IVisitationDetailDomainService } from './interface/visitation-detail-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { VisitationDetailModel } from '../../entity/visitation-detail.entity';
+import { QueryRunner, Repository } from 'typeorm';
+import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
+import { MemberModel } from '../../../members/entity/member.entity';
+import { VisitationDetailDto } from '../../dto/visitation-detail.dto';
 
 @Injectable()
 export class VisitationDetailDomainService
   implements IVisitationDetailDomainService
 {
-  constructor() {}
+  constructor(
+    @InjectRepository(VisitationDetailModel)
+    private readonly repository: Repository<VisitationDetailModel>,
+  ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(VisitationDetailModel)
+      : this.repository;
+  }
+
+  async createVisitationDetail(
+    metaData: VisitationMetaModel,
+    member: MemberModel,
+    dto: VisitationDetailDto,
+    qr: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    return repository.save({
+      visitationMeta: metaData,
+      member,
+      visitationContent: dto.visitationContent,
+      visitationPray: dto.visitationPray,
+    });
+  }
 }

--- a/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
@@ -11,6 +11,7 @@ import { ChurchModel } from '../../../churches/entity/church.entity';
 import { CreateVisitationMetaDto } from '../../dto/meta/create-visitation-meta.dto';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { VisitationMetaException } from '../../const/exception/visitation-meta.exception';
+import { UpdateVisitationMetaDto } from '../../dto/meta/update-visitation-meta.dto';
 
 @Injectable()
 export class VisitationMetaDomainService
@@ -120,7 +121,7 @@ export class VisitationMetaDomainService
 
   async updateVisitationMetaData(
     visitationMetaData: VisitationMetaModel,
-    dto: any,
+    dto: UpdateVisitationMetaDto,
     qr?: QueryRunner,
   ): Promise<VisitationMetaModel> {
     const visitationMetaRepository = this.getVisitationMetaRepository(qr);

--- a/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
@@ -102,13 +102,15 @@ export class VisitationMetaDomainService
     church: ChurchModel,
     instructor: MemberModel,
     dto: CreateVisitationMetaDto,
-    qr?: QueryRunner,
+    qr: QueryRunner,
+    reportTo?: MemberModel,
   ) {
     const visitationMetaRepository = this.getVisitationMetaRepository(qr);
 
     return visitationMetaRepository.save({
-      church,
+      churchId: church.id,
       instructor,
+      visitationStatus: dto.visitationStatus,
       visitationMethod: dto.visitationMethod,
       visitationType: dto.visitationType,
       visitationTitle: dto.visitationTitle,

--- a/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
@@ -1,0 +1,153 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { IVisitationMetaDomainService } from './interface/visitation-meta-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
+import { QueryRunner, Repository } from 'typeorm';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { CreateVisitationMetaDto } from '../../dto/meta/create-visitation-meta.dto';
+import { MemberModel } from '../../../members/entity/member.entity';
+import { VisitationMetaException } from '../../const/exception/visitation-meta.exception';
+
+@Injectable()
+export class VisitationMetaDomainService
+  implements IVisitationMetaDomainService
+{
+  constructor(
+    @InjectRepository(VisitationMetaModel)
+    private readonly visitationMetaRepository: Repository<VisitationMetaModel>,
+  ) {}
+
+  private getVisitationMetaRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(VisitationMetaModel)
+      : this.visitationMetaRepository;
+  }
+
+  async paginateVisitations(
+    church: ChurchModel,
+  ): Promise<{ visitations: VisitationMetaModel[]; totalCount: number }> {
+    const repository = this.getVisitationMetaRepository();
+
+    const [visitations, totalCount] = await Promise.all([
+      repository.find({
+        where: {
+          churchId: church.id,
+        },
+        relations: {
+          visitationDetails: {
+            member: true,
+          },
+        },
+      }),
+      repository.count({
+        where: {
+          churchId: church.id,
+        },
+      }),
+    ]);
+
+    return { visitations, totalCount };
+  }
+
+  async findVisitationMetaById(
+    church: ChurchModel,
+    visitationMetaId: number,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getVisitationMetaRepository(qr);
+
+    const visitation = await repository.findOne({
+      where: {
+        churchId: church.id,
+        id: visitationMetaId,
+      },
+      relations: {
+        instructor: true,
+      },
+    });
+
+    if (!visitation) {
+      throw new NotFoundException(VisitationMetaException.NOT_FOUND);
+    }
+
+    return visitation;
+  }
+
+  async findVisitationMetaModelById(
+    church: ChurchModel,
+    visitationMetaId: number,
+    qr?: QueryRunner,
+  ): Promise<VisitationMetaModel> {
+    const repository = this.getVisitationMetaRepository(qr);
+
+    const metaData = await repository.findOne({
+      where: {
+        id: visitationMetaId,
+        churchId: church.id,
+      },
+    });
+
+    if (!metaData) {
+      throw new NotFoundException(VisitationMetaException.NOT_FOUND);
+    }
+
+    return metaData;
+  }
+
+  async createVisitationMetaData(
+    church: ChurchModel,
+    instructor: MemberModel,
+    dto: CreateVisitationMetaDto,
+    qr?: QueryRunner,
+  ) {
+    const visitationMetaRepository = this.getVisitationMetaRepository(qr);
+
+    return visitationMetaRepository.save({
+      church,
+      instructor,
+      visitationMethod: dto.visitationMethod,
+      visitationType: dto.visitationType,
+      visitationTitle: dto.visitationTitle,
+      visitationDate: dto.visitationDate,
+    });
+  }
+
+  async updateVisitationMetaData(
+    visitationMetaData: VisitationMetaModel,
+    dto: any,
+    qr?: QueryRunner,
+  ): Promise<VisitationMetaModel> {
+    const visitationMetaRepository = this.getVisitationMetaRepository(qr);
+
+    const result = await visitationMetaRepository.update(
+      {
+        id: visitationMetaData.id,
+      },
+      {
+        ...dto,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException();
+    }
+
+    const meta = await this.visitationMetaRepository.findOne({
+      where: {
+        id: visitationMetaData.id,
+      },
+    });
+
+    if (!meta) {
+      throw new InternalServerErrorException(
+        VisitationMetaException.UPDATE_ERROR,
+      );
+    }
+
+    return meta;
+  }
+}

--- a/backend/src/visitation/visitation-domain/visitation-domain.module.ts
+++ b/backend/src/visitation/visitation-domain/visitation-domain.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { VisitationMetaModel } from '../entity/visitation-meta.entity';
+import { VisitationDetailModel } from '../entity/visitation-detail.entity';
+import { IVISITATION_META_DOMAIN_SERVICE } from './service/interface/visitation-meta-domain.service.interface';
+import { VisitationMetaDomainService } from './service/visitation-meta-domain.service';
+import { IVISITATION_DETAIL_DOMAIN_SERVICE } from './service/interface/visitation-detail-domain.service.interface';
+import { VisitationDetailDomainService } from './service/visitation-detail-domain.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([VisitationMetaModel, VisitationDetailModel]),
+  ],
+  providers: [
+    {
+      provide: IVISITATION_META_DOMAIN_SERVICE,
+      useClass: VisitationMetaDomainService,
+    },
+    {
+      provide: IVISITATION_DETAIL_DOMAIN_SERVICE,
+      useClass: VisitationDetailDomainService,
+    },
+  ],
+  exports: [IVISITATION_DETAIL_DOMAIN_SERVICE, IVISITATION_META_DOMAIN_SERVICE],
+})
+export class VisitationDomainModule {}

--- a/backend/src/visitation/visitation.controller.ts
+++ b/backend/src/visitation/visitation.controller.ts
@@ -1,0 +1,76 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { VisitationService } from './visitation.service';
+import { CreateVisitationMetaDto } from './dto/meta/create-visitation-meta.dto';
+import { UpdateVisitationMetaDto } from './dto/meta/update-visitation-meta.dto';
+import { TransactionInterceptor } from '../common/interceptor/transaction.interceptor';
+import { QueryRunner } from '../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm';
+
+@ApiTags('Visitations')
+@Controller('visitations')
+export class VisitationController {
+  constructor(private readonly visitationService: VisitationService) {}
+
+  @Get()
+  getVisitations(@Param('churchId', ParseIntPipe) churchId: number) {
+    return this.visitationService.getVisitations(churchId);
+  }
+
+  @Post('meta')
+  postVisitationMetaData(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Body() dto: CreateVisitationMetaDto,
+  ) {
+    return this.visitationService.createVisitingMetaData(churchId, dto);
+  }
+
+  @Post(':metaId/details')
+  postVisitationDetail(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('metaId', ParseIntPipe) metaId: number,
+  ) {}
+
+  @Patch(':metaId/details/:detailId')
+  patchVisitationDetail() {}
+
+  @Get(':visitingId')
+  @UseInterceptors(TransactionInterceptor)
+  getVisitingById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('visitingId', ParseIntPipe) visitingMetaDataId: number,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.visitationService.getVisitationById(
+      churchId,
+      visitingMetaDataId,
+      qr,
+    );
+  }
+
+  @Patch(':visitationId')
+  patchVisitationMetaData(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('visitationId', ParseIntPipe) visitationMetaDataId: number,
+    @Body() dto: UpdateVisitationMetaDto,
+  ) {
+    return this.visitationService.updateVisitingMetaData(
+      churchId,
+      visitationMetaDataId,
+      dto,
+    );
+  }
+
+  @Delete(':visitingId')
+  deleteVisiting(@Param('visitingId', ParseIntPipe) visitingId) {}
+}

--- a/backend/src/visitation/visitation.controller.ts
+++ b/backend/src/visitation/visitation.controller.ts
@@ -10,7 +10,7 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { VisitationService } from './visitation.service';
 import { UpdateVisitationMetaDto } from './dto/meta/update-visitation-meta.dto';
 import { TransactionInterceptor } from '../common/interceptor/transaction.interceptor';
@@ -28,11 +28,22 @@ import { JwtAccessPayload } from '../auth/type/jwt';
 export class VisitationController {
   constructor(private readonly visitationService: VisitationService) {}
 
+  @ApiOperation({
+    summary: '교회의 심방 목록 조회',
+  })
   @Get()
   getVisitations(@Param('churchId', ParseIntPipe) churchId: number) {
     return this.visitationService.getVisitations(churchId);
   }
 
+  @ApiOperation({
+    summary: '심방 생성 (인증 필요)',
+    description:
+      '<p>심방을 생성합니다.</p>' +
+      '<p>심방의 예약과 기록은 VisitationStatus 로 구분합니다.</p>' +
+      '<p>예약 생성 시 --> VisitationStatus: RESERVE</p>' +
+      '<p>기록 생성 시 --> VisitationStatus: DONE</p>',
+  })
   @Post()
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   @UseInterceptors(TransactionInterceptor)
@@ -51,23 +62,26 @@ export class VisitationController {
     );
   }
 
-  @Patch(':metaId/details/:detailId')
-  patchVisitationDetail() {}
-
-  @Get(':visitingId')
+  @ApiOperation({
+    summary: '특정 심방 상세 내용 조회',
+  })
+  @Get(':visitationId')
   @UseInterceptors(TransactionInterceptor)
   getVisitingById(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('visitingId', ParseIntPipe) visitingMetaDataId: number,
+    @Param('visitationId', ParseIntPipe) visitationMetaDataId: number,
     @QueryRunner() qr: QR,
   ) {
     return this.visitationService.getVisitationById(
       churchId,
-      visitingMetaDataId,
+      visitationMetaDataId,
       qr,
     );
   }
 
+  @ApiOperation({
+    summary: '심방의 메타 데이터 수정',
+  })
   @Patch(':visitationId')
   patchVisitationMetaData(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -81,6 +95,36 @@ export class VisitationController {
     );
   }
 
-  @Delete(':visitingId')
-  deleteVisiting(@Param('visitingId', ParseIntPipe) visitingId) {}
+  @ApiOperation({
+    summary: '심방 삭제 (메타 + 세부)',
+  })
+  @Delete(':visitationId')
+  deleteVisiting(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('visitationId', ParseIntPipe) visitationId: number,
+  ) {
+    return visitationId;
+  }
+
+  @ApiOperation({
+    summary: '심방 세부 내용 작성',
+  })
+  @Patch(':visitationId/details/:detailId')
+  patchVisitationDetail(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('visitationId', ParseIntPipe) visitationId: number,
+    @Param('detailId', ParseIntPipe) detailId: number,
+  ) {
+    return `${churchId} ${visitationId} ${detailId}`;
+  }
+
+  @ApiOperation({
+    summary: '심방 세부 내용 삭제',
+  })
+  @Delete(':visitationId/details/:detailId')
+  deleteVisitationDetail(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('visitationId', ParseIntPipe) visitationId: number,
+    @Param('detailId', ParseIntPipe) detailId: number,
+  ) {}
 }

--- a/backend/src/visitation/visitation.controller.ts
+++ b/backend/src/visitation/visitation.controller.ts
@@ -7,15 +7,21 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { VisitationService } from './visitation.service';
-import { CreateVisitationMetaDto } from './dto/meta/create-visitation-meta.dto';
 import { UpdateVisitationMetaDto } from './dto/meta/update-visitation-meta.dto';
 import { TransactionInterceptor } from '../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
+import { CreateVisitationDto } from './dto/create-visitation.dto';
+import { ChurchManagerGuard } from '../churches/guard/church-manager-guard.service';
+import { AccessTokenGuard } from '../auth/guard/jwt.guard';
+import { Token } from '../auth/decorator/jwt.decorator';
+import { AuthType } from '../auth/const/enum/auth-type.enum';
+import { JwtAccessPayload } from '../auth/type/jwt';
 
 @ApiTags('Visitations')
 @Controller('visitations')
@@ -27,19 +33,23 @@ export class VisitationController {
     return this.visitationService.getVisitations(churchId);
   }
 
-  @Post('meta')
-  postVisitationMetaData(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Body() dto: CreateVisitationMetaDto,
+  @Post()
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
+  @UseInterceptors(TransactionInterceptor)
+  postVisitationReservation(
+    @Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
+    @Param('churchId', ParseIntPipe)
+    churchId: number,
+    @Body() dto: CreateVisitationDto,
+    @QueryRunner() qr: QR,
   ) {
-    return this.visitationService.createVisitingMetaData(churchId, dto);
+    return this.visitationService.createVisitation(
+      accessPayload,
+      churchId,
+      dto,
+      qr,
+    );
   }
-
-  @Post(':metaId/details')
-  postVisitationDetail(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('metaId', ParseIntPipe) metaId: number,
-  ) {}
 
   @Patch(':metaId/details/:detailId')
   patchVisitationDetail() {}

--- a/backend/src/visitation/visitation.module.ts
+++ b/backend/src/visitation/visitation.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { RouterModule } from '@nestjs/core';
+import { VisitationController } from './visitation.controller';
+import { VisitationService } from './visitation.service';
+import { VisitationDomainModule } from './visitation-domain/visitation-domain.module';
+import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
+import { UserDomainModule } from '../user/user-domain/user-domain.module';
+import { MembersDomainModule } from '../members/member-domain/members-domain.module';
+
+@Module({
+  imports: [
+    RouterModule.register([
+      { path: 'churches/:churchId', module: VisitationModule },
+    ]),
+
+    ChurchesDomainModule,
+    UserDomainModule,
+    MembersDomainModule,
+
+    VisitationDomainModule,
+  ],
+  controllers: [VisitationController],
+  providers: [VisitationService],
+})
+export class VisitationModule {}

--- a/backend/src/visitation/visitation.module.ts
+++ b/backend/src/visitation/visitation.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { RouterModule } from '@nestjs/core';
-import { VisitationController } from './visitation.controller';
+import { VisitationController } from './controller/visitation.controller';
 import { VisitationService } from './visitation.service';
 import { VisitationDomainModule } from './visitation-domain/visitation-domain.module';
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
 import { UserDomainModule } from '../user/user-domain/user-domain.module';
 import { MembersDomainModule } from '../members/member-domain/members-domain.module';
+import { VisitationDetailController } from './controller/visitation-detail.controller';
 
 @Module({
   imports: [
@@ -19,7 +20,7 @@ import { MembersDomainModule } from '../members/member-domain/members-domain.mod
 
     VisitationDomainModule,
   ],
-  controllers: [VisitationController],
+  controllers: [VisitationController, VisitationDetailController],
   providers: [VisitationService],
 })
 export class VisitationModule {}

--- a/backend/src/visitation/visitation.service.ts
+++ b/backend/src/visitation/visitation.service.ts
@@ -1,4 +1,10 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import {
   IVISITATION_META_DOMAIN_SERVICE,
   IVisitationMetaDomainService,
@@ -12,10 +18,6 @@ import {
   IChurchesDomainService,
 } from '../churches/churches-domain/interface/churches-domain.service.interface';
 import {
-  IUSER_DOMAIN_SERVICE,
-  IUserDomainService,
-} from '../user/user-domain/interface/user-domain.service.interface';
-import {
   IMEMBERS_DOMAIN_SERVICE,
   IMembersDomainService,
 } from '../members/member-domain/service/interface/members-domain.service.interface';
@@ -26,18 +28,21 @@ import { VisitationDetailModel } from './entity/visitation-detail.entity';
 import { VisitationMetaModel } from './entity/visitation-meta.entity';
 import { CreateVisitationDto } from './dto/create-visitation.dto';
 import { JwtAccessPayload } from '../auth/type/jwt';
-import { VisitationMetaException } from './const/exception/visitation-meta.exception';
+import { VisitationException } from './const/exception/visitation.exception';
 import { CreateVisitationMetaDto } from './dto/meta/create-visitation-meta.dto';
 import { GetVisitationDto } from './dto/get-visitation.dto';
 import { VisitationType } from './const/visitation-type.enum';
+import { UpdateVisitationDetailDto } from './dto/detail/update-visitation-detail.dto';
+import { UpdateVisitationDto } from './dto/update-visitation.dto';
+import { VisitationDetailDto } from './dto/visitation-detail.dto';
+import { ChurchModel } from '../churches/entity/church.entity';
+import { MemberModel } from '../members/entity/member.entity';
 
 @Injectable()
 export class VisitationService {
   constructor(
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,
-    @Inject(IUSER_DOMAIN_SERVICE)
-    private readonly userDomainService: IUserDomainService,
     @Inject(IMEMBERS_DOMAIN_SERVICE)
     private readonly membersDomainService: IMembersDomainService,
 
@@ -56,6 +61,9 @@ export class VisitationService {
 
     return {
       data: visitations,
+      take: dto.take,
+      page: dto.page,
+      totalPage: Math.ceil(totalCount / dto.take),
       totalCount,
     };
   }
@@ -115,13 +123,7 @@ export class VisitationService {
     );
 
     // 심방 진행자 검증
-    if (
-      !instructor.user.role ||
-      (instructor.user.role !== UserRole.mainAdmin &&
-        instructor.user.role !== UserRole.manager)
-    ) {
-      throw new BadRequestException(VisitationMetaException.INVALID_INSTRUCTOR);
-    }
+    this.checkInstructorAuthorization(instructor);
 
     const memberIds = dto.visitationDetails.map((detail) => detail.memberId);
 
@@ -131,27 +133,35 @@ export class VisitationService {
       qr,
     );
 
-    const createVisitationMetaDto: CreateVisitationMetaDto = {
-      instructorId: dto.instructorId,
-      visitationStatus: dto.visitationStatus,
-      visitationMethod: dto.visitationMethod,
-      visitationType:
-        memberIds.length > 1 ? VisitationType.GROUP : VisitationType.SINGLE,
-      visitationTitle: dto.visitationTitle,
-      visitationDate: dto.visitationDate,
-      creator: creatorMember,
-    };
+    const visitationMeta = await this.createVisitationMeta(
+      church,
+      creatorMember,
+      instructor,
+      members,
+      dto,
+      qr,
+    );
 
-    const metaData =
-      await this.visitationMetaDomainService.createVisitationMetaData(
-        church,
-        instructor,
-        createVisitationMetaDto,
-        members,
-        qr,
-      );
+    await this.createVisitationDetails(church, visitationMeta, dto, qr);
 
-    const detailData = await Promise.all(
+    return this.getVisitationById(churchId, visitationMeta.id, qr);
+  }
+
+  /**
+   * 심방 생성 시 대상자들의 심방 세부 데이터 생성
+   * @param church 교회 엔티티
+   * @param visitationMeta 사전에 생성된 심방 메타 데이터
+   * @param dto 심방 생성 DTO
+   * @param qr 트랜잭션을 위한 QueryRunner
+   * @private
+   */
+  private async createVisitationDetails(
+    church: ChurchModel,
+    visitationMeta: VisitationMetaModel,
+    dto: CreateVisitationDto,
+    qr: QueryRunner,
+  ) {
+    return Promise.all(
       dto.visitationDetails.map(async (visitationDetailDto) => {
         const member = await this.membersDomainService.findMemberModelById(
           church,
@@ -165,29 +175,192 @@ export class VisitationService {
         );
 
         return this.visitationDetailDomainService.createVisitationDetail(
-          metaData,
+          visitationMeta,
           member,
           visitationDetailDto,
           qr,
         );
       }),
     );
+  }
 
-    const { user, ...instructorMember } = instructor;
-
-    const reservedVisitation = {
-      ...metaData,
-      instructor: instructorMember,
-      visitationDetails: detailData,
+  /**
+   * 심방 생성 시 심방의 메타 데이터 생성
+   * @param church 교회 엔티티
+   * @param creatorMember 심방 생성 교인
+   * @param instructor 심방 진행자
+   * @param members 심방 대상자 (교인 엔티티 배열)
+   * @param dto 심방 생성 DTO
+   * @param qr 트랜잭션을 위한 QueryRunner
+   * @private
+   */
+  private async createVisitationMeta(
+    church: ChurchModel,
+    creatorMember: MemberModel,
+    instructor: MemberModel,
+    members: MemberModel[],
+    dto: CreateVisitationDto,
+    qr: QueryRunner,
+  ) {
+    const createVisitationMetaDto: CreateVisitationMetaDto = {
+      instructorId: dto.instructorId,
+      visitationStatus: dto.visitationStatus,
+      visitationMethod: dto.visitationMethod,
+      visitationType:
+        members.length > 1 ? VisitationType.GROUP : VisitationType.SINGLE,
+      visitationTitle: dto.visitationTitle,
+      visitationDate: dto.visitationDate,
+      creator: creatorMember,
     };
 
-    return reservedVisitation;
+    return this.visitationMetaDomainService.createVisitationMetaData(
+      church,
+      instructor,
+      createVisitationMetaDto,
+      members,
+      qr,
+    );
+  }
+
+  private checkInstructorAuthorization(instructor?: MemberModel) {
+    if (!instructor) {
+      return;
+    }
+
+    if (
+      !instructor.user ||
+      (instructor.user.role !== UserRole.mainAdmin &&
+        instructor.user.role !== UserRole.manager)
+    ) {
+      throw new BadRequestException(VisitationException.INVALID_INSTRUCTOR);
+    }
+  }
+
+  private async updateVisitationMembers(
+    church: ChurchModel,
+    visitationMeta: VisitationMetaModel,
+    dto: UpdateVisitationDto,
+    qr: QueryRunner,
+  ) {
+    if (!visitationMeta.members) {
+      throw new InternalServerErrorException('심방 대상자 불러오기 실패');
+    }
+
+    let visitationMembers = [...visitationMeta.members];
+
+    // 교인이 추가되는 경우 추가할 수 있는지 확인
+    if (dto.addMemberIds) {
+      const visitationMemberIds = visitationMeta.members.map(
+        (member) => member.id,
+      );
+
+      const alreadyExistMember: number[] = [];
+
+      dto.addMemberIds.forEach((memberId) => {
+        if (visitationMemberIds.includes(memberId)) {
+          alreadyExistMember.push(memberId);
+        }
+      });
+
+      if (alreadyExistMember.length > 0) {
+        throw new ConflictException(
+          VisitationException.ALREADY_EXIST_TARGET_MEMBER(alreadyExistMember),
+        );
+      }
+
+      const newMembers = await this.membersDomainService.findMembersById(
+        church,
+        dto.addMemberIds,
+        qr,
+      );
+
+      // 새 심방 대상자 추가
+      visitationMembers.push(...newMembers);
+
+      await Promise.all(
+        dto.addMemberIds.map(async (memberId) => {
+          const member = await this.membersDomainService.findMemberModelById(
+            church,
+            memberId,
+            qr,
+          );
+
+          const detailDto: VisitationDetailDto = {
+            memberId: memberId,
+          };
+
+          return this.visitationDetailDomainService.createVisitationDetail(
+            visitationMeta,
+            member,
+            detailDto,
+            qr,
+          );
+        }),
+      );
+    }
+
+    // 교인이 삭제되는 경우 삭제할 수 있는지 확인
+    if (dto.deleteMemberIds) {
+      const visitationMemberIds = visitationMeta.members.map(
+        (member) => member.id,
+      );
+
+      const notExistMember: number[] = [];
+
+      // 심방 대상자에 존재하지 않는 id 값 필터링
+      dto.deleteMemberIds.forEach((memberId) => {
+        if (!visitationMemberIds.includes(memberId)) {
+          notExistMember.push(memberId);
+        }
+      });
+
+      if (notExistMember.length > 0) {
+        throw new ConflictException(
+          VisitationException.NOT_EXIST_DELETE_TARGET_MEMBER(notExistMember),
+        );
+      }
+
+      visitationMembers = visitationMembers.filter(
+        (member) => !dto.deleteMemberIds?.includes(member.id),
+      );
+
+      await Promise.all(
+        dto.deleteMemberIds.map(async (memberId) => {
+          const member = await this.membersDomainService.findMemberModelById(
+            church,
+            memberId,
+            qr,
+          );
+
+          const deleteTarget =
+            await this.visitationDetailDomainService.findVisitationDetailByMetaAndMemberId(
+              visitationMeta,
+              member,
+              qr,
+            );
+
+          await this.visitationDetailDomainService.deleteVisitationDetail(
+            deleteTarget,
+            qr,
+          );
+        }),
+      );
+    }
+
+    await this.visitationMetaDomainService.updateVisitationMember(
+      visitationMeta,
+      visitationMembers,
+      qr,
+    );
+
+    return visitationMembers;
   }
 
   async updateVisitationMetaData(
     churchId: number,
     visitationMetaDataId: number,
-    dto: UpdateVisitationMetaDto,
+    dto: UpdateVisitationDto,
+    qr: QueryRunner,
   ) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
@@ -196,11 +369,61 @@ export class VisitationService {
       await this.visitationMetaDomainService.findVisitationMetaModelById(
         church,
         visitationMetaDataId,
+        qr,
+        { members: true },
       );
 
-    return this.visitationMetaDomainService.updateVisitationMetaData(
+    // 심방 진행자 변경 시
+    const newInstructor =
+      dto.instructorId && dto.instructorId !== targetMetaData.instructorId
+        ? await this.membersDomainService.findMemberModelById(
+            church,
+            dto.instructorId,
+            qr,
+            { user: true },
+          )
+        : undefined;
+
+    // 새로운 심방 진행자의 권한 확인
+    this.checkInstructorAuthorization(newInstructor);
+
+    // 심방 대상자 변경
+    let visitationType: VisitationType = targetMetaData.visitationType;
+
+    if (dto.addMemberIds || dto.deleteMemberIds) {
+      const newVisitationMembers = await this.updateVisitationMembers(
+        church,
+        targetMetaData,
+        dto,
+        qr,
+      );
+
+      visitationType =
+        newVisitationMembers.length > 1
+          ? VisitationType.GROUP
+          : VisitationType.SINGLE;
+    }
+
+    const updateVisitationMetaDto: UpdateVisitationMetaDto = {
+      visitationDate: dto.visitationDate,
+      visitationMethod: dto.visitationMethod,
+      visitationType,
+      visitationStatus: dto.visitationStatus,
+      visitationTitle: dto.visitationTitle,
+      instructorId: dto.instructorId,
+    };
+
+    await this.visitationMetaDomainService.updateVisitationMetaData(
       targetMetaData,
-      dto,
+      updateVisitationMetaDto,
+      newInstructor,
+      qr,
+    );
+
+    return this.visitationMetaDomainService.findVisitationMetaById(
+      church,
+      visitationMetaDataId,
+      qr,
     );
   }
 
@@ -226,6 +449,34 @@ export class VisitationService {
     await this.visitationDetailDomainService.deleteVisitationDetailsCascade(
       metaData,
       qr,
+    );
+  }
+
+  async updateVisitationDetail(
+    churchId: number,
+    visitationId: number,
+    detailId: number,
+    dto: UpdateVisitationDetailDto,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const metaData =
+      await this.visitationMetaDomainService.findVisitationMetaModelById(
+        church,
+        visitationId,
+      );
+
+    const detailData =
+      await this.visitationDetailDomainService.findVisitationDetailModelById(
+        metaData,
+        detailId,
+      );
+
+    return this.visitationDetailDomainService.updateVisitationDetail(
+      metaData,
+      detailData,
+      dto,
     );
   }
 }

--- a/backend/src/visitation/visitation.service.ts
+++ b/backend/src/visitation/visitation.service.ts
@@ -1,0 +1,129 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import {
+  IVISITATION_META_DOMAIN_SERVICE,
+  IVisitationMetaDomainService,
+} from './visitation-domain/service/interface/visitation-meta-domain.service.interface';
+import {
+  IVISITATION_DETAIL_DOMAIN_SERVICE,
+  IVisitationDetailDomainService,
+} from './visitation-domain/service/interface/visitation-detail-domain.service.interface';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../churches/churches-domain/interface/churches-domain.service.interface';
+import { CreateVisitationMetaDto } from './dto/meta/create-visitation-meta.dto';
+import {
+  IUSER_DOMAIN_SERVICE,
+  IUserDomainService,
+} from '../user/user-domain/interface/user-domain.service.interface';
+import {
+  IMEMBERS_DOMAIN_SERVICE,
+  IMembersDomainService,
+} from '../members/member-domain/service/interface/members-domain.service.interface';
+import { UserRole } from '../user/const/user-role.enum';
+import { VisitationMetaException } from './const/exception/visitation-meta.exception';
+import { UpdateVisitationMetaDto } from './dto/meta/update-visitation-meta.dto';
+import { QueryRunner } from 'typeorm';
+import { VisitationDetailModel } from './entity/visitation-detail.entity';
+import { VisitationMetaModel } from './entity/visitation-meta.entity';
+
+@Injectable()
+export class VisitationService {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IUSER_DOMAIN_SERVICE)
+    private readonly userDomainService: IUserDomainService,
+    @Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,
+
+    @Inject(IVISITATION_META_DOMAIN_SERVICE)
+    private readonly visitationMetaDomainService: IVisitationMetaDomainService,
+    @Inject(IVISITATION_DETAIL_DOMAIN_SERVICE)
+    private readonly visitationDetailDomainService: IVisitationDetailDomainService,
+  ) {}
+
+  async getVisitations(churchId: number) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const { visitations, totalCount } =
+      await this.visitationMetaDomainService.paginateVisitations(church);
+
+    return {
+      data: visitations,
+      totalCount,
+    };
+  }
+
+  async getVisitationById(
+    churchId: number,
+    visitingMetaDataId: number,
+    qr: QueryRunner,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const visitationMeta =
+      await this.visitationMetaDomainService.findVisitationMetaById(
+        church,
+        visitingMetaDataId,
+        qr,
+      );
+
+    const visitationDetails: VisitationDetailModel[] = [];
+
+    const visitation: VisitationMetaModel = {
+      ...visitationMeta,
+      visitationDetails,
+    };
+
+    return visitation;
+  }
+
+  async createVisitingMetaData(churchId: number, dto: CreateVisitationMetaDto) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const instructor = await this.membersDomainService.findMemberModelById(
+      church,
+      dto.instructorId,
+      undefined,
+      { user: true },
+    );
+
+    if (
+      !instructor.user ||
+      (instructor.user.role !== UserRole.mainAdmin &&
+        instructor.user.role !== UserRole.manager)
+    ) {
+      throw new BadRequestException(VisitationMetaException.INVALID_INSTRUCTOR);
+    }
+
+    return this.visitationMetaDomainService.createVisitationMetaData(
+      church,
+      instructor,
+      dto,
+    );
+  }
+
+  async updateVisitingMetaData(
+    churchId: number,
+    visitationMetaDataId: number,
+    dto: UpdateVisitationMetaDto,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const targetMetaData =
+      await this.visitationMetaDomainService.findVisitationMetaModelById(
+        church,
+        visitationMetaDataId,
+      );
+
+    return this.visitationMetaDomainService.updateVisitationMetaData(
+      targetMetaData,
+      dto,
+    );
+  }
+}


### PR DESCRIPTION
## 주요 내용  
심방(Visitation) 도메인의 전체 CRUD 기능을 구현하였으며,  
메타데이터와 세부데이터를 기반으로 하는 구조로 설계되었습니다.  
심방 생성, 수정, 조회, 삭제 및 목록 페이지네이션까지 전반적인 기능을 완성했습니다.  

## 세부 내용  

### 심방 목록  
- 페이지네이션 기반 심방 목록 조회  
- 필터 및 정렬(진행일, 생성일, 수정일), 검색(제목, 날짜 범위, 상태, 방식, 종류, 진행자 등) 지원  

### 심방 조회  
- 개별 심방 메타데이터 및 세부데이터 조회 기능  

### 심방 생성  
- 메타데이터 + 세부데이터를 함께 생성  
- 메타데이터: 상태, 날짜, 방식, 종류(자동 지정), 진행자, 제목, 대상자  
- 세부데이터: 대상자별 심방 내용 및 기도제목  
- 대상자 수에 따라 **개인/그룹 심방** 자동 분류  

### 심방 메타데이터 수정  
- `addMemberIds`: 대상자 추가 시 자동으로 세부데이터 생성  
- `deleteMemberIds`: 대상자 삭제 시 해당 세부데이터 제거  
- 대상자 수 변경에 따른 개인/그룹 심방 자동 재분류  
- 날짜, 방식, 상태, 진행자, 제목 수정 지원  

### 심방 세부데이터 수정  
- 심방 완료 이후 내용 및 기도제목 수정 가능  

### 심방 삭제  
- 메타데이터 삭제 시 연관된 모든 세부데이터 함께 삭제  

이번 기능 구현을 통해 심방 생성부터 관리, 종료까지의 전체 흐름을 일관되게 처리할 수 있으며,  
관리자가 손쉽게 심방 일정을 계획하고 기록을 관리할 수 있도록 고도화된 구조로 완성되었습니다. 📋✨  
