### PR TITLE
feat: 회원의 교회 가입 신청 기능 및 승인/거절/삭제 처리 추가

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -44,6 +44,7 @@ import { VisitationDetailModel } from './visitation/entity/visitation-detail.ent
 import { ReportModule } from './report/report.module';
 import { ReportModel } from './report/entity/report.entity';
 import { VisitationReportModel } from './report/entity/visitation-report.entity';
+import { ChurchJoinRequestModel } from './churches/entity/church-join-request.entity';
 
 @Module({
   imports: [
@@ -115,6 +116,8 @@ import { VisitationReportModel } from './report/entity/visitation-report.entity'
           UserModel,
           // 교회 관련 엔티티
           ChurchModel,
+          // 교회 가입 엔티티
+          ChurchJoinRequestModel,
           // 교인 관련 엔티티
           RequestInfoModel,
           MemberModel,

--- a/backend/src/churches/church-join-requests.controller.ts
+++ b/backend/src/churches/church-join-requests.controller.ts
@@ -1,0 +1,86 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ChurchesService } from './churches.service';
+import {
+  ApiAcceptChurchJoinRequest,
+  ApiDeleteChurchJoinRequest,
+  ApiGetChurchJoinRequest,
+  ApiPostChurchJoinRequest,
+  ApiRejectChurchJoinRequest,
+} from './const/swagger/churches/controller.swagger';
+import { AccessTokenGuard } from '../auth/guard/jwt.guard';
+import { ChurchManagerGuard } from './guard/church-manager-guard.service';
+import { Token } from '../auth/decorator/jwt.decorator';
+import { AuthType } from '../auth/const/enum/auth-type.enum';
+import { JwtAccessPayload } from '../auth/type/jwt';
+import { TransactionInterceptor } from '../common/interceptor/transaction.interceptor';
+import { QueryRunner } from '../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm/query-runner/QueryRunner';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('Churches:Join Requests')
+@Controller(':churchId/join')
+export class ChurchJoinRequestsController {
+  constructor(private readonly churchesService: ChurchesService) {}
+
+  @ApiGetChurchJoinRequest()
+  @Get(':churchId/join')
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
+  getChurchJoinRequests(
+    @Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
+    @Param('churchId', ParseIntPipe) churchId: number,
+  ) {
+    return this.churchesService.getChurchJoinRequests(churchId);
+  }
+
+  @ApiPostChurchJoinRequest()
+  @Post(':churchId/join')
+  @UseGuards(AccessTokenGuard)
+  postChurchJoinRequest(
+    @Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
+    @Param('churchId', ParseIntPipe) churchId: number,
+  ) {
+    return this.churchesService.postChurchJoinRequest(accessPayload, churchId);
+  }
+
+  @ApiAcceptChurchJoinRequest()
+  @Patch(':churchId/join/:joinId/accept')
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
+  @UseInterceptors(TransactionInterceptor)
+  acceptChurchJoinRequest(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('joinId', ParseIntPipe) joinId: number,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.churchesService.acceptChurchJoinRequest(churchId, joinId, qr);
+  }
+
+  @ApiRejectChurchJoinRequest()
+  @Patch(':churchId/join/:joinId/reject')
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
+  rejectChurchJoinRequest(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('joinId', ParseIntPipe) joinId: number,
+  ) {
+    return this.churchesService.rejectChurchJoinRequest(churchId, joinId);
+  }
+
+  @ApiDeleteChurchJoinRequest()
+  @Delete(':churchId/join/:joinId')
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
+  deleteChurchJoinRequest(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('joinId', ParseIntPipe) joinId: number,
+  ) {
+    return this.churchesService.deleteChurchJoinRequest(churchId, joinId);
+  }
+}

--- a/backend/src/churches/churches-domain/church-join-requests-domain.service.ts
+++ b/backend/src/churches/churches-domain/church-join-requests-domain.service.ts
@@ -1,0 +1,125 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { IChurchJoinRequestDomainService } from './interface/church-join-requests-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ChurchJoinRequestModel } from '../entity/church-join-request.entity';
+import { QueryRunner, Repository, UpdateResult } from 'typeorm';
+import { ChurchModel } from '../entity/church.entity';
+import { UserModel } from '../../user/entity/user.entity';
+import { ChurchJoinRequestStatusEnum } from '../const/church-join-request-status.enum';
+import { ChurchJoinRequestException } from '../const/exception/church.exception';
+
+@Injectable()
+export class ChurchJoinRequestsDomainService
+  implements IChurchJoinRequestDomainService
+{
+  constructor(
+    @InjectRepository(ChurchJoinRequestModel)
+    private readonly churchJoinRequestsRepository: Repository<ChurchJoinRequestModel>,
+  ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(ChurchJoinRequestModel)
+      : this.churchJoinRequestsRepository;
+  }
+
+  createChurchJoinRequest(
+    church: ChurchModel,
+    user: UserModel,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    return repository.save({
+      church,
+      user,
+      status: ChurchJoinRequestStatusEnum.PENDING,
+    });
+  }
+
+  findChurchJoinRequests(
+    church: ChurchModel,
+    qr?: QueryRunner,
+  ): Promise<ChurchJoinRequestModel[]> {
+    const repository = this.getRepository(qr);
+
+    return repository.find({
+      where: {
+        churchId: church.id,
+      },
+      relations: {
+        user: true,
+      },
+    });
+  }
+
+  async findChurchJoinRequestById(
+    church: ChurchModel,
+    joinId: number,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    const request = await repository.findOne({
+      where: {
+        churchId: church.id,
+        id: joinId,
+      },
+      relations: {
+        user: true,
+      },
+    });
+
+    if (!request) {
+      throw new NotFoundException(ChurchJoinRequestException.NOT_FOUND);
+    }
+
+    return request;
+  }
+
+  async updateChurchJoinRequest(
+    joinRequest: ChurchJoinRequestModel,
+    status: ChurchJoinRequestStatusEnum,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    const result = await repository.update(
+      {
+        id: joinRequest.id,
+      },
+      {
+        status,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        ChurchJoinRequestException.UPDATE_ERROR,
+      );
+    }
+
+    return result;
+  }
+
+  async deleteChurchJoinRequest(
+    joinRequest: ChurchJoinRequestModel,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    const result = await repository.softDelete(joinRequest.id);
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        ChurchJoinRequestException.DELETE_ERROR,
+      );
+    }
+
+    return result;
+  }
+}

--- a/backend/src/churches/churches-domain/churches-domain.module.ts
+++ b/backend/src/churches/churches-domain/churches-domain.module.ts
@@ -3,12 +3,19 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ChurchModel } from '../entity/church.entity';
 import { ICHURCHES_DOMAIN_SERVICE } from './interface/churches-domain.service.interface';
 import { ChurchesDomainService } from './churhes-domain.service';
+import { ChurchJoinRequestModel } from '../entity/church-join-request.entity';
+import { ICHURCH_JOIN_REQUESTS_DOMAIN } from './interface/church-join-requests-domain.service.interface';
+import { ChurchJoinRequestsDomainService } from './church-join-requests-domain.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ChurchModel])],
+  imports: [TypeOrmModule.forFeature([ChurchModel, ChurchJoinRequestModel])],
   providers: [
     { provide: ICHURCHES_DOMAIN_SERVICE, useClass: ChurchesDomainService },
+    {
+      provide: ICHURCH_JOIN_REQUESTS_DOMAIN,
+      useClass: ChurchJoinRequestsDomainService,
+    },
   ],
-  exports: [ICHURCHES_DOMAIN_SERVICE],
+  exports: [ICHURCHES_DOMAIN_SERVICE, ICHURCH_JOIN_REQUESTS_DOMAIN],
 })
 export class ChurchesDomainModule {}

--- a/backend/src/churches/churches-domain/interface/church-join-requests-domain.service.interface.ts
+++ b/backend/src/churches/churches-domain/interface/church-join-requests-domain.service.interface.ts
@@ -1,0 +1,39 @@
+import { ChurchModel } from '../../entity/church.entity';
+import { UserModel } from '../../../user/entity/user.entity';
+import { QueryRunner, UpdateResult } from 'typeorm';
+import { ChurchJoinRequestModel } from '../../entity/church-join-request.entity';
+import { ChurchJoinRequestStatusEnum } from '../../const/church-join-request-status.enum';
+
+export const ICHURCH_JOIN_REQUESTS_DOMAIN = Symbol(
+  'ICHURCH_JOIN_REQUESTS_DOMAIN',
+);
+
+export interface IChurchJoinRequestDomainService {
+  createChurchJoinRequest(
+    church: ChurchModel,
+    user: UserModel,
+    qr?: QueryRunner,
+  ): Promise<ChurchJoinRequestModel>;
+
+  findChurchJoinRequests(
+    church: ChurchModel,
+    qr?: QueryRunner,
+  ): Promise<ChurchJoinRequestModel[]>;
+
+  findChurchJoinRequestById(
+    church: ChurchModel,
+    joinId: number,
+    qr?: QueryRunner,
+  ): Promise<ChurchJoinRequestModel>;
+
+  updateChurchJoinRequest(
+    joinRequest: ChurchJoinRequestModel,
+    status: ChurchJoinRequestStatusEnum,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  deleteChurchJoinRequest(
+    joinRequest: ChurchJoinRequestModel,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+}

--- a/backend/src/churches/churches.controller.ts
+++ b/backend/src/churches/churches.controller.ts
@@ -17,8 +17,8 @@ import { ApiBearerAuth } from '@nestjs/swagger';
 import { Token } from '../auth/decorator/jwt.decorator';
 import { JwtAccessPayload } from '../auth/type/jwt';
 import {
-  ChurchManagerGuard,
   ChurchMainAdminGuard,
+  ChurchManagerGuard,
 } from './guard/church-manager-guard.service';
 import { UpdateChurchDto } from './dto/update-church.dto';
 import {

--- a/backend/src/churches/churches.module.ts
+++ b/backend/src/churches/churches.module.ts
@@ -4,10 +4,11 @@ import { ChurchesController } from './churches.controller';
 import { JwtModule } from '@nestjs/jwt';
 import { UserDomainModule } from '../user/user-domain/user-domain.module';
 import { ChurchesDomainModule } from './churches-domain/churches-domain.module';
+import { ChurchJoinRequestsController } from './church-join-requests.controller';
 
 @Module({
   imports: [JwtModule.register({}), UserDomainModule, ChurchesDomainModule],
-  controllers: [ChurchesController],
+  controllers: [ChurchesController, ChurchJoinRequestsController],
   providers: [ChurchesService],
 })
 export class ChurchesModule {}

--- a/backend/src/churches/churches.service.ts
+++ b/backend/src/churches/churches.service.ts
@@ -1,4 +1,10 @@
-import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
 import { QueryRunner } from 'typeorm';
 import { CreateChurchDto } from './dto/create-church.dto';
 import { JwtAccessPayload } from '../auth/type/jwt';
@@ -12,13 +18,24 @@ import {
   IUserDomainService,
 } from '../user/user-domain/interface/user-domain.service.interface';
 import { UserRole } from '../user/const/user-role.enum';
-import { ChurchException } from './const/exception/church.exception';
+import {
+  ChurchException,
+  ChurchJoinRequestException,
+} from './const/exception/church.exception';
+import {
+  ICHURCH_JOIN_REQUESTS_DOMAIN,
+  IChurchJoinRequestDomainService,
+} from './churches-domain/interface/church-join-requests-domain.service.interface';
+import { UserException } from '../user/exception/user.exception';
+import { ChurchJoinRequestStatusEnum } from './const/church-join-request-status.enum';
 
 @Injectable()
 export class ChurchesService {
   constructor(
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(ICHURCH_JOIN_REQUESTS_DOMAIN)
+    private readonly churchJoinRequestsDomainService: IChurchJoinRequestDomainService,
     @Inject(IUSER_DOMAIN_SERVICE)
     private readonly userDomainService: IUserDomainService,
   ) {}
@@ -68,5 +85,144 @@ export class ChurchesService {
     const church = await this.churchesDomainService.findChurchModelById(id, qr);
 
     return this.churchesDomainService.deleteChurch(church, qr);
+  }
+
+  async postChurchJoinRequest(
+    accessPayload: JwtAccessPayload,
+    churchId: number,
+  ) {
+    const userId = accessPayload.id;
+    const user = await this.userDomainService.findUserById(userId);
+
+    if (user.church) {
+      throw new ConflictException(UserException.ALREADY_JOINED);
+    }
+
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    return this.churchJoinRequestsDomainService.createChurchJoinRequest(
+      church,
+      user,
+    );
+  }
+
+  async getChurchJoinRequests(churchId: number) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    return this.churchJoinRequestsDomainService.findChurchJoinRequests(church);
+  }
+
+  async acceptChurchJoinRequest(
+    churchId: number,
+    joinId: number,
+    qr: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const joinRequest =
+      await this.churchJoinRequestsDomainService.findChurchJoinRequestById(
+        church,
+        joinId,
+        qr,
+      );
+
+    if (joinRequest.status === ChurchJoinRequestStatusEnum.APPROVED) {
+      throw new BadRequestException(
+        ChurchJoinRequestException.ALREADY_APPROVED,
+      );
+    }
+
+    await this.churchJoinRequestsDomainService.updateChurchJoinRequest(
+      joinRequest,
+      ChurchJoinRequestStatusEnum.APPROVED,
+      qr,
+    );
+
+    await this.userDomainService.signInChurch(
+      joinRequest.user,
+      church,
+      UserRole.member,
+      qr,
+    );
+
+    return this.churchJoinRequestsDomainService.findChurchJoinRequestById(
+      church,
+      joinId,
+      qr,
+    );
+  }
+
+  async rejectChurchJoinRequest(
+    churchId: number,
+    joinId: number,
+    qr?: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const joinRequest =
+      await this.churchJoinRequestsDomainService.findChurchJoinRequestById(
+        church,
+        joinId,
+        qr,
+      );
+    if (joinRequest.status === ChurchJoinRequestStatusEnum.APPROVED) {
+      throw new BadRequestException(
+        ChurchJoinRequestException.ALREADY_APPROVED,
+      );
+    }
+    if (joinRequest.status === ChurchJoinRequestStatusEnum.REJECTED) {
+      throw new BadRequestException(
+        ChurchJoinRequestException.ALREADY_REJECTED,
+      );
+    }
+
+    await this.churchJoinRequestsDomainService.updateChurchJoinRequest(
+      joinRequest,
+      ChurchJoinRequestStatusEnum.REJECTED,
+      qr,
+    );
+
+    return this.churchJoinRequestsDomainService.findChurchJoinRequestById(
+      church,
+      joinId,
+      qr,
+    );
+  }
+
+  async deleteChurchJoinRequest(
+    churchId: number,
+    joinId: number,
+    qr?: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const joinRequest =
+      await this.churchJoinRequestsDomainService.findChurchJoinRequestById(
+        church,
+        joinId,
+        qr,
+      );
+
+    if (joinRequest.status === ChurchJoinRequestStatusEnum.PENDING) {
+      throw new BadRequestException(ChurchJoinRequestException.NOT_DECIDED);
+    }
+
+    await this.churchJoinRequestsDomainService.deleteChurchJoinRequest(
+      joinRequest,
+      qr,
+    );
+
+    return `ChurchJoinRequest id: ${joinId} deleted`;
   }
 }

--- a/backend/src/churches/const/church-join-request-status.enum.ts
+++ b/backend/src/churches/const/church-join-request-status.enum.ts
@@ -1,0 +1,5 @@
+export enum ChurchJoinRequestStatusEnum {
+  PENDING = 'PENDING',
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+}

--- a/backend/src/churches/const/exception/church.exception.ts
+++ b/backend/src/churches/const/exception/church.exception.ts
@@ -5,3 +5,12 @@ export const ChurchException = {
   DELETE_ERROR: '교회 삭제 도중 에러 발생',
   NOT_FOUND: '해당 교회를 찾을 수 없습니다.',
 };
+
+export const ChurchJoinRequestException = {
+  ALREADY_APPROVED: '이미 가입 허가된 요청입니다.',
+  ALREADY_REJECTED: '이미 가입 거절된 요청입니다.',
+  NOT_DECIDED: '승인되거나 거절된 요청만 삭제할 수 있습니다.',
+  NOT_FOUND: '가입 요청을 찾을 수 없습니다.',
+  UPDATE_ERROR: '가입 요청 업데이트 도중 에러 발생',
+  DELETE_ERROR: '가입 요청 삭제 도중 에러 발생',
+};

--- a/backend/src/churches/const/swagger/churches/controller.swagger.ts
+++ b/backend/src/churches/const/swagger/churches/controller.swagger.ts
@@ -86,3 +86,55 @@ export const ApiDeleteChurch = () =>
         '<p>AccessToken 필요, 메인관리자 권한만 삭제 가능</p>',
     }),
   );
+
+export const ApiGetChurchJoinRequest = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교회 가입 신청 목록 조회 (임시)',
+      description:
+        '<h2>교회 가입 신청 목록을 조회합니다.</h2>' +
+        '<p>교회 관리자(mainAdmin, manager)만 조회 가능</p>',
+    }),
+  );
+
+export const ApiPostChurchJoinRequest = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교회 가입 신청',
+      description:
+        '<h2>교회에 가입을 신청합니다.</h2>' +
+        '<p>교회에 가입하지 않은 유저만 요청 가능</p>',
+    }),
+  );
+
+export const ApiAcceptChurchJoinRequest = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교회 가입 신청 허가',
+      description:
+        '<h2>교회 가입 신청을 허가합니다.</h2>' +
+        '<p>이미 허가된 신청에 요청 불가능</p>',
+    }),
+  );
+
+export const ApiRejectChurchJoinRequest = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교회 가입 신청 거절',
+      description:
+        '<h2>교회 가입 신청을 거절합니다.</h2>' +
+        '<p>이미 허가, 거절된 신청에 요청 불가능</p>' +
+        '<p>PENDING 상태인 신청만 가능</p>',
+    }),
+  );
+
+export const ApiDeleteChurchJoinRequest = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교회 가입 신청 삭제',
+      description:
+        '<h2>교회 가입 신청을 삭제합니다.</h2>' +
+        '<p>처리 완료된 신청만 삭제 가능</p>' +
+        '<p>PENDING 상태인 신청 삭제 불가능</p>',
+    }),
+  );

--- a/backend/src/churches/dto/update-church-join-request.dto.ts
+++ b/backend/src/churches/dto/update-church-join-request.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty, PartialType, PickType } from '@nestjs/swagger';
+import { ChurchJoinRequestModel } from '../entity/church-join-request.entity';
+import { ChurchJoinRequestStatusEnum } from '../const/church-join-request-status.enum';
+
+export class UpdateChurchJoinRequestDto extends PartialType(
+  PickType(ChurchJoinRequestModel, ['status']),
+) {
+  @ApiProperty({
+    description: '',
+  })
+  override status: ChurchJoinRequestStatusEnum;
+}

--- a/backend/src/churches/entity/church-join-request.entity.ts
+++ b/backend/src/churches/entity/church-join-request.entity.ts
@@ -1,0 +1,36 @@
+import { BaseModel } from '../../common/entity/base.entity';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToOne,
+} from 'typeorm';
+import { ChurchModel } from './church.entity';
+import { UserModel } from '../../user/entity/user.entity';
+import { ChurchJoinRequestStatusEnum } from '../const/church-join-request-status.enum';
+
+@Entity()
+export class ChurchJoinRequestModel extends BaseModel {
+  @Index()
+  @Column()
+  churchId: number;
+
+  @ManyToOne(() => ChurchModel, (church) => church.joinRequests)
+  church: ChurchModel;
+
+  @Index()
+  @Column()
+  userId: number;
+
+  @OneToOne(() => UserModel, (user) => user.joinRequest)
+  @JoinColumn({ name: 'userId' })
+  user: UserModel;
+
+  @Column({
+    enum: ChurchJoinRequestStatusEnum,
+    default: ChurchJoinRequestStatusEnum.PENDING,
+  })
+  status: ChurchJoinRequestStatusEnum;
+}

--- a/backend/src/churches/entity/church.entity.ts
+++ b/backend/src/churches/entity/church.entity.ts
@@ -11,6 +11,7 @@ import { MinistryModel } from '../../management/ministries/entity/ministry.entit
 import { MemberModel } from '../../members/entity/member.entity';
 import { RequestInfoModel } from '../../request-info/entity/request-info.entity';
 import { VisitationMetaModel } from '../../visitation/entity/visitation-meta.entity';
+import { ChurchJoinRequestModel } from './church-join-request.entity';
 
 @Entity()
 export class ChurchModel extends BaseModel {
@@ -67,6 +68,9 @@ export class ChurchModel extends BaseModel {
 
   @OneToMany(() => MemberModel, (member) => member.church)
   members: MemberModel[];
+
+  @OneToMany(() => ChurchJoinRequestModel, (joinRequest) => joinRequest.church)
+  joinRequests: ChurchJoinRequestModel[];
 
   @OneToMany(() => VisitationMetaModel, (visitingMeta) => visitingMeta.church)
   visitations: VisitationMetaModel[];

--- a/backend/src/churches/guard/church-manager-guard.service.ts
+++ b/backend/src/churches/guard/church-manager-guard.service.ts
@@ -9,6 +9,34 @@ import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
 } from '../churches-domain/interface/churches-domain.service.interface';
+import {
+  IUSER_DOMAIN_SERVICE,
+  IUserDomainService,
+} from '../../user/user-domain/interface/user-domain.service.interface';
+
+@Injectable()
+export class ChurchMemberGuard implements CanActivate {
+  constructor(
+    @Inject(IUSER_DOMAIN_SERVICE)
+    private readonly userDomainService: IUserDomainService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+
+    const token = req.tokenPayload;
+
+    const user = await this.userDomainService.findUserById(token.id);
+
+    const churchId = parseInt(req.body.churchId);
+
+    if (user.churchId !== churchId) {
+      throw new ForbiddenException('해당 교회의 교인만 접근할 수 있습니다.');
+    }
+
+    return true;
+  }
+}
 
 @Injectable()
 export class ChurchManagerGuard implements CanActivate {

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -32,12 +32,12 @@ import { VisitationMetaModel } from '../../visitation/entity/visitation-meta.ent
 
 @Entity()
 export class MemberModel extends BaseModel {
-  @Index()
-  @Column({ nullable: true })
-  userId: number;
+  //@Index()
+  //@Column({ nullable: true })
+  //userId: number;
 
   @OneToOne(() => UserModel, (user) => user.member)
-  @JoinColumn({ name: 'userId' })
+  //@JoinColumn({ name: 'userId' })
   user: UserModel;
 
   @Column()

--- a/backend/src/members/member-domain/service/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/service/interface/members-domain.service.interface.ts
@@ -49,13 +49,6 @@ export interface IMembersDomainService {
     relationOptions?: FindOptionsRelations<MemberModel>,
   ): Promise<MemberModel>;
 
-  findMemberModelByUserId(
-    church: ChurchModel,
-    userId: number,
-    qr?: QueryRunner,
-    relationOptions?: FindOptionsRelations<MemberModel>,
-  ): Promise<MemberModel>;
-
   findDeleteMemberModelById(
     church: ChurchModel,
     memberId: number,

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -149,29 +149,6 @@ export class MembersDomainService implements IMembersDomainService {
     return member;
   }
 
-  async findMemberModelByUserId(
-    church: ChurchModel,
-    userId: number,
-    qr?: QueryRunner,
-    relationOptions?: FindOptionsRelations<MemberModel>,
-  ) {
-    const membersRepository = this.getMembersRepository(qr);
-
-    const member = await membersRepository.findOne({
-      where: {
-        churchId: church.id,
-        userId,
-      },
-      relations: relationOptions,
-    });
-
-    if (!member) {
-      throw new NotFoundException(MemberException.NOT_FOUND);
-    }
-
-    return member;
-  }
-
   async findDeleteMemberModelById(
     church: ChurchModel,
     memberId: number,

--- a/backend/src/user/entity/user.entity.ts
+++ b/backend/src/user/entity/user.entity.ts
@@ -10,14 +10,18 @@ import { BaseModel } from '../../common/entity/base.entity';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { UserRole } from '../const/user-role.enum';
 import { MemberModel } from '../../members/entity/member.entity';
+import { ChurchJoinRequestModel } from '../../churches/entity/church-join-request.entity';
+import { Exclude } from 'class-transformer';
 
 @Entity()
 export class UserModel extends BaseModel {
   @Index()
   @Column()
+  @Exclude()
   provider: string;
 
   @Column()
+  @Exclude()
   providerId: string;
 
   @Column()
@@ -32,12 +36,21 @@ export class UserModel extends BaseModel {
   @Column({ default: false })
   privacyPolicyAgreed: boolean;
 
+  @Index()
+  @Column({ nullable: true })
+  churchId: number;
+
   @ManyToOne(() => ChurchModel, (church) => church.users)
+  @JoinColumn({ name: 'churchId' })
   church: ChurchModel;
 
   @Column({ enum: UserRole, default: UserRole.none })
   role: UserRole;
 
+  @OneToOne(() => ChurchJoinRequestModel, (joinRequest) => joinRequest.user)
+  joinRequest: ChurchJoinRequestModel;
+
+  @Index()
   @Column({ nullable: true })
   memberId: number;
 

--- a/backend/src/user/exception/user.exception.ts
+++ b/backend/src/user/exception/user.exception.ts
@@ -1,0 +1,6 @@
+export const UserException = {
+  NOT_FOUND: '사용자를 찾을 수 없습니다.',
+  ALREADY_JOINED: '이미 소속된 교회가 있습니다.',
+  UPDATE_ERROR: '사용자 업데이트 도중 에러 발생',
+  DELETE_ERROR: '사용자 삭제 도중 에러 발생',
+};

--- a/backend/src/user/user-domain/interface/user-domain.service.interface.ts
+++ b/backend/src/user/user-domain/interface/user-domain.service.interface.ts
@@ -11,6 +11,8 @@ export const IUSER_DOMAIN_SERVICE = Symbol('IUserDomainService');
 export interface IUserDomainService {
   findUserById(id: number, qr?: QueryRunner): Promise<UserModel>;
 
+  getMemberIdByUserId(id: number, qr?: QueryRunner): Promise<number>;
+
   findUserModelByOAuth(
     provider: string,
     providerId: string,

--- a/backend/src/user/user-domain/user-domain.service.ts
+++ b/backend/src/user/user-domain/user-domain.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   InternalServerErrorException,
   NotFoundException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserModel } from '../entity/user.entity';
@@ -43,6 +44,22 @@ export class UserDomainService implements IUserDomainService {
     }
 
     return user;
+  }
+
+  async getMemberIdByUserId(id: number, qr?: QueryRunner) {
+    const userRepository = this.getUserRepository(qr);
+
+    const user = await userRepository.findOne({
+      where: {
+        id,
+      },
+    });
+
+    if (!user) {
+      throw new UnauthorizedException();
+    }
+
+    return user.memberId;
   }
 
   findUserModelByOAuth(provider: string, providerId: string, qr?: QueryRunner) {
@@ -130,6 +147,8 @@ export class UserDomainService implements IUserDomainService {
     user: UserModel,
   ): Promise<UserModel> {
     const userRepository = this.getUserRepository();
+
+    console.log('test2');
 
     await userRepository.update(
       {

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -7,7 +7,7 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { UserService } from './user.service';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AccessTokenGuard } from '../auth/guard/jwt.guard';
 import { Token } from '../auth/decorator/jwt.decorator';
 import { AuthType } from '../auth/const/enum/auth-type.enum';
@@ -16,20 +16,23 @@ import { TransactionInterceptor } from '../common/interceptor/transaction.interc
 import { QueryRunner } from '../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
 import { LinkMemberToUserDto } from './dto/link-member-to-user.dto';
-import { SignInChurchDto } from './dto/sign-in-church.dto';
+import { ChurchMemberGuard } from '../churches/guard/church-manager-guard.service';
 
 @ApiTags('User')
 @Controller('users')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
+  @ApiOperation({
+    summary: '내 회원 정보 불러오기',
+  })
   @Get()
   @UseGuards(AccessTokenGuard)
   getUser(@Token(AuthType.ACCESS) accessToken: JwtAccessPayload) {
     return this.userService.getUserById(accessToken.id);
   }
 
-  @Post('sign-in-church')
+  /*@Post('sign-in-church')
   @UseGuards(AccessTokenGuard)
   @UseInterceptors(TransactionInterceptor)
   signInChurch(
@@ -38,10 +41,16 @@ export class UserController {
     @QueryRunner() qr: QR,
   ) {
     return this.userService.signInChurch(accessToken.id, dto.churchId, qr);
-  }
+  }*/
 
+  @ApiOperation({
+    summary: '회원 정보와 교인 정보 연결하기',
+    description:
+      '<h2>내 회원 정보와 소속 교회의 교인 정보를 연결합니다.</h2>' +
+      '<p>교회에 소속된 회원만 요청 가능합니다.</p>',
+  })
   @Post('link-member')
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchMemberGuard)
   @UseInterceptors(TransactionInterceptor)
   linkMemberToUser(
     @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -23,23 +23,7 @@ export class UserService {
     private readonly churchesDomainService: IChurchesDomainService,
     @Inject(IMEMBERS_DOMAIN_SERVICE)
     private readonly membersDomainService: IMembersDomainService,
-
-    /*@InjectRepository(MemberModel)
-    @Inject(ICHURCHES_DOMAIN_SERVICE)
-    private readonly churchesDomainService: IChurchesDomainService,
-    @InjectRepository(MemberModel)
-    private readonly memberRepository: Repository<MemberModel>,
-    @InjectRepository(ChurchModel)
-    private readonly churchRepository: Repository<ChurchModel>,*/
   ) {}
-
-  /*private getMemberRepository(qr?: QueryRunner) {
-    return qr ? qr.manager.getRepository(MemberModel) : this.memberRepository;
-  }*/
-
-  /*private getChurchRepository(qr?: QueryRunner) {
-    return qr ? qr.manager.getRepository(ChurchModel) : this.churchRepository;
-  }*/
 
   async getUserById(id: number) {
     return this.userDomainService.findUserById(id);
@@ -56,22 +40,6 @@ export class UserService {
       churchId,
       qr,
     );
-    /*const church = await this.getChurchRepository(qr).findOne({
-      where: {
-        id: churchId,
-      },
-    });
-
-    if (!church) {
-      throw new NotFoundException('해당 교회를 찾을 수 없습니다.');
-    }*/
-
-    /*// 사용자 정보 업데이트
-    await this.userDomainService.updateUser(
-      user,
-      { role: UserRole.member },
-      qr,
-    );*/
 
     // 사용자 - 교회 관계 설정
     await this.userDomainService.signInChurch(
@@ -80,6 +48,8 @@ export class UserService {
       UserRole.member,
       qr,
     );
+
+    return this.userDomainService.findUserById(userId, qr);
   }
 
   async linkMemberToUser(
@@ -117,6 +87,8 @@ export class UserService {
         '계정 정보와 교인 정보가 일치하지 않습니다.',
       );
     }
+
+    console.log('test');
 
     return this.userDomainService.linkMemberToUser(member, user);
   }

--- a/backend/src/visitation/visitation.service.ts
+++ b/backend/src/visitation/visitation.service.ts
@@ -43,12 +43,18 @@ import {
   IVISITATION_REPORT_DOMAIN_SERVICE,
   IVisitationReportDomainService,
 } from '../report/report-domain/service/visitation-report-domain.service.interface';
+import {
+  IUSER_DOMAIN_SERVICE,
+  IUserDomainService,
+} from '../user/user-domain/interface/user-domain.service.interface';
 
 @Injectable()
 export class VisitationService {
   constructor(
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IUSER_DOMAIN_SERVICE)
+    private readonly userDomainService: IUserDomainService,
     @Inject(IMEMBERS_DOMAIN_SERVICE)
     private readonly membersDomainService: IMembersDomainService,
 
@@ -118,12 +124,21 @@ export class VisitationService {
       qr,
     );
 
-    const creatorMember =
-      await this.membersDomainService.findMemberModelByUserId(
+    const creatorMemberId = await this.userDomainService.getMemberIdByUserId(
+      accessPayload.id,
+      qr,
+    );
+
+    const creatorMember = await this.membersDomainService.findMemberModelById(
+      church,
+      creatorMemberId,
+      qr,
+    );
+    /*await this.membersDomainService.findMemberModelByUserId(
         church,
         accessPayload.id,
         qr,
-      );
+      );*/
 
     const instructor = await this.membersDomainService.findMemberModelById(
       church,


### PR DESCRIPTION
## 주요 내용
회원이 회원가입 후 교회에 가입 신청을 할 수 있는 기능을 추가하였고,
교회 측에서는 해당 신청을 승인, 거절, 삭제할 수 있도록 처리 기능을 구현하였습니다.
또한, 회원과 교인 데이터 간 연결이 정상적으로 되지 않던 문제를 해결하였습니다.

## 세부 내용
- 회원 가입 이후 `교회 가입 신청서` 작성 기능 추가
- 교회 관리자는 다음 작업 가능:
  - 가입 신청 승인 → 회원이 교인으로 등록됨
  - 가입 신청 거절 → 상태 변경, 연동 없음
  - 가입 신청 삭제 → 신청 기록 제거
- 가입 승인 시 회원과 교인 데이터를 정확히 연결하도록 처리 로직 수정
- 잘못된 매핑 또는 누락으로 인해 연결되지 않던 문제 해결

이번 기능 추가로 인해 회원 → 교회 가입 → 교인 등록까지의 흐름이 안정적으로 연결되었고, 교회 관리자 입장에서의 가입 관리가 명확하게 이루어지도록 개선되었습니다. 🏛️🧾✅