### PR TITLE
feat: 심방 피보고자 및 대상자 관리 기능 추가 및 상세 엔드포인트 분리  

### DIFF
--- a/backend/src/common/const/http-status-text.const.ts
+++ b/backend/src/common/const/http-status-text.const.ts
@@ -1,0 +1,10 @@
+import { HttpStatus } from '@nestjs/common';
+
+export const HttpStatusText = {
+  [HttpStatus.BAD_REQUEST]: 'Bad Request',
+  [HttpStatus.UNAUTHORIZED]: 'Unauthorized',
+  [HttpStatus.FORBIDDEN]: 'Forbidden',
+  [HttpStatus.NOT_FOUND]: 'Not Found',
+  [HttpStatus.CONFLICT]: 'Conflict',
+  [HttpStatus.INTERNAL_SERVER_ERROR]: 'Internal Server Error',
+};

--- a/backend/src/report/entity/report.entity.ts
+++ b/backend/src/report/entity/report.entity.ts
@@ -1,16 +1,18 @@
 import { BaseModel } from '../../common/entity/base.entity';
 import { MemberModel } from '../../members/entity/member.entity';
-import { Column, Entity, ManyToOne, TableInheritance } from 'typeorm';
+import { Column, Entity, Index, ManyToOne, TableInheritance } from 'typeorm';
 
 @Entity()
 @TableInheritance({ column: { type: 'varchar', name: 'reportType' } })
 export abstract class ReportModel extends BaseModel {
+  @Index()
   @Column()
   senderId: number;
 
   @ManyToOne(() => MemberModel)
   sender: MemberModel;
 
+  @Index()
   @Column()
   receiverId: number;
 

--- a/backend/src/report/entity/visitation-report.entity.ts
+++ b/backend/src/report/entity/visitation-report.entity.ts
@@ -1,9 +1,10 @@
-import { ChildEntity, Column, ManyToOne } from 'typeorm';
+import { ChildEntity, Column, Index, ManyToOne } from 'typeorm';
 import { VisitationMetaModel } from '../../visitation/entity/visitation-meta.entity';
 import { ReportModel } from './report.entity';
 
 @ChildEntity('VISITATION')
 export class VisitationReportModel extends ReportModel {
+  @Index()
   @Column()
   visitationId: number;
 

--- a/backend/src/report/report-domain/interface/visitation-report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/visitation-report-domain.service.interface.ts
@@ -47,4 +47,9 @@ export interface IVisitationReportDomainService {
     visitationReport: VisitationReportModel,
     qr?: QueryRunner,
   ): Promise<UpdateResult>;
+
+  deleteVisitationReports(
+    visitationReports: VisitationReportModel[],
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
 }

--- a/backend/src/report/report-domain/service/visitation-report-domain.service.ts
+++ b/backend/src/report/report-domain/service/visitation-report-domain.service.ts
@@ -16,6 +16,7 @@ import {
 } from '@nestjs/common';
 import { VisitationReportException } from '../../const/exception/visitation-report.exception';
 import { UpdateVisitationReportDto } from '../../dto/visitation-report/update-visitation-report.dto';
+import { ReportModel } from '../../entity/report.entity';
 
 export class VisitationReportDomainService
   implements IVisitationReportDomainService
@@ -176,5 +177,16 @@ export class VisitationReportDomainService
     }
 
     return result;
+  }
+
+  async deleteVisitationReports(
+    visitationReports: ReportModel[],
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    const reportIds = visitationReports.map((r) => r.id);
+
+    return repository.softDelete(reportIds);
   }
 }

--- a/backend/src/visitation/const/exception/add-conflict.exception.ts
+++ b/backend/src/visitation/const/exception/add-conflict.exception.ts
@@ -1,0 +1,13 @@
+import { ConflictException, HttpStatus } from '@nestjs/common';
+import { HttpStatusText } from '../../../common/const/http-status-text.const';
+
+export class AddConflictException extends ConflictException {
+  constructor(message: string, duplicatedIds: number[]) {
+    super({
+      message,
+      duplicatedIds,
+      error: HttpStatusText[HttpStatus.CONFLICT],
+      statusCode: HttpStatus.CONFLICT,
+    });
+  }
+}

--- a/backend/src/visitation/const/exception/remove-conflict.exception.ts
+++ b/backend/src/visitation/const/exception/remove-conflict.exception.ts
@@ -1,0 +1,13 @@
+import { ConflictException, HttpStatus } from '@nestjs/common';
+import { HttpStatusText } from '../../../common/const/http-status-text.const';
+
+export class RemoveConflictException extends ConflictException {
+  constructor(message: string, notExistIds: number[]) {
+    super({
+      message,
+      notExistIds,
+      error: HttpStatusText[HttpStatus.CONFLICT],
+      statusCode: HttpStatus.CONFLICT,
+    });
+  }
+}

--- a/backend/src/visitation/const/exception/visitation.exception.ts
+++ b/backend/src/visitation/const/exception/visitation.exception.ts
@@ -5,12 +5,15 @@ export const VisitationException = {
   UPDATE_ERROR: '심방 데이터 업데이트 도중 에러 발생',
   DELETE_ERROR: '심방 데이터 삭제 도중 에러 발생',
 
-  ALREADY_EXIST_TARGET_MEMBER: (alreadyExistMember: number[]) =>
-    `이미 존재하는 심방 대상자입니다. 존재하는 교인 id: [${alreadyExistMember.join(', ')}]`,
-  NOT_EXIST_DELETE_TARGET_MEMBER: (notExistMemberId: number[]) =>
-    `삭제 대상자가 심방 대상자에 포함되어 있지 않습니다. 존재하지 않는 교인 id: [${notExistMemberId.join(', ')}]`,
+  ALREADY_EXIST_TARGET_MEMBER: `이미 존재하는 심방 대상자입니다. `,
+  NOT_EXIST_DELETE_TARGET_MEMBER: `삭제 대상자가 심방 대상자에 포함되어 있지 않습니다. `,
 
   MEMBER_RELATION_ERROR: '심방 대상자 불러오기 실패',
+
+  INVALID_REPORT_RECEIVER:
+    '피보고자로 등록할 수 없는 교인이 포함되어 있습니다.',
+  ALREADY_REPORTED_MEMBER: '이미 피보고자로 등록된 교인입니다.',
+  NOT_EXIST_REPORTED_MEMBER: '삭제 대상자가 피보고자에 포함되어 있지 않습니다.',
 };
 
 export const VisitationDetailException = {

--- a/backend/src/visitation/controller/visitation-detail.controller.ts
+++ b/backend/src/visitation/controller/visitation-detail.controller.ts
@@ -1,0 +1,27 @@
+import { Body, Controller, Param, ParseIntPipe, Patch } from '@nestjs/common';
+import { ApiPatchVisitationDetail } from '../const/swagger/visitation.swagger';
+import { UpdateVisitationDetailDto } from '../dto/internal/detail/update-visitation-detail.dto';
+import { VisitationService } from '../visitation.service';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('Visitations:Details')
+@Controller('visitations/:visitationId/details')
+export class VisitationDetailController {
+  constructor(private readonly visitationService: VisitationService) {}
+
+  @ApiPatchVisitationDetail()
+  @Patch(':detailId')
+  patchVisitationDetail(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('visitationId', ParseIntPipe) visitationId: number,
+    @Param('detailId', ParseIntPipe) detailId: number,
+    @Body() dto: UpdateVisitationDetailDto,
+  ) {
+    return this.visitationService.updateVisitationDetail(
+      churchId,
+      visitationId,
+      detailId,
+      dto,
+    );
+  }
+}

--- a/backend/src/visitation/controller/visitation.controller.ts
+++ b/backend/src/visitation/controller/visitation.controller.ts
@@ -11,7 +11,7 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { VisitationService } from '../visitation.service';
 import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
@@ -27,13 +27,13 @@ import {
   ApiDeleteVisitation,
   ApiGetVisitationById,
   ApiGetVisitations,
-  ApiPatchVisitationDetail,
   ApiPatchVisitationMeta,
   ApiPostVisitation,
 } from '../const/swagger/visitation.swagger';
 import { UpdateVisitationDto } from '../dto/update-visitation.dto';
 import { VisitationPaginationResultDto } from '../dto/visitation-pagination-result.dto';
-import { UpdateVisitationDetailDto } from '../dto/internal/detail/update-visitation-detail.dto';
+import { AddReceiverDto } from '../dto/add-receiver.dto';
+import { DeleteReceiverDto } from '../dto/delete-receiver.dto';
 
 @ApiTags('Visitations')
 @Controller('visitations')
@@ -111,19 +111,41 @@ export class VisitationController {
     return this.visitationService.deleteVisitation(churchId, visitationId, qr);
   }
 
-  @ApiPatchVisitationDetail()
-  @Patch(':detailId')
-  patchVisitationDetail(
+  @ApiOperation({
+    summary: '심방 보고자 추가',
+  })
+  @Patch(':visitationId/add-receivers')
+  @UseInterceptors(TransactionInterceptor)
+  addReportReceivers(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('visitationId', ParseIntPipe) visitationId: number,
-    @Param('detailId', ParseIntPipe) detailId: number,
-    @Body() dto: UpdateVisitationDetailDto,
+    @Body() dto: AddReceiverDto,
+    @QueryRunner() qr: QR,
   ) {
-    return this.visitationService.updateVisitationDetail(
+    return this.visitationService.addReportReceivers(
       churchId,
       visitationId,
-      detailId,
-      dto,
+      dto.receiverIds,
+      qr,
+    );
+  }
+
+  @ApiOperation({
+    summary: '심방 보고자 삭제',
+  })
+  @Patch(':visitationId/delete-receivers')
+  @UseInterceptors(TransactionInterceptor)
+  removeReportReceivers(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('visitationId', ParseIntPipe) visitationId: number,
+    @Body() dto: DeleteReceiverDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.visitationService.deleteReportReceivers(
+      churchId,
+      visitationId,
+      dto.receiverIds,
+      qr,
     );
   }
 }

--- a/backend/src/visitation/dto/add-receiver.dto.ts
+++ b/backend/src/visitation/dto/add-receiver.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { CreateVisitationDto } from './create-visitation.dto';
+import { IsArray, IsNumber, IsOptional, Min } from 'class-validator';
+
+export class AddReceiverDto extends PickType(CreateVisitationDto, [
+  'receiverIds',
+]) {
+  @ApiProperty({
+    description: '심방 피보고자 ID',
+    isArray: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsArray()
+  @IsNumber({}, { each: true })
+  @Min(1, { each: true })
+  override receiverIds: number[];
+}

--- a/backend/src/visitation/dto/create-visitation.dto.ts
+++ b/backend/src/visitation/dto/create-visitation.dto.ts
@@ -79,7 +79,6 @@ export class CreateVisitationDto {
     required: false,
   })
   @IsOptional()
-  //@TransformNumberArray()
   @IsArray()
   @IsNumber({}, { each: true })
   @Min(1, { each: true })

--- a/backend/src/visitation/dto/delete-receiver.dto.ts
+++ b/backend/src/visitation/dto/delete-receiver.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { CreateVisitationDto } from './create-visitation.dto';
+import { IsArray, IsNumber, IsOptional, Min } from 'class-validator';
+
+export class DeleteReceiverDto extends PickType(CreateVisitationDto, [
+  'receiverIds',
+]) {
+  @ApiProperty({
+    description: '심방 피보고자 ID',
+    isArray: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsArray()
+  @IsNumber({}, { each: true })
+  @Min(1, { each: true })
+  override receiverIds: number[];
+}

--- a/backend/src/visitation/visitation.module.ts
+++ b/backend/src/visitation/visitation.module.ts
@@ -7,6 +7,7 @@ import { ChurchesDomainModule } from '../churches/churches-domain/churches-domai
 import { UserDomainModule } from '../user/user-domain/user-domain.module';
 import { MembersDomainModule } from '../members/member-domain/members-domain.module';
 import { VisitationReportDomainModule } from '../report/report-domain/visitation-report-domain.module';
+import { VisitationDetailController } from './controller/visitation-detail.controller';
 
 @Module({
   imports: [
@@ -21,7 +22,7 @@ import { VisitationReportDomainModule } from '../report/report-domain/visitation
     VisitationDomainModule,
     VisitationReportDomainModule,
   ],
-  controllers: [VisitationController],
+  controllers: [VisitationController, VisitationDetailController],
   providers: [VisitationService],
 })
 export class VisitationModule {}

--- a/backend/src/visitation/visitation.service.ts
+++ b/backend/src/visitation/visitation.service.ts
@@ -321,7 +321,7 @@ export class VisitationService {
         church,
         visitationMeta,
         dto.deleteMemberIds,
-        visitationMembers,
+        //visitationMembers,
         qr,
       );
 

--- a/backend/src/visitation/visitation.service.ts
+++ b/backend/src/visitation/visitation.service.ts
@@ -1,5 +1,5 @@
 import {
-  ConflictException,
+  BadRequestException,
   ForbiddenException,
   Inject,
   Injectable,
@@ -47,6 +47,8 @@ import {
   IUSER_DOMAIN_SERVICE,
   IUserDomainService,
 } from '../user/user-domain/interface/user-domain.service.interface';
+import { AddConflictException } from './const/exception/add-conflict.exception';
+import { RemoveConflictException } from './const/exception/remove-conflict.exception';
 
 @Injectable()
 export class VisitationService {
@@ -304,100 +306,28 @@ export class VisitationService {
 
     // 교인이 추가되는 경우 추가할 수 있는지 확인
     if (dto.addMemberIds) {
-      const visitationMemberIds = visitationMeta.members.map(
-        (member) => member.id,
-      );
-
-      const alreadyExistMember: number[] = [];
-
-      dto.addMemberIds.forEach((memberId) => {
-        if (visitationMemberIds.includes(memberId)) {
-          alreadyExistMember.push(memberId);
-        }
-      });
-
-      if (alreadyExistMember.length > 0) {
-        throw new ConflictException(
-          VisitationException.ALREADY_EXIST_TARGET_MEMBER(alreadyExistMember),
-        );
-      }
-
-      const newMembers = await this.membersDomainService.findMembersById(
+      await this.handleAddVisitationMembers(
         church,
+        visitationMeta,
         dto.addMemberIds,
+        visitationMembers,
         qr,
-      );
-
-      // 새 심방 대상자 추가
-      visitationMembers.push(...newMembers);
-
-      await Promise.all(
-        dto.addMemberIds.map(async (memberId) => {
-          const member = await this.membersDomainService.findMemberModelById(
-            church,
-            memberId,
-            qr,
-          );
-
-          const detailDto: VisitationDetailDto = {
-            memberId: memberId,
-          };
-
-          return this.visitationDetailDomainService.createVisitationDetail(
-            visitationMeta,
-            member,
-            detailDto,
-            qr,
-          );
-        }),
       );
     }
 
     // 교인이 삭제되는 경우 삭제할 수 있는지 확인
     if (dto.deleteMemberIds) {
-      const visitationMemberIds = visitationMeta.members.map(
-        (member) => member.id,
+      await this.handleDeleteVisitationMembers(
+        church,
+        visitationMeta,
+        dto.deleteMemberIds,
+        visitationMembers,
+        qr,
       );
 
-      const notExistMember: number[] = [];
-
-      // 심방 대상자에 존재하지 않는 id 값 필터링
-      dto.deleteMemberIds.forEach((memberId) => {
-        if (!visitationMemberIds.includes(memberId)) {
-          notExistMember.push(memberId);
-        }
-      });
-
-      if (notExistMember.length > 0) {
-        throw new ConflictException(
-          VisitationException.NOT_EXIST_DELETE_TARGET_MEMBER(notExistMember),
-        );
-      }
-
+      // 삭제되지 않고 남은 교인들
       visitationMembers = visitationMembers.filter(
         (member) => !dto.deleteMemberIds?.includes(member.id),
-      );
-
-      await Promise.all(
-        dto.deleteMemberIds.map(async (memberId) => {
-          const member = await this.membersDomainService.findMemberModelById(
-            church,
-            memberId,
-            qr,
-          );
-
-          const deleteTarget =
-            await this.visitationDetailDomainService.findVisitationDetailByMetaAndMemberId(
-              visitationMeta,
-              member,
-              qr,
-            );
-
-          await this.visitationDetailDomainService.deleteVisitationDetail(
-            deleteTarget,
-            qr,
-          );
-        }),
       );
     }
 
@@ -408,6 +338,105 @@ export class VisitationService {
     );
 
     return visitationMembers;
+  }
+
+  private async handleDeleteVisitationMembers(
+    church: ChurchModel,
+    visitationMeta: VisitationMetaModel,
+    deleteMemberIds: number[],
+    //visitationMembers: MemberModel[],
+    qr: QueryRunner,
+  ) {
+    const visitationMemberIdSet = new Set(
+      visitationMeta.members.map((member) => member.id),
+    );
+
+    const notExistMember = deleteMemberIds.filter(
+      (id) => !visitationMemberIdSet.has(id),
+    );
+
+    if (notExistMember.length > 0) {
+      throw new RemoveConflictException(
+        VisitationException.NOT_EXIST_DELETE_TARGET_MEMBER,
+        notExistMember,
+      );
+    }
+
+    await Promise.all(
+      deleteMemberIds.map(async (memberId) => {
+        const member = await this.membersDomainService.findMemberModelById(
+          church,
+          memberId,
+          qr,
+        );
+
+        const deleteTarget =
+          await this.visitationDetailDomainService.findVisitationDetailByMetaAndMemberId(
+            visitationMeta,
+            member,
+            qr,
+          );
+
+        return this.visitationDetailDomainService.deleteVisitationDetail(
+          deleteTarget,
+          qr,
+        );
+      }),
+    );
+  }
+
+  private async handleAddVisitationMembers(
+    church: ChurchModel,
+    visitationMeta: VisitationMetaModel,
+    addMemberIds: number[],
+    visitationMembers: MemberModel[],
+    qr: QueryRunner,
+  ) {
+    const visitationMemberIdSet = new Set(
+      visitationMeta.members.map((member) => member.id),
+    );
+
+    const duplicatedIds = addMemberIds.filter((id) =>
+      visitationMemberIdSet.has(id),
+    );
+
+    if (duplicatedIds.length > 0) {
+      throw new AddConflictException(
+        VisitationException.ALREADY_EXIST_TARGET_MEMBER,
+        duplicatedIds,
+      );
+    }
+
+    const newMembers = await this.membersDomainService.findMembersById(
+      church,
+      addMemberIds,
+      qr,
+    );
+
+    // 새 심방 대상자 추가
+    visitationMembers.push(...newMembers);
+
+    // 심방 세부 정보 생성 (VisitationDetailModel)
+    await Promise.all(
+      addMemberIds.map(async (memberId) => {
+        const member = await this.membersDomainService.findMemberModelById(
+          church,
+          memberId,
+          qr,
+        );
+
+        const detailDto: VisitationDetailDto = {
+          memberId: memberId,
+        };
+
+        return this.visitationDetailDomainService.createVisitationDetail(
+          visitationMeta,
+          member,
+          detailDto,
+          qr,
+        );
+      }),
+    );
   }
 
   async updateVisitationData(
@@ -533,5 +562,131 @@ export class VisitationService {
       detailData,
       dto,
     );
+  }
+
+  async addReportReceivers(
+    churchId: number,
+    visitationId: number,
+    newReceiverIds: number[],
+    qr: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const visitation =
+      await this.visitationMetaDomainService.findVisitationMetaModelById(
+        church,
+        visitationId,
+        qr,
+        { instructor: true, reports: true },
+      );
+
+    const reports = visitation.reports;
+    const oldReceiverIds = new Set(reports.map((report) => report.receiverId));
+
+    const duplicated = newReceiverIds.filter((id) => oldReceiverIds.has(id));
+
+    if (duplicated.length > 0) {
+      throw new AddConflictException(
+        VisitationException.ALREADY_REPORTED_MEMBER,
+        duplicated,
+      );
+    }
+
+    const newReceivers = await this.membersDomainService.findMembersById(
+      church,
+      newReceiverIds,
+      qr,
+      { user: true },
+    );
+
+    const isAvailableReceivers = newReceivers.some((receiver) => {
+      return (
+        receiver.user &&
+        (receiver.user.role === UserRole.mainAdmin ||
+          receiver.user.role === UserRole.manager)
+      );
+    });
+
+    if (!isAvailableReceivers) {
+      throw new BadRequestException(
+        VisitationException.INVALID_REPORT_RECEIVER,
+      );
+    }
+
+    await Promise.all(
+      newReceivers.map((receiver) => {
+        return this.visitationReportDomainService.createVisitationReport(
+          visitation,
+          visitation.instructor,
+          receiver,
+          qr,
+        );
+      }),
+    );
+
+    return {
+      visitationId,
+      addedReceivers: newReceivers.map((r) => ({
+        id: r.id,
+        name: r.name,
+      })),
+      addedCount: newReceivers.length,
+    };
+  }
+
+  async deleteReportReceivers(
+    churchId: number,
+    visitationId: number,
+    deleteReceiverIds: number[],
+    qr: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const visitation =
+      await this.visitationMetaDomainService.findVisitationMetaModelById(
+        church,
+        visitationId,
+        qr,
+        { instructor: true, reports: { receiver: true } },
+      );
+
+    const reports = visitation.reports;
+    const oldReceiverIds = new Set(reports.map((report) => report.receiverId));
+
+    const notExistReceivers = deleteReceiverIds.filter(
+      (id) => !oldReceiverIds.has(id),
+    );
+
+    if (notExistReceivers.length > 0) {
+      throw new RemoveConflictException(
+        VisitationException.NOT_EXIST_REPORTED_MEMBER,
+        notExistReceivers,
+      );
+    }
+
+    const deleteReports = reports.filter((report) =>
+      deleteReceiverIds.includes(report.receiverId),
+    );
+
+    const result =
+      await this.visitationReportDomainService.deleteVisitationReports(
+        deleteReports,
+        qr,
+      );
+
+    return {
+      visitationId,
+      deletedReceivers: deleteReports.map((r) => ({
+        id: r.receiver.id,
+        name: r.receiver.name,
+      })),
+      deletedCount: result.affected,
+    };
   }
 }


### PR DESCRIPTION
## 주요 내용  
심방의 피보고자(보고 받을 교인)를 추가하거나 삭제할 수 있는 전용 엔드포인트를 추가하였고,  
중복 또는 존재하지 않는 교인에 대한 처리 방식도 명확히 개선하였습니다.  
또한 심방 세부 사항에 대한 개별 조회/수정 엔드포인트를 분리하였습니다.  

## 세부 내용  

### 피보고자 추가/삭제 기능  
- `POST /churches/{churchId}/visitations/{visitationId}/add-receivers`  
  - 피보고자(교인 ID 목록) 추가  
  - 이미 등록된 교인을 추가하려는 경우 `ConflictException` 발생  
    - 응답 메시지에 `duplicatedIds` 포함  

- `POST /churches/{churchId}/visitations/{visitationId}/delete-receivers`  
  - 피보고자(교인 ID 목록) 삭제  
  - 존재하지 않는 피보고자를 삭제하려는 경우 `ConflictException` 발생  
    - 응답 메시지에 `notExistIds` 포함  

### 대상자 추가/삭제 시 검증 개선  
- 심방 대상자 추가 시 이미 포함된 대상자는 `duplicatedIds`로 응답  
- 대상자 삭제 시 포함되지 않은 교인은 `notExistIds`로 응답  

### 세부 사항 엔드포인트 분리  
- 심방 세부 데이터의 개별 접근 엔드포인트 분리  
  - `GET /churches/{churchId}/visitations/{visitationId}/details/{detailId}`  
  - 추후 수정/삭제 등의 개별 조작을 위한 구조 기반 마련  

이번 기능 확장으로 심방 보고 및 대상자 관리의 유연성과 명확성이 향상되었고,  
에러 메시지의 세분화를 통해 사용자 측에서도 정확한 오류 처리가 가능해졌습니다.  
