### PR TITLE
feat: 심방 생성 시 피보고자 지정 시 자동 보고 생성 기능 추가

### DIFF
--- a/backend/src/members/member-domain/service/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/service/interface/members-domain.service.interface.ts
@@ -33,6 +33,7 @@ export interface IMembersDomainService {
     church: ChurchModel,
     ids: number[],
     qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<MemberModel>,
   ): Promise<MemberModel[]>;
 
   findMemberById(

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -84,6 +84,7 @@ export class MembersDomainService implements IMembersDomainService {
     church: ChurchModel,
     ids: number[],
     qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<MemberModel>,
   ): Promise<MemberModel[]> {
     const repository = this.getMembersRepository(qr);
 
@@ -92,6 +93,7 @@ export class MembersDomainService implements IMembersDomainService {
         churchId: church.id,
         id: In(ids),
       },
+      relations: relationOptions,
     });
 
     if (members.length !== ids.length) {

--- a/backend/src/report/entity/visitation-report.entity.ts
+++ b/backend/src/report/entity/visitation-report.entity.ts
@@ -7,6 +7,6 @@ export class VisitationReportModel extends ReportModel {
   @Column()
   visitationId: number;
 
-  @ManyToOne(() => VisitationMetaModel)
+  @ManyToOne(() => VisitationMetaModel, (visitation) => visitation.reports)
   visitation: VisitationMetaModel;
 }

--- a/backend/src/visitation/const/exception/visitation.exception.ts
+++ b/backend/src/visitation/const/exception/visitation.exception.ts
@@ -1,13 +1,14 @@
 export const VisitationException = {
   NOT_FOUND: '심방 데이터를 찾을 수 없습니다.',
   INVALID_INSTRUCTOR: '심방 진행자로 등록할 수 없는 교인입니다.',
+  INVALID_RECEIVER: '심방 피보고자로 등록할 수 없는 교인입니다.',
   UPDATE_ERROR: '심방 데이터 업데이트 도중 에러 발생',
   DELETE_ERROR: '심방 데이터 삭제 도중 에러 발생',
 
-  ALREADY_EXIST_TARGET_MEMBER: (alreadyExistMember: number | number[]) =>
-    `이미 존재하는 심방 대상자입니다. 존재하는 교인 id: [${alreadyExistMember}]`,
-  NOT_EXIST_DELETE_TARGET_MEMBER: (notExistMemberId: number | number[]) =>
-    `삭제 대상자가 심방 대상자에 포함되어 있지 않습니다. 존재하지 않는 교인 id: [${notExistMemberId}]`,
+  ALREADY_EXIST_TARGET_MEMBER: (alreadyExistMember: number[]) =>
+    `이미 존재하는 심방 대상자입니다. 존재하는 교인 id: [${alreadyExistMember.join(', ')}]`,
+  NOT_EXIST_DELETE_TARGET_MEMBER: (notExistMemberId: number[]) =>
+    `삭제 대상자가 심방 대상자에 포함되어 있지 않습니다. 존재하지 않는 교인 id: [${notExistMemberId.join(', ')}]`,
 };
 
 export const VisitationDetailException = {

--- a/backend/src/visitation/const/visitation-find-options.const.ts
+++ b/backend/src/visitation/const/visitation-find-options.const.ts
@@ -19,6 +19,13 @@ export const VisitationRelationOptions: FindOptionsRelations<VisitationMetaModel
       group: true,
       groupRole: true,
     },
+    reports: {
+      receiver: {
+        officer: true,
+        group: true,
+        groupRole: true,
+      },
+    },
   };
 
 export const VisitationSelectOptions: FindOptionsSelect<VisitationMetaModel> = {
@@ -68,6 +75,27 @@ export const VisitationSelectOptions: FindOptionsSelect<VisitationMetaModel> = {
     groupRole: {
       id: true,
       role: true,
+    },
+  },
+  reports: {
+    id: true,
+    isRead: true,
+    isConfirmed: true,
+    receiver: {
+      id: true,
+      name: true,
+      officer: {
+        id: true,
+        name: true,
+      },
+      group: {
+        id: true,
+        name: true,
+      },
+      groupRole: {
+        id: true,
+        role: true,
+      },
     },
   },
 };

--- a/backend/src/visitation/dto/create-visitation.dto.ts
+++ b/backend/src/visitation/dto/create-visitation.dto.ts
@@ -1,4 +1,5 @@
 import {
+  IsArray,
   IsBoolean,
   IsDate,
   IsEnum,
@@ -71,4 +72,16 @@ export class CreateVisitationDto {
   @Type(() => VisitationDetailDto)
   @VisitationDetailValidator()
   visitationDetails: VisitationDetailDto[];
+
+  @ApiProperty({
+    description: '심방 피보고자 ID',
+    isArray: true,
+    required: false,
+  })
+  @IsOptional()
+  //@TransformNumberArray()
+  @IsArray()
+  @IsNumber({}, { each: true })
+  @Min(1, { each: true })
+  receiverIds?: number[];
 }

--- a/backend/src/visitation/entity/visitation-meta.entity.ts
+++ b/backend/src/visitation/entity/visitation-meta.entity.ts
@@ -15,6 +15,7 @@ import { VisitationType } from '../const/visitation-type.enum';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { MemberModel } from '../../members/entity/member.entity';
 import { VisitationStatus } from '../const/visitation-status.enum';
+import { VisitationReportModel } from '../../report/entity/visitation-report.entity';
 
 @Entity()
 export class VisitationMetaModel extends BaseModel {
@@ -71,4 +72,10 @@ export class VisitationMetaModel extends BaseModel {
     (visitingDetail) => visitingDetail.visitationMeta,
   )
   visitationDetails: VisitationDetailModel[];
+
+  @OneToMany(
+    () => VisitationReportModel,
+    (visitingReport) => visitingReport.visitation,
+  )
+  reports: VisitationReportModel[];
 }


### PR DESCRIPTION
## 주요 내용
심방을 생성할 때 피보고자(보고를 받을 사용자)가 지정된 경우,
해당 피보고자에게 자동으로 심방 보고(`VisitationReport`)가 생성되도록 기능을 추가하였습니다.

## 세부 내용
- 심방 생성 요청 시 `reportIds` 필드 처리
- 피보고자가 존재할 경우 해당 사용자들에 대한 `VisitationReport` 자동 생성
- 생성된 보고는 심방 메타데이터와 연관되어 관리됨
- 초기 상태: `isRead = false`, `isConfirmed = false`
- 다중 피보고자 지정 시 각각의 보고가 개별 생성됨

이번 기능을 통해 심방과 동시에 보고 체계를 자동으로 구성할 수 있게 되었으며,
보고 누락 없이 체계적인 관리가 가능해졌습니다. 📝🔔