### PR TITLE
refactor: 계정 연동 구조 개선 및 연동 교인 전용 엔드포인트 분리

### DIFF
--- a/backend/src/churches/service/church-join-request.service.ts
+++ b/backend/src/churches/service/church-join-request.service.ts
@@ -161,7 +161,12 @@ export class ChurchJoinRequestService {
       throw new ConflictException(MemberException.ALREADY_LINKED);
     }
 
-    await this.userDomainService.linkMemberToUser(linkMember, joinRequest.user);
+    //await this.userDomainService.linkMemberToUser(linkMember, joinRequest.user);
+    await this.membersDomainService.linkUserToMember(
+      linkMember,
+      joinRequest.user,
+      qr,
+    );
 
     return this.churchJoinRequestsDomainService.findChurchJoinRequestById(
       church,

--- a/backend/src/members/controller/members.controller.ts
+++ b/backend/src/members/controller/members.controller.ts
@@ -18,10 +18,9 @@ import { UpdateMemberDto } from '../dto/update-member.dto';
 import { GetMemberDto } from '../dto/get-member.dto';
 import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
-import { GetManagerMemberDto } from '../dto/get-manager-member.dto';
 
 @ApiTags('Churches:Members')
-@Controller()
+@Controller('members')
 export class MembersController {
   constructor(private readonly membersService: MembersService) {}
 
@@ -41,14 +40,6 @@ export class MembersController {
     @QueryRunner() qr: QR,
   ) {
     return this.membersService.createMember(churchId, dto, qr);
-  }
-
-  @Get('managers')
-  getManagerMembers(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Query() dto: GetManagerMemberDto,
-  ) {
-    return this.membersService.getMembers(churchId, dto, undefined, true);
   }
 
   @Get(':memberId')

--- a/backend/src/members/controller/user-members.controller.ts
+++ b/backend/src/members/controller/user-members.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { GetManagerMemberDto } from '../dto/get-manager-member.dto';
+import { MembersService } from '../service/members.service';
+import { GetMemberDto } from '../dto/get-member.dto';
+
+@ApiTags('Churches:User-Members')
+@Controller('user-members')
+export class UserMembersController {
+  constructor(private readonly membersService: MembersService) {}
+
+  @Get()
+  getUserMembers(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetMemberDto,
+  ) {
+    return this.membersService.getUserMembers(churchId, dto);
+  }
+
+  @Get('managers')
+  getManagerMembers(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetManagerMemberDto,
+  ) {
+    return this.membersService.getMembers(churchId, dto, undefined, true);
+  }
+}

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -32,7 +32,12 @@ import { VisitationMetaModel } from '../../visitation/entity/visitation-meta.ent
 
 @Entity()
 export class MemberModel extends BaseModel {
+  @Index()
+  @Column({ nullable: true })
+  userId: number;
+
   @OneToOne(() => UserModel, (user) => user.member)
+  @JoinColumn({ name: 'userId' })
   user: UserModel;
 
   @Column()

--- a/backend/src/members/member-domain/service/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/service/interface/members-domain.service.interface.ts
@@ -16,6 +16,7 @@ import { OfficerModel } from '../../../../management/officers/entity/officer.ent
 import { MinistryModel } from '../../../../management/ministries/entity/ministry.entity';
 import { GroupModel } from '../../../../management/groups/entity/group.entity';
 import { GroupRoleModel } from '../../../../management/groups/entity/group-role.entity';
+import { UserModel } from '../../../../user/entity/user.entity';
 
 export const IMEMBERS_DOMAIN_SERVICE = Symbol('IMEMBERS_DOMAIN_SERVICE');
 
@@ -48,6 +49,19 @@ export interface IMembersDomainService {
     qr?: QueryRunner,
     relationOptions?: FindOptionsRelations<MemberModel>,
   ): Promise<MemberModel>;
+
+  findMemberModelByUserId(
+    church: ChurchModel,
+    userId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<MemberModel>,
+  ): Promise<MemberModel>;
+
+  linkUserToMember(
+    member: MemberModel,
+    user: UserModel,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
 
   findDeleteMemberModelById(
     church: ChurchModel,

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -31,6 +31,7 @@ import { OfficerModel } from '../../../management/officers/entity/officer.entity
 import { MinistryModel } from '../../../management/ministries/entity/ministry.entity';
 import { GroupModel } from '../../../management/groups/entity/group.entity';
 import { GroupRoleModel } from '../../../management/groups/entity/group-role.entity';
+import { UserModel } from '../../../user/entity/user.entity';
 
 @Injectable()
 export class MembersDomainService implements IMembersDomainService {
@@ -124,6 +125,52 @@ export class MembersDomainService implements IMembersDomainService {
     }
 
     return member;
+  }
+
+  async findMemberModelByUserId(
+    church: ChurchModel,
+    userId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<MemberModel>,
+  ) {
+    const membersRepository = this.getMembersRepository(qr);
+
+    const member = await membersRepository.findOne({
+      where: {
+        userId,
+        churchId: church.id,
+      },
+      relations: relationOptions,
+    });
+
+    if (!member) {
+      throw new NotFoundException(MemberException.NOT_FOUND);
+    }
+
+    return member;
+  }
+
+  async linkUserToMember(
+    member: MemberModel,
+    user: UserModel,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getMembersRepository(qr);
+
+    const result = await repository.update(
+      {
+        id: member.id,
+      },
+      {
+        user: user,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException('계정 연결 중 에러 발생');
+    }
+
+    return result;
   }
 
   async findMemberModelById(

--- a/backend/src/members/members.module.ts
+++ b/backend/src/members/members.module.ts
@@ -11,19 +11,20 @@ import { EducationDomainModule } from '../management/educations/service/educatio
 import { MembersDomainModule } from './member-domain/members-domain.module';
 import { ISEARCH_MEMBERS_SERVICE } from './service/interface/search-members.service.interface';
 import { FamilyRelationDomainModule } from '../family-relation/family-relation-domain/family-relation-domain.module';
+import { UserMembersController } from './controller/user-members.controller';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([MemberModel, ChurchModel]),
     RouterModule.register([
-      { path: 'churches/:churchId/members', module: MembersModule },
+      { path: 'churches/:churchId', module: MembersModule },
     ]),
     ChurchesDomainModule,
     MembersDomainModule,
     FamilyRelationDomainModule,
     EducationDomainModule,
   ],
-  controllers: [MembersController],
+  controllers: [MembersController, UserMembersController],
   providers: [
     MembersService,
     {

--- a/backend/src/members/service/members.service.ts
+++ b/backend/src/members/service/members.service.ts
@@ -1,6 +1,13 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { MemberModel } from '../entity/member.entity';
-import { FindOptionsOrder, FindOptionsWhere, In, QueryRunner } from 'typeorm';
+import {
+  FindOptionsOrder,
+  FindOptionsWhere,
+  In,
+  IsNull,
+  Not,
+  QueryRunner,
+} from 'typeorm';
 import { CreateMemberDto } from '../dto/create-member.dto';
 import { UpdateMemberDto } from '../dto/update-member.dto';
 import { GetMemberDto } from '../dto/get-member.dto';
@@ -60,6 +67,34 @@ export class MembersService {
         role: In([UserRole.mainAdmin, UserRole.manager]),
       };
     }
+
+    const orderOptions: FindOptionsOrder<MemberModel> =
+      this.searchMembersService.parseOrderOption(dto);
+
+    const relationOptions = this.searchMembersService.parseRelationOption(dto);
+
+    const selectOptions = this.searchMembersService.parseSelectOption(dto);
+
+    return this.membersDomainService.findMembers(
+      dto,
+      whereOptions,
+      orderOptions,
+      relationOptions,
+      selectOptions,
+      qr,
+    );
+  }
+
+  async getUserMembers(churchId: number, dto: GetMemberDto, qr?: QueryRunner) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const whereOptions: FindOptionsWhere<MemberModel> =
+      this.searchMembersService.parseWhereOption(church, dto);
+
+    whereOptions.userId = Not(IsNull());
 
     const orderOptions: FindOptionsOrder<MemberModel> =
       this.searchMembersService.parseOrderOption(dto);

--- a/backend/src/user/entity/user.entity.ts
+++ b/backend/src/user/entity/user.entity.ts
@@ -51,11 +51,11 @@ export class UserModel extends BaseModel {
   @OneToMany(() => ChurchJoinRequestModel, (joinRequest) => joinRequest.user)
   joinRequest: ChurchJoinRequestModel;
 
-  @Index()
+  /*@Index()
   @Column({ nullable: true })
-  memberId: number;
+  memberId: number;*/
 
   @OneToOne(() => MemberModel, (member) => member.user)
-  @JoinColumn({ name: 'memberId' })
+  //@JoinColumn({ name: 'memberId' })
   member: MemberModel;
 }

--- a/backend/src/user/user-domain/interface/user-domain.service.interface.ts
+++ b/backend/src/user/user-domain/interface/user-domain.service.interface.ts
@@ -11,7 +11,7 @@ export const IUSER_DOMAIN_SERVICE = Symbol('IUserDomainService');
 export interface IUserDomainService {
   findUserById(id: number, qr?: QueryRunner): Promise<UserModel>;
 
-  getMemberIdByUserId(id: number, qr?: QueryRunner): Promise<number>;
+  //getMemberIdByUserId(id: number, qr?: QueryRunner): Promise<number>;
 
   findUserModelByOAuth(
     provider: string,

--- a/backend/src/user/user-domain/user-domain.service.ts
+++ b/backend/src/user/user-domain/user-domain.service.ts
@@ -3,7 +3,6 @@ import {
   Injectable,
   InternalServerErrorException,
   NotFoundException,
-  UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserModel } from '../entity/user.entity';
@@ -46,7 +45,7 @@ export class UserDomainService implements IUserDomainService {
     return user;
   }
 
-  async getMemberIdByUserId(id: number, qr?: QueryRunner) {
+  /*async getMemberIdByUserId(id: number, qr?: QueryRunner) {
     const userRepository = this.getUserRepository(qr);
 
     const user = await userRepository.findOne({
@@ -60,7 +59,7 @@ export class UserDomainService implements IUserDomainService {
     }
 
     return user.memberId;
-  }
+  }*/
 
   findUserModelByOAuth(provider: string, providerId: string, qr?: QueryRunner) {
     const userRepository = this.getUserRepository(qr);

--- a/backend/src/visitation/visitation.service.ts
+++ b/backend/src/visitation/visitation.service.ts
@@ -124,16 +124,17 @@ export class VisitationService {
       qr,
     );
 
-    const creatorMemberId = await this.userDomainService.getMemberIdByUserId(
+    /*const creatorMemberId = await this.userDomainService.getMemberIdByUserId(
       accessPayload.id,
       qr,
-    );
+    );*/
 
-    const creatorMember = await this.membersDomainService.findMemberModelById(
-      church,
-      creatorMemberId,
-      qr,
-    );
+    const creatorMember =
+      await this.membersDomainService.findMemberModelByUserId(
+        church,
+        accessPayload.id,
+        qr,
+      );
     /*await this.membersDomainService.findMemberModelByUserId(
         church,
         accessPayload.id,


### PR DESCRIPTION
## 주요 내용
`UserModel`과 `MemberModel` 간의 연동 구조를 현실에 맞게 재설계하고, 계정 연동된 교인을 대상으로 한 전용 API 경로(`/user-members`)를 분리하였습니다. 또한 계정 연동 관련 도메인 로직을 `MemberDomainService`로 이동하여 구조를 개선하였습니다.

## 세부 내용

### 연관 관계 방향 수정
- `@JoinColumn`을 `UserModel` → `MemberModel`로 이동
  - 대부분의 로직이 `MemberModel` 중심으로 동작하기 때문
  - 실질적인 주체가 교인(`Member`)이라는 구조 반영

### 도메인 로직 이동 및 기능 추가
- 계정 연동 관련 로직을 `UserDomainService` → `MemberDomainService`로 이동
- `userId`로 교인을 조회하는 메서드 `findMemberByUserId()` 추가
  - 계정 연동 기반으로 교인을 찾는 도메인 전용 메소드

### 계정 연동 교인 전용 엔드포인트 분리
- 기존 교인 조회 API에서 계정 연동 여부에 따라 구분되던 로직을 `/churches/{churchId}/user-members`로 분리
  - 계정이 연동된 교인만 조회하는 전용 엔드포인트
  - 관리자 권한을 가진 교인만 필터링하는 엔드포인트도 이동

이번 변경을 통해 계정 연동 구조가 보다 명확하게 정리되었으며,
교인 중심의 도메인 모델 설계와 사용자 기반 기능 분리가 구조적으로 정돈되었습니다.
또한 계정 연동 교인만을 대상으로 하는 API 분리로, 사용성과 유지보수성 모두 향상되었습니다.