### PR TITLE
feat: 교회 교인 수(memberCount) 속성 추가 및 자동 관리 기능 도입

### DIFF
--- a/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
+++ b/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
@@ -48,4 +48,14 @@ export interface IChurchesDomainService {
     newCode: string,
     qr: QueryRunner | undefined,
   ): Promise<UpdateResult>;
+
+  incrementMemberCount(
+    church: ChurchModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  decrementMemberCount(
+    church: ChurchModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
 }

--- a/backend/src/churches/churches-domain/service/churhes-domain.service.ts
+++ b/backend/src/churches/churches-domain/service/churhes-domain.service.ts
@@ -286,4 +286,42 @@ export class ChurchesDomainService implements IChurchesDomainService {
       )
       .map((manager) => manager.id);
   }
+
+  async incrementMemberCount(
+    church: ChurchModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const churchesRepository = this.getChurchRepository(qr);
+
+    const result = await churchesRepository.increment(
+      { id: church.id },
+      'memberCount',
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(ChurchException.UPDATE_ERROR);
+    }
+
+    return result;
+  }
+
+  async decrementMemberCount(
+    church: ChurchModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const churchesRepository = this.getChurchRepository(qr);
+
+    const result = await churchesRepository.decrement(
+      { id: church.id },
+      'memberCount',
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(ChurchException.UPDATE_ERROR);
+    }
+
+    return result;
+  }
 }

--- a/backend/src/churches/controller/churches.controller.ts
+++ b/backend/src/churches/controller/churches.controller.ts
@@ -13,7 +13,7 @@ import {
 import { ChurchesService } from '../service/churches.service';
 import { CreateChurchDto } from '../dto/create-church.dto';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
-import { ApiBearerAuth } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import { Token } from '../../auth/decorator/jwt.decorator';
 import { JwtAccessPayload } from '../../auth/type/jwt';
 import {
@@ -85,6 +85,9 @@ export class ChurchesController {
     return this.churchesService.deleteChurchById(churchId);
   }
 
+  @ApiOperation({
+    summary: '가입 코드 수정',
+  })
   @Patch(':churchId/join-code')
   @UseGuards(AccessTokenGuard, ChurchMainAdminGuard)
   @UseInterceptors(TransactionInterceptor)
@@ -100,6 +103,9 @@ export class ChurchesController {
     );
   }
 
+  @ApiOperation({
+    summary: '최고 관리자(mainAdmin) 양도',
+  })
   @Patch(':churchId/main-admin')
   @UseGuards(AccessTokenGuard, ChurchMainAdminGuard)
   @UseInterceptors(TransactionInterceptor)
@@ -117,5 +123,14 @@ export class ChurchesController {
       dto,
       qr,
     );
+  }
+
+  @ApiOperation({
+    summary: '교인 수 새로고침',
+  })
+  @Patch(':churchId/refresh-member-count')
+  @UseGuards(AccessTokenGuard, ChurchMainAdminGuard)
+  refreshMemberCount(@Param('churchId', ParseIntPipe) churchId: number) {
+    return this.churchesService.refreshMemberCount(churchId);
   }
 }

--- a/backend/src/churches/dto/update-church.dto.ts
+++ b/backend/src/churches/dto/update-church.dto.ts
@@ -1,6 +1,8 @@
-import { OmitType, PartialType, PickType } from '@nestjs/swagger';
+import { OmitType, PartialType } from '@nestjs/swagger';
 import { CreateChurchDto } from './create-church.dto';
 
 export class UpdateChurchDto extends PartialType(
   OmitType(CreateChurchDto, ['name', 'identifyNumber', 'denomination']),
-) {}
+) {
+  memberCount?: number;
+}

--- a/backend/src/churches/entity/church.entity.ts
+++ b/backend/src/churches/entity/church.entity.ts
@@ -41,6 +41,9 @@ export class ChurchModel extends BaseModel {
   @Column({ enum: MemberSize, nullable: true })
   memberSize: MemberSize;
 
+  @Column({ default: 0 })
+  memberCount: number;
+
   @OneToMany(() => UserModel, (user) => user.church)
   users: UserModel[];
 

--- a/backend/src/churches/service/churches.service.ts
+++ b/backend/src/churches/service/churches.service.ts
@@ -159,4 +159,22 @@ export class ChurchesService {
 
     return this.churchesDomainService.findChurchById(churchId, qr);
   }
+
+  async refreshMemberCount(churchId: number, qr?: QueryRunner) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const memberCount = await this.membersDomainService.countAllMembers(
+      church,
+      qr,
+    );
+
+    const updateChurchDto: UpdateChurchDto = {
+      memberCount,
+    };
+
+    return this.churchesDomainService.updateChurch(church, updateChurchDto);
+  }
 }

--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -37,6 +37,8 @@ export interface IMembersDomainService {
     relationOptions?: FindOptionsRelations<MemberModel>,
   ): Promise<MemberModel[]>;
 
+  countAllMembers(church: ChurchModel, qr?: QueryRunner): Promise<number>;
+
   findMemberById(
     church: ChurchModel,
     memberId: number,

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -81,6 +81,16 @@ export class MembersDomainService implements IMembersDomainService {
     return resultDto;
   }
 
+  async countAllMembers(church: ChurchModel, qr?: QueryRunner) {
+    const membersRepository = this.getMembersRepository(qr);
+
+    return membersRepository.count({
+      where: {
+        churchId: church.id,
+      },
+    });
+  }
+
   async findMembersById(
     church: ChurchModel,
     ids: number[],

--- a/backend/src/members/service/members.service.ts
+++ b/backend/src/members/service/members.service.ts
@@ -38,8 +38,6 @@ export class MembersService {
     private readonly searchMembersService: ISearchMembersService,
     @Inject(IFAMILY_RELATION_DOMAIN_SERVICE)
     private readonly familyDomainService: IFamilyRelationDomainService,
-
-    //@Inject(IEDUCATION_TERM_DOMAIN_SERVICE)
   ) {}
 
   async getMembers(churchId: number, dto: GetMemberDto, qr?: QueryRunner) {
@@ -88,6 +86,10 @@ export class MembersService {
       churchId,
       qr,
     );
+
+    // 교회의 교인 수 증가
+    await this.churchesDomainService.incrementMemberCount(church, qr);
+    church.memberCount++;
 
     const newMember = await this.membersDomainService.createMember(
       church,
@@ -162,6 +164,9 @@ export class MembersService {
 
     // 가족 관계 모두 삭제
     await this.familyDomainService.deleteAllFamilyRelations(targetMember, qr);
+
+    // 교회 교인 수 감소
+    await this.churchesDomainService.decrementMemberCount(church, qr);
 
     // 이벤트는 트랜잭션 처리 불가능 본 요청과 이벤트 요청은 서로 달라서 본 요청 응답이 나갈 때
     // 트랜잭션이 끝나게 되어 이벤트 요청에서 트랜잭션 처리를 할 수 없음


### PR DESCRIPTION
## 주요 내용
`Church` 엔티티에 교인 수(`memberCount`) 속성을 추가하고,
교인 추가/삭제 시 자동으로 갱신되도록 처리하였으며,
정합성 유지를 위한 수동 리프레시 엔드포인트도 추가하였습니다.

## 세부 내용
- `Church` 모델에 `memberCount` 필드 추가
- 교인 생성 시 `memberCount` +1, 삭제 시 `memberCount` -1 처리
- `/churches/{churchId}/refresh-member-count` 엔드포인트 추가
  - 실제 교인 수를 기준으로 `memberCount`를 재계산
  - 데이터 불일치 상황에 대비한 수동 동기화 용도

이번 기능 추가로 교회의 교인 수를 빠르게 조회할 수 있으며,
정확한 통계를 유지할 수 있도록 자동 및 수동 업데이트 체계를 함께 제공합니다.