### PR TITLE
feat: 계정 연동 교인 전용 엔드포인트 및 권한 수정 기능 추가

### DIFF
--- a/backend/src/members/const/default-find-options.const.ts
+++ b/backend/src/members/const/default-find-options.const.ts
@@ -9,14 +9,12 @@ export const DefaultMemberRelationOption: FindOptionsRelations<MemberModel> = {
   },
   officer: true,
   ministries: true,
-  //educations: true,
   educations: {
-    educationTerm: true /*{
-      education: true,
-    },*/,
+    educationTerm: true,
   },
   group: true,
   groupRole: true,
+  user: true,
 };
 
 export const DefaultMemberSelectOption: FindOptionsSelect<MemberModel> = {
@@ -38,11 +36,7 @@ export const DefaultMemberSelectOption: FindOptionsSelect<MemberModel> = {
     educationTerm: {
       id: true,
       term: true,
-      educationName: true /*
-      education: {
-        id: true,
-        name: true,
-      },*/,
+      educationName: true,
     },
   },
   group: {
@@ -53,20 +47,20 @@ export const DefaultMemberSelectOption: FindOptionsSelect<MemberModel> = {
     id: true,
     role: true,
   },
+  user: {
+    role: true,
+  },
 };
 
 export const DefaultMembersRelationOption: FindOptionsRelations<MemberModel> = {
-  //guidedBy: true,
   group: true,
   groupRole: true,
   ministries: true,
-  //educations: true,
   educations: {
-    educationTerm: true /*{
-      education: true,
-    }*/,
+    educationTerm: true,
   },
   officer: true,
+  user: true,
 };
 
 export const DefaultMembersSelectOption: FindOptionsSelect<MemberModel> = {
@@ -91,23 +85,21 @@ export const DefaultMembersSelectOption: FindOptionsSelect<MemberModel> = {
     id: true,
     name: true,
   },
-  //educations: true,
   educations: {
     id: true,
     status: true,
     educationTerm: {
       id: true,
       term: true,
-      educationName: true /*
-      education: {
-        id: true,
-        name: true,
-      },*/,
+      educationName: true,
     },
   },
   officer: {
     id: true,
     name: true,
+  },
+  user: {
+    role: true,
   },
 };
 

--- a/backend/src/members/controller/user-members.controller.ts
+++ b/backend/src/members/controller/user-members.controller.ts
@@ -1,27 +1,36 @@
-import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Query,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { GetManagerMemberDto } from '../dto/get-manager-member.dto';
-import { MembersService } from '../service/members.service';
-import { GetMemberDto } from '../dto/get-member.dto';
+import { GetUserMemberDto } from '../dto/get-user-member.dto';
+import { UpdateMemberRoleDto } from '../dto/role/update-member-role.dto';
+import { UserMembersService } from '../service/user-members.service';
 
 @ApiTags('Churches:User-Members')
 @Controller('user-members')
 export class UserMembersController {
-  constructor(private readonly membersService: MembersService) {}
+  constructor(private readonly userMembersService: UserMembersService) {}
 
   @Get()
   getUserMembers(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Query() dto: GetMemberDto,
+    @Query() dto: GetUserMemberDto,
   ) {
-    return this.membersService.getUserMembers(churchId, dto);
+    return this.userMembersService.getUserMembers(churchId, dto);
   }
 
-  @Get('managers')
-  getManagerMembers(
+  @Patch(':memberId/role')
+  patchUserMemberRole(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Query() dto: GetManagerMemberDto,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Body() dto: UpdateMemberRoleDto,
   ) {
-    return this.membersService.getMembers(churchId, dto, undefined, true);
+    return this.userMembersService.updateMemberRole(churchId, memberId, dto);
   }
 }

--- a/backend/src/members/dto/get-manager-member.dto.ts
+++ b/backend/src/members/dto/get-manager-member.dto.ts
@@ -1,3 +1,0 @@
-import { GetMemberDto } from './get-member.dto';
-
-export class GetManagerMemberDto extends GetMemberDto {}

--- a/backend/src/members/dto/get-user-member.dto.ts
+++ b/backend/src/members/dto/get-user-member.dto.ts
@@ -1,0 +1,19 @@
+import { GetMemberDto } from './get-member.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { UserRole } from '../../user/const/user-role.enum';
+import { TransformStringArray } from '../../common/decorator/transformer/transform-array';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class GetUserMemberDto extends GetMemberDto {
+  @ApiProperty({
+    description: '교인 권한 변경',
+    isArray: true,
+    enum: UserRole,
+    required: false,
+  })
+  @IsOptional()
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  @TransformStringArray()
+  userRole?: UserRole[];
+}

--- a/backend/src/members/dto/role/update-member-role.dto.ts
+++ b/backend/src/members/dto/role/update-member-role.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { UserRole } from '../../../user/const/user-role.enum';
+import { IsIn } from 'class-validator';
+
+export class UpdateMemberRoleDto {
+  @ApiProperty({
+    description: '변경할 권한',
+    enum: UserRole,
+  })
+  @IsIn([UserRole.member, UserRole.manager])
+  role: UserRole.member | UserRole.manager;
+}

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -22,7 +22,7 @@ import { GetMemberDto } from '../../dto/get-member.dto';
 import { MemberPaginationResultDto } from '../../dto/member-pagination-result.dto';
 import {
   DefaultMemberRelationOption,
-  DefaultMembersSelectOption,
+  DefaultMemberSelectOption,
 } from '../../const/default-find-options.const';
 import { MemberException } from '../../const/exception/member.exception';
 import { CreateMemberDto } from '../../dto/create-member.dto';
@@ -117,7 +117,7 @@ export class MembersDomainService implements IMembersDomainService {
         churchId: church.id,
       },
       relations: DefaultMemberRelationOption,
-      select: DefaultMembersSelectOption,
+      select: DefaultMemberSelectOption,
     });
 
     if (!member) {

--- a/backend/src/members/members.module.ts
+++ b/backend/src/members/members.module.ts
@@ -12,6 +12,8 @@ import { MembersDomainModule } from './member-domain/members-domain.module';
 import { ISEARCH_MEMBERS_SERVICE } from './service/interface/search-members.service.interface';
 import { FamilyRelationDomainModule } from '../family-relation/family-relation-domain/family-relation-domain.module';
 import { UserMembersController } from './controller/user-members.controller';
+import { UserDomainModule } from '../user/user-domain/user-domain.module';
+import { UserMembersService } from './service/user-members.service';
 
 @Module({
   imports: [
@@ -19,6 +21,7 @@ import { UserMembersController } from './controller/user-members.controller';
     RouterModule.register([
       { path: 'churches/:churchId', module: MembersModule },
     ]),
+    UserDomainModule,
     ChurchesDomainModule,
     MembersDomainModule,
     FamilyRelationDomainModule,
@@ -27,6 +30,7 @@ import { UserMembersController } from './controller/user-members.controller';
   controllers: [MembersController, UserMembersController],
   providers: [
     MembersService,
+    UserMembersService,
     {
       provide: ISEARCH_MEMBERS_SERVICE,
       useClass: SearchMembersService,

--- a/backend/src/members/service/members.service.ts
+++ b/backend/src/members/service/members.service.ts
@@ -1,13 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { MemberModel } from '../entity/member.entity';
-import {
-  FindOptionsOrder,
-  FindOptionsWhere,
-  In,
-  IsNull,
-  Not,
-  QueryRunner,
-} from 'typeorm';
+import { FindOptionsOrder, FindOptionsWhere, QueryRunner } from 'typeorm';
 import { CreateMemberDto } from '../dto/create-member.dto';
 import { UpdateMemberDto } from '../dto/update-member.dto';
 import { GetMemberDto } from '../dto/get-member.dto';
@@ -31,7 +24,6 @@ import {
   IFAMILY_RELATION_DOMAIN_SERVICE,
   IFamilyRelationDomainService,
 } from '../../family-relation/family-relation-domain/service/interface/family-relation-domain.service.interface';
-import { UserRole } from '../../user/const/user-role.enum';
 
 @Injectable()
 export class MembersService {
@@ -48,12 +40,7 @@ export class MembersService {
     private readonly familyDomainService: IFamilyRelationDomainService,
   ) {}
 
-  async getMembers(
-    churchId: number,
-    dto: GetMemberDto,
-    qr?: QueryRunner,
-    findManager?: boolean,
-  ) {
+  async getMembers(churchId: number, dto: GetMemberDto, qr?: QueryRunner) {
     const church = await this.churchesDomainService.findChurchModelById(
       churchId,
       qr,
@@ -61,40 +48,6 @@ export class MembersService {
 
     const whereOptions: FindOptionsWhere<MemberModel> =
       this.searchMembersService.parseWhereOption(church, dto);
-
-    if (findManager) {
-      whereOptions.user = {
-        role: In([UserRole.mainAdmin, UserRole.manager]),
-      };
-    }
-
-    const orderOptions: FindOptionsOrder<MemberModel> =
-      this.searchMembersService.parseOrderOption(dto);
-
-    const relationOptions = this.searchMembersService.parseRelationOption(dto);
-
-    const selectOptions = this.searchMembersService.parseSelectOption(dto);
-
-    return this.membersDomainService.findMembers(
-      dto,
-      whereOptions,
-      orderOptions,
-      relationOptions,
-      selectOptions,
-      qr,
-    );
-  }
-
-  async getUserMembers(churchId: number, dto: GetMemberDto, qr?: QueryRunner) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const whereOptions: FindOptionsWhere<MemberModel> =
-      this.searchMembersService.parseWhereOption(church, dto);
-
-    whereOptions.userId = Not(IsNull());
 
     const orderOptions: FindOptionsOrder<MemberModel> =
       this.searchMembersService.parseOrderOption(dto);
@@ -154,14 +107,6 @@ export class MembersService {
         dto.relation,
         qr,
       );
-
-      /*await this.fetchFamilyRelation(
-        churchId,
-        newMember.id,
-        dto.familyMemberId,
-        dto.relation,
-        qr,
-      );*/
     }
 
     return newMember;
@@ -225,132 +170,4 @@ export class MembersService {
 
     return new ResponseDeleteDto(true, targetMember.id);
   }
-
-  /*async getFamilyRelation(
-    churchId: number,
-    memberId: number,
-    qr?: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const member = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-      qr,
-      {},
-    );
-
-    //return this.familyService.getFamilyRelations(member);
-  }*/
-
-  /*async createFamilyRelation(
-    churchId: number,
-    memberId: number,
-    dto: CreateFamilyRelationDto,
-    qr: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const [member, familyMember] = await Promise.all([
-      this.membersDomainService.findMemberModelById(church, memberId, qr, {}),
-      this.membersDomainService.findMemberModelById(
-        church,
-        dto.familyMemberId,
-        qr,
-        {},
-      ),
-    ]);
-
-    /!*return this.familyService.createFamilyMember(
-      member,
-      familyMember,
-      dto.relation,
-      qr,
-    );*!/
-  }*/
-
-  /*async fetchFamilyRelation(
-    churchId: number,
-    memberId: number,
-    familyMemberId: number,
-    relation: string,
-    qr: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const [member, familyMember] = await Promise.all([
-      this.membersDomainService.findMemberModelById(church, memberId, qr, {}),
-      this.membersDomainService.findMemberModelById(
-        church,
-        familyMemberId,
-        qr,
-        {},
-      ),
-    ]);
-
-    /!*return this.familyService.fetchAndCreateFamilyRelation(
-      member,
-      familyMember,
-      relation,
-      qr,
-    );*!/
-  }*/
-
-  /*async patchFamilyRelation(
-    churchId: number,
-    memberId: number,
-    familyMemberId: number,
-    relation: string,
-    qr: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const [me, family] = await Promise.all([
-      this.membersDomainService.findMemberModelById(church, memberId, qr, {}),
-      this.membersDomainService.findMemberModelById(
-        church,
-        familyMemberId,
-        qr,
-        {},
-      ),
-    ]);
-
-    //return this.familyService.updateFamilyRelation(me, family, relation, qr);
-  }*/
-
-  /*async deleteFamilyRelation(
-    churchId: number,
-    memberId: number,
-    familyMemberId: number,
-    qr?: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const [me, family] = await Promise.all([
-      this.membersDomainService.findMemberModelById(church, memberId, qr, {}),
-      this.membersDomainService.findMemberModelById(
-        church,
-        familyMemberId,
-        qr,
-        {},
-      ),
-    ]);
-
-    //return this.familyService.deleteFamilyRelation(me, family, qr);
-  }*/
 }

--- a/backend/src/members/service/user-members.service.ts
+++ b/backend/src/members/service/user-members.service.ts
@@ -1,0 +1,110 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IUSER_DOMAIN_SERVICE,
+  IUserDomainService,
+} from '../../user/user-domain/interface/user-domain.service.interface';
+import {
+  IMEMBERS_DOMAIN_SERVICE,
+  IMembersDomainService,
+} from '../member-domain/service/interface/members-domain.service.interface';
+import {
+  ISEARCH_MEMBERS_SERVICE,
+  ISearchMembersService,
+} from './interface/search-members.service.interface';
+import {
+  FindOptionsOrder,
+  FindOptionsWhere,
+  In,
+  IsNull,
+  Not,
+  QueryRunner,
+} from 'typeorm';
+import { MemberModel } from '../entity/member.entity';
+import { UpdateMemberRoleDto } from '../dto/role/update-member-role.dto';
+import { UpdateUserDto } from '../../user/dto/update-user.dto';
+import { GetUserMemberDto } from '../dto/get-user-member.dto';
+
+@Injectable()
+export class UserMembersService {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IUSER_DOMAIN_SERVICE)
+    private readonly userDomainService: IUserDomainService,
+    @Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,
+    @Inject(ISEARCH_MEMBERS_SERVICE)
+    private readonly searchMembersService: ISearchMembersService,
+  ) {}
+
+  async getUserMembers(
+    churchId: number,
+    dto: GetUserMemberDto,
+    qr?: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const whereOptions: FindOptionsWhere<MemberModel> =
+      this.searchMembersService.parseWhereOption(church, dto);
+
+    whereOptions.userId = Not(IsNull());
+    whereOptions.user = { role: dto.userRole && In(dto.userRole) };
+
+    const orderOptions: FindOptionsOrder<MemberModel> =
+      this.searchMembersService.parseOrderOption(dto);
+
+    const relationOptions = this.searchMembersService.parseRelationOption(dto);
+
+    const selectOptions = this.searchMembersService.parseSelectOption(dto);
+
+    return this.membersDomainService.findMembers(
+      dto,
+      whereOptions,
+      orderOptions,
+      relationOptions,
+      selectOptions,
+      qr,
+    );
+  }
+
+  async updateMemberRole(
+    churchId: number,
+    memberId: number,
+    dto: UpdateMemberRoleDto,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const member = await this.membersDomainService.findMemberModelById(
+      church,
+      memberId,
+      undefined,
+      { user: true },
+    );
+
+    if (!member.userId) {
+      throw new BadRequestException('계정 연동이 되어있지 않은 교인입니다.');
+    }
+
+    if (member.user.role === dto.role) {
+      throw new BadRequestException('이미 동일한 권한입니다.');
+    }
+
+    const user = await this.userDomainService.findUserById(member.userId);
+
+    const updateUserDto: UpdateUserDto = {
+      role: dto.role,
+    };
+
+    await this.userDomainService.updateUser(user, updateUserDto);
+
+    return this.membersDomainService.findMemberById(church, memberId);
+  }
+}


### PR DESCRIPTION
## 주요 내용
계정이 연동된 교인만을 대상으로 조회 및 권한 수정을 할 수 있는 전용 엔드포인트를 추가하였고, 모든 교인 응답에 계정 연동 여부에 따른 사용자 권한 정보를 포함하도록 개선하였습니다.

## 세부 내용

### 계정 연동 교인 조회 엔드포인트 추가
- `GET /churches/{churchId}/user-members`
  - 계정이 연동된 교인만 조회
  - 기존 교인 목록 조회 API와 동일한 필터 및 정렬 조건 사용 가능
  - 권한 필터링: `mainAdmin`, `manager`, `member` 중 하나 또는 다중 조건 지정 가능
  - 예: 관리자 조회 시 `mainAdmin`, `manager` 동시 필터링 가능

### 계정 연동 교인의 권한 수정 API 추가
- `PATCH /churches/{churchId}/user-members/{memberId}/role`
  - 계정이 연동된 교인의 권한을 `member` 또는 `manager`로 변경 가능
  - `mainAdmin`으로의 권한 승격은 제한
  - 현재 권한과 동일한 권한으로의 변경은 `BadRequestException` 처리

### 교인 응답에 user.role 정보 포함
- 모든 교인 응답 DTO에 `user.role` 프로퍼티 추가
  - 계정 연동 시: `member`, `manager`, `mainAdmin` 중 하나
  - 계정 미연동 시: `null`

이번 기능을 통해 계정 연동 교인에 대한 관리가 명확하게 분리되었고,
권한 수정 시의 조건 제어와 역할 기반 필터링으로 교회 관리 기능의 안전성과 유연성이 향상되었습니다.