### PR TITLE
feat: 교회 업무(Task) 수정 및 삭제 기능 추가

### DIFF
--- a/backend/src/members/const/member-find-options.const.ts
+++ b/backend/src/members/const/member-find-options.const.ts
@@ -1,0 +1,25 @@
+import { FindOptionsRelations, FindOptionsSelect } from 'typeorm';
+import { MemberModel } from '../entity/member.entity';
+
+export const MemberSummarizedRelation: FindOptionsRelations<MemberModel> = {
+  officer: true,
+  group: true,
+  groupRole: true,
+};
+
+export const MemberSummarizedSelect: FindOptionsSelect<MemberModel> = {
+  id: true,
+  name: true,
+  officer: {
+    id: true,
+    name: true,
+  },
+  group: {
+    id: true,
+    name: true,
+  },
+  groupRole: {
+    id: true,
+    role: true,
+  },
+};

--- a/backend/src/task/const/exception-message/task.exception.ts
+++ b/backend/src/task/const/exception-message/task.exception.ts
@@ -1,7 +1,17 @@
+import { MAX_SUB_TASK_COUNT } from '../task.constraints';
+
 export const TaskException = {
+  EXCEED_MAX_SUB_TASK: `하위 업무는 최대 ${MAX_SUB_TASK_COUNT}개까지 등록할 수 있습니다.`,
+  UPDATE_ERROR: '업무 내용 업데이트 도중 에러 발생',
+  DELETE_ERROR: '업무 삭제 도중 에러 발생',
+  INVALID_CHANGE_PARENT_TASK: '하위 업무로 변경할 수 없는 업무입니다.',
+  TASK_HAS_DEPENDENCIES: '하위 업무가 존재하는 업무는 삭제할 수 없습니다.',
+
   NOT_FOUND: (purpose: string = '') =>
     `해당 ${purpose}업무를 찾을 수 없습니다.`,
 
+  INVALID_START_DATE: '시작 날짜는 종료 날짜를 넘어설 수 없습니다.',
+  INVALID_END_DATE: '종료 날짜는 시작 날짜를 앞설 수 없습니다.',
   INVALID_PARENT_TASK: '잘못된 상위 그룹 설정입니다.',
   INVALID_IN_CHARGE_MEMBER: '업무 담당자는 관리자 이상만 가능합니다.',
 };

--- a/backend/src/task/const/swagger/task.swagger.ts
+++ b/backend/src/task/const/swagger/task.swagger.ts
@@ -1,0 +1,45 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+export const ApiGetTasks = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '업무 목록 조회',
+    }),
+  );
+
+export const ApiPostTask = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '업무 생성',
+      description:
+        '<h2>교회 업무를 생성합니다.</h2>' +
+        '<p><b>로그인 필요 (manager 이상 권한 필요)</b></p>' +
+        '<p>parentTaskId - 상위 업무 ID, 하위 업무는 지정할 수 없음 (업무의 depth 는 1단계), 하위 업무는 최대 10개까지 추가 가능</p>' +
+        '<p>title - 제목, 특수문자 사용불가능 (서식 지정 불가능)</p>' +
+        '<p>taskStartDate, taskEndDate - 업무 시작/종료 날짜, 종료 날짜는 시작 날짜를 앞설 수 없음</p>' +
+        '<p>comment - 업무 내용, 서식 지정 가능 (script, iframe 등 태그 사용 불가능)</p>' +
+        '<p>inChargeId - 업무 담당자 ID, manager 이상 권한 필요</p>',
+    }),
+  );
+
+export const ApiGetTaskById = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '업무 단건 조회',
+    }),
+  );
+
+export const ApiPatchTask = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '업무 수정',
+    }),
+  );
+
+export const ApiDeleteTask = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '업무 삭제',
+    }),
+  );

--- a/backend/src/task/const/task-find-options.const.ts
+++ b/backend/src/task/const/task-find-options.const.ts
@@ -1,25 +1,51 @@
 import { FindOptionsRelations, FindOptionsSelect } from 'typeorm';
 import { TaskModel } from '../entity/task.entity';
+import {
+  MemberSummarizedRelation,
+  MemberSummarizedSelect,
+} from '../../members/const/member-find-options.const';
+
+export const TasksFindOptionsRelation: FindOptionsRelations<TaskModel> = {
+  subTasks: {
+    inCharge: MemberSummarizedRelation,
+  },
+  inCharge: MemberSummarizedRelation,
+};
+
+const SubTaskFindOptionsSelect: FindOptionsSelect<TaskModel> = {
+  id: true,
+  title: true,
+  taskStartDate: true,
+  taskEndDate: true,
+  createdAt: true,
+  updatedAt: true,
+  taskType: true,
+  taskStatus: true,
+  parentTaskId: true,
+  inCharge: MemberSummarizedSelect,
+};
+
+export const TasksFindOptionsSelect: FindOptionsSelect<TaskModel> = {
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+  churchId: true,
+  taskType: true,
+  title: true,
+  taskStatus: true,
+  taskStartDate: true,
+  taskEndDate: true,
+  subTasks: SubTaskFindOptionsSelect,
+  inCharge: MemberSummarizedSelect,
+};
 
 export const TaskFindOptionsRelation: FindOptionsRelations<TaskModel> = {
   parentTask: true,
   subTasks: {
-    inCharge: {
-      officer: true,
-      group: true,
-      groupRole: true,
-    },
+    inCharge: MemberSummarizedRelation,
   },
-  inCharge: {
-    officer: true,
-    group: true,
-    groupRole: true,
-  },
-  creator: {
-    officer: true,
-    group: true,
-    groupRole: true,
-  },
+  inCharge: MemberSummarizedRelation,
+  creator: MemberSummarizedRelation,
 };
 
 export const TaskFindOptionsSelect: FindOptionsSelect<TaskModel> = {
@@ -27,61 +53,10 @@ export const TaskFindOptionsSelect: FindOptionsSelect<TaskModel> = {
     id: true,
     title: true,
     taskStatus: true,
-  },
-  subTasks: {
-    id: true,
-    title: true,
-    taskStatus: true,
     taskStartDate: true,
     taskEndDate: true,
-    inChargeId: true,
-    inCharge: {
-      id: true,
-      name: true,
-      officer: {
-        id: true,
-        name: true,
-      },
-      group: {
-        id: true,
-        name: true,
-      },
-      groupRole: {
-        id: true,
-        role: true,
-      },
-    },
   },
-  inCharge: {
-    id: true,
-    name: true,
-    officer: {
-      id: true,
-      name: true,
-    },
-    group: {
-      id: true,
-      name: true,
-    },
-    groupRole: {
-      id: true,
-      role: true,
-    },
-  },
-  creator: {
-    id: true,
-    name: true,
-    officer: {
-      id: true,
-      name: true,
-    },
-    group: {
-      id: true,
-      name: true,
-    },
-    groupRole: {
-      id: true,
-      role: true,
-    },
-  },
+  subTasks: SubTaskFindOptionsSelect,
+  inCharge: MemberSummarizedSelect,
+  creator: MemberSummarizedSelect,
 };

--- a/backend/src/task/const/task-type.enum.ts
+++ b/backend/src/task/const/task-type.enum.ts
@@ -1,4 +1,5 @@
 export enum TaskType {
   parent = 'parentTask',
   subTask = 'subTask',
+  none = 'none',
 }

--- a/backend/src/task/const/task.constraints.ts
+++ b/backend/src/task/const/task.constraints.ts
@@ -1,0 +1,1 @@
+export const MAX_SUB_TASK_COUNT = 10;

--- a/backend/src/task/controller/task.controller.ts
+++ b/backend/src/task/controller/task.controller.ts
@@ -23,12 +23,21 @@ import { Token } from '../../auth/decorator/jwt.decorator';
 import { JwtAccessPayload } from '../../auth/type/jwt';
 import { AuthType } from '../../auth/const/enum/auth-type.enum';
 import { GetTasksDto } from '../dto/request/get-tasks.dto';
+import { UpdateTaskDto } from '../dto/request/update-task.dto';
+import {
+  ApiDeleteTask,
+  ApiGetTaskById,
+  ApiGetTasks,
+  ApiPatchTask,
+  ApiPostTask,
+} from '../const/swagger/task.swagger';
 
 @ApiTags('Tasks')
 @Controller()
 export class TaskController {
   constructor(private readonly taskService: TaskService) {}
 
+  @ApiGetTasks()
   @Get()
   getTasks(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -37,6 +46,7 @@ export class TaskController {
     return this.taskService.getTasks(churchId, dto);
   }
 
+  @ApiPostTask()
   @Post()
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   @UseInterceptors(TransactionInterceptor)
@@ -49,6 +59,7 @@ export class TaskController {
     return this.taskService.postTask(churchId, accessPayload.id, dto, qr);
   }
 
+  @ApiGetTaskById()
   @Get(':taskId')
   async getTaskById(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -57,15 +68,26 @@ export class TaskController {
     return this.taskService.getTaskById(churchId, taskId);
   }
 
+  @ApiPatchTask()
   @Patch(':taskId')
+  @UseInterceptors(TransactionInterceptor)
   patchTask(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('taskId', ParseIntPipe) taskId: number,
-  ) {}
+    @Body() dto: UpdateTaskDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.taskService.patchTask(churchId, taskId, dto, qr);
+  }
 
+  @ApiDeleteTask()
   @Delete(':taskId')
+  @UseInterceptors(TransactionInterceptor)
   deleteTask(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('taskId', ParseIntPipe) taskId: number,
-  ) {}
+    @QueryRunner() qr: QR,
+  ) {
+    return this.taskService.deleteTask(churchId, taskId, qr);
+  }
 }

--- a/backend/src/task/dto/request/update-task.dto.ts
+++ b/backend/src/task/dto/request/update-task.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateTaskDto } from './create-task.dto';
+
+export class UpdateTaskDto extends PartialType(CreateTaskDto) {}

--- a/backend/src/task/dto/response/delete-task-response.dto.ts
+++ b/backend/src/task/dto/response/delete-task-response.dto.ts
@@ -1,0 +1,12 @@
+import { BaseDeleteResponseDto } from '../../../common/dto/reponse/base-delete-response.dto';
+
+export class DeleteTaskResponseDto extends BaseDeleteResponseDto {
+  constructor(
+    public readonly timestamp: Date,
+    public readonly id: number,
+    public readonly title: string,
+    public readonly success: boolean,
+  ) {
+    super(timestamp, id, success);
+  }
+}

--- a/backend/src/task/dto/response/patch-task-response.dto.ts
+++ b/backend/src/task/dto/response/patch-task-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePatchResponseDto } from '../../../common/dto/reponse/base-patch-response.dto';
+import { TaskModel } from '../../entity/task.entity';
+
+export class PatchTaskResponseDto extends BasePatchResponseDto<TaskModel> {
+  constructor(data: TaskModel) {
+    super(data);
+  }
+}

--- a/backend/src/task/task-domain/interface/task-domain.service.interface.ts
+++ b/backend/src/task/task-domain/interface/task-domain.service.interface.ts
@@ -1,10 +1,11 @@
 import { ChurchModel } from '../../../churches/entity/church.entity';
-import { FindOptionsRelations, QueryRunner } from 'typeorm';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { TaskModel } from '../../entity/task.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { CreateTaskDto } from '../../dto/request/create-task.dto';
 import { GetTasksDto } from '../../dto/request/get-tasks.dto';
 import { TaskDomainPaginationResultDto } from '../../dto/task-domain-pagination-result.dto';
+import { UpdateTaskDto } from '../../dto/request/update-task.dto';
 
 export const ITASK_DOMAIN_SERVICE = Symbol('ITASK_DOMAIN_SERVICE');
 
@@ -39,4 +40,14 @@ export interface ITaskDomainService {
     dto: CreateTaskDto,
     qr: QueryRunner,
   ): Promise<TaskModel>;
+
+  updateTask(
+    targetTask: TaskModel,
+    newInChargeMember: MemberModel | null,
+    newParentTask: TaskModel | null,
+    dto: UpdateTaskDto,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  deleteTask(targetTask: TaskModel, qr: QueryRunner): Promise<void>;
 }

--- a/backend/src/task/task-domain/service/task-domain.service.ts
+++ b/backend/src/task/task-domain/service/task-domain.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   ConflictException,
   Injectable,
+  InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -25,12 +26,16 @@ import { MemberModel } from '../../../members/entity/member.entity';
 import {
   TaskFindOptionsRelation,
   TaskFindOptionsSelect,
+  TasksFindOptionsRelation,
+  TasksFindOptionsSelect,
 } from '../../const/task-find-options.const';
 import { TaskType } from '../../const/task-type.enum';
 import { UserRole } from '../../../user/const/user-role.enum';
 import { MemberException } from '../../../members/const/exception/member.exception';
 import { GetTasksDto } from '../../dto/request/get-tasks.dto';
 import { TaskOrder } from '../../const/task-order.enum';
+import { MAX_SUB_TASK_COUNT } from '../../const/task.constraints';
+import { UpdateTaskDto } from '../../dto/request/update-task.dto';
 
 @Injectable()
 export class TaskDomainService implements ITaskDomainService {
@@ -76,6 +81,8 @@ export class TaskDomainService implements ITaskDomainService {
           taskStatus: dto.taskStatus,
           inChargeId: dto.inChargeId,
         },
+        relations: TasksFindOptionsRelation,
+        select: TasksFindOptionsSelect,
         order,
         take: dto.take,
         skip: dto.take * (dto.page - 1),
@@ -103,10 +110,8 @@ export class TaskDomainService implements ITaskDomainService {
         churchId: church.id,
         id: taskId,
       },
-      relations: {
-        ...TaskFindOptionsRelation,
-      },
-      select: { ...TaskFindOptionsSelect },
+      relations: TaskFindOptionsRelation,
+      select: TaskFindOptionsSelect,
     });
 
     if (!task) {
@@ -153,6 +158,24 @@ export class TaskDomainService implements ITaskDomainService {
     }
   }
 
+  private async assertSubTaskLimitNotExceeded(
+    parentTask: TaskModel,
+    qr: QueryRunner,
+  ) {
+    const taskRepository = this.getTaskRepository(qr);
+
+    const subTaskCount = await taskRepository.count({
+      where: {
+        parentTaskId: parentTask.id,
+        taskType: TaskType.subTask,
+      },
+    });
+
+    if (subTaskCount >= MAX_SUB_TASK_COUNT) {
+      throw new ConflictException(TaskException.EXCEED_MAX_SUB_TASK);
+    }
+  }
+
   async createTask(
     church: ChurchModel,
     creatorMember: MemberModel,
@@ -167,6 +190,10 @@ export class TaskDomainService implements ITaskDomainService {
       throw new BadRequestException(TaskException.INVALID_PARENT_TASK);
     }
 
+    if (parentTask) {
+      await this.assertSubTaskLimitNotExceeded(parentTask, qr);
+    }
+
     return taskRepository.save({
       churchId: church.id,
       creatorId: creatorMember.id,
@@ -179,5 +206,95 @@ export class TaskDomainService implements ITaskDomainService {
       taskEndDate: dto.taskEndDate,
       comment: dto.comment,
     });
+  }
+
+  private assertValidTaskDate(targetTask: TaskModel, dto: UpdateTaskDto) {
+    // 시작 날짜 변경 시
+    if (dto.taskStartDate && !dto.taskEndDate) {
+      if (dto.taskStartDate > targetTask.taskEndDate) {
+        throw new ConflictException(TaskException.INVALID_START_DATE);
+      }
+    }
+    // 종료 날짜 변경 시
+    else if (!dto.taskStartDate && dto.taskEndDate) {
+      if (targetTask.taskStartDate > dto.taskEndDate) {
+        throw new ConflictException(TaskException.INVALID_END_DATE);
+      }
+    } else {
+      return;
+    }
+  }
+
+  async updateTask(
+    targetTask: TaskModel,
+    newInChargeMember: MemberModel | null,
+    newParentTask: TaskModel | null,
+    dto: UpdateTaskDto,
+    qr: QueryRunner,
+  ) {
+    if (newParentTask) {
+      // 하위 업무가 존재할 경우(자신이 상위업무) 새로운 상위 업무를 지정할 수 없음.
+      if (targetTask.subTasks.length !== 0) {
+        throw new ConflictException(TaskException.INVALID_CHANGE_PARENT_TASK);
+      }
+
+      await this.assertSubTaskLimitNotExceeded(newParentTask, qr);
+
+      if (newParentTask.id === targetTask.id) {
+        throw new ConflictException(TaskException.INVALID_PARENT_TASK);
+      }
+    }
+
+    const taskRepository = this.getTaskRepository(qr);
+
+    this.assertValidTaskDate(targetTask, dto);
+
+    const result = await taskRepository.update(
+      {
+        id: targetTask.id,
+      },
+      {
+        inChargeId: newInChargeMember ? newInChargeMember.id : undefined,
+        parentTaskId: newParentTask ? newParentTask.id : undefined,
+        title: dto.title,
+        taskStatus: dto.taskStatus,
+        taskStartDate: dto.taskStartDate,
+        taskEndDate: dto.taskEndDate,
+        comment: dto.comment,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(TaskException.UPDATE_ERROR);
+    }
+
+    return result;
+  }
+
+  async deleteTask(targetTask: TaskModel, qr: QueryRunner): Promise<void> {
+    const taskRepository = this.getTaskRepository(qr);
+
+    if (targetTask.taskType === TaskType.parent) {
+      const subTaskCount = await taskRepository.count({
+        where: {
+          parentTaskId: targetTask.id,
+          taskType: TaskType.subTask,
+        },
+      });
+
+      if (subTaskCount > 0) {
+        throw new ConflictException(TaskException.TASK_HAS_DEPENDENCIES);
+      }
+    }
+
+    const result = await taskRepository.softDelete({
+      id: targetTask.id,
+    });
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(TaskException.DELETE_ERROR);
+    }
+
+    return;
   }
 }


### PR DESCRIPTION
## 주요 내용
교회 업무(Task)에 대해 수정 및 삭제 기능을 추가하였으며,
업무 위계(depth) 및 날짜 유효성에 대한 비즈니스 규칙을 적용하였습니다.

## 세부 내용

### 수정 기능 추가 (`PATCH /churches/{churchId}/tasks/{taskId}`)
- 수정 가능 항목:
  - 상위 업무(`parentTaskId`)
  - 제목(`title`)
  - 업무 상태(`taskStatus`)
  - 시작/종료 날짜(`taskStartDate`, `taskEndDate`)
  - 내용(`description`)
  - 담당자(`inChargeId`)
- 제약 조건:
  - **하위 업무를 가진 업무는 상위 업무를 변경할 수 없음** → 하위 업무를 보유한 경우 더 깊은 depth 지정 방지
  - **시작일은 종료일을 초과할 수 없음**, 종료일도 시작일 이전일 수 없음

### 삭제 기능 추가 (`DELETE /churches/{churchId}/tasks/{taskId}`)
- 업무 단일 삭제 처리
- 추후 연관된 하위 업무 처리 여부에 대한 정책은 추가될 수 있음

이번 기능 확장으로 교회 업무(Task)의 관리 범위가 넓어졌으며,
위계 안정성과 날짜 정합성을 보장하는 도메인 규칙이 적용되었습니다.