### PR TITLE
feat: 관리자 권한 내 교인 검색 기능 추가

### DIFF
--- a/backend/src/members/controller/members.controller.ts
+++ b/backend/src/members/controller/members.controller.ts
@@ -18,6 +18,7 @@ import { UpdateMemberDto } from '../dto/update-member.dto';
 import { GetMemberDto } from '../dto/get-member.dto';
 import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
+import { GetManagerMemberDto } from '../dto/get-manager-member.dto';
 
 @ApiTags('Churches:Members')
 @Controller()
@@ -36,10 +37,18 @@ export class MembersController {
   @UseInterceptors(TransactionInterceptor)
   postMember(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Body(/*FamilyRelationPipe*/) dto: CreateMemberDto,
+    @Body() dto: CreateMemberDto,
     @QueryRunner() qr: QR,
   ) {
     return this.membersService.createMember(churchId, dto, qr);
+  }
+
+  @Get('managers')
+  getManagerMembers(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetManagerMemberDto,
+  ) {
+    return this.membersService.getMembers(churchId, dto, undefined, true);
   }
 
   @Get(':memberId')

--- a/backend/src/members/dto/get-manager-member.dto.ts
+++ b/backend/src/members/dto/get-manager-member.dto.ts
@@ -1,0 +1,3 @@
+import { GetMemberDto } from './get-member.dto';
+
+export class GetManagerMemberDto extends GetMemberDto {}

--- a/backend/src/members/service/members.service.ts
+++ b/backend/src/members/service/members.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { MemberModel } from '../entity/member.entity';
-import { FindOptionsOrder, FindOptionsWhere, QueryRunner } from 'typeorm';
+import { FindOptionsOrder, FindOptionsWhere, In, QueryRunner } from 'typeorm';
 import { CreateMemberDto } from '../dto/create-member.dto';
 import { UpdateMemberDto } from '../dto/update-member.dto';
 import { GetMemberDto } from '../dto/get-member.dto';
@@ -24,6 +24,7 @@ import {
   IFAMILY_RELATION_DOMAIN_SERVICE,
   IFamilyRelationDomainService,
 } from '../../family-relation/family-relation-domain/service/interface/family-relation-domain.service.interface';
+import { UserRole } from '../../user/const/user-role.enum';
 
 @Injectable()
 export class MembersService {
@@ -40,7 +41,12 @@ export class MembersService {
     private readonly familyDomainService: IFamilyRelationDomainService,
   ) {}
 
-  async getMembers(churchId: number, dto: GetMemberDto, qr?: QueryRunner) {
+  async getMembers(
+    churchId: number,
+    dto: GetMemberDto,
+    qr?: QueryRunner,
+    findManager?: boolean,
+  ) {
     const church = await this.churchesDomainService.findChurchModelById(
       churchId,
       qr,
@@ -48,6 +54,12 @@ export class MembersService {
 
     const whereOptions: FindOptionsWhere<MemberModel> =
       this.searchMembersService.parseWhereOption(church, dto);
+
+    if (findManager) {
+      whereOptions.user = {
+        role: In([UserRole.mainAdmin, UserRole.manager]),
+      };
+    }
 
     const orderOptions: FindOptionsOrder<MemberModel> =
       this.searchMembersService.parseOrderOption(dto);


### PR DESCRIPTION
## 주요 내용
관리자가 자신의 권한 범위 내에서만 교인을 검색할 수 있는 엔드포인트를 추가하였습니다.

## 세부 내용
- 관리자 권한 및 소속 교회를 기준으로 검색 결과 제한
- 이름, 연락처 등 조건으로 교인 검색 가능
- 권한 외 교인은 검색 결과에서 제외
- 기존 교인 검색 API와는 별도로 분리된 엔드포인트로 제공