### PR TITLE
refactor: 직분(officer) 관리 기능 리팩토링 및 페이징/응답 구조 통일

### DIFF
--- a/backend/src/management/officers/const/exception/officers.exception.ts
+++ b/backend/src/management/officers/const/exception/officers.exception.ts
@@ -1,5 +1,5 @@
 export const OfficersException = {
   NOT_FOUND: '해당 직분을 찾을 수 없습니다.',
   ALREADY_EXIST: '이미 존재하는 직분입니다.',
-  HAS_DEPENDENCIES: '해당 사역에 속한 교인이 존재합니다.',
+  HAS_DEPENDENCIES: '해당 직분에 속한 교인이 존재합니다.',
 };

--- a/backend/src/management/officers/const/officer-order.enum.ts
+++ b/backend/src/management/officers/const/officer-order.enum.ts
@@ -1,0 +1,5 @@
+export enum OfficerOrderEnum {
+  createdAt = 'createdAt',
+  updatedAt = 'updatedAt',
+  name = 'name',
+}

--- a/backend/src/management/officers/const/swagger/officers.swagger.ts
+++ b/backend/src/management/officers/const/swagger/officers.swagger.ts
@@ -1,0 +1,30 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+export const ApiGetOfficers = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교회 내의 직분 조회',
+    }),
+  );
+
+export const ApiPostOfficer = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '직분 생성',
+    }),
+  );
+
+export const ApiPatchOfficer = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '직분 수정',
+    }),
+  );
+
+export const ApiDeleteOfficer = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '직분 삭제',
+    }),
+  );

--- a/backend/src/management/officers/controller/officers.controller.ts
+++ b/backend/src/management/officers/controller/officers.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Query,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
@@ -16,17 +17,29 @@ import { OfficersService } from '../service/officers.service';
 import { QueryRunner as QR } from 'typeorm';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
+import {
+  ApiDeleteOfficer,
+  ApiGetOfficers,
+  ApiPatchOfficer,
+  ApiPostOfficer,
+} from '../const/swagger/officers.swagger';
+import { GetOfficersDto } from '../dto/request/get-officers.dto';
 
 @ApiTags('Management:Officers')
 @Controller('officers')
 export class OfficersController {
   constructor(private readonly officersService: OfficersService) {}
 
+  @ApiGetOfficers()
   @Get()
-  getOfficers(@Param('churchId', ParseIntPipe) churchId: number) {
-    return this.officersService.getOfficers(churchId);
+  getOfficers(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetOfficersDto,
+  ) {
+    return this.officersService.getOfficers(churchId, dto);
   }
 
+  @ApiPostOfficer()
   @Post()
   @UseInterceptors(TransactionInterceptor)
   postOfficer(
@@ -37,6 +50,7 @@ export class OfficersController {
     return this.officersService.createOfficer(churchId, dto, qr);
   }
 
+  @ApiPatchOfficer()
   @Patch(':officerId')
   @UseInterceptors(TransactionInterceptor)
   patchOfficer(
@@ -48,6 +62,7 @@ export class OfficersController {
     return this.officersService.updateOfficer(churchId, officerId, dto, qr);
   }
 
+  @ApiDeleteOfficer()
   @Delete(':officerId')
   @UseInterceptors(TransactionInterceptor)
   deleteOfficer(

--- a/backend/src/management/officers/dto/create-officer.dto.ts
+++ b/backend/src/management/officers/dto/create-officer.dto.ts
@@ -6,7 +6,8 @@ import { IsNoSpecialChar } from '../../../common/decorator/validator/is-title.de
 export class CreateOfficerDto {
   @ApiProperty({
     name: 'name',
-    description: '생성하고자 하는 이름',
+    description:
+      '<p>직분 이름</p>' + '<p>특수문자 불가, 띄어쓰기 사용 시 제거</p>',
     example: '장로',
   })
   @IsString()

--- a/backend/src/management/officers/dto/officer-domain-pagination-result.dto.ts
+++ b/backend/src/management/officers/dto/officer-domain-pagination-result.dto.ts
@@ -1,0 +1,11 @@
+import { OfficerModel } from '../entity/officer.entity';
+import { BaseDomainOffsetPaginationResultDto } from '../../../common/dto/base-domain-offset-pagination-result.dto';
+
+export class OfficerDomainPaginationResultDto extends BaseDomainOffsetPaginationResultDto<OfficerModel> {
+  constructor(
+    public readonly data: OfficerModel[],
+    public readonly totalCount: number,
+  ) {
+    super(data, totalCount);
+  }
+}

--- a/backend/src/management/officers/dto/request/get-officers.dto.ts
+++ b/backend/src/management/officers/dto/request/get-officers.dto.ts
@@ -1,0 +1,16 @@
+import { BaseOffsetPaginationRequestDto } from '../../../../common/dto/request/base-offset-pagination-request.dto';
+import { OfficerOrderEnum } from '../../const/officer-order.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+
+export class GetOfficersDto extends BaseOffsetPaginationRequestDto<OfficerOrderEnum> {
+  @ApiProperty({
+    description: '정렬 기준 (생성일, 수정일, 이름)',
+    enum: OfficerOrderEnum,
+    default: OfficerOrderEnum.createdAt,
+    required: false,
+  })
+  @IsEnum(OfficerOrderEnum)
+  @IsOptional()
+  order: OfficerOrderEnum = OfficerOrderEnum.createdAt;
+}

--- a/backend/src/management/officers/dto/response/officer-delete-response.dto.ts
+++ b/backend/src/management/officers/dto/response/officer-delete-response.dto.ts
@@ -1,0 +1,12 @@
+import { BaseDeleteResponseDto } from '../../../../common/dto/reponse/base-delete-response.dto';
+
+export class OfficerDeleteResponse extends BaseDeleteResponseDto {
+  constructor(
+    public readonly timestamp: Date,
+    public readonly id: number,
+    public readonly name: string,
+    public readonly success: boolean,
+  ) {
+    super(timestamp, id, success);
+  }
+}

--- a/backend/src/management/officers/dto/response/officer-pagination-response.dto.ts
+++ b/backend/src/management/officers/dto/response/officer-pagination-response.dto.ts
@@ -1,0 +1,14 @@
+import { OfficerModel } from '../../entity/officer.entity';
+import { BaseOffsetPaginationResponseDto } from '../../../../common/dto/reponse/base-offset-pagination-response.dto';
+
+export class OfficerPaginationResponseDto extends BaseOffsetPaginationResponseDto<OfficerModel> {
+  constructor(
+    public readonly data: OfficerModel[],
+    public readonly totalCount: number,
+    public readonly count: number,
+    public readonly page: number,
+    public readonly totalPage: number,
+  ) {
+    super(data, totalCount, count, page, totalPage);
+  }
+}

--- a/backend/src/management/officers/dto/response/officer-patch.response.dto.ts
+++ b/backend/src/management/officers/dto/response/officer-patch.response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePatchResponseDto } from '../../../../common/dto/reponse/base-patch-response.dto';
+import { OfficerModel } from '../../entity/officer.entity';
+
+export class OfficerPatchResponse extends BasePatchResponseDto<OfficerModel> {
+  constructor(public readonly data: OfficerModel) {
+    super(data);
+  }
+}

--- a/backend/src/management/officers/dto/response/officer-post-response.dto.ts
+++ b/backend/src/management/officers/dto/response/officer-post-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePostResponseDto } from '../../../../common/dto/reponse/base-post-response.dto';
+import { OfficerModel } from '../../entity/officer.entity';
+
+export class OfficerPostResponse extends BasePostResponseDto<OfficerModel> {
+  constructor(public readonly data: OfficerModel) {
+    super(data);
+  }
+}

--- a/backend/src/management/officers/entity/officer.entity.ts
+++ b/backend/src/management/officers/entity/officer.entity.ts
@@ -1,14 +1,4 @@
-import {
-  BeforeRemove,
-  BeforeSoftRemove,
-  Column,
-  Entity,
-  Index,
-  ManyToOne,
-  OneToMany,
-  Unique,
-} from 'typeorm';
-import { ConflictException } from '@nestjs/common';
+import { Column, Entity, Index, ManyToOne, OneToMany, Unique } from 'typeorm';
 import { BaseModel } from '../../../common/entity/base.entity';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
@@ -39,7 +29,7 @@ export class OfficerModel extends BaseModel {
   )
   history: OfficerHistoryModel[];
 
-  @BeforeRemove()
+  /*@BeforeRemove()
   @BeforeSoftRemove()
   preventIfHasMember() {
     if (this.members.length > 0) {
@@ -49,5 +39,5 @@ export class OfficerModel extends BaseModel {
         `해당 직분을 갖고 있는 교인이 존재합니다.\n${memberNames}`,
       );
     }
-  }
+  }*/
 }

--- a/backend/src/management/officers/officer-domain/interface/officers-domain.service.interface.ts
+++ b/backend/src/management/officers/officer-domain/interface/officers-domain.service.interface.ts
@@ -3,11 +3,17 @@ import { FindOptionsRelations, QueryRunner } from 'typeorm';
 import { OfficerModel } from '../../entity/officer.entity';
 import { CreateOfficerDto } from '../../dto/create-officer.dto';
 import { UpdateOfficerDto } from '../../dto/update-officer.dto';
+import { GetOfficersDto } from '../../dto/request/get-officers.dto';
+import { OfficerDomainPaginationResultDto } from '../../dto/officer-domain-pagination-result.dto';
 
 export const IOFFICERS_DOMAIN_SERVICE = Symbol('IOFFICERS_DOMAIN_SERVICE');
 
 export interface IOfficersDomainService {
-  findOfficers(church: ChurchModel, qr?: QueryRunner): Promise<OfficerModel[]>;
+  findOfficers(
+    church: ChurchModel,
+    dto: GetOfficersDto,
+    qr?: QueryRunner,
+  ): Promise<OfficerDomainPaginationResultDto>;
 
   findOfficerById(
     church: ChurchModel,
@@ -35,7 +41,7 @@ export interface IOfficersDomainService {
     qr?: QueryRunner,
   ): Promise<OfficerModel>;
 
-  deleteOfficer(officer: OfficerModel, qr?: QueryRunner): Promise<string>;
+  deleteOfficer(officer: OfficerModel, qr?: QueryRunner): Promise<void>;
 
   incrementMembersCount(
     officer: OfficerModel,

--- a/backend/src/management/officers/service/officers.service.ts
+++ b/backend/src/management/officers/service/officers.service.ts
@@ -10,6 +10,11 @@ import {
   IOFFICERS_DOMAIN_SERVICE,
   IOfficersDomainService,
 } from '../officer-domain/interface/officers-domain.service.interface';
+import { GetOfficersDto } from '../dto/request/get-officers.dto';
+import { OfficerPaginationResponseDto } from '../dto/response/officer-pagination-response.dto';
+import { OfficerPostResponse } from '../dto/response/officer-post-response.dto';
+import { OfficerPatchResponse } from '../dto/response/officer-patch.response.dto';
+import { OfficerDeleteResponse } from '../dto/response/officer-delete-response.dto';
 
 @Injectable()
 export class OfficersService {
@@ -20,43 +25,26 @@ export class OfficersService {
     private readonly officersDomainService: IOfficersDomainService,
   ) {}
 
-  async getOfficers(churchId: number, qr?: QueryRunner) {
+  async getOfficers(churchId: number, dto: GetOfficersDto, qr?: QueryRunner) {
     const church = await this.churchesDomainService.findChurchModelById(
       churchId,
       qr,
     );
 
-    return this.officersDomainService.findOfficers(church, qr);
-  }
-
-  /*async getOfficerById(churchId: number, officerId: number, qr?: QueryRunner) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    return this.officersDomainService.findOfficerById(church, officerId, qr);
-
-  }*/
-
-  /*async getOfficerModelById(
-    churchId: number,
-    officerId: number,
-    qr?: QueryRunner,
-    relationOptions?: FindOptionsRelations<OfficerModel>,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    return this.officersDomainService.findOfficerModelById(
+    const { data, totalCount } = await this.officersDomainService.findOfficers(
       church,
-      officerId,
+      dto,
       qr,
-      relationOptions,
     );
-  }*/
+
+    return new OfficerPaginationResponseDto(
+      data,
+      totalCount,
+      data.length,
+      dto.page,
+      Math.ceil(totalCount / dto.take),
+    );
+  }
 
   async createOfficer(
     churchId: number,
@@ -68,7 +56,13 @@ export class OfficersService {
       qr,
     );
 
-    return this.officersDomainService.createOfficer(church, dto, qr);
+    const officer = await this.officersDomainService.createOfficer(
+      church,
+      dto,
+      qr,
+    );
+
+    return new OfficerPostResponse(officer);
   }
 
   async updateOfficer(
@@ -88,7 +82,14 @@ export class OfficersService {
       qr,
     );
 
-    return this.officersDomainService.updateOfficer(church, officer, dto, qr);
+    const updatedOfficer = await this.officersDomainService.updateOfficer(
+      church,
+      officer,
+      dto,
+      qr,
+    );
+
+    return new OfficerPatchResponse(updatedOfficer);
   }
 
   async deleteOfficer(churchId: number, officerId: number, qr?: QueryRunner) {
@@ -101,12 +102,20 @@ export class OfficersService {
       church,
       officerId,
       qr,
+      { members: true },
     );
 
-    return this.officersDomainService.deleteOfficer(officer, qr);
+    await this.officersDomainService.deleteOfficer(officer, qr);
+
+    return new OfficerDeleteResponse(
+      new Date(),
+      officer.id,
+      officer.name,
+      true,
+    );
   }
 
-  async incrementMembersCount(
+  /*async incrementMembersCount(
     churchId: number,
     officerId: number,
     qr: QueryRunner,
@@ -123,9 +132,9 @@ export class OfficersService {
     );
 
     return this.officersDomainService.incrementMembersCount(officer, qr);
-  }
+  }*/
 
-  async decrementMembersCount(
+  /*async decrementMembersCount(
     churchId: number,
     officerId: number,
     qr: QueryRunner,
@@ -142,5 +151,5 @@ export class OfficersService {
     );
 
     return this.officersDomainService.decrementMembersCount(officer, qr);
-  }
+  }*/
 }


### PR DESCRIPTION
## 주요 내용
교회 직분(officer) 관리 기능을 리팩토링하여,
DB 레벨에서 중복 생성을 방지하고, 조회/삭제 응답 구조를 일관되게 통일하였습니다.

## 세부 내용

### 직분 생성/수정 로직 개선
- `churchId`, `name`에 대해 복합 유니크 제약 설정 (DB 레벨 중복 방지)
- 생성/수정 시 동일 이름으로 soft delete된 데이터가 존재할 경우
  - 해당 데이터를 완전 삭제한 후 새로 생성/수정하도록 처리

### 직분 조회 기능 개선
- 직분 목록 조회 시 페이징 처리 적용
  - `take`, `page` 쿼리 파라미터 사용
  - 응답 포맷: `{ data, totalCount, count, page, totalPage }`

### 응답 구조 통일
- 생성/수정 응답: `{ data: OfficerModel, timestamp: Date }`
- 삭제 응답: `{ id, name, timestamp, success }`

## 기대 효과
- 직분 이름 중복 생성 문제를 DB 레벨에서 원천 차단
- 대량 직분 목록 조회 시 성능 최적화
- 모든 응답의 일관성 확보로 클라이언트 처리 간소화

이번 리팩토링을 통해 직분 관리 기능의 신뢰성과 성능이 전반적으로 개선되었습니다.