### PR TITLE
refactor: 교회 그룹 조회 엔드포인트 페이징 및 parentGroupId 기반 조회로 변경

### DIFF
--- a/backend/src/common/dto/reponse/base-delete-result.dto.ts
+++ b/backend/src/common/dto/reponse/base-delete-result.dto.ts
@@ -1,0 +1,7 @@
+export abstract class BaseDeleteResultDto {
+  protected constructor(
+    public readonly timestamp: Date,
+    public readonly id: number,
+    public readonly success: boolean,
+  ) {}
+}

--- a/backend/src/management/groups/const/group-order.enum.ts
+++ b/backend/src/management/groups/const/group-order.enum.ts
@@ -1,0 +1,5 @@
+export enum GroupOrderEnum {
+  createdAt = 'createdAt',
+  updatedAt = 'updatedAt',
+  name = 'name',
+}

--- a/backend/src/management/groups/const/swagger/group.swagger.ts
+++ b/backend/src/management/groups/const/swagger/group.swagger.ts
@@ -1,0 +1,72 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
+
+export const ApiGetGroups = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교회의 그룹 조회',
+      description:
+        '<h2>교회 내의 그룹을 조회합니다.</h2>' +
+        '<p>parentGroupId 의 자식 그룹들을 조회합니다.</p>' +
+        '<p>parentGroupId 값을 포함하지 않을 경우 해당 교회의 최상위 그룹들을 조회합니다.</p>',
+    }),
+    ApiParam({
+      name: 'churchId',
+      description: '교회 id',
+    }),
+  );
+
+export const ApiPostGroups = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교회 그룹 생성',
+      description:
+        '<h2>교회 내의 그룹을 생성합니다.</h2>' +
+        '<p>그룹 이름에는 특수문자 및 띄어쓰기를 사용할 수 없습니다.</p>' +
+        '<p>띄어쓰기가 포함된 경우 이를 제거하고 이름으로 지정합니다.</p>',
+    }),
+  );
+
+export const ApiGetGroupById = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '특정 그룹 조회',
+      description:
+        '<h2>교회 내의 특정 그룹을 조회합니다.</h2>' +
+        '<p>포함된 내용</p>' +
+        '<p>1. 그룹 내 역할 (groupRoles) - deprecated</p>' +
+        '<p>2. 자식 그룹의 id (childGroupIds)</p>' +
+        '<p>3. 부모 그룹의 id, 이름, depth (parentGroups)</p>',
+    }),
+  );
+
+export const ApiPatchGroup = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '그룹 수정',
+      description:
+        '<h2>교회 내의 그룹을 수정합니다.</h2>' +
+        '<p>수정 가능 요소</p>' +
+        '<p>1. 그룹 이름 (중복 불가)</p>' +
+        '<p>2. 상위 그룹</p>' +
+        '<p>상위 그룹을 없애려는 경우 ministryGroupId 를 null 로 설정</p>',
+    }),
+  );
+
+export const ApiDeleteGroup = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '그룹 삭제',
+      description:
+        '<h2>교회 내의 그룹을 삭제합니다.</h2>' +
+        '<p>하위 그룹 또는 소속 그룹원이 있는 경우 삭제가 불가능합니다. (BadRequestException)</p>',
+    }),
+  );
+
+export const ApiGetChildGroupIds = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '하위 그룹 id 조회',
+      description: '<h2>해당 그룹의 하위 그룹들의 id 값을 조회합니다.</h2>',
+    }),
+  );

--- a/backend/src/management/groups/controller/groups.controller.ts
+++ b/backend/src/management/groups/controller/groups.controller.ts
@@ -7,37 +7,41 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Query,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { GroupsService } from '../service/groups.service';
 import { CreateGroupDto } from '../dto/create-group.dto';
 import { UpdateGroupDto } from '../dto/update-group.dto';
 import { QueryRunner as QR } from 'typeorm';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
+import {
+  ApiDeleteGroup,
+  ApiGetChildGroupIds,
+  ApiGetGroupById,
+  ApiGetGroups,
+  ApiPatchGroup,
+  ApiPostGroups,
+} from '../const/swagger/group.swagger';
+import { GetGroupDto } from '../dto/get-group.dto';
 
 @ApiTags('Management:Groups')
 @Controller('groups')
 export class GroupsController {
   constructor(private readonly groupsService: GroupsService) {}
 
-  @ApiOperation({
-    summary: '교회의 그룹 조회',
-    description: '<h2>교회 내의 그룹을 조회합니다.</h2>',
-  })
+  @ApiGetGroups()
   @Get()
-  getGroups(@Param('churchId', ParseIntPipe) churchId: number) {
-    return this.groupsService.getGroups(churchId);
+  getGroups(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetGroupDto,
+  ) {
+    return this.groupsService.getGroups(churchId, dto);
   }
 
-  @ApiOperation({
-    summary: '교회 그룹 생성',
-    description:
-      '<h2>교회 내의 그룹을 생성합니다.</h2>' +
-      '<p>그룹 이름에는 특수문자 및 띄어쓰기를 사용할 수 없습니다.</p>' +
-      '<p>띄어쓰기가 포함된 경우 이를 제거하고 이름으로 지정합니다.</p>',
-  })
+  @ApiPostGroups()
   @Post()
   @UseInterceptors(TransactionInterceptor)
   postGroup(
@@ -48,15 +52,7 @@ export class GroupsController {
     return this.groupsService.createGroup(churchId, dto, qr);
   }
 
-  @ApiOperation({
-    summary: '특정 그룹 조회',
-    description:
-      '<h2>교회 내의 특정 그룹을 조회합니다.</h2>' +
-      '<p>포함된 내용</p>' +
-      '<p>1. 그룹 내 역할 (groupRoles) - deprecated</p>' +
-      '<p>2. 자식 그룹의 id (childGroupIds)</p>' +
-      '<p>3. 부모 그룹의 id, 이름, depth (parentGroups)</p>',
-  })
+  @ApiGetGroupById()
   @Get(':groupId')
   getGroupById(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -65,15 +61,7 @@ export class GroupsController {
     return this.groupsService.getGroupByIdWithParents(churchId, groupId);
   }
 
-  @ApiOperation({
-    summary: '그룹 수정',
-    description:
-      '<h2>교회 내의 그룹을 수정합니다.</h2>' +
-      '<p>수정 가능 요소</p>' +
-      '<p>1. 그룹 이름 (중복 불가)</p>' +
-      '<p>2. 상위 그룹</p>' +
-      '<p>상위 그룹을 없애려는 경우 ministryGroupId 를 null 로 설정</p>',
-  })
+  @ApiPatchGroup()
   @Patch(':groupId')
   @UseInterceptors(TransactionInterceptor)
   patchGroup(
@@ -85,12 +73,7 @@ export class GroupsController {
     return this.groupsService.updateGroup(churchId, groupId, dto, qr);
   }
 
-  @ApiOperation({
-    summary: '그룹 삭제',
-    description:
-      '<h2>교회 내의 그룹을 삭제합니다.</h2>' +
-      '<p>하위 그룹 또는 소속 그룹원이 있는 경우 삭제가 불가능합니다. (BadRequestException)</p>',
-  })
+  @ApiDeleteGroup()
   @Delete(':groupId')
   @UseInterceptors(TransactionInterceptor)
   deleteGroup(
@@ -102,49 +85,12 @@ export class GroupsController {
     return this.groupsService.deleteGroup(churchId, groupId, qr /*cascade*/);
   }
 
-  @ApiOperation({
-    summary: '하위 그룹 id 조회',
-    description: '<h2>해당 그룹의 하위 그룹들의 id 값을 조회합니다.</h2>',
-  })
+  @ApiGetChildGroupIds()
   @Get(':groupId/childGroups')
-  getGroupsCascade(
+  getChildGroupIds(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('groupId', ParseIntPipe) groupId: number,
   ) {
-    return this.groupsService.getGroupsCascade(churchId, groupId);
+    return this.groupsService.getChildGroupIds(churchId, groupId);
   }
-
-  /*@Get(':groupId/role')
-  getGroupRoles(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('groupId', ParseIntPipe) groupId: number,
-  ) {
-    return this.groupsService.getGroupRoles(churchId, groupId);
-  }
-
-  @Post(':groupId/role')
-  postGroupRole(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('groupId', ParseIntPipe) groupId: number,
-    @Body() dto: CreateGroupRoleDto,
-  ) {
-    return this.groupsService.createGroupRole(churchId, groupId, dto);
-  }
-
-  @Patch(':groupId/role/:roleId')
-  patchGroupRole(
-    @Param('groupId', ParseIntPipe) groupId: number,
-    @Param('roleId', ParseIntPipe) roleId: number,
-    @Body() dto: UpdateGroupRoleDto,
-  ) {
-    return this.groupsService.updateGroupRole(groupId, roleId, dto);
-  }
-
-  @Delete(':groupId/role/:roleId')
-  deleteGroupRole(
-    @Param('groupId', ParseIntPipe) groupId: number,
-    @Param('roleId', ParseIntPipe) roleId: number,
-  ) {
-    return this.groupsService.deleteGroupRole(groupId, roleId);
-  }*/
 }

--- a/backend/src/management/groups/dto/get-group.dto.ts
+++ b/backend/src/management/groups/dto/get-group.dto.ts
@@ -1,0 +1,50 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsIn, IsNumber, IsOptional } from 'class-validator';
+import { GroupOrderEnum } from '../const/group-order.enum';
+
+export class GetGroupDto {
+  @ApiProperty({
+    description: '<p>부모 그룹 id</p>' + '<p>최상위 그룹 조회 시 포함 X</p>',
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  parentGroupId: number = 0;
+
+  @ApiProperty({
+    description: '요청 데이터 개수',
+    default: 20,
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  take: number = 20;
+
+  @ApiProperty({
+    description: '요청 페이지',
+    default: 1,
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  page: number = 1;
+
+  @ApiProperty({
+    description: '정렬 기준 (생성일, 수정일, 이름)',
+    enum: GroupOrderEnum,
+    default: GroupOrderEnum.createdAt,
+    required: false,
+  })
+  @IsEnum(GroupOrderEnum)
+  @IsOptional()
+  order: GroupOrderEnum = GroupOrderEnum.createdAt;
+
+  @ApiProperty({
+    description: '정렬 내림차순 / 오름차순',
+    default: 'asc',
+    required: false,
+  })
+  @IsIn(['asc', 'desc', 'ASC', 'DESC'])
+  @IsOptional()
+  orderDirection: 'asc' | 'desc' | 'ASC' | 'DESC' = 'asc';
+}

--- a/backend/src/management/groups/dto/response/group-delete-result.dto.ts
+++ b/backend/src/management/groups/dto/response/group-delete-result.dto.ts
@@ -1,0 +1,12 @@
+import { BaseDeleteResultDto } from '../../../../common/dto/reponse/base-delete-result.dto';
+
+export class GroupDeleteResultDto extends BaseDeleteResultDto {
+  constructor(
+    public readonly timestamp: Date,
+    public readonly id: number,
+    public readonly name: string,
+    public readonly success: boolean,
+  ) {
+    super(timestamp, id, success);
+  }
+}

--- a/backend/src/management/groups/dto/response/group-pagination-result.dto.ts
+++ b/backend/src/management/groups/dto/response/group-pagination-result.dto.ts
@@ -1,0 +1,14 @@
+import { BaseOffsetPaginationResultDto } from '../../../../common/dto/base-offset-pagination-result.dto';
+import { GroupModel } from '../../entity/group.entity';
+
+export class GroupPaginationResultDto extends BaseOffsetPaginationResultDto<GroupModel> {
+  constructor(
+    public readonly data: GroupModel[],
+    public readonly totalCount: number,
+    public readonly count: number,
+    public readonly page: number,
+    public readonly totalPage: number,
+  ) {
+    super(data, totalCount, count, page);
+  }
+}

--- a/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
+++ b/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
@@ -3,6 +3,7 @@ import { ChurchModel } from '../../../../churches/entity/church.entity';
 import { FindOptionsRelations, QueryRunner } from 'typeorm';
 import { CreateGroupDto } from '../../dto/create-group.dto';
 import { UpdateGroupDto } from '../../dto/update-group.dto';
+import { GetGroupDto } from '../../dto/get-group.dto';
 
 export interface ParentGroup {
   id: number;
@@ -18,7 +19,10 @@ export interface GroupModelWithParentGroups extends GroupModel {
 export const IGROUPS_DOMAIN_SERVICE = Symbol('IGROUPS_DOMAIN_SERVICE');
 
 export interface IGroupsDomainService {
-  findGroups(church: ChurchModel): Promise<GroupModel[]>;
+  findGroups(
+    church: ChurchModel,
+    dto: GetGroupDto,
+  ): Promise<{ data: GroupModel[]; totalCount: number }>;
 
   findGroupById(
     church: ChurchModel,
@@ -59,11 +63,7 @@ export interface IGroupsDomainService {
     newParentGroup: GroupModel | null,
   ): Promise<GroupModel>;
 
-  deleteGroup(
-    churchId: number,
-    groupId: number,
-    qr: QueryRunner,
-  ): Promise<string>;
+  deleteGroup(deleteTarget: GroupModel, qr: QueryRunner): Promise<void>;
 
   findChildGroupIds(group: GroupModel, qr?: QueryRunner): Promise<number[]>;
 


### PR DESCRIPTION
## 주요 내용
기존 교회 그룹 전체 조회 엔드포인트를 수정하여,
페이징 처리와 parentGroupId 기반 하위 그룹 조회 방식으로 변경하였습니다.

## 세부 내용
- 그룹 조회 시 `parentGroupId`를 쿼리로 전달하도록 변경
  - parentGroupId가 있을 경우 해당 그룹의 자식 그룹 목록 조회
  - parentGroupId가 없을 경우 교회의 최상위 그룹 목록 조회
- 페이징 처리 적용
  - `take`, `page` 쿼리 파라미터로 페이지네이션 가능
  - 응답 포맷: `{ data, totalCount, count, page, totalPage }`
- 기존 전체 그룹 트리 조회 방식 제거 → 필요한 부분만 조회하도록 최적화

이번 변경을 통해 그룹 조회 성능이 개선되었고,
대규모 그룹 데이터 환경에서도 안정적이고 효율적인 조회가 가능해졌습니다.