### PR TITLE
feat: 심방 보고 조회 기능 및 정렬/필터링 기능 추가

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -41,6 +41,9 @@ import { MemberHistoryModule } from './member-history/member-history.module';
 import { VisitationModule } from './visitation/visitation.module';
 import { VisitationMetaModel } from './visitation/entity/visitation-meta.entity';
 import { VisitationDetailModel } from './visitation/entity/visitation-detail.entity';
+import { ReportModule } from './report/report.module';
+import { ReportModel } from './report/entity/base-report.entity';
+import { VisitationReportModel } from './report/entity/visitation-report.entity';
 
 @Module({
   imports: [
@@ -137,6 +140,9 @@ import { VisitationDetailModel } from './visitation/entity/visitation-detail.ent
           // 심방 관련 엔티티
           VisitationMetaModel,
           VisitationDetailModel,
+          // 업무 보고 관련 엔티티
+          ReportModel,
+          VisitationReportModel,
         ],
         synchronize: true,
       }),
@@ -155,6 +161,7 @@ import { VisitationDetailModel } from './visitation/entity/visitation-detail.ent
     ChurchesModule,
     RequestInfoModule,
     MembersModule,
+    ReportModule,
     FamilyRelationModule,
     MemberHistoryModule,
     ManagementModule,

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -210,13 +210,6 @@ export class MemberModel extends BaseModel {
   )
   createdVisitations: VisitationMetaModel[];
 
-  // 보고 받을 심방
-  @ManyToMany(
-    () => VisitationMetaModel,
-    (visitationMeta) => visitationMeta.reportTo,
-  )
-  visitationReports: VisitationMetaModel[];
-
   // 참여한 심방
   @ManyToMany(
     () => VisitationMetaModel,
@@ -230,4 +223,6 @@ export class MemberModel extends BaseModel {
     (visitingDetail) => visitingDetail.member,
   )
   visitationDetails: VisitationDetailModel[];
+
+  // ------------------ 보고 -------------------------
 }

--- a/backend/src/report/const/visitation-report-order.enum.ts
+++ b/backend/src/report/const/visitation-report-order.enum.ts
@@ -1,0 +1,5 @@
+export enum VisitationReportOrderEnum {
+  createdAt = 'createdAt',
+  updatedAt = 'updatedAt',
+  reportedAt = 'reportedAt',
+}

--- a/backend/src/report/dto/visitation-report/get-visitation-report.dto.ts
+++ b/backend/src/report/dto/visitation-report/get-visitation-report.dto.ts
@@ -1,0 +1,60 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsBoolean,
+  IsEnum,
+  IsIn,
+  IsNumber,
+  IsOptional,
+  Min,
+} from 'class-validator';
+import { VisitationOrderEnum } from '../../../visitation/const/order.enum';
+import { VisitationReportOrderEnum } from '../../const/visitation-report-order.enum';
+
+export class GetVisitationReportDto {
+  @ApiProperty({
+    description: '요청 데이터 개수',
+    default: 20,
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  take: number = 20;
+
+  @ApiProperty({
+    description: '요청 페이지',
+    default: 1,
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  page: number = 1;
+
+  @ApiProperty({
+    description: '정렬 기준',
+    enum: VisitationOrderEnum,
+    default: VisitationReportOrderEnum.createdAt,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(VisitationReportOrderEnum)
+  order: VisitationReportOrderEnum = VisitationReportOrderEnum.createdAt;
+
+  @ApiProperty({
+    description: '정렬 오름차순 / 내림차순',
+    default: 'desc',
+    required: false,
+  })
+  @IsOptional()
+  @IsIn(['asc', 'desc', 'ASC', 'DESC'])
+  orderDirection: 'asc' | 'desc' | 'ASC' | 'DESC' = 'desc';
+
+  @ApiProperty({
+    description: '읽은 보고 or 읽지 않은 보고',
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  isRead: boolean;
+}

--- a/backend/src/report/dto/visitation-report/visitation-report-pagination-result.dto.ts
+++ b/backend/src/report/dto/visitation-report/visitation-report-pagination-result.dto.ts
@@ -1,0 +1,7 @@
+import { BasePaginationResultDto } from '../../../common/dto/base-pagination-result.dto';
+import { VisitationReportModel } from '../../entity/visitation-report.entity';
+
+export interface VisitationReportPaginationResultDto
+  extends BasePaginationResultDto<VisitationReportModel> {
+  totalPage: number;
+}

--- a/backend/src/report/entity/base-report.entity.ts
+++ b/backend/src/report/entity/base-report.entity.ts
@@ -1,0 +1,25 @@
+import { BaseModel } from '../../common/entity/base.entity';
+import { MemberModel } from '../../members/entity/member.entity';
+import { Column, Entity, ManyToOne, TableInheritance } from 'typeorm';
+
+@Entity()
+@TableInheritance({ column: { type: 'varchar', name: 'reportType' } })
+export abstract class ReportModel extends BaseModel {
+  @Column()
+  senderId: number;
+
+  @ManyToOne(() => MemberModel)
+  sender: MemberModel;
+
+  @Column()
+  receiverId: number;
+
+  @ManyToOne(() => MemberModel)
+  receiver: MemberModel;
+
+  @Column({ type: 'timestamp', default: new Date() })
+  reportedAt: Date;
+
+  @Column({ default: false })
+  isRead: boolean;
+}

--- a/backend/src/report/entity/visitation-report.entity.ts
+++ b/backend/src/report/entity/visitation-report.entity.ts
@@ -1,0 +1,12 @@
+import { ChildEntity, Column, ManyToOne } from 'typeorm';
+import { VisitationMetaModel } from '../../visitation/entity/visitation-meta.entity';
+import { ReportModel } from './base-report.entity';
+
+@ChildEntity('VISITATION')
+export class VisitationReportModel extends ReportModel {
+  @Column()
+  visitationId: number;
+
+  @ManyToOne(() => VisitationMetaModel)
+  visitation: VisitationMetaModel;
+}

--- a/backend/src/report/exception/visitation-report.exception.ts
+++ b/backend/src/report/exception/visitation-report.exception.ts
@@ -1,0 +1,5 @@
+export const VisitationReportException = {
+  NOT_FOUND: '해당 심방 보고를 찾을 수 없습니다.',
+  UPDATE_ERROR: '심방 보고 업데이트 도중 에러 발생',
+  DELETE_ERROR: '심방 보고 삭제 도중 에러 발생',
+};

--- a/backend/src/report/report-domain/service/visitation-report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/service/visitation-report-domain.service.interface.ts
@@ -1,0 +1,30 @@
+import { VisitationMetaModel } from '../../../visitation/entity/visitation-meta.entity';
+import { MemberModel } from '../../../members/entity/member.entity';
+import { QueryRunner } from 'typeorm';
+import { VisitationReportModel } from '../../entity/visitation-report.entity';
+import { GetVisitationReportDto } from '../../dto/visitation-report/get-visitation-report.dto';
+
+export const IVISITATION_REPORT_DOMAIN_SERVICE = Symbol(
+  'IVISITATION_REPORT_DOMAIN_SERVICE',
+);
+
+export interface IVisitationReportDomainService {
+  findVisitationReportsByReceiver(
+    receiver: MemberModel,
+    dto: GetVisitationReportDto,
+    qr?: QueryRunner,
+  ): Promise<{ data: VisitationReportModel[]; totalCount: number }>;
+
+  createVisitationReport(
+    visitation: VisitationMetaModel,
+    sender: MemberModel,
+    receiver: MemberModel,
+    qr: QueryRunner,
+  ): Promise<VisitationReportModel>;
+
+  findVisitationReportById(
+    receiver: MemberModel,
+    reportId: number,
+    qr: QueryRunner,
+  ): Promise<VisitationReportModel>;
+}

--- a/backend/src/report/report-domain/service/visitation-report-domain.service.ts
+++ b/backend/src/report/report-domain/service/visitation-report-domain.service.ts
@@ -1,0 +1,106 @@
+import { IVisitationReportDomainService } from './visitation-report-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { VisitationReportModel } from '../../entity/visitation-report.entity';
+import { QueryRunner, Repository } from 'typeorm';
+import { VisitationMetaModel } from '../../../visitation/entity/visitation-meta.entity';
+import { MemberModel } from '../../../members/entity/member.entity';
+import { GetVisitationReportDto } from '../../dto/visitation-report/get-visitation-report.dto';
+import { NotFoundException } from '@nestjs/common';
+import { VisitationReportException } from '../../exception/visitation-report.exception';
+
+export class VisitationReportDomainService
+  implements IVisitationReportDomainService
+{
+  constructor(
+    @InjectRepository(VisitationReportModel)
+    private readonly visitationReportRepository: Repository<VisitationReportModel>,
+  ) {}
+
+  private getRepository = (qr?: QueryRunner) =>
+    qr
+      ? qr.manager.getRepository(VisitationReportModel)
+      : this.visitationReportRepository;
+
+  createVisitationReport(
+    visitation: VisitationMetaModel,
+    sender: MemberModel,
+    receiver: MemberModel,
+    qr: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    return repository.save({
+      visitation,
+      sender,
+      receiver,
+      reportedAt: new Date(),
+      isRead: false,
+    });
+  }
+
+  async findVisitationReportsByReceiver(
+    receiver: MemberModel,
+    dto: GetVisitationReportDto,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    const [data, totalCount] = await Promise.all([
+      repository.find({
+        where: {
+          receiverId: receiver.id,
+          isRead: dto.isRead,
+        },
+        order: {
+          [dto.order]: dto.orderDirection,
+        },
+        take: dto.take,
+        skip: dto.take * (dto.page - 1),
+      }),
+      repository.count({
+        where: {
+          receiverId: receiver.id,
+          isRead: dto.isRead,
+        },
+      }),
+    ]);
+
+    return { data, totalCount };
+  }
+
+  async findVisitationReportById(
+    receiver: MemberModel,
+    reportId: number,
+    qr: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    const report = await repository.findOne({
+      where: {
+        receiverId: receiver.id,
+        id: reportId,
+      },
+      relations: {
+        sender: {
+          officer: true,
+          group: true,
+          groupRole: true,
+        },
+        visitation: {
+          instructor: true,
+          members: true,
+        },
+      },
+    });
+
+    if (!report) {
+      throw new NotFoundException(VisitationReportException.NOT_FOUND);
+    }
+
+    report.isRead = true;
+
+    repository.save(report);
+
+    return report;
+  }
+}

--- a/backend/src/report/report-domain/visitation-report-domain.module.ts
+++ b/backend/src/report/report-domain/visitation-report-domain.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { VisitationReportModel } from '../entity/visitation-report.entity';
+import { IVISITATION_REPORT_DOMAIN_SERVICE } from './service/visitation-report-domain.service.interface';
+import { VisitationReportDomainService } from './service/visitation-report-domain.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([VisitationReportModel])],
+  providers: [
+    {
+      provide: IVISITATION_REPORT_DOMAIN_SERVICE,
+      useClass: VisitationReportDomainService,
+    },
+  ],
+  exports: [IVISITATION_REPORT_DOMAIN_SERVICE],
+})
+export class VisitationReportDomainModule {}

--- a/backend/src/report/report.controller.ts
+++ b/backend/src/report/report.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { GetVisitationReportDto } from './dto/visitation-report/get-visitation-report.dto';
+import { ReportService } from './report.service';
+import { QueryRunner } from '../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm';
+
+@ApiTags('Churches:Members:Reports')
+@Controller('reports')
+export class ReportController {
+  constructor(private readonly reportService: ReportService) {}
+
+  @Get('visitations')
+  getVisitationReports(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Query() dto: GetVisitationReportDto,
+  ) {
+    return this.reportService.getVisitationReport(churchId, memberId, dto);
+  }
+
+  @Get('visitations/:visitationReportId')
+  getVisitationReportById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Param('visitationReportId', ParseIntPipe) visitationReportId: number,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.reportService.getVisitationReportById(
+      churchId,
+      memberId,
+      visitationReportId,
+      qr,
+    );
+  }
+}

--- a/backend/src/report/report.module.ts
+++ b/backend/src/report/report.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { VisitationReportDomainModule } from './report-domain/visitation-report-domain.module';
+import { RouterModule } from '@nestjs/core';
+import { ReportController } from './report.controller';
+import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
+import { MembersDomainModule } from '../members/member-domain/members-domain.module';
+import { ReportService } from './report.service';
+
+@Module({
+  imports: [
+    RouterModule.register([
+      { path: 'churches/:churchId/members/:memberId', module: ReportModule },
+    ]),
+    ChurchesDomainModule,
+    MembersDomainModule,
+    VisitationReportDomainModule,
+  ],
+  controllers: [ReportController],
+  providers: [ReportService],
+  exports: [],
+})
+export class ReportModule {}

--- a/backend/src/report/report.service.ts
+++ b/backend/src/report/report.service.ts
@@ -1,0 +1,85 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  IVISITATION_REPORT_DOMAIN_SERVICE,
+  IVisitationReportDomainService,
+} from './report-domain/service/visitation-report-domain.service.interface';
+import { GetVisitationReportDto } from './dto/visitation-report/get-visitation-report.dto';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IMEMBERS_DOMAIN_SERVICE,
+  IMembersDomainService,
+} from '../members/member-domain/service/interface/members-domain.service.interface';
+import { VisitationReportPaginationResultDto } from './dto/visitation-report/visitation-report-pagination-result.dto';
+import { QueryRunner } from 'typeorm';
+
+@Injectable()
+export class ReportService {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,
+
+    @Inject(IVISITATION_REPORT_DOMAIN_SERVICE)
+    private readonly visitationReportDomainService: IVisitationReportDomainService,
+  ) {}
+
+  async getVisitationReport(
+    churchId: number,
+    memberId: number,
+    dto: GetVisitationReportDto,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+    const receiver = await this.membersDomainService.findMemberModelById(
+      church,
+      memberId,
+      undefined,
+      { user: true },
+    );
+
+    const { data, totalCount } =
+      await this.visitationReportDomainService.findVisitationReportsByReceiver(
+        receiver,
+        dto,
+      );
+
+    const paginationResult: VisitationReportPaginationResultDto = {
+      totalCount,
+      data: data,
+      count: dto.take,
+      page: dto.page,
+      totalPage: Math.ceil(totalCount / dto.take),
+    };
+
+    return paginationResult;
+  }
+
+  async getVisitationReportById(
+    churchId: number,
+    memberId: number,
+    visitationReportId: number,
+    qr: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const receiver = await this.membersDomainService.findMemberModelById(
+      church,
+      memberId,
+      qr,
+      { user: true },
+    );
+
+    return this.visitationReportDomainService.findVisitationReportById(
+      receiver,
+      visitationReportId,
+      qr,
+    );
+  }
+}

--- a/backend/src/visitation/entity/visitation-meta.entity.ts
+++ b/backend/src/visitation/entity/visitation-meta.entity.ts
@@ -62,10 +62,6 @@ export class VisitationMetaModel extends BaseModel {
   @JoinColumn({ name: 'creatorId' })
   creator: MemberModel;
 
-  @ManyToMany(() => MemberModel, (member) => member.visitationReports)
-  @JoinTable()
-  reportTo: MemberModel[];
-
   @ManyToMany(() => MemberModel, (member) => member.visitationMetas)
   @JoinTable()
   members: MemberModel[];

--- a/backend/src/visitation/visitation.module.ts
+++ b/backend/src/visitation/visitation.module.ts
@@ -6,6 +6,7 @@ import { VisitationDomainModule } from './visitation-domain/visitation-domain.mo
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
 import { UserDomainModule } from '../user/user-domain/user-domain.module';
 import { MembersDomainModule } from '../members/member-domain/members-domain.module';
+import { VisitationReportDomainModule } from '../report/report-domain/visitation-report-domain.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { MembersDomainModule } from '../members/member-domain/members-domain.mod
     MembersDomainModule,
 
     VisitationDomainModule,
+    VisitationReportDomainModule,
   ],
   controllers: [VisitationController],
   providers: [VisitationService],

--- a/backend/src/visitation/visitation.service.ts
+++ b/backend/src/visitation/visitation.service.ts
@@ -39,6 +39,10 @@ import { ChurchModel } from '../churches/entity/church.entity';
 import { MemberModel } from '../members/entity/member.entity';
 import { VisitationDetailDto } from './dto/visittion-detail.dto';
 import { MemberException } from '../members/const/exception/member.exception';
+import {
+  IVISITATION_REPORT_DOMAIN_SERVICE,
+  IVisitationReportDomainService,
+} from '../report/report-domain/service/visitation-report-domain.service.interface';
 
 @Injectable()
 export class VisitationService {
@@ -52,6 +56,9 @@ export class VisitationService {
     private readonly visitationMetaDomainService: IVisitationMetaDomainService,
     @Inject(IVISITATION_DETAIL_DOMAIN_SERVICE)
     private readonly visitationDetailDomainService: IVisitationDetailDomainService,
+
+    @Inject(IVISITATION_REPORT_DOMAIN_SERVICE)
+    private readonly visitationReportDomainService: IVisitationReportDomainService,
   ) {}
 
   async getVisitations(churchId: number, dto: GetVisitationDto) {


### PR DESCRIPTION
## 주요 내용
심방 보고 전체 조회 및 특정 보고 조회 기능을 추가하고,
전체 목록 조회 시 정렬과 필터링이 가능하도록 기능을 확장하였습니다.
또한, 특정 보고를 조회할 경우 해당 보고의 `isRead` 값을 자동으로 `true`로 처리하도록 개선하였습니다.

## 세부 내용
- 심방 보고 전체 조회 API 추가
  - 정렬 기준: 생성일(`createdAt`), 수정일(`updatedAt`), 보고일(`reportedAt`)
  - 필터 조건: `isRead` 여부에 따른 필터링
- 특정 심방 보고 조회 기능 추가
  - 조회 시 해당 보고의 `isRead` 값을 자동으로 `true`로 업데이트
- 정렬 및 필터 기능은 쿼리 파라미터로 전달받아 동적으로 처리
- 보고 상태 확인 및 관리 기능을 위한 기반 확보

이번 기능 추가를 통해 심방 보고 데이터를 보다 유연하게 조회하고,
읽음 상태를 자동으로 관리할 수 있어 사용자 경험과 보고 관리 효율성이 크게 향상되었습니다. 📝📊