### PR TITLE
feat: 심방 생성/수정 시 종료일자 필드 및 대상자 수 제한 로직 추가

### DIFF
--- a/backend/src/report/dto/visitation-report/get-visitation-report.dto.ts
+++ b/backend/src/report/dto/visitation-report/get-visitation-report.dto.ts
@@ -7,7 +7,7 @@ import {
   IsOptional,
   Min,
 } from 'class-validator';
-import { VisitationOrderEnum } from '../../../visitation/const/order.enum';
+import { VisitationOrderEnum } from '../../../visitation/const/visitation-order.enum';
 import { VisitationReportOrderEnum } from '../../const/visitation-report-order.enum';
 
 export class GetVisitationReportDto {

--- a/backend/src/visitation/const/exception/visitation.exception.ts
+++ b/backend/src/visitation/const/exception/visitation.exception.ts
@@ -14,6 +14,7 @@ export const VisitationException = {
     '피보고자로 등록할 수 없는 교인이 포함되어 있습니다.',
   ALREADY_REPORTED_MEMBER: '이미 피보고자로 등록된 교인입니다.',
   NOT_EXIST_REPORTED_MEMBER: '삭제 대상자가 피보고자에 포함되어 있지 않습니다.',
+  EXCEED_VISITATION_MEMBER: '심방 대상자는 최대 30명까지만 등록할 수 있습니다.',
 };
 
 export const VisitationDetailException = {

--- a/backend/src/visitation/const/swagger/visitation.swagger.ts
+++ b/backend/src/visitation/const/swagger/visitation.swagger.ts
@@ -17,8 +17,8 @@ export const ApiGetVisitations = () =>
         '<p>order: 정렬 기준 (기본값: 심방 날짜)</p>' +
         '<p>orderDirection: 정렬 차순 (기본값: 내림차순)</p>' +
         '<h3>필터링 조건</h3>' +
-        '<p>fromVisitationDate: 심방 날짜 ~ 부터</p>' +
-        '<p>toVisitationDate: 심방 날짜 ~ 까지</p>' +
+        '<p>fromVisitationDate: 심방 시작 날짜 ~ 부터</p>' +
+        '<p>toVisitationDate: 심방 시작 날짜 ~ 까지</p>' +
         '<p>visitationStatus: 심방 상태 (예약 / 완료 / 지연)</p>' +
         '<p>visitationMethod: 심방 방식 (대면 / 비대면)</p>' +
         '<p>visitationType: 심방 종류 (개인 / 그룹)</p>' +

--- a/backend/src/visitation/const/visitation-order.enum.ts
+++ b/backend/src/visitation/const/visitation-order.enum.ts
@@ -1,5 +1,5 @@
 export enum VisitationOrderEnum {
-  visitationDate = 'visitationDate',
+  visitationStartDate = 'visitationStartDate',
   createdAt = 'createdAt',
   updatedAt = 'updatedAt',
 }

--- a/backend/src/visitation/controller/visitation-detail.controller.ts
+++ b/backend/src/visitation/controller/visitation-detail.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Param, ParseIntPipe, Patch } from '@nestjs/common';
 import { ApiPatchVisitationDetail } from '../const/swagger/visitation.swagger';
 import { UpdateVisitationDetailDto } from '../dto/internal/detail/update-visitation-detail.dto';
-import { VisitationService } from '../visitation.service';
+import { VisitationService } from '../service/visitation.service';
 import { ApiTags } from '@nestjs/swagger';
 
 @ApiTags('Visitations:Details')

--- a/backend/src/visitation/controller/visitation.controller.ts
+++ b/backend/src/visitation/controller/visitation.controller.ts
@@ -12,7 +12,7 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
-import { VisitationService } from '../visitation.service';
+import { VisitationService } from '../service/visitation.service';
 import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
@@ -31,8 +31,8 @@ import {
   ApiPostVisitation,
 } from '../const/swagger/visitation.swagger';
 import { UpdateVisitationDto } from '../dto/update-visitation.dto';
-import { AddReceiverDto } from '../dto/add-receiver.dto';
-import { DeleteReceiverDto } from '../dto/delete-receiver.dto';
+import { AddReceiverDto } from '../dto/receiever/add-receiver.dto';
+import { DeleteReceiverDto } from '../dto/receiever/delete-receiver.dto';
 
 @ApiTags('Visitations')
 @Controller('visitations')

--- a/backend/src/visitation/dto/create-visitation.dto.ts
+++ b/backend/src/visitation/dto/create-visitation.dto.ts
@@ -1,6 +1,6 @@
 import {
+  ArrayMaxSize,
   IsArray,
-  IsBoolean,
   IsDate,
   IsEnum,
   IsNumber,
@@ -18,16 +18,18 @@ import { VisitationDetailValidator } from '../decorator/visitation-detail.valida
 import { VisitationDetailDto } from './visittion-detail.dto';
 import { RemoveSpaces } from '../../common/decorator/transformer/remove-spaces';
 import { SanitizeDto } from '../../common/decorator/sanitize-target.decorator';
+import { IsAfterDate } from '../../common/decorator/validator/is-after-date.decorator';
+import { VisitationException } from '../const/exception/visitation.exception';
 
 @SanitizeDto()
 export class CreateVisitationDto {
-  @ApiProperty({
+  /*@ApiProperty({
     description: 'API 테스트 시 true (심방 진행자의 권한 체크 건너뛰기)',
     default: false,
   })
   @IsOptional()
   @IsBoolean()
-  isTest: boolean = false;
+  isTest: boolean = false;*/
 
   @ApiProperty({
     description: '심방 상태 (예약 / 완료 / 지연)',
@@ -60,10 +62,17 @@ export class CreateVisitationDto {
   instructorId: number;
 
   @ApiProperty({
-    description: '심방 날짜',
+    description: '심방 시작 날짜',
   })
   @IsDate()
-  visitationDate: Date;
+  visitationStartDate: Date;
+
+  @ApiProperty({
+    description: '심방 종료 날짜',
+  })
+  @IsDate()
+  @IsAfterDate('visitationStartDate')
+  visitationEndDate: Date;
 
   @ApiProperty({
     description: '심방 세부 정보',
@@ -72,6 +81,9 @@ export class CreateVisitationDto {
   })
   @ValidateNested({ each: true })
   @Type(() => VisitationDetailDto)
+  @ArrayMaxSize(30, {
+    message: VisitationException.EXCEED_VISITATION_MEMBER,
+  })
   @VisitationDetailValidator()
   visitationDetails: VisitationDetailDto[];
 

--- a/backend/src/visitation/dto/get-visitation.dto.ts
+++ b/backend/src/visitation/dto/get-visitation.dto.ts
@@ -10,9 +10,10 @@ import {
 } from 'class-validator';
 import { VisitationStatus } from '../const/visitation-status.enum';
 import { TransformStringArray } from '../../common/decorator/transformer/transform-array';
-import { VisitationOrderEnum } from '../const/order.enum';
+import { VisitationOrderEnum } from '../const/visitation-order.enum';
 import { VisitationMethod } from '../const/visitation-method.enum';
 import { VisitationType } from '../const/visitation-type.enum';
+import { IsAfterDate } from '../../common/decorator/validator/is-after-date.decorator';
 
 export class GetVisitationDto {
   @ApiProperty({
@@ -38,12 +39,12 @@ export class GetVisitationDto {
   @ApiProperty({
     description: '정렬 기준',
     enum: VisitationOrderEnum,
-    default: VisitationOrderEnum.visitationDate,
+    default: VisitationOrderEnum.visitationStartDate,
     required: false,
   })
   @IsOptional()
   @IsEnum(VisitationOrderEnum)
-  order: VisitationOrderEnum = VisitationOrderEnum.visitationDate;
+  order: VisitationOrderEnum = VisitationOrderEnum.visitationStartDate;
 
   @ApiProperty({
     description: '정렬 오름차순 / 내림차순',
@@ -68,6 +69,7 @@ export class GetVisitationDto {
   })
   @IsOptional()
   @IsDate()
+  @IsAfterDate('fromVisitationDate')
   toVisitationDate?: Date;
 
   @ApiProperty({

--- a/backend/src/visitation/dto/receiever/add-receiver.dto.ts
+++ b/backend/src/visitation/dto/receiever/add-receiver.dto.ts
@@ -1,8 +1,8 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
-import { CreateVisitationDto } from './create-visitation.dto';
+import { CreateVisitationDto } from '../create-visitation.dto';
 import { IsArray, IsNumber, IsOptional, Min } from 'class-validator';
 
-export class DeleteReceiverDto extends PickType(CreateVisitationDto, [
+export class AddReceiverDto extends PickType(CreateVisitationDto, [
   'receiverIds',
 ]) {
   @ApiProperty({

--- a/backend/src/visitation/dto/receiever/delete-receiver.dto.ts
+++ b/backend/src/visitation/dto/receiever/delete-receiver.dto.ts
@@ -1,8 +1,8 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
-import { CreateVisitationDto } from './create-visitation.dto';
+import { CreateVisitationDto } from '../create-visitation.dto';
 import { IsArray, IsNumber, IsOptional, Min } from 'class-validator';
 
-export class AddReceiverDto extends PickType(CreateVisitationDto, [
+export class DeleteReceiverDto extends PickType(CreateVisitationDto, [
   'receiverIds',
 ]) {
   @ApiProperty({

--- a/backend/src/visitation/dto/update-visitation.dto.ts
+++ b/backend/src/visitation/dto/update-visitation.dto.ts
@@ -1,7 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
   IsArray,
-  IsBoolean,
   IsDate,
   IsEnum,
   IsNotEmpty,
@@ -14,6 +13,7 @@ import { TransformNumberArray } from '../../common/decorator/transformer/transfo
 import { VisitationStatus } from '../const/visitation-status.enum';
 import { VisitationMethod } from '../const/visitation-method.enum';
 import { RemoveSpaces } from '../../common/decorator/transformer/remove-spaces';
+import { IsAfterDate } from '../../common/decorator/validator/is-after-date.decorator';
 
 export class UpdateVisitationDto {
   @ApiProperty({
@@ -60,7 +60,16 @@ export class UpdateVisitationDto {
   })
   @IsOptional()
   @IsDate()
-  visitationDate?: Date;
+  visitationStartDate?: Date;
+
+  @ApiProperty({
+    description: '심방 종료 날짜',
+    required: false,
+  })
+  @IsOptional()
+  @IsDate()
+  @IsAfterDate('visitationStartDate')
+  visitationEndDate?: Date;
 
   @ApiProperty({
     description: '심방 대상자 추가할 교인 ID 들',
@@ -82,11 +91,11 @@ export class UpdateVisitationDto {
   @TransformNumberArray()
   deleteMemberIds?: number[];
 
-  @ApiProperty({
+  /*@ApiProperty({
     description: 'API 테스트 시 true (심방 진행자의 권한 체크 건너뛰기)',
     default: false,
   })
   @IsOptional()
   @IsBoolean()
-  isTest: boolean = false;
+  isTest: boolean = false;*/
 }

--- a/backend/src/visitation/entity/visitation-meta.entity.ts
+++ b/backend/src/visitation/entity/visitation-meta.entity.ts
@@ -41,8 +41,12 @@ export class VisitationMetaModel extends BaseModel {
   visitationType: VisitationType;
 
   @Index()
-  @Column({ type: 'timestamptz', comment: '심방 일자' })
-  visitationDate: Date;
+  @Column({ type: 'timestamptz', comment: '심방 시작 일자' })
+  visitationStartDate: Date;
+
+  @Index()
+  @Column({ type: 'timestamptz', comment: '심방 종료 일자' })
+  visitationEndDate: Date;
 
   @Column({ length: 50, comment: '심방 제목' })
   visitationTitle: string;

--- a/backend/src/visitation/service/visitation-detail.service.ts
+++ b/backend/src/visitation/service/visitation-detail.service.ts
@@ -1,0 +1,47 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  IVISITATION_DETAIL_DOMAIN_SERVICE,
+  IVisitationDetailDomainService,
+} from '../visitation-domain/interface/visitation-detail-domain.service.interface';
+import { VisitationMetaModel } from '../entity/visitation-meta.entity';
+import { MemberModel } from '../../members/entity/member.entity';
+import { CreateVisitationDto } from '../dto/create-visitation.dto';
+import { QueryRunner } from 'typeorm';
+import { MemberException } from '../../members/const/exception/member.exception';
+import { VisitationDetailDto } from '../dto/visittion-detail.dto';
+
+@Injectable()
+export class VisitationDetailService {
+  constructor(
+    @Inject(IVISITATION_DETAIL_DOMAIN_SERVICE)
+    private readonly visitationDetailDomainService: IVisitationDetailDomainService,
+  ) {}
+
+  createVisitationDetails(
+    visitationMeta: VisitationMetaModel,
+    members: MemberModel[],
+    dto: CreateVisitationDto,
+    qr: QueryRunner,
+  ) {
+    return Promise.all(
+      dto.visitationDetails.map(
+        async (visitationDetailDto: VisitationDetailDto) => {
+          const visitationMember = members.find(
+            (member) => member.id === visitationDetailDto.memberId,
+          );
+
+          if (!visitationMember) {
+            throw new NotFoundException(MemberException.NOT_FOUND);
+          }
+
+          return this.visitationDetailDomainService.createVisitationDetail(
+            visitationMeta,
+            visitationMember,
+            visitationDetailDto,
+            qr,
+          );
+        },
+      ),
+    );
+  }
+}

--- a/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
@@ -57,7 +57,7 @@ export class VisitationMetaDomainService
 
   private parseWhereOptions(dto: GetVisitationDto) {
     return {
-      visitationDate: this.parseVisitationDate(dto),
+      visitationStartDate: this.parseVisitationDate(dto),
       visitationStatus: dto.visitationStatus && In(dto.visitationStatus),
       visitationMethod: dto.visitationMethod && In(dto.visitationMethod),
       visitationType: dto.visitationType && In(dto.visitationType),
@@ -159,7 +159,7 @@ export class VisitationMetaDomainService
       visitationMethod: dto.visitationMethod,
       visitationType: dto.visitationType,
       visitationTitle: dto.visitationTitle,
-      visitationDate: dto.visitationDate,
+      visitationStartDate: dto.visitationDate,
       //reportTo: reportTo ? reportTo : undefined,
     });
   }

--- a/backend/src/visitation/visitation.module.ts
+++ b/backend/src/visitation/visitation.module.ts
@@ -1,28 +1,26 @@
 import { Module } from '@nestjs/common';
 import { RouterModule } from '@nestjs/core';
 import { VisitationController } from './controller/visitation.controller';
-import { VisitationService } from './visitation.service';
+import { VisitationService } from './service/visitation.service';
 import { VisitationDomainModule } from './visitation-domain/visitation-domain.module';
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
-import { UserDomainModule } from '../user/user-domain/user-domain.module';
 import { MembersDomainModule } from '../members/member-domain/members-domain.module';
 import { VisitationReportDomainModule } from '../report/report-domain/visitation-report-domain.module';
 import { VisitationDetailController } from './controller/visitation-detail.controller';
+import { VisitationDetailService } from './service/visitation-detail.service';
 
 @Module({
   imports: [
     RouterModule.register([
       { path: 'churches/:churchId', module: VisitationModule },
     ]),
-
     ChurchesDomainModule,
-    UserDomainModule,
     MembersDomainModule,
 
     VisitationDomainModule,
     VisitationReportDomainModule,
   ],
   controllers: [VisitationController, VisitationDetailController],
-  providers: [VisitationService],
+  providers: [VisitationService, VisitationDetailService],
 })
 export class VisitationModule {}


### PR DESCRIPTION
## 주요 내용
심방 생성 및 수정 시 종료일자(`visitationEndDate`)를 명시적으로 입력받도록 구조를 변경하였으며, 심방 대상자는 최대 30명까지만 등록할 수 있도록 제한을 추가하였습니다.

## 세부 내용

### 심방 일자 구조 변경
- 기존 단일 필드 `visitationDate` → `visitationStartDate`, `visitationEndDate`로 분리
- `visitationEndDate`는 `visitationStartDate`보다 같거나 이후 날짜만 허용
- 날짜 유효성은 DTO에서 validation 처리

### 심방 대상자 수 제한
- 대상자는 최대 30명까지만 등록 가능
- 생성 시: DTO 레벨에서 배열 길이로 제한
- 수정 시: 기존 대상자 수 + 추가 대상자 수의 합을 기준으로 검사
  - 제한 초과 시 예외 처리 (`BadRequestException` 등)

이번 개선을 통해 심방 기간의 명확한 범위 설정이 가능해졌고,
대상자 수에 대한 명시적 제약을 통해 데이터 과부하나 UI 처리 부담을 줄일 수 있게 되었습니다.