### PR TITLE
fix: 교회 생성 시 자동 생성된 교인과 사용자 계정 간 링크 오류 수정

### DIFF
--- a/backend/src/churches/service/churches.service.ts
+++ b/backend/src/churches/service/churches.service.ts
@@ -83,7 +83,8 @@ export class ChurchesService {
       qr,
     );
 
-    await this.userDomainService.linkMemberToUser(mainAdminMember, user, qr);
+    //await this.userDomainService.linkMemberToUser(mainAdminMember, user, qr);
+    await this.membersDomainService.linkUserToMember(mainAdminMember, user, qr);
 
     return newChurch;
   }


### PR DESCRIPTION
## 주요 내용
교회 생성 시 자동으로 생성되는 교인(Member)과
해당 교회를 생성한 사용자 계정(User) 간의 연결 과정에서 발생하던
연동(link) 문제를 수정하였습니다.

## 세부 내용
- 교회 생성 시 자동 생성되는 교인 정보와 사용자 계정을 정상적으로 연결
- 사용자-교인 간 연동 로직의 참조 방향 및 JoinColumn 설정 오류 수정

이번 수정으로 교회 생성 직후 사용자 계정과 교인 데이터 간의 연동이 안정적으로 동작하며, 초기 관리자 권한 설정 및 관련 로직이 정상적으로 이어지도록 개선되었습니다.