### PR TITLE
feat: 교회 업무 보고(TaskReport) 도메인 로직 구현

### DIFF
--- a/backend/src/report/const/exception/task-report.exception.ts
+++ b/backend/src/report/const/exception/task-report.exception.ts
@@ -1,0 +1,5 @@
+export const TaskReportException = {
+  NOT_FOUND: '해당 업무 보고를 찾을 수 없습니다.',
+  UPDATE_ERROR: '업무 보고 업데이트 도중 에러 발생',
+  DELETE_ERROR: '업무 보고 삭제 도중 에러 발생',
+};

--- a/backend/src/report/dto/task-report/task-report-domain-pagination-result.dto.ts
+++ b/backend/src/report/dto/task-report/task-report-domain-pagination-result.dto.ts
@@ -1,0 +1,8 @@
+import { BaseDomainOffsetPaginationResultDto } from '../../../common/dto/base-domain-offset-pagination-result.dto';
+import { TaskReportModel } from '../../entity/task-report.entity';
+
+export class TaskReportDomainPaginationResultDto extends BaseDomainOffsetPaginationResultDto<TaskReportModel> {
+  constructor(data: TaskReportModel[], totalCount: number) {
+    super(data, totalCount);
+  }
+}

--- a/backend/src/report/report-domain/interface/task-report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/task-report-domain.service.interface.ts
@@ -1,5 +1,48 @@
+import { TaskModel } from '../../../task/entity/task.entity';
+import { MemberModel } from '../../../members/entity/member.entity';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
+import { TaskReportModel } from '../../entity/task-report.entity';
+import { TaskReportDomainPaginationResultDto } from '../../dto/task-report/task-report-domain-pagination-result.dto';
+
 export const ITASK_REPORT_DOMAIN_SERVICE = Symbol(
   'ITASK_REPORT_DOMAIN_SERVICE',
 );
 
-export interface ITaskReportDomainService {}
+export interface ITaskReportDomainService {
+  createTaskReport(
+    task: TaskModel,
+    sender: MemberModel,
+    receiver: MemberModel,
+    qr: QueryRunner,
+  ): Promise<TaskReportModel>;
+
+  findTaskReportsByReceiver(
+    receiver: MemberModel,
+    dto: any,
+    qr?: QueryRunner,
+  ): Promise<TaskReportDomainPaginationResultDto>;
+
+  findTaskReportModelById(
+    receiver: MemberModel,
+    reportId: number,
+    isRead: boolean,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<TaskReportModel>,
+  ): Promise<TaskReportModel>;
+
+  updateTaskReport(
+    taskReport: TaskReportModel,
+    dto: any,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  deleteTaskReport(
+    taskReport: TaskReportModel,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  deleteTaskReports(
+    taskReports: TaskReportModel[],
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+}

--- a/backend/src/report/report-domain/service/task-report-domain.service.ts
+++ b/backend/src/report/report-domain/service/task-report-domain.service.ts
@@ -1,8 +1,16 @@
-import { Injectable } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { TaskReportModel } from '../../entity/task-report.entity';
-import { Repository } from 'typeorm';
+import { FindOptionsRelations, QueryRunner, Repository } from 'typeorm';
 import { ITaskReportDomainService } from '../interface/task-report-domain.service.interface';
+import { TaskModel } from '../../../task/entity/task.entity';
+import { MemberModel } from '../../../members/entity/member.entity';
+import { TaskReportException } from '../../const/exception/task-report.exception';
+import { TaskReportDomainPaginationResultDto } from '../../dto/task-report/task-report-domain-pagination-result.dto';
 
 @Injectable()
 export class TaskReportDomainService implements ITaskReportDomainService {
@@ -10,4 +18,122 @@ export class TaskReportDomainService implements ITaskReportDomainService {
     @InjectRepository(TaskReportModel)
     private readonly taskReportRepository: Repository<TaskReportModel>,
   ) {}
+
+  private getTaskReportRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(TaskReportModel)
+      : this.taskReportRepository;
+  }
+
+  createTaskReport(
+    task: TaskModel,
+    sender: MemberModel,
+    receiver: MemberModel,
+    qr: QueryRunner,
+  ) {
+    const repository = this.getTaskReportRepository(qr);
+
+    return repository.save({
+      task: task,
+      sender,
+      receiver,
+      reportedAt: new Date(),
+      isRead: false,
+      isConfirmed: false,
+    });
+  }
+
+  async findTaskReportsByReceiver(
+    receiver: MemberModel,
+    dto: any,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getTaskReportRepository(qr);
+
+    const [data, totalCount] = await Promise.all([
+      repository.find({
+        where: {
+          receiverId: receiver.id,
+        },
+      }),
+      repository.count({
+        where: {
+          receiverId: receiver.id,
+        },
+      }),
+    ]);
+
+    return new TaskReportDomainPaginationResultDto(data, totalCount);
+  }
+
+  async findTaskReportModelById(
+    receiver: MemberModel,
+    reportId: number,
+    isRead: boolean,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<TaskReportModel>,
+  ) {
+    const repository = this.getTaskReportRepository(qr);
+
+    const report = await repository.findOne({
+      where: {
+        id: reportId,
+        receiverId: receiver.id,
+      },
+      relations: relationOptions,
+    });
+
+    if (!report) {
+      throw new NotFoundException(TaskReportException.NOT_FOUND);
+    }
+
+    report.isRead = true;
+
+    isRead && repository.save(report);
+
+    return report;
+  }
+
+  async updateTaskReport(
+    taskReport: TaskReportModel,
+    dto: any,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getTaskReportRepository(qr);
+
+    const result = await repository.update(
+      {
+        id: taskReport.id,
+      },
+      {
+        ...dto,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(TaskReportException.UPDATE_ERROR);
+    }
+
+    return result;
+  }
+
+  async deleteTaskReport(taskReport: TaskReportModel, qr?: QueryRunner) {
+    const repository = this.getTaskReportRepository(qr);
+
+    const result = await repository.softDelete({ id: taskReport.id });
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(TaskReportException.DELETE_ERROR);
+    }
+
+    return result;
+  }
+
+  async deleteTaskReports(taskReports: TaskReportModel[], qr?: QueryRunner) {
+    const repository = this.getTaskReportRepository(qr);
+
+    const reportIds = taskReports.map((taskReport) => taskReport.id);
+
+    return repository.softDelete(reportIds);
+  }
 }


### PR DESCRIPTION
## 주요 내용
교회 업무(Task)에 대한 보고(TaskReport) 기능의 도메인 로직을 구현하였습니다. 구조 및 동작 방식은 기존 심방 보고(VisitationReport)와 동일한 패턴을 따릅니다.

## 세부 내용
- `TaskReportModel` 도메인 엔티티 정의
- 보고 생성, 조회, 수정, 삭제에 필요한 도메인 서비스 및 관련 메서드 구현
- 기본 필드: 업무 ID, 보고자 ID, 수신자 ID, 보고 상태, 읽음 여부, 확인 여부 등
- 도메인 계층에서 비즈니스 제약과 상태 변경 로직 관리
- `TaskReportDomainService` 구성 및 의존성 주입

이번 커밋으로 TaskReport에 대한 도메인 중심의 관리가 가능해졌으며,
심방 보고와 유사한 방식으로 교회 내 업무 보고 흐름을 일관되게 구성할 수 있습니다.