### PR TITLE
feat: 가입 신청 일일 횟수 제한 및 통계 모델 추가

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -45,6 +45,7 @@ import { ReportModule } from './report/report.module';
 import { ReportModel } from './report/entity/report.entity';
 import { VisitationReportModel } from './report/entity/visitation-report.entity';
 import { ChurchJoinRequestModel } from './churches/entity/church-join-request.entity';
+import { ChurchJoinRequestStatModel } from './churches/entity/church-join-request-stat.entity';
 
 @Module({
   imports: [
@@ -118,6 +119,7 @@ import { ChurchJoinRequestModel } from './churches/entity/church-join-request.en
           ChurchModel,
           // 교회 가입 엔티티
           ChurchJoinRequestModel,
+          ChurchJoinRequestStatModel,
           // 교인 관련 엔티티
           RequestInfoModel,
           MemberModel,

--- a/backend/src/churches/churches-domain/churches-domain.module.ts
+++ b/backend/src/churches/churches-domain/churches-domain.module.ts
@@ -4,18 +4,35 @@ import { ChurchModel } from '../entity/church.entity';
 import { ICHURCHES_DOMAIN_SERVICE } from './interface/churches-domain.service.interface';
 import { ChurchesDomainService } from './service/churhes-domain.service';
 import { ChurchJoinRequestModel } from '../entity/church-join-request.entity';
-import { ICHURCH_JOIN_REQUESTS_DOMAIN } from './interface/church-join-requests-domain.service.interface';
+import { ICHURCH_JOIN_REQUESTS_DOMAIN_SERVICE } from './interface/church-join-requests-domain.service.interface';
 import { ChurchJoinRequestsDomainService } from './service/church-join-requests-domain.service';
+import { ICHURCH_JOIN_REQUEST_STATS_DOMAIN_SERVICE } from './interface/church-join-request-stats-domain.service.interface';
+import { ChurchJoinRequestStatsDomainService } from './service/church-join-request-stats-domain.service';
+import { ChurchJoinRequestStatModel } from '../entity/church-join-request-stat.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ChurchModel, ChurchJoinRequestModel])],
+  imports: [
+    TypeOrmModule.forFeature([
+      ChurchModel,
+      ChurchJoinRequestModel,
+      ChurchJoinRequestStatModel,
+    ]),
+  ],
   providers: [
     { provide: ICHURCHES_DOMAIN_SERVICE, useClass: ChurchesDomainService },
     {
-      provide: ICHURCH_JOIN_REQUESTS_DOMAIN,
+      provide: ICHURCH_JOIN_REQUESTS_DOMAIN_SERVICE,
       useClass: ChurchJoinRequestsDomainService,
     },
+    {
+      provide: ICHURCH_JOIN_REQUEST_STATS_DOMAIN_SERVICE,
+      useClass: ChurchJoinRequestStatsDomainService,
+    },
   ],
-  exports: [ICHURCHES_DOMAIN_SERVICE, ICHURCH_JOIN_REQUESTS_DOMAIN],
+  exports: [
+    ICHURCHES_DOMAIN_SERVICE,
+    ICHURCH_JOIN_REQUESTS_DOMAIN_SERVICE,
+    ICHURCH_JOIN_REQUEST_STATS_DOMAIN_SERVICE,
+  ],
 })
 export class ChurchesDomainModule {}

--- a/backend/src/churches/churches-domain/interface/church-join-request-stats-domain.service.interface.ts
+++ b/backend/src/churches/churches-domain/interface/church-join-request-stats-domain.service.interface.ts
@@ -1,0 +1,12 @@
+import { UserModel } from '../../../user/entity/user.entity';
+import { QueryRunner } from 'typeorm';
+
+export const ICHURCH_JOIN_REQUEST_STATS_DOMAIN_SERVICE = Symbol(
+  'ICHURCH_JOIN_REQUEST_STATS_DOMAIN_SERVICE',
+);
+
+export interface IChurchJoinRequestStatsDomainService {
+  increaseAttemptsCount(user: UserModel, qr?: QueryRunner): Promise<void>;
+
+  getTopRequestUsers(): Promise<any[]>;
+}

--- a/backend/src/churches/churches-domain/interface/church-join-requests-domain.service.interface.ts
+++ b/backend/src/churches/churches-domain/interface/church-join-requests-domain.service.interface.ts
@@ -4,8 +4,8 @@ import { QueryRunner, UpdateResult } from 'typeorm';
 import { ChurchJoinRequestModel } from '../../entity/church-join-request.entity';
 import { ChurchJoinRequestStatusEnum } from '../../const/church-join-request-status.enum';
 
-export const ICHURCH_JOIN_REQUESTS_DOMAIN = Symbol(
-  'ICHURCH_JOIN_REQUESTS_DOMAIN',
+export const ICHURCH_JOIN_REQUESTS_DOMAIN_SERVICE = Symbol(
+  'ICHURCH_JOIN_REQUESTS_DOMAIN_SERVICE',
 );
 
 export interface IChurchJoinRequestDomainService {

--- a/backend/src/churches/churches-domain/service/church-join-request-stats-domain.service.ts
+++ b/backend/src/churches/churches-domain/service/church-join-request-stats-domain.service.ts
@@ -1,0 +1,63 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { IChurchJoinRequestStatsDomainService } from '../interface/church-join-request-stats-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ChurchJoinRequestStatModel } from '../../entity/church-join-request-stat.entity';
+import { QueryRunner, Repository } from 'typeorm';
+import { UserModel } from '../../../user/entity/user.entity';
+import { ChurchJoinRequestException } from '../../const/exception/church.exception';
+import { ChurchJoinRequestConstraints } from '../../const/church-join-request.constraints';
+
+@Injectable()
+export class ChurchJoinRequestStatsDomainService
+  implements IChurchJoinRequestStatsDomainService
+{
+  constructor(
+    @InjectRepository(ChurchJoinRequestStatModel)
+    private readonly repository: Repository<ChurchJoinRequestStatModel>,
+  ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(ChurchJoinRequestStatModel)
+      : this.repository;
+  }
+
+  async increaseAttemptsCount(user: UserModel, qr?: QueryRunner) {
+    const repository = this.getRepository(qr);
+
+    const today = new Date().toISOString().split('T')[0];
+
+    let stat = await repository.findOne({
+      where: { userId: user.id, date: today },
+    });
+
+    if (!stat) {
+      stat = repository.create({ userId: user.id, date: today, attempts: 1 });
+    } else {
+      if (stat.attempts >= 5) {
+        throw new BadRequestException(
+          ChurchJoinRequestException.TOO_MANY_REQUESTS(
+            ChurchJoinRequestConstraints.MAX_ATTEMPTS,
+          ),
+        );
+      }
+
+      stat.attempts += 1;
+    }
+
+    await repository.save(stat);
+  }
+
+  async getTopRequestUsers() {
+    return this.repository
+      .createQueryBuilder('stat')
+      .leftJoin('stat.user', 'user')
+      .select('stat.userId', 'userId')
+      .addSelect('SUM(stat.attempts)', 'totalAttempts')
+      .where("stat.date >= CURRENT_DATE - INTERVAL '7 days'")
+      .groupBy('stat.userId')
+      .orderBy('"totalAttempts"', 'DESC')
+      .limit(10)
+      .getRawMany();
+  }
+}

--- a/backend/src/churches/const/church-join-request.constraints.ts
+++ b/backend/src/churches/const/church-join-request.constraints.ts
@@ -1,0 +1,3 @@
+export const ChurchJoinRequestConstraints = {
+  MAX_ATTEMPTS: 5,
+};

--- a/backend/src/churches/const/exception/church.exception.ts
+++ b/backend/src/churches/const/exception/church.exception.ts
@@ -16,4 +16,6 @@ export const ChurchJoinRequestException = {
   NOT_FOUND: '가입 요청을 찾을 수 없습니다.',
   UPDATE_ERROR: '가입 요청 업데이트 도중 에러 발생',
   DELETE_ERROR: '가입 요청 삭제 도중 에러 발생',
+  TOO_MANY_REQUESTS: (maxAttempts: number) =>
+    `하루 최대 ${maxAttempts}회의 가입 신청만 가능합니다.`,
 };

--- a/backend/src/churches/controller/church-join-requests.controller.ts
+++ b/backend/src/churches/controller/church-join-requests.controller.ts
@@ -37,11 +37,17 @@ export class ChurchJoinRequestsController {
   @ApiPostChurchJoinRequest()
   @Post(':churchId/join')
   @UseGuards(AccessTokenGuard)
+  @UseInterceptors(TransactionInterceptor)
   postChurchJoinRequest(
     @Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
     @Param('churchId', ParseIntPipe) churchId: number,
+    @QueryRunner() qr: QR,
   ) {
-    return this.churchesService.postChurchJoinRequest(accessPayload, churchId);
+    return this.churchesService.postChurchJoinRequest(
+      accessPayload,
+      churchId,
+      qr,
+    );
   }
 
   @ApiGetChurchJoinRequest()
@@ -90,5 +96,10 @@ export class ChurchJoinRequestsController {
     @Param('joinId', ParseIntPipe) joinId: number,
   ) {
     return this.churchesService.deleteChurchJoinRequest(churchId, joinId);
+  }
+
+  @Get(':churchId/join/stats')
+  getTopRequestUsers() {
+    return this.churchesService.getTopRequestUsers();
   }
 }

--- a/backend/src/churches/entity/church-join-request-stat.entity.ts
+++ b/backend/src/churches/entity/church-join-request-stat.entity.ts
@@ -1,0 +1,21 @@
+import { BaseModel } from '../../common/entity/base.entity';
+import { Column, Entity, Index, ManyToOne, Unique } from 'typeorm';
+import { UserModel } from '../../user/entity/user.entity';
+
+@Entity()
+@Unique(['userId', 'date'])
+export class ChurchJoinRequestStatModel extends BaseModel {
+  @Index()
+  @Column()
+  userId: number;
+
+  @ManyToOne(() => UserModel)
+  user: UserModel;
+
+  @Index()
+  @Column({ type: 'date' })
+  date: string;
+
+  @Column({ default: 1 })
+  attempts: number;
+}

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -14,7 +14,7 @@ import {
   IMembersDomainService,
 } from '../members/member-domain/service/interface/members-domain.service.interface';
 import {
-  ICHURCH_JOIN_REQUESTS_DOMAIN,
+  ICHURCH_JOIN_REQUESTS_DOMAIN_SERVICE,
   IChurchJoinRequestDomainService,
 } from '../churches/churches-domain/interface/church-join-requests-domain.service.interface';
 import { ChurchJoinRequestStatusEnum } from '../churches/const/church-join-request-status.enum';
@@ -26,7 +26,7 @@ export class UserService {
     private readonly userDomainService: IUserDomainService,
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,
-    @Inject(ICHURCH_JOIN_REQUESTS_DOMAIN)
+    @Inject(ICHURCH_JOIN_REQUESTS_DOMAIN_SERVICE)
     private readonly churchJoinRequestsDomainService: IChurchJoinRequestDomainService,
 
     @Inject(IMEMBERS_DOMAIN_SERVICE)


### PR DESCRIPTION
## 주요 내용
사용자가 하루에 최대 5회까지 교회 가입 신청을 할 수 있도록 제약을 추가하고,
신청 횟수와 이력을 기록하기 위한 `ChurchJoinRequestStatModel`을 도입하여 향후 통계 기반 분석이 가능하도록 구조를 개선하였습니다.

## 세부 내용
- 사용자별 교회 가입 신청 횟수를 저장/관리하는 `ChurchJoinRequestStatModel` 추가
  - 신청 일자 기준으로 사용자별 신청 횟수 기록
  - 추후 관리자 페이지에서 가입 신청 통계 조회 가능
- 하루에 최대 5회까지만 가입 신청 가능하도록 제한
  - 신청 시 현재 날짜 기준 횟수 조회 및 증가
  - 5회 초과 시 가입 신청 차단 처리
- 신청 횟수는 매일 자정(00시) 기준으로 초기화되도록 설계

이번 기능 추가를 통해 가입 신청 요청에 대한 제어와 이력 추적이 가능해졌으며,
불필요한 반복 신청을 방지하고, 교회 가입 흐름을 더욱 안정적으로 관리할 수 있게 되었습니다.