### PR TITLE
feat: 교인 권한 관리 기능 고도화 및 mainAdmin 양도 기능 추가  

### DIFF
--- a/backend/src/churches/const/exception/church.exception.ts
+++ b/backend/src/churches/const/exception/church.exception.ts
@@ -6,6 +6,9 @@ export const ChurchException = {
   NOT_FOUND: '해당 교회를 찾을 수 없습니다.',
   ALREADY_EXIST_JOIN_CODE: '이미 존재하는 교회 가입 코드입니다.',
   INVALID_CHURCH_CODE: '교회 코드는 영문자와 숫자만 사용할 수 있습니다.',
+  SAME_MAIN_ADMIN: '동일한 교회 최고 관리자입니다.',
+  INVALID_NEW_MAIN_ADMIN:
+    '관리자 권한의 교인에게만 교회 최고 관리자 권한을 넘길 수 있습니다.',
 };
 
 export const ChurchJoinRequestException = {

--- a/backend/src/churches/controller/churches.controller.ts
+++ b/backend/src/churches/controller/churches.controller.ts
@@ -33,6 +33,7 @@ import { TransactionInterceptor } from '../../common/interceptor/transaction.int
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
 import { UpdateChurchJoinCodeDto } from '../dto/update-church-join-code.dto';
+import { TransferMainAdminDto } from '../dto/transfer-main-admin.dto';
 
 @Controller('churches')
 export class ChurchesController {
@@ -76,6 +77,14 @@ export class ChurchesController {
     return this.churchesService.updateChurch(churchId, dto);
   }
 
+  @ApiDeleteChurch()
+  @Delete(':churchId')
+  @ApiBearerAuth()
+  @UseGuards(AccessTokenGuard, ChurchMainAdminGuard)
+  deleteChurch(@Param('churchId', ParseIntPipe) churchId: number) {
+    return this.churchesService.deleteChurchById(churchId);
+  }
+
   @Patch(':churchId/join-code')
   @UseGuards(AccessTokenGuard, ChurchMainAdminGuard)
   @UseInterceptors(TransactionInterceptor)
@@ -91,11 +100,22 @@ export class ChurchesController {
     );
   }
 
-  @ApiDeleteChurch()
-  @Delete(':churchId')
-  @ApiBearerAuth()
+  @Patch(':churchId/main-admin')
   @UseGuards(AccessTokenGuard, ChurchMainAdminGuard)
-  deleteChurch(@Param('churchId', ParseIntPipe) churchId: number) {
-    return this.churchesService.deleteChurchById(churchId);
+  @UseInterceptors(TransactionInterceptor)
+  transferMainAdmin(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
+    @Body() dto: TransferMainAdminDto,
+    @QueryRunner() qr: QR,
+  ) {
+    const mainAdminUserId = accessPayload.id;
+
+    return this.churchesService.transferMainAdmin(
+      churchId,
+      mainAdminUserId,
+      dto,
+      qr,
+    );
   }
 }

--- a/backend/src/churches/dto/transfer-main-admin.dto.ts
+++ b/backend/src/churches/dto/transfer-main-admin.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber } from 'class-validator';
+
+export class TransferMainAdminDto {
+  @ApiProperty({
+    description: '새로운 mainAdmin 이 될 교인의 ID',
+  })
+  @IsNumber()
+  newMainAdminMemberId: number;
+}

--- a/backend/src/churches/service/church-join-request.service.ts
+++ b/backend/src/churches/service/church-join-request.service.ts
@@ -161,7 +161,12 @@ export class ChurchJoinRequestService {
       throw new ConflictException(MemberException.ALREADY_LINKED);
     }
 
-    await this.userDomainService.linkMemberToUser(linkMember, joinRequest.user);
+    //await this.userDomainService.linkMemberToUser(linkMember, joinRequest.user);
+    await this.membersDomainService.linkUserToMember(
+      linkMember,
+      joinRequest.user,
+      qr,
+    );
 
     return this.churchJoinRequestsDomainService.findChurchJoinRequestById(
       church,

--- a/backend/src/members/const/default-find-options.const.ts
+++ b/backend/src/members/const/default-find-options.const.ts
@@ -9,14 +9,12 @@ export const DefaultMemberRelationOption: FindOptionsRelations<MemberModel> = {
   },
   officer: true,
   ministries: true,
-  //educations: true,
   educations: {
-    educationTerm: true /*{
-      education: true,
-    },*/,
+    educationTerm: true,
   },
   group: true,
   groupRole: true,
+  user: true,
 };
 
 export const DefaultMemberSelectOption: FindOptionsSelect<MemberModel> = {
@@ -38,11 +36,7 @@ export const DefaultMemberSelectOption: FindOptionsSelect<MemberModel> = {
     educationTerm: {
       id: true,
       term: true,
-      educationName: true /*
-      education: {
-        id: true,
-        name: true,
-      },*/,
+      educationName: true,
     },
   },
   group: {
@@ -53,20 +47,20 @@ export const DefaultMemberSelectOption: FindOptionsSelect<MemberModel> = {
     id: true,
     role: true,
   },
+  user: {
+    role: true,
+  },
 };
 
 export const DefaultMembersRelationOption: FindOptionsRelations<MemberModel> = {
-  //guidedBy: true,
   group: true,
   groupRole: true,
   ministries: true,
-  //educations: true,
   educations: {
-    educationTerm: true /*{
-      education: true,
-    }*/,
+    educationTerm: true,
   },
   officer: true,
+  user: true,
 };
 
 export const DefaultMembersSelectOption: FindOptionsSelect<MemberModel> = {
@@ -91,23 +85,21 @@ export const DefaultMembersSelectOption: FindOptionsSelect<MemberModel> = {
     id: true,
     name: true,
   },
-  //educations: true,
   educations: {
     id: true,
     status: true,
     educationTerm: {
       id: true,
       term: true,
-      educationName: true /*
-      education: {
-        id: true,
-        name: true,
-      },*/,
+      educationName: true,
     },
   },
   officer: {
     id: true,
     name: true,
+  },
+  user: {
+    role: true,
   },
 };
 

--- a/backend/src/members/controller/members.controller.ts
+++ b/backend/src/members/controller/members.controller.ts
@@ -18,10 +18,9 @@ import { UpdateMemberDto } from '../dto/update-member.dto';
 import { GetMemberDto } from '../dto/get-member.dto';
 import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
-import { GetManagerMemberDto } from '../dto/get-manager-member.dto';
 
 @ApiTags('Churches:Members')
-@Controller()
+@Controller('members')
 export class MembersController {
   constructor(private readonly membersService: MembersService) {}
 
@@ -41,14 +40,6 @@ export class MembersController {
     @QueryRunner() qr: QR,
   ) {
     return this.membersService.createMember(churchId, dto, qr);
-  }
-
-  @Get('managers')
-  getManagerMembers(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Query() dto: GetManagerMemberDto,
-  ) {
-    return this.membersService.getMembers(churchId, dto, undefined, true);
   }
 
   @Get(':memberId')

--- a/backend/src/members/controller/user-members.controller.ts
+++ b/backend/src/members/controller/user-members.controller.ts
@@ -1,27 +1,36 @@
-import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Query,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { GetManagerMemberDto } from '../dto/get-manager-member.dto';
-import { MembersService } from '../service/members.service';
-import { GetMemberDto } from '../dto/get-member.dto';
+import { GetUserMemberDto } from '../dto/get-user-member.dto';
+import { UpdateMemberRoleDto } from '../dto/role/update-member-role.dto';
+import { UserMembersService } from '../service/user-members.service';
 
 @ApiTags('Churches:User-Members')
 @Controller('user-members')
 export class UserMembersController {
-  constructor(private readonly membersService: MembersService) {}
+  constructor(private readonly userMembersService: UserMembersService) {}
 
   @Get()
   getUserMembers(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Query() dto: GetMemberDto,
+    @Query() dto: GetUserMemberDto,
   ) {
-    return this.membersService.getUserMembers(churchId, dto);
+    return this.userMembersService.getUserMembers(churchId, dto);
   }
 
-  @Get('managers')
-  getManagerMembers(
+  @Patch(':memberId/role')
+  patchUserMemberRole(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Query() dto: GetManagerMemberDto,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Body() dto: UpdateMemberRoleDto,
   ) {
-    return this.membersService.getMembers(churchId, dto, undefined, true);
+    return this.userMembersService.updateMemberRole(churchId, memberId, dto);
   }
 }

--- a/backend/src/members/controller/user-members.controller.ts
+++ b/backend/src/members/controller/user-members.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { GetManagerMemberDto } from '../dto/get-manager-member.dto';
+import { MembersService } from '../service/members.service';
+import { GetMemberDto } from '../dto/get-member.dto';
+
+@ApiTags('Churches:User-Members')
+@Controller('user-members')
+export class UserMembersController {
+  constructor(private readonly membersService: MembersService) {}
+
+  @Get()
+  getUserMembers(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetMemberDto,
+  ) {
+    return this.membersService.getUserMembers(churchId, dto);
+  }
+
+  @Get('managers')
+  getManagerMembers(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetManagerMemberDto,
+  ) {
+    return this.membersService.getMembers(churchId, dto, undefined, true);
+  }
+}

--- a/backend/src/members/dto/get-manager-member.dto.ts
+++ b/backend/src/members/dto/get-manager-member.dto.ts
@@ -1,3 +1,0 @@
-import { GetMemberDto } from './get-member.dto';
-
-export class GetManagerMemberDto extends GetMemberDto {}

--- a/backend/src/members/dto/get-user-member.dto.ts
+++ b/backend/src/members/dto/get-user-member.dto.ts
@@ -1,0 +1,19 @@
+import { GetMemberDto } from './get-member.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { UserRole } from '../../user/const/user-role.enum';
+import { TransformStringArray } from '../../common/decorator/transformer/transform-array';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class GetUserMemberDto extends GetMemberDto {
+  @ApiProperty({
+    description: '교인 권한 변경',
+    isArray: true,
+    enum: UserRole,
+    required: false,
+  })
+  @IsOptional()
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  @TransformStringArray()
+  userRole?: UserRole[];
+}

--- a/backend/src/members/dto/role/update-member-role.dto.ts
+++ b/backend/src/members/dto/role/update-member-role.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { UserRole } from '../../../user/const/user-role.enum';
+import { IsIn } from 'class-validator';
+
+export class UpdateMemberRoleDto {
+  @ApiProperty({
+    description: '변경할 권한',
+    enum: UserRole,
+  })
+  @IsIn([UserRole.member, UserRole.manager])
+  role: UserRole.member | UserRole.manager;
+}

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -32,7 +32,12 @@ import { VisitationMetaModel } from '../../visitation/entity/visitation-meta.ent
 
 @Entity()
 export class MemberModel extends BaseModel {
+  @Index()
+  @Column({ nullable: true })
+  userId: number;
+
   @OneToOne(() => UserModel, (user) => user.member)
+  @JoinColumn({ name: 'userId' })
   user: UserModel;
 
   @Column()

--- a/backend/src/members/member-domain/service/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/service/interface/members-domain.service.interface.ts
@@ -16,6 +16,7 @@ import { OfficerModel } from '../../../../management/officers/entity/officer.ent
 import { MinistryModel } from '../../../../management/ministries/entity/ministry.entity';
 import { GroupModel } from '../../../../management/groups/entity/group.entity';
 import { GroupRoleModel } from '../../../../management/groups/entity/group-role.entity';
+import { UserModel } from '../../../../user/entity/user.entity';
 
 export const IMEMBERS_DOMAIN_SERVICE = Symbol('IMEMBERS_DOMAIN_SERVICE');
 
@@ -48,6 +49,19 @@ export interface IMembersDomainService {
     qr?: QueryRunner,
     relationOptions?: FindOptionsRelations<MemberModel>,
   ): Promise<MemberModel>;
+
+  findMemberModelByUserId(
+    church: ChurchModel,
+    userId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<MemberModel>,
+  ): Promise<MemberModel>;
+
+  linkUserToMember(
+    member: MemberModel,
+    user: UserModel,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
 
   findDeleteMemberModelById(
     church: ChurchModel,

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -31,6 +31,7 @@ import { OfficerModel } from '../../../management/officers/entity/officer.entity
 import { MinistryModel } from '../../../management/ministries/entity/ministry.entity';
 import { GroupModel } from '../../../management/groups/entity/group.entity';
 import { GroupRoleModel } from '../../../management/groups/entity/group-role.entity';
+import { UserModel } from '../../../user/entity/user.entity';
 
 @Injectable()
 export class MembersDomainService implements IMembersDomainService {
@@ -124,6 +125,52 @@ export class MembersDomainService implements IMembersDomainService {
     }
 
     return member;
+  }
+
+  async findMemberModelByUserId(
+    church: ChurchModel,
+    userId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<MemberModel>,
+  ) {
+    const membersRepository = this.getMembersRepository(qr);
+
+    const member = await membersRepository.findOne({
+      where: {
+        userId,
+        churchId: church.id,
+      },
+      relations: relationOptions,
+    });
+
+    if (!member) {
+      throw new NotFoundException(MemberException.NOT_FOUND);
+    }
+
+    return member;
+  }
+
+  async linkUserToMember(
+    member: MemberModel,
+    user: UserModel,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getMembersRepository(qr);
+
+    const result = await repository.update(
+      {
+        id: member.id,
+      },
+      {
+        user: user,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException('계정 연결 중 에러 발생');
+    }
+
+    return result;
   }
 
   async findMemberModelById(

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -22,7 +22,7 @@ import { GetMemberDto } from '../../dto/get-member.dto';
 import { MemberPaginationResultDto } from '../../dto/member-pagination-result.dto';
 import {
   DefaultMemberRelationOption,
-  DefaultMembersSelectOption,
+  DefaultMemberSelectOption,
 } from '../../const/default-find-options.const';
 import { MemberException } from '../../const/exception/member.exception';
 import { CreateMemberDto } from '../../dto/create-member.dto';
@@ -117,7 +117,7 @@ export class MembersDomainService implements IMembersDomainService {
         churchId: church.id,
       },
       relations: DefaultMemberRelationOption,
-      select: DefaultMembersSelectOption,
+      select: DefaultMemberSelectOption,
     });
 
     if (!member) {

--- a/backend/src/members/members.module.ts
+++ b/backend/src/members/members.module.ts
@@ -11,19 +11,20 @@ import { EducationDomainModule } from '../management/educations/service/educatio
 import { MembersDomainModule } from './member-domain/members-domain.module';
 import { ISEARCH_MEMBERS_SERVICE } from './service/interface/search-members.service.interface';
 import { FamilyRelationDomainModule } from '../family-relation/family-relation-domain/family-relation-domain.module';
+import { UserMembersController } from './controller/user-members.controller';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([MemberModel, ChurchModel]),
     RouterModule.register([
-      { path: 'churches/:churchId/members', module: MembersModule },
+      { path: 'churches/:churchId', module: MembersModule },
     ]),
     ChurchesDomainModule,
     MembersDomainModule,
     FamilyRelationDomainModule,
     EducationDomainModule,
   ],
-  controllers: [MembersController],
+  controllers: [MembersController, UserMembersController],
   providers: [
     MembersService,
     {

--- a/backend/src/members/members.module.ts
+++ b/backend/src/members/members.module.ts
@@ -12,6 +12,8 @@ import { MembersDomainModule } from './member-domain/members-domain.module';
 import { ISEARCH_MEMBERS_SERVICE } from './service/interface/search-members.service.interface';
 import { FamilyRelationDomainModule } from '../family-relation/family-relation-domain/family-relation-domain.module';
 import { UserMembersController } from './controller/user-members.controller';
+import { UserDomainModule } from '../user/user-domain/user-domain.module';
+import { UserMembersService } from './service/user-members.service';
 
 @Module({
   imports: [
@@ -19,6 +21,7 @@ import { UserMembersController } from './controller/user-members.controller';
     RouterModule.register([
       { path: 'churches/:churchId', module: MembersModule },
     ]),
+    UserDomainModule,
     ChurchesDomainModule,
     MembersDomainModule,
     FamilyRelationDomainModule,
@@ -27,6 +30,7 @@ import { UserMembersController } from './controller/user-members.controller';
   controllers: [MembersController, UserMembersController],
   providers: [
     MembersService,
+    UserMembersService,
     {
       provide: ISEARCH_MEMBERS_SERVICE,
       useClass: SearchMembersService,

--- a/backend/src/members/service/members.service.ts
+++ b/backend/src/members/service/members.service.ts
@@ -1,6 +1,13 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { MemberModel } from '../entity/member.entity';
-import { FindOptionsOrder, FindOptionsWhere, In, QueryRunner } from 'typeorm';
+import {
+  FindOptionsOrder,
+  FindOptionsWhere,
+  In,
+  IsNull,
+  Not,
+  QueryRunner,
+} from 'typeorm';
 import { CreateMemberDto } from '../dto/create-member.dto';
 import { UpdateMemberDto } from '../dto/update-member.dto';
 import { GetMemberDto } from '../dto/get-member.dto';
@@ -60,6 +67,34 @@ export class MembersService {
         role: In([UserRole.mainAdmin, UserRole.manager]),
       };
     }
+
+    const orderOptions: FindOptionsOrder<MemberModel> =
+      this.searchMembersService.parseOrderOption(dto);
+
+    const relationOptions = this.searchMembersService.parseRelationOption(dto);
+
+    const selectOptions = this.searchMembersService.parseSelectOption(dto);
+
+    return this.membersDomainService.findMembers(
+      dto,
+      whereOptions,
+      orderOptions,
+      relationOptions,
+      selectOptions,
+      qr,
+    );
+  }
+
+  async getUserMembers(churchId: number, dto: GetMemberDto, qr?: QueryRunner) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const whereOptions: FindOptionsWhere<MemberModel> =
+      this.searchMembersService.parseWhereOption(church, dto);
+
+    whereOptions.userId = Not(IsNull());
 
     const orderOptions: FindOptionsOrder<MemberModel> =
       this.searchMembersService.parseOrderOption(dto);

--- a/backend/src/members/service/members.service.ts
+++ b/backend/src/members/service/members.service.ts
@@ -1,13 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { MemberModel } from '../entity/member.entity';
-import {
-  FindOptionsOrder,
-  FindOptionsWhere,
-  In,
-  IsNull,
-  Not,
-  QueryRunner,
-} from 'typeorm';
+import { FindOptionsOrder, FindOptionsWhere, QueryRunner } from 'typeorm';
 import { CreateMemberDto } from '../dto/create-member.dto';
 import { UpdateMemberDto } from '../dto/update-member.dto';
 import { GetMemberDto } from '../dto/get-member.dto';
@@ -31,7 +24,6 @@ import {
   IFAMILY_RELATION_DOMAIN_SERVICE,
   IFamilyRelationDomainService,
 } from '../../family-relation/family-relation-domain/service/interface/family-relation-domain.service.interface';
-import { UserRole } from '../../user/const/user-role.enum';
 
 @Injectable()
 export class MembersService {
@@ -48,12 +40,7 @@ export class MembersService {
     private readonly familyDomainService: IFamilyRelationDomainService,
   ) {}
 
-  async getMembers(
-    churchId: number,
-    dto: GetMemberDto,
-    qr?: QueryRunner,
-    findManager?: boolean,
-  ) {
+  async getMembers(churchId: number, dto: GetMemberDto, qr?: QueryRunner) {
     const church = await this.churchesDomainService.findChurchModelById(
       churchId,
       qr,
@@ -61,40 +48,6 @@ export class MembersService {
 
     const whereOptions: FindOptionsWhere<MemberModel> =
       this.searchMembersService.parseWhereOption(church, dto);
-
-    if (findManager) {
-      whereOptions.user = {
-        role: In([UserRole.mainAdmin, UserRole.manager]),
-      };
-    }
-
-    const orderOptions: FindOptionsOrder<MemberModel> =
-      this.searchMembersService.parseOrderOption(dto);
-
-    const relationOptions = this.searchMembersService.parseRelationOption(dto);
-
-    const selectOptions = this.searchMembersService.parseSelectOption(dto);
-
-    return this.membersDomainService.findMembers(
-      dto,
-      whereOptions,
-      orderOptions,
-      relationOptions,
-      selectOptions,
-      qr,
-    );
-  }
-
-  async getUserMembers(churchId: number, dto: GetMemberDto, qr?: QueryRunner) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const whereOptions: FindOptionsWhere<MemberModel> =
-      this.searchMembersService.parseWhereOption(church, dto);
-
-    whereOptions.userId = Not(IsNull());
 
     const orderOptions: FindOptionsOrder<MemberModel> =
       this.searchMembersService.parseOrderOption(dto);
@@ -154,14 +107,6 @@ export class MembersService {
         dto.relation,
         qr,
       );
-
-      /*await this.fetchFamilyRelation(
-        churchId,
-        newMember.id,
-        dto.familyMemberId,
-        dto.relation,
-        qr,
-      );*/
     }
 
     return newMember;
@@ -225,132 +170,4 @@ export class MembersService {
 
     return new ResponseDeleteDto(true, targetMember.id);
   }
-
-  /*async getFamilyRelation(
-    churchId: number,
-    memberId: number,
-    qr?: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const member = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-      qr,
-      {},
-    );
-
-    //return this.familyService.getFamilyRelations(member);
-  }*/
-
-  /*async createFamilyRelation(
-    churchId: number,
-    memberId: number,
-    dto: CreateFamilyRelationDto,
-    qr: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const [member, familyMember] = await Promise.all([
-      this.membersDomainService.findMemberModelById(church, memberId, qr, {}),
-      this.membersDomainService.findMemberModelById(
-        church,
-        dto.familyMemberId,
-        qr,
-        {},
-      ),
-    ]);
-
-    /!*return this.familyService.createFamilyMember(
-      member,
-      familyMember,
-      dto.relation,
-      qr,
-    );*!/
-  }*/
-
-  /*async fetchFamilyRelation(
-    churchId: number,
-    memberId: number,
-    familyMemberId: number,
-    relation: string,
-    qr: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const [member, familyMember] = await Promise.all([
-      this.membersDomainService.findMemberModelById(church, memberId, qr, {}),
-      this.membersDomainService.findMemberModelById(
-        church,
-        familyMemberId,
-        qr,
-        {},
-      ),
-    ]);
-
-    /!*return this.familyService.fetchAndCreateFamilyRelation(
-      member,
-      familyMember,
-      relation,
-      qr,
-    );*!/
-  }*/
-
-  /*async patchFamilyRelation(
-    churchId: number,
-    memberId: number,
-    familyMemberId: number,
-    relation: string,
-    qr: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const [me, family] = await Promise.all([
-      this.membersDomainService.findMemberModelById(church, memberId, qr, {}),
-      this.membersDomainService.findMemberModelById(
-        church,
-        familyMemberId,
-        qr,
-        {},
-      ),
-    ]);
-
-    //return this.familyService.updateFamilyRelation(me, family, relation, qr);
-  }*/
-
-  /*async deleteFamilyRelation(
-    churchId: number,
-    memberId: number,
-    familyMemberId: number,
-    qr?: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const [me, family] = await Promise.all([
-      this.membersDomainService.findMemberModelById(church, memberId, qr, {}),
-      this.membersDomainService.findMemberModelById(
-        church,
-        familyMemberId,
-        qr,
-        {},
-      ),
-    ]);
-
-    //return this.familyService.deleteFamilyRelation(me, family, qr);
-  }*/
 }

--- a/backend/src/members/service/user-members.service.ts
+++ b/backend/src/members/service/user-members.service.ts
@@ -1,0 +1,110 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IUSER_DOMAIN_SERVICE,
+  IUserDomainService,
+} from '../../user/user-domain/interface/user-domain.service.interface';
+import {
+  IMEMBERS_DOMAIN_SERVICE,
+  IMembersDomainService,
+} from '../member-domain/service/interface/members-domain.service.interface';
+import {
+  ISEARCH_MEMBERS_SERVICE,
+  ISearchMembersService,
+} from './interface/search-members.service.interface';
+import {
+  FindOptionsOrder,
+  FindOptionsWhere,
+  In,
+  IsNull,
+  Not,
+  QueryRunner,
+} from 'typeorm';
+import { MemberModel } from '../entity/member.entity';
+import { UpdateMemberRoleDto } from '../dto/role/update-member-role.dto';
+import { UpdateUserDto } from '../../user/dto/update-user.dto';
+import { GetUserMemberDto } from '../dto/get-user-member.dto';
+
+@Injectable()
+export class UserMembersService {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IUSER_DOMAIN_SERVICE)
+    private readonly userDomainService: IUserDomainService,
+    @Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,
+    @Inject(ISEARCH_MEMBERS_SERVICE)
+    private readonly searchMembersService: ISearchMembersService,
+  ) {}
+
+  async getUserMembers(
+    churchId: number,
+    dto: GetUserMemberDto,
+    qr?: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const whereOptions: FindOptionsWhere<MemberModel> =
+      this.searchMembersService.parseWhereOption(church, dto);
+
+    whereOptions.userId = Not(IsNull());
+    whereOptions.user = { role: dto.userRole && In(dto.userRole) };
+
+    const orderOptions: FindOptionsOrder<MemberModel> =
+      this.searchMembersService.parseOrderOption(dto);
+
+    const relationOptions = this.searchMembersService.parseRelationOption(dto);
+
+    const selectOptions = this.searchMembersService.parseSelectOption(dto);
+
+    return this.membersDomainService.findMembers(
+      dto,
+      whereOptions,
+      orderOptions,
+      relationOptions,
+      selectOptions,
+      qr,
+    );
+  }
+
+  async updateMemberRole(
+    churchId: number,
+    memberId: number,
+    dto: UpdateMemberRoleDto,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const member = await this.membersDomainService.findMemberModelById(
+      church,
+      memberId,
+      undefined,
+      { user: true },
+    );
+
+    if (!member.userId) {
+      throw new BadRequestException('계정 연동이 되어있지 않은 교인입니다.');
+    }
+
+    if (member.user.role === dto.role) {
+      throw new BadRequestException('이미 동일한 권한입니다.');
+    }
+
+    const user = await this.userDomainService.findUserById(member.userId);
+
+    const updateUserDto: UpdateUserDto = {
+      role: dto.role,
+    };
+
+    await this.userDomainService.updateUser(user, updateUserDto);
+
+    return this.membersDomainService.findMemberById(church, memberId);
+  }
+}

--- a/backend/src/user/entity/user.entity.ts
+++ b/backend/src/user/entity/user.entity.ts
@@ -51,11 +51,11 @@ export class UserModel extends BaseModel {
   @OneToMany(() => ChurchJoinRequestModel, (joinRequest) => joinRequest.user)
   joinRequest: ChurchJoinRequestModel;
 
-  @Index()
+  /*@Index()
   @Column({ nullable: true })
-  memberId: number;
+  memberId: number;*/
 
   @OneToOne(() => MemberModel, (member) => member.user)
-  @JoinColumn({ name: 'memberId' })
+  //@JoinColumn({ name: 'memberId' })
   member: MemberModel;
 }

--- a/backend/src/user/exception/user.exception.ts
+++ b/backend/src/user/exception/user.exception.ts
@@ -1,6 +1,8 @@
 export const UserException = {
   NOT_FOUND: '사용자를 찾을 수 없습니다.',
+  ALREADY_EXIST: '이미 가입된 계정입니다.',
   ALREADY_JOINED: '이미 소속된 교회가 있습니다.',
+  CANNOT_CREATE_CHURCH: '소속된 교회가 있을 경우, 교회를 생성할 수 없습니다.',
   UPDATE_ERROR: '사용자 업데이트 도중 에러 발생',
   DELETE_ERROR: '사용자 삭제 도중 에러 발생',
 };

--- a/backend/src/user/user-domain/interface/user-domain.service.interface.ts
+++ b/backend/src/user/user-domain/interface/user-domain.service.interface.ts
@@ -11,8 +11,6 @@ export const IUSER_DOMAIN_SERVICE = Symbol('IUserDomainService');
 export interface IUserDomainService {
   findUserById(id: number, qr?: QueryRunner): Promise<UserModel>;
 
-  //getMemberIdByUserId(id: number, qr?: QueryRunner): Promise<number>;
-
   findUserModelByOAuth(
     provider: string,
     providerId: string,
@@ -47,4 +45,12 @@ export interface IUserDomainService {
     user: UserModel,
     qr?: QueryRunner,
   ): Promise<UserModel>;
+
+  findMainAdminUser(church: ChurchModel, qr?: QueryRunner): Promise<UserModel>;
+
+  transferMainAdmin(
+    beforeMainAdmin: UserModel,
+    newMainAdmin: UserModel,
+    qr: QueryRunner,
+  ): Promise<void>;
 }

--- a/backend/src/user/user-domain/interface/user-domain.service.interface.ts
+++ b/backend/src/user/user-domain/interface/user-domain.service.interface.ts
@@ -11,7 +11,7 @@ export const IUSER_DOMAIN_SERVICE = Symbol('IUserDomainService');
 export interface IUserDomainService {
   findUserById(id: number, qr?: QueryRunner): Promise<UserModel>;
 
-  getMemberIdByUserId(id: number, qr?: QueryRunner): Promise<number>;
+  //getMemberIdByUserId(id: number, qr?: QueryRunner): Promise<number>;
 
   findUserModelByOAuth(
     provider: string,

--- a/backend/src/user/user-domain/user-domain.service.ts
+++ b/backend/src/user/user-domain/user-domain.service.ts
@@ -3,7 +3,6 @@ import {
   Injectable,
   InternalServerErrorException,
   NotFoundException,
-  UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserModel } from '../entity/user.entity';
@@ -46,7 +45,7 @@ export class UserDomainService implements IUserDomainService {
     return user;
   }
 
-  async getMemberIdByUserId(id: number, qr?: QueryRunner) {
+  /*async getMemberIdByUserId(id: number, qr?: QueryRunner) {
     const userRepository = this.getUserRepository(qr);
 
     const user = await userRepository.findOne({
@@ -60,7 +59,7 @@ export class UserDomainService implements IUserDomainService {
     }
 
     return user.memberId;
-  }
+  }*/
 
   findUserModelByOAuth(provider: string, providerId: string, qr?: QueryRunner) {
     const userRepository = this.getUserRepository(qr);

--- a/backend/src/user/user-domain/user-domain.service.ts
+++ b/backend/src/user/user-domain/user-domain.service.ts
@@ -13,6 +13,7 @@ import { ChurchModel } from '../../churches/entity/church.entity';
 import { UpdateUserDto } from '../dto/update-user.dto';
 import { UserRole } from '../const/user-role.enum';
 import { MemberModel } from '../../members/entity/member.entity';
+import { UserException } from '../exception/user.exception';
 
 @Injectable()
 export class UserDomainService implements IUserDomainService {
@@ -39,27 +40,11 @@ export class UserDomainService implements IUserDomainService {
     });
 
     if (!user) {
-      throw new NotFoundException('존재하지 않는 유저입니다.');
+      throw new NotFoundException(UserException.NOT_FOUND);
     }
 
     return user;
   }
-
-  /*async getMemberIdByUserId(id: number, qr?: QueryRunner) {
-    const userRepository = this.getUserRepository(qr);
-
-    const user = await userRepository.findOne({
-      where: {
-        id,
-      },
-    });
-
-    if (!user) {
-      throw new UnauthorizedException();
-    }
-
-    return user.memberId;
-  }*/
 
   findUserModelByOAuth(provider: string, providerId: string, qr?: QueryRunner) {
     const userRepository = this.getUserRepository(qr);
@@ -89,7 +74,7 @@ export class UserDomainService implements IUserDomainService {
     const isExistUser = await this.isExistUser(dto.provider, dto.providerId);
 
     if (isExistUser) {
-      throw new BadRequestException('이미 가입된 계정입니다.');
+      throw new BadRequestException(UserException.ALREADY_EXIST);
     }
 
     const userRepository = this.getUserRepository(qr);
@@ -114,9 +99,7 @@ export class UserDomainService implements IUserDomainService {
 
   isAbleToCreateChurch(user: UserModel): boolean {
     if (user.role !== UserRole.none) {
-      throw new BadRequestException(
-        '소속된 교회가 있을 경우, 교회를 생성할 수 없습니다.',
-      );
+      throw new BadRequestException(UserException.CANNOT_CREATE_CHURCH);
     }
 
     return true;
@@ -168,9 +151,51 @@ export class UserDomainService implements IUserDomainService {
     });
 
     if (!updatedUser) {
-      throw new InternalServerErrorException('교인 연결 중 에러 발생');
+      throw new InternalServerErrorException(UserException.UPDATE_ERROR);
     }
 
     return updatedUser;
+  }
+
+  async findMainAdminUser(
+    church: ChurchModel,
+    qr?: QueryRunner,
+  ): Promise<UserModel> {
+    const userRepository = this.getUserRepository(qr);
+
+    const mainAdmin = await userRepository.findOne({
+      where: {
+        churchId: church.id,
+        role: UserRole.mainAdmin,
+      },
+      relations: {
+        member: true,
+      },
+    });
+
+    if (!mainAdmin) {
+      throw new NotFoundException(UserException.NOT_FOUND);
+    }
+
+    return mainAdmin;
+  }
+
+  async transferMainAdmin(
+    beforeMainAdmin: UserModel,
+    newMainAdmin: UserModel,
+    qr: QueryRunner,
+  ) {
+    const userRepository = this.getUserRepository(qr);
+
+    await Promise.all([
+      userRepository.update(
+        { id: beforeMainAdmin.id },
+        { role: UserRole.manager },
+      ),
+      userRepository.update(
+        { id: newMainAdmin.id },
+        { role: UserRole.mainAdmin },
+      ),
+    ]);
   }
 }

--- a/backend/src/visitation/visitation.service.ts
+++ b/backend/src/visitation/visitation.service.ts
@@ -124,16 +124,17 @@ export class VisitationService {
       qr,
     );
 
-    const creatorMemberId = await this.userDomainService.getMemberIdByUserId(
+    /*const creatorMemberId = await this.userDomainService.getMemberIdByUserId(
       accessPayload.id,
       qr,
-    );
+    );*/
 
-    const creatorMember = await this.membersDomainService.findMemberModelById(
-      church,
-      creatorMemberId,
-      qr,
-    );
+    const creatorMember =
+      await this.membersDomainService.findMemberModelByUserId(
+        church,
+        accessPayload.id,
+        qr,
+      );
     /*await this.membersDomainService.findMemberModelByUserId(
         church,
         accessPayload.id,


### PR DESCRIPTION
## 주요 내용  
계정 연동 교인의 권한을 안전하게 수정할 수 있는 기능과  
교회의 최고 관리자(mainAdmin) 권한을 다른 관리자(manager)에게 양도할 수 있는 기능을 추가하였습니다.  
또한, 계정 연동 교인 전용 API를 통해 역할 기반 조회 및 관리가 가능하도록 개선하였습니다.  

## 세부 내용  

### 계정 연동 교인 권한 수정 기능  
- `PATCH /churches/{churchId}/user-members/{memberId}/role`  
  - `manager`, `member` 간 권한 변경 가능  
  - 같은 권한으로의 변경 요청은 허용되지 않음 (`BadRequestException`)  
  - `mainAdmin`으로의 권한 승격은 금지  
- `GET /churches/{churchId}/user-members`  
  - 계정 연동된 교인만 필터링하여 조회  
  - 역할 기반 필터링 지원 (`mainAdmin`, `manager`, `member`)  
- 모든 교인 응답에 `user.role` 필드 추가 (연동되지 않은 경우 `null`)  

### mainAdmin 양도 기능 추가  
- `PATCH /churches/{churchId}/main-admin`  
  - 교회의 mainAdmin 권한을 다른 `manager`에게 양도 가능  
  - 양도 후, 기존 mainAdmin은 `manager`로 자동 권한 변경  
  - 자신에게 양도하는 요청은 차단 (`BadRequestException`)  
  - 대상 교인은 동일 교회 소속이어야 하며 `manager` 권한 필요  

이번 PR을 통해 교회의 사용자 권한 관리가 더욱 명확하고 안전하게 정비되었으며,  
mainAdmin 권한 이전과 계정 연동 교인에 대한 관리 기능이 완성되었습니다.  
