### PR TITLE
feat: 교회 업무(Task) 도메인 초기 구현 – 엔티티 및 목록/생성/조회 기능 추가

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -46,6 +46,8 @@ import { ReportModel } from './report/entity/report.entity';
 import { VisitationReportModel } from './report/entity/visitation-report.entity';
 import { ChurchJoinRequestModel } from './churches/entity/church-join-request.entity';
 import { ChurchJoinRequestStatModel } from './churches/entity/church-join-request-stat.entity';
+import { TaskModule } from './task/task.module';
+import { TaskModel } from './task/entity/task.entity';
 
 @Module({
   imports: [
@@ -145,9 +147,11 @@ import { ChurchJoinRequestStatModel } from './churches/entity/church-join-reques
           // 심방 관련 엔티티
           VisitationMetaModel,
           VisitationDetailModel,
-          // 업무 보고 관련 엔티티
+          // 보고 관련 엔티티
           ReportModel,
           VisitationReportModel,
+          // 업무 관련 엔티티
+          TaskModel,
         ],
         synchronize: true,
       }),
@@ -171,6 +175,7 @@ import { ChurchJoinRequestStatModel } from './churches/entity/church-join-reques
     MemberHistoryModule,
     ManagementModule,
     VisitationModule,
+    TaskModule,
 
     ChurchesDomainModule,
     MembersDomainModule,

--- a/backend/src/churches/entity/church.entity.ts
+++ b/backend/src/churches/entity/church.entity.ts
@@ -12,6 +12,7 @@ import { RequestInfoModel } from '../../request-info/entity/request-info.entity'
 import { VisitationMetaModel } from '../../visitation/entity/visitation-meta.entity';
 import { ChurchJoinRequestModel } from './church-join-request.entity';
 import { Exclude } from 'class-transformer';
+import { TaskModel } from '../../task/entity/task.entity';
 
 @Entity()
 @Unique(['joinCode'])
@@ -72,12 +73,19 @@ export class ChurchModel extends BaseModel {
   @OneToMany(() => RequestInfoModel, (requestInfo) => requestInfo.church)
   requestInfos: RequestInfoModel[];
 
+  // 교인
   @OneToMany(() => MemberModel, (member) => member.church)
   members: MemberModel[];
 
+  // 계정 가입
   @OneToMany(() => ChurchJoinRequestModel, (joinRequest) => joinRequest.church)
   joinRequests: ChurchJoinRequestModel[];
 
+  // 심방
   @OneToMany(() => VisitationMetaModel, (visitingMeta) => visitingMeta.church)
   visitations: VisitationMetaModel[];
+
+  // 업무
+  @OneToMany(() => TaskModel, (task) => task.church)
+  tasks: TaskModel[];
 }

--- a/backend/src/churches/service/churches.service.ts
+++ b/backend/src/churches/service/churches.service.ts
@@ -83,7 +83,8 @@ export class ChurchesService {
       qr,
     );
 
-    await this.userDomainService.linkMemberToUser(mainAdminMember, user, qr);
+    //await this.userDomainService.linkMemberToUser(mainAdminMember, user, qr);
+    await this.membersDomainService.linkUserToMember(mainAdminMember, user, qr);
 
     return newChurch;
   }

--- a/backend/src/common/dto/reponse/base-get-response.dto.ts
+++ b/backend/src/common/dto/reponse/base-get-response.dto.ts
@@ -1,3 +1,6 @@
 export abstract class BaseGetResponseDto<T> {
-  protected constructor(data: T, timestamp: Date = new Date()) {}
+  protected constructor(
+    public readonly data: T,
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -29,6 +29,7 @@ import { OfficerHistoryModel } from '../../member-history/entity/officer-history
 import { GroupHistoryModel } from '../../member-history/entity/group-history.entity';
 import { VisitationDetailModel } from '../../visitation/entity/visitation-detail.entity';
 import { VisitationMetaModel } from '../../visitation/entity/visitation-meta.entity';
+import { TaskModel } from '../../task/entity/task.entity';
 
 @Entity()
 export class MemberModel extends BaseModel {
@@ -196,6 +197,8 @@ export class MemberModel extends BaseModel {
   @OneToMany(() => GroupHistoryModel, (groupHistory) => groupHistory.member)
   groupHistory: GroupHistoryModel[];
 
+  // --------------- 심방 -------------------
+
   // 진행하는 심방
   @OneToMany(
     () => VisitationMetaModel,
@@ -223,6 +226,20 @@ export class MemberModel extends BaseModel {
     (visitingDetail) => visitingDetail.member,
   )
   visitationDetails: VisitationDetailModel[];
+
+  // --------------- 심방 -------------------
+
+  // --------------- 업무 -------------------
+
+  // 생성한 업무
+  @OneToMany(() => TaskModel, (task) => task.creator)
+  createdTask: TaskModel[];
+
+  // 할당 받은 업무
+  @OneToMany(() => TaskModel, (task) => task.inCharge)
+  assignedTask: TaskModel[];
+
+  // --------------- 업무 -------------------
 
   // ------------------ 보고 -------------------------
 }

--- a/backend/src/task/const/exception-message/task.exception.ts
+++ b/backend/src/task/const/exception-message/task.exception.ts
@@ -1,0 +1,7 @@
+export const TaskException = {
+  NOT_FOUND: (purpose: string = '') =>
+    `해당 ${purpose}업무를 찾을 수 없습니다.`,
+
+  INVALID_PARENT_TASK: '잘못된 상위 그룹 설정입니다.',
+  INVALID_IN_CHARGE_MEMBER: '업무 담당자는 관리자 이상만 가능합니다.',
+};

--- a/backend/src/task/const/task-find-options.const.ts
+++ b/backend/src/task/const/task-find-options.const.ts
@@ -1,0 +1,87 @@
+import { FindOptionsRelations, FindOptionsSelect } from 'typeorm';
+import { TaskModel } from '../entity/task.entity';
+
+export const TaskFindOptionsRelation: FindOptionsRelations<TaskModel> = {
+  parentTask: true,
+  subTasks: {
+    inCharge: {
+      officer: true,
+      group: true,
+      groupRole: true,
+    },
+  },
+  inCharge: {
+    officer: true,
+    group: true,
+    groupRole: true,
+  },
+  creator: {
+    officer: true,
+    group: true,
+    groupRole: true,
+  },
+};
+
+export const TaskFindOptionsSelect: FindOptionsSelect<TaskModel> = {
+  parentTask: {
+    id: true,
+    title: true,
+    taskStatus: true,
+  },
+  subTasks: {
+    id: true,
+    title: true,
+    taskStatus: true,
+    taskStartDate: true,
+    taskEndDate: true,
+    inChargeId: true,
+    inCharge: {
+      id: true,
+      name: true,
+      officer: {
+        id: true,
+        name: true,
+      },
+      group: {
+        id: true,
+        name: true,
+      },
+      groupRole: {
+        id: true,
+        role: true,
+      },
+    },
+  },
+  inCharge: {
+    id: true,
+    name: true,
+    officer: {
+      id: true,
+      name: true,
+    },
+    group: {
+      id: true,
+      name: true,
+    },
+    groupRole: {
+      id: true,
+      role: true,
+    },
+  },
+  creator: {
+    id: true,
+    name: true,
+    officer: {
+      id: true,
+      name: true,
+    },
+    group: {
+      id: true,
+      name: true,
+    },
+    groupRole: {
+      id: true,
+      role: true,
+    },
+  },
+};

--- a/backend/src/task/const/task-order.enum.ts
+++ b/backend/src/task/const/task-order.enum.ts
@@ -1,0 +1,6 @@
+export enum TaskOrder {
+  createdAt = 'createdAt',
+  updatedAt = 'updatedAt',
+  title = 'title',
+  taskStartDate = 'taskStartDate',
+}

--- a/backend/src/task/const/task-status.enum.ts
+++ b/backend/src/task/const/task-status.enum.ts
@@ -1,0 +1,6 @@
+export enum TaskStatus {
+  RESERVE = 'reserve',
+  IN_PROGRESS = 'inProgress',
+  DONE = 'done',
+  PENDING = 'pending',
+}

--- a/backend/src/task/const/task-tree.enum.ts
+++ b/backend/src/task/const/task-tree.enum.ts
@@ -1,0 +1,5 @@
+export enum TaskTreeEnum {
+  parent = '상위 ',
+  child = '하위 ',
+  none = '',
+}

--- a/backend/src/task/const/task-type.enum.ts
+++ b/backend/src/task/const/task-type.enum.ts
@@ -1,0 +1,4 @@
+export enum TaskType {
+  parent = 'parentTask',
+  subTask = 'subTask',
+}

--- a/backend/src/task/controller/task.controller.ts
+++ b/backend/src/task/controller/task.controller.ts
@@ -1,0 +1,71 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { TaskService } from '../service/task.service';
+import { ApiTags } from '@nestjs/swagger';
+import { CreateTaskDto } from '../dto/request/create-task.dto';
+import { QueryRunner } from '../../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm';
+import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { ChurchManagerGuard } from '../../churches/guard/church-guard.service';
+import { Token } from '../../auth/decorator/jwt.decorator';
+import { JwtAccessPayload } from '../../auth/type/jwt';
+import { AuthType } from '../../auth/const/enum/auth-type.enum';
+import { GetTasksDto } from '../dto/request/get-tasks.dto';
+
+@ApiTags('Tasks')
+@Controller()
+export class TaskController {
+  constructor(private readonly taskService: TaskService) {}
+
+  @Get()
+  getTasks(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetTasksDto,
+  ) {
+    return this.taskService.getTasks(churchId, dto);
+  }
+
+  @Post()
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
+  @UseInterceptors(TransactionInterceptor)
+  postTask(
+    @Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Body() dto: CreateTaskDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.taskService.postTask(churchId, accessPayload.id, dto, qr);
+  }
+
+  @Get(':taskId')
+  async getTaskById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('taskId', ParseIntPipe) taskId: number,
+  ) {
+    return this.taskService.getTaskById(churchId, taskId);
+  }
+
+  @Patch(':taskId')
+  patchTask(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('taskId', ParseIntPipe) taskId: number,
+  ) {}
+
+  @Delete(':taskId')
+  deleteTask(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('taskId', ParseIntPipe) taskId: number,
+  ) {}
+}

--- a/backend/src/task/dto/request/create-task.dto.ts
+++ b/backend/src/task/dto/request/create-task.dto.ts
@@ -1,0 +1,86 @@
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { TaskModel } from '../../entity/task.entity';
+import {
+  IsDate,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { IsNoSpecialChar } from '../../../common/decorator/validator/is-title.decorator';
+import { RemoveSpaces } from '../../../common/decorator/transformer/remove-spaces';
+import { SanitizeDto } from '../../../common/decorator/sanitize-target.decorator';
+import { TaskStatus } from '../../const/task-status.enum';
+import { IsAfterDate } from '../../../common/decorator/validator/is-after-date.decorator';
+
+@SanitizeDto()
+export class CreateTaskDto extends PickType(TaskModel, [
+  'parentTaskId',
+  'title',
+  'taskStatus',
+  'taskStartDate',
+  'taskEndDate',
+  'comment',
+  'inChargeId',
+]) {
+  @ApiProperty({
+    description: '상위 업무 ID',
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  override parentTaskId: number;
+
+  @ApiProperty({
+    description: '업무 제목',
+    maxLength: 50,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @IsNoSpecialChar()
+  @RemoveSpaces()
+  @MaxLength(50)
+  override title: string;
+
+  @ApiProperty({
+    description: '업무 상태 (예약 / 진행중 / 완료 / 지연)',
+    enum: TaskStatus,
+    default: TaskStatus.RESERVE,
+  })
+  @IsEnum(TaskStatus)
+  override taskStatus: TaskStatus = TaskStatus.RESERVE;
+
+  @ApiProperty({
+    description: '업무 시작 일자',
+  })
+  @IsDate()
+  override taskStartDate: Date;
+
+  @ApiProperty({
+    description: '업무 종료 일자',
+  })
+  @IsDate()
+  @IsAfterDate('taskStartDate')
+  override taskEndDate: Date;
+
+  @ApiProperty({
+    description: '업무 내용 코멘트',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  comment: string;
+
+  @ApiProperty({
+    description: '업무 담당자 ID',
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  override inChargeId: number;
+}

--- a/backend/src/task/dto/request/get-tasks.dto.ts
+++ b/backend/src/task/dto/request/get-tasks.dto.ts
@@ -1,0 +1,71 @@
+import { BaseOffsetPaginationRequestDto } from '../../../common/dto/request/base-offset-pagination-request.dto';
+import { TaskOrder } from '../../const/task-order.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsDate,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+import { RemoveSpaces } from '../../../common/decorator/transformer/remove-spaces';
+import { IsNoSpecialChar } from '../../../common/decorator/validator/is-title.decorator';
+import { TaskStatus } from '../../const/task-status.enum';
+import { IsAfterDate } from '../../../common/decorator/validator/is-after-date.decorator';
+
+export class GetTasksDto extends BaseOffsetPaginationRequestDto<TaskOrder> {
+  @ApiProperty({
+    description: '정렬 조건',
+    enum: TaskOrder,
+    default: TaskOrder.taskStartDate,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(TaskOrder)
+  order: TaskOrder = TaskOrder.taskStartDate;
+
+  @ApiProperty({
+    description: '업무 제목',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @RemoveSpaces()
+  @IsNoSpecialChar()
+  title?: string;
+
+  @ApiProperty({
+    description: '업무 시작 날짜 ~ 부터',
+    required: false,
+  })
+  @IsOptional()
+  @IsDate()
+  fromTaskStartDate?: Date;
+
+  @ApiProperty({
+    description: '업무 시작 날짜 ~ 까지',
+    required: false,
+  })
+  @IsOptional()
+  @IsDate()
+  @IsAfterDate('fromTaskStartDate')
+  toTaskStartDate?: Date;
+
+  @ApiProperty({
+    description: '업무 상태 (예정 / 진행중 / 완료 / 지연)',
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(TaskStatus)
+  taskStatus?: TaskStatus;
+
+  @ApiProperty({
+    description: '업무 담당자 ID',
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  inChargeId?: number;
+}

--- a/backend/src/task/dto/response/get-task-response.dto.ts
+++ b/backend/src/task/dto/response/get-task-response.dto.ts
@@ -1,0 +1,8 @@
+import { BaseGetResponseDto } from '../../../common/dto/reponse/base-get-response.dto';
+import { TaskModel } from '../../entity/task.entity';
+
+export class GetTaskResponseDto extends BaseGetResponseDto<TaskModel> {
+  constructor(data: TaskModel, timestamp: Date) {
+    super(data, timestamp);
+  }
+}

--- a/backend/src/task/dto/response/post-task-response.dto.ts
+++ b/backend/src/task/dto/response/post-task-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePostResponseDto } from '../../../common/dto/reponse/base-post-response.dto';
+import { TaskModel } from '../../entity/task.entity';
+
+export class PostTaskResponseDto extends BasePostResponseDto<TaskModel> {
+  constructor(data: TaskModel, timestamp: Date) {
+    super(data, timestamp);
+  }
+}

--- a/backend/src/task/dto/response/task-pagination-result.dto.ts
+++ b/backend/src/task/dto/response/task-pagination-result.dto.ts
@@ -1,0 +1,14 @@
+import { BaseOffsetPaginationResponseDto } from '../../../common/dto/reponse/base-offset-pagination-response.dto';
+import { TaskModel } from '../../entity/task.entity';
+
+export class TaskPaginationResultDto extends BaseOffsetPaginationResponseDto<TaskModel> {
+  constructor(
+    data: TaskModel[],
+    totalCount: number,
+    count: number,
+    page: number,
+    totalPage: number,
+  ) {
+    super(data, totalCount, count, page, totalPage);
+  }
+}

--- a/backend/src/task/dto/task-domain-pagination-result.dto.ts
+++ b/backend/src/task/dto/task-domain-pagination-result.dto.ts
@@ -1,0 +1,8 @@
+import { BaseDomainOffsetPaginationResultDto } from '../../common/dto/base-domain-offset-pagination-result.dto';
+import { TaskModel } from '../entity/task.entity';
+
+export class TaskDomainPaginationResultDto extends BaseDomainOffsetPaginationResultDto<TaskModel> {
+  constructor(data: TaskModel[], totalCount: number) {
+    super(data, totalCount);
+  }
+}

--- a/backend/src/task/entity/task.entity.ts
+++ b/backend/src/task/entity/task.entity.ts
@@ -1,0 +1,86 @@
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+} from 'typeorm';
+import { BaseModel, BaseModelColumns } from '../../common/entity/base.entity';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { TaskStatus } from '../const/task-status.enum';
+import { MemberModel } from '../../members/entity/member.entity';
+import { TaskType } from '../const/task-type.enum';
+
+@Entity()
+export class TaskModel extends BaseModel {
+  @Index()
+  @Column()
+  churchId: number;
+
+  @ManyToOne(() => ChurchModel, (church) => church.tasks)
+  @JoinColumn({ name: 'churchId' })
+  church: ChurchModel;
+
+  @Column({ enum: TaskType, default: TaskType.parent })
+  taskType: TaskType;
+
+  @Column({ length: 50, comment: '업무 제목' })
+  title: string;
+
+  @Column({
+    enum: TaskStatus,
+    default: TaskStatus.RESERVE,
+  })
+  taskStatus: TaskStatus;
+
+  @Index()
+  @Column({ type: 'timestamptz', comment: '업무 시작 일자' })
+  taskStartDate: Date;
+
+  @Column({ type: 'timestamptz', comment: '업무 종료 일자' })
+  taskEndDate: Date;
+
+  @OneToMany(() => TaskModel, (subTask) => subTask.parentTask)
+  subTasks: TaskModel[];
+
+  @Index()
+  @Column({ comment: '상위 업무 ID', nullable: true })
+  parentTaskId: number | null;
+
+  @ManyToOne(() => TaskModel, (parentTask) => parentTask.subTasks)
+  parentTask: TaskModel;
+
+  @Column({ default: '' })
+  comment: string;
+
+  @Index()
+  @Column({ comment: '담당자 ID', nullable: true })
+  inChargeId: number;
+
+  @ManyToOne(() => MemberModel, (member) => member.assignedTask)
+  @JoinColumn({ name: 'inChargeId' })
+  inCharge: MemberModel;
+
+  @Index()
+  @Column({ comment: '업무 생성자 ID' })
+  creatorId: number;
+
+  @ManyToOne(() => MemberModel, (member) => member.createdTask)
+  @JoinColumn({ name: 'creatorId' })
+  creator: MemberModel;
+
+  /*
+  추가할 컬럼
+  == 1. 담당자 --> ManyToMany
+  == 2. 생성자 --> ManyToOne
+  3. 보고서 --> OneToMany
+  == 4. 하위 업무 --> OneToMany
+  == 5. 상위 업무 --> ManyToOne
+   */
+}
+
+export const TaskModelColumns = {
+  ...BaseModelColumns,
+  title: 'title',
+};

--- a/backend/src/task/service/task.service.ts
+++ b/backend/src/task/service/task.service.ts
@@ -1,0 +1,112 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  ITASK_DOMAIN_SERVICE,
+  ITaskDomainService,
+} from '../task-domain/interface/task-domain.service.interface';
+import { CreateTaskDto } from '../dto/request/create-task.dto';
+import { QueryRunner } from 'typeorm';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IMEMBERS_DOMAIN_SERVICE,
+  IMembersDomainService,
+} from '../../members/member-domain/interface/members-domain.service.interface';
+import { PostTaskResponseDto } from '../dto/response/post-task-response.dto';
+import { TaskTreeEnum } from '../const/task-tree.enum';
+import { GetTaskResponseDto } from '../dto/response/get-task-response.dto';
+import { GetTasksDto } from '../dto/request/get-tasks.dto';
+import { TaskPaginationResultDto } from '../dto/response/task-pagination-result.dto';
+
+@Injectable()
+export class TaskService {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,
+
+    @Inject(ITASK_DOMAIN_SERVICE)
+    private readonly taskDomainService: ITaskDomainService,
+  ) {}
+
+  async getTasks(churchId: number, dto: GetTasksDto, qr?: QueryRunner) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const result = await this.taskDomainService.findTasks(church, dto, qr);
+
+    return new TaskPaginationResultDto(
+      result.data,
+      result.totalCount,
+      result.data.length,
+      dto.page,
+      Math.ceil(result.totalCount / dto.take),
+    );
+  }
+
+  async postTask(
+    churchId: number,
+    creatorUserId: number,
+    dto: CreateTaskDto,
+    qr: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const creatorMember =
+      await this.membersDomainService.findMemberModelByUserId(
+        church,
+        creatorUserId,
+        qr,
+      );
+
+    const inChargeMember = dto.inChargeId
+      ? await this.membersDomainService.findMemberModelById(
+          church,
+          dto.inChargeId,
+          qr,
+          { user: true },
+        )
+      : null;
+
+    // 업무 담당자 권한 체크
+    inChargeMember &&
+      this.taskDomainService.assertValidInChargeMember(inChargeMember);
+
+    // 상위 업무
+    const parentTask = dto.parentTaskId
+      ? await this.taskDomainService.findTaskModelById(
+          church,
+          dto.parentTaskId,
+          TaskTreeEnum.parent,
+          qr,
+        )
+      : null;
+
+    const newTask = await this.taskDomainService.createTask(
+      church,
+      creatorMember,
+      parentTask,
+      inChargeMember,
+      dto,
+      qr,
+    );
+
+    return new PostTaskResponseDto(newTask, new Date());
+  }
+
+  async getTaskById(churchId: number, taskId: number) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const task = await this.taskDomainService.findTaskById(church, taskId);
+
+    return new GetTaskResponseDto(task, new Date());
+  }
+}

--- a/backend/src/task/task-domain/interface/task-domain.service.interface.ts
+++ b/backend/src/task/task-domain/interface/task-domain.service.interface.ts
@@ -1,0 +1,42 @@
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { FindOptionsRelations, QueryRunner } from 'typeorm';
+import { TaskModel } from '../../entity/task.entity';
+import { MemberModel } from '../../../members/entity/member.entity';
+import { CreateTaskDto } from '../../dto/request/create-task.dto';
+import { GetTasksDto } from '../../dto/request/get-tasks.dto';
+import { TaskDomainPaginationResultDto } from '../../dto/task-domain-pagination-result.dto';
+
+export const ITASK_DOMAIN_SERVICE = Symbol('ITASK_DOMAIN_SERVICE');
+
+export interface ITaskDomainService {
+  findTasks(
+    church: ChurchModel,
+    dto: GetTasksDto,
+    qr?: QueryRunner,
+  ): Promise<TaskDomainPaginationResultDto>;
+
+  findTaskById(
+    church: ChurchModel,
+    taskId: number,
+    qr?: QueryRunner,
+  ): Promise<TaskModel>;
+
+  findTaskModelById(
+    church: ChurchModel,
+    taskId: number,
+    purpose?: string,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<TaskModel>,
+  ): Promise<TaskModel>;
+
+  assertValidInChargeMember(inChargeMember: MemberModel): void;
+
+  createTask(
+    church: ChurchModel,
+    creatorMember: MemberModel,
+    parentTask: TaskModel | null,
+    inChargeMember: MemberModel | null,
+    dto: CreateTaskDto,
+    qr: QueryRunner,
+  ): Promise<TaskModel>;
+}

--- a/backend/src/task/task-domain/service/task-domain.service.ts
+++ b/backend/src/task/task-domain/service/task-domain.service.ts
@@ -1,0 +1,183 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { TaskModel } from '../../entity/task.entity';
+import {
+  Between,
+  FindOptionsOrder,
+  FindOptionsRelations,
+  LessThanOrEqual,
+  Like,
+  MoreThanOrEqual,
+  QueryRunner,
+  Repository,
+} from 'typeorm';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { TaskDomainPaginationResultDto } from '../../dto/task-domain-pagination-result.dto';
+import { TaskException } from '../../const/exception-message/task.exception';
+import { CreateTaskDto } from '../../dto/request/create-task.dto';
+import { ITaskDomainService } from '../interface/task-domain.service.interface';
+import { MemberModel } from '../../../members/entity/member.entity';
+import {
+  TaskFindOptionsRelation,
+  TaskFindOptionsSelect,
+} from '../../const/task-find-options.const';
+import { TaskType } from '../../const/task-type.enum';
+import { UserRole } from '../../../user/const/user-role.enum';
+import { MemberException } from '../../../members/const/exception/member.exception';
+import { GetTasksDto } from '../../dto/request/get-tasks.dto';
+import { TaskOrder } from '../../const/task-order.enum';
+
+@Injectable()
+export class TaskDomainService implements ITaskDomainService {
+  constructor(
+    @InjectRepository(TaskModel)
+    private readonly taskRepository: Repository<TaskModel>,
+  ) {}
+
+  private getTaskRepository(qr?: QueryRunner) {
+    return qr ? qr.manager.getRepository(TaskModel) : this.taskRepository;
+  }
+
+  private parseTaskDate(dto: GetTasksDto) {
+    if (dto.fromTaskStartDate && !dto.toTaskStartDate) {
+      return MoreThanOrEqual(dto.fromTaskStartDate);
+    } else if (!dto.fromTaskStartDate && dto.toTaskStartDate) {
+      return LessThanOrEqual(dto.toTaskStartDate);
+    } else if (dto.fromTaskStartDate && dto.toTaskStartDate) {
+      return Between(dto.fromTaskStartDate, dto.toTaskStartDate);
+    } else {
+      return undefined;
+    }
+  }
+
+  async findTasks(church: ChurchModel, dto: GetTasksDto, qr?: QueryRunner) {
+    const taskRepository = this.getTaskRepository(qr);
+
+    const order: FindOptionsOrder<TaskModel> = {
+      [dto.order]: dto.orderDirection,
+    };
+
+    if (dto.order !== TaskOrder.createdAt) {
+      order.createdAt = 'asc';
+    }
+
+    const [data, totalCount] = await Promise.all([
+      taskRepository.find({
+        where: {
+          churchId: church.id,
+          taskType: TaskType.parent,
+          title: dto.title && Like(`%${dto.title}%`),
+          taskStartDate: this.parseTaskDate(dto),
+          taskStatus: dto.taskStatus,
+          inChargeId: dto.inChargeId,
+        },
+        order,
+        take: dto.take,
+        skip: dto.take * (dto.page - 1),
+      }),
+      taskRepository.count({
+        where: {
+          churchId: church.id,
+          taskType: TaskType.parent,
+          title: dto.title && Like(`%${dto.title}%`),
+          taskStartDate: this.parseTaskDate(dto),
+          taskStatus: dto.taskStatus,
+          inChargeId: dto.inChargeId,
+        },
+      }),
+    ]);
+
+    return new TaskDomainPaginationResultDto(data, totalCount);
+  }
+
+  async findTaskById(church: ChurchModel, taskId: number, qr?: QueryRunner) {
+    const taskRepository = this.getTaskRepository(qr);
+
+    const task = await taskRepository.findOne({
+      where: {
+        churchId: church.id,
+        id: taskId,
+      },
+      relations: {
+        ...TaskFindOptionsRelation,
+      },
+      select: { ...TaskFindOptionsSelect },
+    });
+
+    if (!task) {
+      throw new NotFoundException(TaskException.NOT_FOUND());
+    }
+
+    return task;
+  }
+
+  async findTaskModelById(
+    church: ChurchModel,
+    taskId: number,
+    purpose?: string,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<TaskModel>,
+  ): Promise<TaskModel> {
+    const taskRepository = this.getTaskRepository(qr);
+
+    const task = await taskRepository.findOne({
+      where: {
+        churchId: church.id,
+        id: taskId,
+      },
+      relations: relationOptions,
+    });
+
+    if (!task) {
+      throw new NotFoundException(TaskException.NOT_FOUND(purpose));
+    }
+
+    return task;
+  }
+
+  assertValidInChargeMember(inChargeMember: MemberModel) {
+    if (!inChargeMember.user) {
+      throw new ConflictException(MemberException.NOT_LINKED_MEMBER);
+    }
+
+    if (
+      inChargeMember.user.role !== UserRole.mainAdmin &&
+      inChargeMember.user.role !== UserRole.manager
+    ) {
+      throw new ConflictException(TaskException.INVALID_IN_CHARGE_MEMBER);
+    }
+  }
+
+  async createTask(
+    church: ChurchModel,
+    creatorMember: MemberModel,
+    parentTask: TaskModel | null,
+    inChargeMember: MemberModel | null,
+    dto: CreateTaskDto,
+    qr: QueryRunner,
+  ) {
+    const taskRepository = this.getTaskRepository(qr);
+
+    if (parentTask && parentTask.taskType === TaskType.subTask) {
+      throw new BadRequestException(TaskException.INVALID_PARENT_TASK);
+    }
+
+    return taskRepository.save({
+      churchId: church.id,
+      creatorId: creatorMember.id,
+      inChargeId: inChargeMember ? inChargeMember.id : undefined,
+      parentTaskId: parentTask ? parentTask.id : undefined,
+      taskType: parentTask ? TaskType.subTask : TaskType.parent,
+      title: dto.title,
+      taskStatus: dto.taskStatus,
+      taskStartDate: dto.taskStartDate,
+      taskEndDate: dto.taskEndDate,
+      comment: dto.comment,
+    });
+  }
+}

--- a/backend/src/task/task-domain/task-domain.module.ts
+++ b/backend/src/task/task-domain/task-domain.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TaskModel } from '../entity/task.entity';
+import { ITASK_DOMAIN_SERVICE } from './interface/task-domain.service.interface';
+import { TaskDomainService } from './service/task-domain.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([TaskModel])],
+  providers: [
+    {
+      provide: ITASK_DOMAIN_SERVICE,
+      useClass: TaskDomainService,
+    },
+  ],
+  exports: [ITASK_DOMAIN_SERVICE],
+})
+export class TaskDomainModule {}

--- a/backend/src/task/task.module.ts
+++ b/backend/src/task/task.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { RouterModule } from '@nestjs/core';
+import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
+import { MembersDomainModule } from '../members/member-domain/members-domain.module';
+import { TaskController } from './controller/task.controller';
+import { TaskService } from './service/task.service';
+import { TaskDomainModule } from './task-domain/task-domain.module';
+
+@Module({
+  imports: [
+    RouterModule.register([
+      { path: 'churches/:churchId/tasks', module: TaskModule },
+    ]),
+    ChurchesDomainModule,
+    MembersDomainModule,
+    TaskDomainModule,
+  ],
+  controllers: [TaskController],
+  providers: [TaskService],
+})
+export class TaskModule {}


### PR DESCRIPTION
## 주요 내용
교회 내 업무(Task)를 관리하기 위한 TaskModel 도메인을 새로 정의하고,
기본적인 CRUD 엔드포인트 중 목록 조회, 생성, 개별 조회 기능을 우선적으로 구현하였습니다.

## 세부 내용
- `TaskModel` 엔티티 생성
  - 교회 ID 기준으로 소속 업무 관리
  - 업무 제목, 내용, 상태, 생성일 등 포함

- 엔드포인트 설계 및 구현
  - 루트 경로: `/churches/{churchId}/tasks`
  - 구현된 기능:
    - **업무 목록 조회** (GET): 페이징 및 조건 기반 조회 가능
    - **업무 생성** (POST): 교회에 새 업무 등록
    - **업무 개별 조회** (GET): 업무 ID 기반 단일 조회

이번 초기 구현을 통해 교회 업무(Task)에 대한 기본적인 생성 및 조회 흐름이 구축되었으며, 향후 수정/삭제/상태 변경 등의 기능을 기반 위에 확장해 나갈 수 있도록 설계되었습니다.