### PR TITLE
feat: 교회 mainAdmin(최고 관리자) 양도 기능 추가

### DIFF
--- a/backend/src/churches/const/exception/church.exception.ts
+++ b/backend/src/churches/const/exception/church.exception.ts
@@ -6,6 +6,9 @@ export const ChurchException = {
   NOT_FOUND: '해당 교회를 찾을 수 없습니다.',
   ALREADY_EXIST_JOIN_CODE: '이미 존재하는 교회 가입 코드입니다.',
   INVALID_CHURCH_CODE: '교회 코드는 영문자와 숫자만 사용할 수 있습니다.',
+  SAME_MAIN_ADMIN: '동일한 교회 최고 관리자입니다.',
+  INVALID_NEW_MAIN_ADMIN:
+    '관리자 권한의 교인에게만 교회 최고 관리자 권한을 넘길 수 있습니다.',
 };
 
 export const ChurchJoinRequestException = {

--- a/backend/src/churches/controller/churches.controller.ts
+++ b/backend/src/churches/controller/churches.controller.ts
@@ -33,6 +33,7 @@ import { TransactionInterceptor } from '../../common/interceptor/transaction.int
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
 import { UpdateChurchJoinCodeDto } from '../dto/update-church-join-code.dto';
+import { TransferMainAdminDto } from '../dto/transfer-main-admin.dto';
 
 @Controller('churches')
 export class ChurchesController {
@@ -76,6 +77,14 @@ export class ChurchesController {
     return this.churchesService.updateChurch(churchId, dto);
   }
 
+  @ApiDeleteChurch()
+  @Delete(':churchId')
+  @ApiBearerAuth()
+  @UseGuards(AccessTokenGuard, ChurchMainAdminGuard)
+  deleteChurch(@Param('churchId', ParseIntPipe) churchId: number) {
+    return this.churchesService.deleteChurchById(churchId);
+  }
+
   @Patch(':churchId/join-code')
   @UseGuards(AccessTokenGuard, ChurchMainAdminGuard)
   @UseInterceptors(TransactionInterceptor)
@@ -91,11 +100,22 @@ export class ChurchesController {
     );
   }
 
-  @ApiDeleteChurch()
-  @Delete(':churchId')
-  @ApiBearerAuth()
+  @Patch(':churchId/main-admin')
   @UseGuards(AccessTokenGuard, ChurchMainAdminGuard)
-  deleteChurch(@Param('churchId', ParseIntPipe) churchId: number) {
-    return this.churchesService.deleteChurchById(churchId);
+  @UseInterceptors(TransactionInterceptor)
+  transferMainAdmin(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
+    @Body() dto: TransferMainAdminDto,
+    @QueryRunner() qr: QR,
+  ) {
+    const mainAdminUserId = accessPayload.id;
+
+    return this.churchesService.transferMainAdmin(
+      churchId,
+      mainAdminUserId,
+      dto,
+      qr,
+    );
   }
 }

--- a/backend/src/churches/dto/transfer-main-admin.dto.ts
+++ b/backend/src/churches/dto/transfer-main-admin.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber } from 'class-validator';
+
+export class TransferMainAdminDto {
+  @ApiProperty({
+    description: '새로운 mainAdmin 이 될 교인의 ID',
+  })
+  @IsNumber()
+  newMainAdminMemberId: number;
+}

--- a/backend/src/user/exception/user.exception.ts
+++ b/backend/src/user/exception/user.exception.ts
@@ -1,6 +1,8 @@
 export const UserException = {
   NOT_FOUND: '사용자를 찾을 수 없습니다.',
+  ALREADY_EXIST: '이미 가입된 계정입니다.',
   ALREADY_JOINED: '이미 소속된 교회가 있습니다.',
+  CANNOT_CREATE_CHURCH: '소속된 교회가 있을 경우, 교회를 생성할 수 없습니다.',
   UPDATE_ERROR: '사용자 업데이트 도중 에러 발생',
   DELETE_ERROR: '사용자 삭제 도중 에러 발생',
 };

--- a/backend/src/user/user-domain/interface/user-domain.service.interface.ts
+++ b/backend/src/user/user-domain/interface/user-domain.service.interface.ts
@@ -11,8 +11,6 @@ export const IUSER_DOMAIN_SERVICE = Symbol('IUserDomainService');
 export interface IUserDomainService {
   findUserById(id: number, qr?: QueryRunner): Promise<UserModel>;
 
-  //getMemberIdByUserId(id: number, qr?: QueryRunner): Promise<number>;
-
   findUserModelByOAuth(
     provider: string,
     providerId: string,
@@ -47,4 +45,12 @@ export interface IUserDomainService {
     user: UserModel,
     qr?: QueryRunner,
   ): Promise<UserModel>;
+
+  findMainAdminUser(church: ChurchModel, qr?: QueryRunner): Promise<UserModel>;
+
+  transferMainAdmin(
+    beforeMainAdmin: UserModel,
+    newMainAdmin: UserModel,
+    qr: QueryRunner,
+  ): Promise<void>;
 }

--- a/backend/src/user/user-domain/user-domain.service.ts
+++ b/backend/src/user/user-domain/user-domain.service.ts
@@ -13,6 +13,7 @@ import { ChurchModel } from '../../churches/entity/church.entity';
 import { UpdateUserDto } from '../dto/update-user.dto';
 import { UserRole } from '../const/user-role.enum';
 import { MemberModel } from '../../members/entity/member.entity';
+import { UserException } from '../exception/user.exception';
 
 @Injectable()
 export class UserDomainService implements IUserDomainService {
@@ -39,27 +40,11 @@ export class UserDomainService implements IUserDomainService {
     });
 
     if (!user) {
-      throw new NotFoundException('존재하지 않는 유저입니다.');
+      throw new NotFoundException(UserException.NOT_FOUND);
     }
 
     return user;
   }
-
-  /*async getMemberIdByUserId(id: number, qr?: QueryRunner) {
-    const userRepository = this.getUserRepository(qr);
-
-    const user = await userRepository.findOne({
-      where: {
-        id,
-      },
-    });
-
-    if (!user) {
-      throw new UnauthorizedException();
-    }
-
-    return user.memberId;
-  }*/
 
   findUserModelByOAuth(provider: string, providerId: string, qr?: QueryRunner) {
     const userRepository = this.getUserRepository(qr);
@@ -89,7 +74,7 @@ export class UserDomainService implements IUserDomainService {
     const isExistUser = await this.isExistUser(dto.provider, dto.providerId);
 
     if (isExistUser) {
-      throw new BadRequestException('이미 가입된 계정입니다.');
+      throw new BadRequestException(UserException.ALREADY_EXIST);
     }
 
     const userRepository = this.getUserRepository(qr);
@@ -114,9 +99,7 @@ export class UserDomainService implements IUserDomainService {
 
   isAbleToCreateChurch(user: UserModel): boolean {
     if (user.role !== UserRole.none) {
-      throw new BadRequestException(
-        '소속된 교회가 있을 경우, 교회를 생성할 수 없습니다.',
-      );
+      throw new BadRequestException(UserException.CANNOT_CREATE_CHURCH);
     }
 
     return true;
@@ -168,9 +151,51 @@ export class UserDomainService implements IUserDomainService {
     });
 
     if (!updatedUser) {
-      throw new InternalServerErrorException('교인 연결 중 에러 발생');
+      throw new InternalServerErrorException(UserException.UPDATE_ERROR);
     }
 
     return updatedUser;
+  }
+
+  async findMainAdminUser(
+    church: ChurchModel,
+    qr?: QueryRunner,
+  ): Promise<UserModel> {
+    const userRepository = this.getUserRepository(qr);
+
+    const mainAdmin = await userRepository.findOne({
+      where: {
+        churchId: church.id,
+        role: UserRole.mainAdmin,
+      },
+      relations: {
+        member: true,
+      },
+    });
+
+    if (!mainAdmin) {
+      throw new NotFoundException(UserException.NOT_FOUND);
+    }
+
+    return mainAdmin;
+  }
+
+  async transferMainAdmin(
+    beforeMainAdmin: UserModel,
+    newMainAdmin: UserModel,
+    qr: QueryRunner,
+  ) {
+    const userRepository = this.getUserRepository(qr);
+
+    await Promise.all([
+      userRepository.update(
+        { id: beforeMainAdmin.id },
+        { role: UserRole.manager },
+      ),
+      userRepository.update(
+        { id: newMainAdmin.id },
+        { role: UserRole.mainAdmin },
+      ),
+    ]);
   }
 }


### PR DESCRIPTION
## 주요 내용
교회의 최고 관리자(`mainAdmin`) 권한을 다른 교인에게 양도할 수 있는 기능을 추가하였습니다. 양도 대상은 반드시 기존 관리자(`manager`) 권한을 가진 교인이어야 하며,
양도 후 기존 mainAdmin은 자동으로 manager로 권한이 변경됩니다.

## 세부 내용
- `PATCH /churches/{churchId}/main-admin` 엔드포인트 추가
  - 본인이 속한 교회의 mainAdmin만 요청 가능
  - 양도 대상 교인은 동일 교회 소속이어야 하며, `manager` 권한을 보유하고 있어야 함
  - 기존 mainAdmin은 자동으로 `manager`로 강등됨
- 예외 처리
  - 대상 교인이 `manager` 권한이 아닌 경우: `BadRequestException`
  - 기존 mainAdmin과 동일한 교인을 지정한 경우: `BadRequestException`

이번 기능을 통해 교회 운영의 연속성과 관리 책임의 이전이 안전하게 이루어질 수 있도록 구조가 정비되었으며, mainAdmin 권한이 명확한 조건과 절차에 따라 관리될 수 있도록 보완되었습니다.