### PR TITLE
feat: 교회 joinCode 기능 및 교회 가입 신청 방식 개선  

### DIFF
--- a/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
+++ b/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
@@ -36,4 +36,10 @@ export interface IChurchesDomainService {
   getChurchManagerIds(churchId: number, qr?: QueryRunner): Promise<number[]>;
 
   getChurchMainAdminIds(churchId: number, qr?: QueryRunner): Promise<number[]>;
+
+  updateChurchJoinCode(
+    church: ChurchModel,
+    newCode: string,
+    qr: QueryRunner | undefined,
+  ): Promise<UpdateResult>;
 }

--- a/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
+++ b/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
@@ -11,6 +11,12 @@ export interface IChurchesDomainService {
 
   findChurchById(id: number, qr?: QueryRunner): Promise<ChurchModel>;
 
+  findChurchModelByJoinCode(
+    joinCode: string,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<ChurchModel>,
+  ): Promise<ChurchModel>;
+
   findChurchModelById(
     id: number,
     qr?: QueryRunner,

--- a/backend/src/churches/churches-domain/service/church-join-requests-domain.service.ts
+++ b/backend/src/churches/churches-domain/service/church-join-requests-domain.service.ts
@@ -48,18 +48,20 @@ export class ChurchJoinRequestsDomainService
     return true;
   }
 
-  createChurchJoinRequest(
+  async createChurchJoinRequest(
     church: ChurchModel,
     user: UserModel,
     qr?: QueryRunner,
   ) {
     const repository = this.getRepository(qr);
 
-    return repository.save({
+    const newRequest = await repository.save({
       church,
       user,
       status: ChurchJoinRequestStatusEnum.PENDING,
     });
+
+    return this.findMyChurchJoinRequestById(user, newRequest.id, qr);
   }
 
   findChurchJoinRequests(

--- a/backend/src/churches/churches-domain/service/churhes-domain.service.ts
+++ b/backend/src/churches/churches-domain/service/churhes-domain.service.ts
@@ -121,6 +121,27 @@ export class ChurchesDomainService implements IChurchesDomainService {
     return church;
   }
 
+  async findChurchModelByJoinCode(
+    joinCode: string,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<ChurchModel>,
+  ): Promise<ChurchModel> {
+    const churchesRepository = this.getChurchRepository(qr);
+
+    const church = await churchesRepository.findOne({
+      where: {
+        joinCode,
+      },
+      relations: relationOptions,
+    });
+
+    if (!church) {
+      throw new NotFoundException(ChurchException.NOT_FOUND);
+    }
+
+    return church;
+  }
+
   async findChurchModelById(
     id: number,
     qr?: QueryRunner,

--- a/backend/src/churches/const/exception/church.exception.ts
+++ b/backend/src/churches/const/exception/church.exception.ts
@@ -5,10 +5,12 @@ export const ChurchException = {
   DELETE_ERROR: '교회 삭제 도중 에러 발생',
   NOT_FOUND: '해당 교회를 찾을 수 없습니다.',
   ALREADY_EXIST_JOIN_CODE: '이미 존재하는 교회 가입 코드입니다.',
+  INVALID_CHURCH_CODE: '교회 코드는 영문자와 숫자만 사용할 수 있습니다.',
 };
 
 export const ChurchJoinRequestException = {
   ALREADY_EXIST: '이미 교회 가입 신청이 존재합니다.',
+  INVALID_CHURCH_CODE: '잘못된 형식의 교회 코드입니다.',
   ALREADY_APPROVED: '이미 가입 허가된 요청입니다.',
   ALREADY_REJECTED: '이미 가입 거절된 요청입니다.',
   CANCELED_REQUEST: '취소된 가입 요청입니다.',

--- a/backend/src/churches/const/exception/church.exception.ts
+++ b/backend/src/churches/const/exception/church.exception.ts
@@ -4,6 +4,7 @@ export const ChurchException = {
   UPDATE_ERROR: '교회 업데이트 도중 에러 발생',
   DELETE_ERROR: '교회 삭제 도중 에러 발생',
   NOT_FOUND: '해당 교회를 찾을 수 없습니다.',
+  ALREADY_EXIST_JOIN_CODE: '이미 존재하는 교회 가입 코드입니다.',
 };
 
 export const ChurchJoinRequestException = {

--- a/backend/src/churches/controller/church-join-requests.controller.ts
+++ b/backend/src/churches/controller/church-join-requests.controller.ts
@@ -28,6 +28,7 @@ import { QueryRunner as QR } from 'typeorm/query-runner/QueryRunner';
 import { ApiTags } from '@nestjs/swagger';
 import { ApproveJoinRequestDto } from '../dto/church-join-request/approve-join-request.dto';
 import { ChurchJoinRequestService } from '../service/church-join-request.service';
+import { CreateJoinRequestDto } from '../dto/church-join-request/create-join-request.dto';
 
 @ApiTags('Churches:Join Requests')
 @Controller('churches')
@@ -35,17 +36,17 @@ export class ChurchJoinRequestsController {
   constructor(private readonly churchesService: ChurchJoinRequestService) {}
 
   @ApiPostChurchJoinRequest()
-  @Post(':churchId/join')
+  @Post('join')
   @UseGuards(AccessTokenGuard)
   @UseInterceptors(TransactionInterceptor)
   postChurchJoinRequest(
     @Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
-    @Param('churchId', ParseIntPipe) churchId: number,
+    @Body() dto: CreateJoinRequestDto,
     @QueryRunner() qr: QR,
   ) {
     return this.churchesService.postChurchJoinRequest(
       accessPayload,
-      churchId,
+      dto.joinCode,
       qr,
     );
   }

--- a/backend/src/churches/controller/churches.controller.ts
+++ b/backend/src/churches/controller/churches.controller.ts
@@ -32,6 +32,7 @@ import { AuthType } from '../../auth/const/enum/auth-type.enum';
 import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
+import { UpdateChurchJoinCodeDto } from '../dto/update-church-join-code.dto';
 
 @Controller('churches')
 export class ChurchesController {
@@ -73,6 +74,21 @@ export class ChurchesController {
     @Body() dto: UpdateChurchDto,
   ) {
     return this.churchesService.updateChurch(churchId, dto);
+  }
+
+  @Patch(':churchId/join-code')
+  @UseGuards(AccessTokenGuard, ChurchMainAdminGuard)
+  @UseInterceptors(TransactionInterceptor)
+  patchChurchJoinCode(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Body() dto: UpdateChurchJoinCodeDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.churchesService.updateChurchJoinCode(
+      churchId,
+      dto.joinCode,
+      qr,
+    );
   }
 
   @ApiDeleteChurch()

--- a/backend/src/churches/dto/church-join-request/create-join-request.dto.ts
+++ b/backend/src/churches/dto/church-join-request/create-join-request.dto.ts
@@ -1,18 +1,18 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString, Length, Matches } from 'class-validator';
 import { Transform } from 'class-transformer';
-import { ChurchException } from '../const/exception/church.exception';
+import { ChurchJoinRequestException } from '../../const/exception/church.exception';
 
-export class UpdateChurchJoinCodeDto {
+export class CreateJoinRequestDto {
   @ApiProperty({
-    description: '교회 코드 (최소 6, 최대 20, 영문+숫자)',
+    description: '교회 가입 코드',
   })
   @IsString()
   @IsNotEmpty()
   @Matches(/^[A-Za-z0-9]+$/, {
-    message: ChurchException.INVALID_CHURCH_CODE,
+    message: ChurchJoinRequestException.INVALID_CHURCH_CODE,
   })
   @Transform(({ value }) => value.toUpperCase())
-  @Length(6, 20)
+  @Length(6, 20, { message: ChurchJoinRequestException.INVALID_CHURCH_CODE })
   joinCode: string;
 }

--- a/backend/src/churches/dto/update-church-join-code.dto.ts
+++ b/backend/src/churches/dto/update-church-join-code.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Length, Matches } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class UpdateChurchJoinCodeDto {
+  @ApiProperty({
+    description: '교회 코드 (최소 6, 최대 20, 영문+숫자)',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^[A-Za-z0-9]+$/, {
+    message: '교회 코드는 영문자와 숫자만 사용할 수 있습니다.',
+  })
+  @Transform(({ value }) => value.toUpperCase())
+  @Length(6, 20)
+  joinCode: string;
+}

--- a/backend/src/churches/entity/church.entity.ts
+++ b/backend/src/churches/entity/church.entity.ts
@@ -12,6 +12,7 @@ import { MemberModel } from '../../members/entity/member.entity';
 import { RequestInfoModel } from '../../request-info/entity/request-info.entity';
 import { VisitationMetaModel } from '../../visitation/entity/visitation-meta.entity';
 import { ChurchJoinRequestModel } from './church-join-request.entity';
+import { Exclude } from 'class-transformer';
 
 @Entity()
 @Unique(['joinCode'])
@@ -62,9 +63,11 @@ export class ChurchModel extends BaseModel {
   ministries: MinistryModel[];
 
   @Column({ default: 0 })
+  @Exclude()
   dailyRequestAttempts: number;
 
   @Column({ default: new Date('1900-01-01'), type: 'timestamptz' })
+  @Exclude()
   lastRequestDate: Date;
 
   @OneToMany(() => RequestInfoModel, (requestInfo) => requestInfo.church)

--- a/backend/src/churches/entity/church.entity.ts
+++ b/backend/src/churches/entity/church.entity.ts
@@ -1,5 +1,5 @@
 import { BaseModel } from '../../common/entity/base.entity';
-import { Column, Entity, OneToMany } from 'typeorm';
+import { Column, Entity, OneToMany, Unique } from 'typeorm';
 import { UserModel } from '../../user/entity/user.entity';
 import { MemberSize } from '../const/member-size.enum';
 import { GroupModel } from '../../management/groups/entity/group.entity';
@@ -14,12 +14,16 @@ import { VisitationMetaModel } from '../../visitation/entity/visitation-meta.ent
 import { ChurchJoinRequestModel } from './church-join-request.entity';
 
 @Entity()
+@Unique(['joinCode'])
 export class ChurchModel extends BaseModel {
   @Column()
   name: string;
 
   @Column({ nullable: true })
   identifyNumber: string;
+
+  @Column({ nullable: true, length: 20 })
+  joinCode: string;
 
   @Column({ nullable: true })
   phone: string;

--- a/backend/src/churches/service/church-join-request.service.ts
+++ b/backend/src/churches/service/church-join-request.service.ts
@@ -51,7 +51,7 @@ export class ChurchJoinRequestService {
 
   async postChurchJoinRequest(
     accessPayload: JwtAccessPayload,
-    churchId: number,
+    joinCode: string,
     qr: QueryRunner,
   ) {
     const userId = accessPayload.id;
@@ -71,8 +71,8 @@ export class ChurchJoinRequestService {
       qr,
     );
 
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
+    const church = await this.churchesDomainService.findChurchModelByJoinCode(
+      joinCode,
       qr,
     );
 

--- a/backend/src/churches/service/churches.service.ts
+++ b/backend/src/churches/service/churches.service.ts
@@ -13,6 +13,10 @@ import {
 } from '../../user/user-domain/interface/user-domain.service.interface';
 import { UserRole } from '../../user/const/user-role.enum';
 import { ChurchException } from '../const/exception/church.exception';
+import {
+  IMEMBERS_DOMAIN_SERVICE,
+  IMembersDomainService,
+} from '../../members/member-domain/service/interface/members-domain.service.interface';
 
 @Injectable()
 export class ChurchesService {
@@ -22,6 +26,8 @@ export class ChurchesService {
 
     @Inject(IUSER_DOMAIN_SERVICE)
     private readonly userDomainService: IUserDomainService,
+    @Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,
   ) {}
 
   findAllChurches() {
@@ -55,6 +61,14 @@ export class ChurchesService {
       qr,
     );
 
+    const mainAdminMember = await this.membersDomainService.createMember(
+      newChurch,
+      { name: user.name, mobilePhone: user.mobilePhone },
+      qr,
+    );
+
+    await this.userDomainService.linkMemberToUser(mainAdminMember, user, qr);
+
     return newChurch;
   }
 
@@ -63,6 +77,21 @@ export class ChurchesService {
       await this.churchesDomainService.findChurchModelById(churchId);
 
     return this.churchesDomainService.updateChurch(church, dto);
+  }
+
+  async updateChurchJoinCode(
+    churchId: number,
+    newCode: string,
+    qr?: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    await this.churchesDomainService.updateChurchJoinCode(church, newCode, qr);
+
+    return this.churchesDomainService.findChurchModelById(churchId, qr);
   }
 
   async deleteChurchById(id: number, qr?: QueryRunner) {

--- a/backend/src/user/user-domain/interface/user-domain.service.interface.ts
+++ b/backend/src/user/user-domain/interface/user-domain.service.interface.ts
@@ -42,5 +42,9 @@ export interface IUserDomainService {
     qr?: QueryRunner,
   ): Promise<UpdateResult>;
 
-  linkMemberToUser(member: MemberModel, user: UserModel): Promise<UserModel>;
+  linkMemberToUser(
+    member: MemberModel,
+    user: UserModel,
+    qr?: QueryRunner,
+  ): Promise<UserModel>;
 }

--- a/backend/src/user/user-domain/user-domain.service.ts
+++ b/backend/src/user/user-domain/user-domain.service.ts
@@ -145,8 +145,9 @@ export class UserDomainService implements IUserDomainService {
   async linkMemberToUser(
     member: MemberModel,
     user: UserModel,
+    qr?: QueryRunner,
   ): Promise<UserModel> {
-    const userRepository = this.getUserRepository();
+    const userRepository = this.getUserRepository(qr);
 
     await userRepository.update(
       {


### PR DESCRIPTION
## 주요 내용  
교회별 고유 식별 코드인 `joinCode`를 도입하고,  
사용자가 교회 가입 신청 시 `joinCode`를 통해 교회를 검색하고 신청할 수 있도록 가입 흐름을 개선하였습니다.  
또한, 교회 생성 시 사용자의 정보로 교인 데이터가 자동 생성되어 사용자와 연결되도록 변경하였습니다.  

## 세부 내용  

### 교회 joinCode 기능  
- 교회 생성 시 랜덤 6자리 대문자 영문 + 숫자 조합의 `joinCode` 자동 생성  
- `PATCH /churches/{churchId}/join-code` 엔드포인트로 교회 관리자가 직접 코드 변경 가능  
  - 최소 6자, 최대 20자  
  - 소문자 입력 시 자동 대문자 변환  
  - 중복된 코드일 경우 `ConflictException` 발생  
- 가입을 위한 교회 검색 시 `joinCode`를 기준으로 조회 가능  

### 교회 가입 신청 방식 개선  
- 기존: 교회 ID로 가입 신청 요청  
- 변경: 사용자가 `joinCode`를 입력하여 교회를 조회 후 가입 신청  
- 존재하지 않거나 폐쇄된 코드일 경우 예외 반환 처리  

### 교회 생성 시 교인 자동 생성 및 연결  
- 사용자가 교회를 생성할 경우, 사용자 정보를 바탕으로 교인 데이터 자동 생성  
- 생성된 교인과 사용자 간 자동 연결 처리  

이번 PR을 통해 사용자 중심의 교회 가입 흐름이 개선되었고,  
교회-사용자 간의 데이터 연결이 보다 일관되고 자동화된 구조로 정비되었습니다.  
