### PR TITLE
fix: visitationEndDate 컬럼 미저장으로 인한 심방 생성 오류 수정

### DIFF
--- a/backend/src/visitation/const/exception/visitation.exception.ts
+++ b/backend/src/visitation/const/exception/visitation.exception.ts
@@ -10,6 +10,9 @@ export const VisitationException = {
 
   MEMBER_RELATION_ERROR: '심방 대상자 불러오기 실패',
 
+  INVALID_START_DATE: '시작 날짜는 종료 날짜보다 늦을 수 없습니다.',
+  INVALID_END_DATE: '종료 날짜는 시작 날짜를 앞설 수 없습니다.',
+
   INVALID_REPORT_RECEIVER:
     '피보고자로 등록할 수 없는 교인이 포함되어 있습니다.',
   ALREADY_REPORTED_MEMBER: '이미 피보고자로 등록된 교인입니다.',

--- a/backend/src/visitation/dto/internal/meta/create-visitation-meta.dto.ts
+++ b/backend/src/visitation/dto/internal/meta/create-visitation-meta.dto.ts
@@ -14,7 +14,9 @@ export class CreateVisitationMetaDto {
 
   instructor: MemberModel;
 
-  visitationDate: Date;
+  visitationStartDate: Date;
+
+  visitationEndDate: Date;
 
   creator: MemberModel;
 }

--- a/backend/src/visitation/dto/internal/meta/update-visitation-meta.dto.ts
+++ b/backend/src/visitation/dto/internal/meta/update-visitation-meta.dto.ts
@@ -14,5 +14,6 @@ export class UpdateVisitationMetaDto {
 
   instructor?: MemberModel;
 
-  visitationDate?: Date;
+  visitationStartDate?: Date;
+  visitationEndDate?: Date;
 }

--- a/backend/src/visitation/service/visitation.service.ts
+++ b/backend/src/visitation/service/visitation.service.ts
@@ -267,7 +267,8 @@ export class VisitationService {
       visitationStatus: dto.visitationStatus,
       visitationMethod: dto.visitationMethod,
       visitationTitle: dto.visitationTitle,
-      visitationDate: dto.visitationStartDate,
+      visitationStartDate: dto.visitationStartDate,
+      visitationEndDate: dto.visitationEndDate,
       visitationType:
         members.length > 1 ? VisitationType.GROUP : VisitationType.SINGLE,
     };
@@ -465,13 +466,13 @@ export class VisitationService {
     // 심방 종료날짜만 변경하는 경우
     if (!dto.visitationStartDate && dto.visitationEndDate) {
       if (dto.visitationEndDate < targetMetaData.visitationStartDate) {
-        throw new BadRequestException('심방 종료 날짜 에러');
+        throw new BadRequestException(VisitationException.INVALID_END_DATE);
       }
     }
     // 심방 시작날짜만 변경하는 경우
     if (dto.visitationStartDate && !dto.visitationEndDate) {
       if (dto.visitationStartDate > targetMetaData.visitationEndDate) {
-        throw new BadRequestException('심방 시작 날짜 에러');
+        throw new BadRequestException(VisitationException.INVALID_START_DATE);
       }
     }
 
@@ -509,7 +510,8 @@ export class VisitationService {
     }
 
     const updateVisitationMetaDto: UpdateVisitationMetaDto = {
-      visitationDate: dto.visitationStartDate,
+      visitationStartDate: dto.visitationStartDate,
+      visitationEndDate: dto.visitationEndDate,
       visitationMethod: dto.visitationMethod,
       visitationType,
       visitationStatus: dto.visitationStatus,

--- a/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
@@ -159,7 +159,8 @@ export class VisitationMetaDomainService
       visitationMethod: dto.visitationMethod,
       visitationType: dto.visitationType,
       visitationTitle: dto.visitationTitle,
-      visitationStartDate: dto.visitationDate,
+      visitationStartDate: dto.visitationStartDate,
+      visitationEndDate: dto.visitationEndDate,
       //reportTo: reportTo ? reportTo : undefined,
     });
   }


### PR DESCRIPTION
## 주요 내용
심방 생성 시 `visitationEndDate` 컬럼이 추가되었음에도 불구하고
해당 값을 DB에 저장하지 않아 발생하던 오류를 수정하였습니다.

## 세부 내용
- `visitationEndDate` 값을 엔티티에 정상적으로 매핑하도록 저장 로직 수정
- DTO → 엔티티 변환 과정에서 누락된 필드 반영
- 유효한 시작일/종료일 입력에도 저장되지 않아 validation 에러가 발생하던 문제 해결

이번 수정으로 심방 생성 시 시작일과 종료일이 모두 안정적으로 저장되며,
날짜 유효성 검증 및 이후 수정/조회 기능에서도 오류 없이 처리됩니다.