### PR TITLE
feat: 교육 기수(EducationTerm) 구조 및 관리 로직 전면 개편

### DIFF
--- a/backend/src/management/educations/const/education-status.enum.ts
+++ b/backend/src/management/educations/const/education-status.enum.ts
@@ -1,5 +1,12 @@
-export enum EducationStatus {
+export enum EducationEnrollmentStatus {
   IN_PROGRESS = 'inProgress',
   COMPLETED = 'completed',
   INCOMPLETE = 'incomplete',
+}
+
+export enum EducationStatus {
+  RESERVE = 'reserve',
+  IN_PROGRESS = 'inProgress',
+  DONE = 'done',
+  PENDING = 'pending',
 }

--- a/backend/src/management/educations/const/exception/education.exception.ts
+++ b/backend/src/management/educations/const/exception/education.exception.ts
@@ -8,13 +8,15 @@ export const EducationException = {
 export const EducationTermException = {
   ALREADY_EXIST: '이미 존재하는 기수입니다.',
   NOT_FOUND: '해당 교육 기수를 찾을 수 없습니다.',
-  UPDATE_ERROR: '교육 기수 업데이트 도중 에러 발생',
-  DELETE_ERROR: '교육 기수 삭제 도중 에러 발생',
-  INVALID_NUMBER_OF_SESSION: '교육 회자는 이수 조건보다 크거나 같아야합니다.',
-  INVALID_NUMBER_OF_CRITERIA: '이수 조건은 교육 회차보다 작거나 같아야합니다.',
   INVALID_START_DATE: '교육 시작일은 종료일보다 뒤일 수 없습니다.',
   INVALID_END_DATE: '교육 종료일은 시작일보다 앞설 수 없습니다.',
-  INVALID_INSTRUCTOR_MEMBER: '교육 진행자로 등록할 수 없는 교인입니다.',
+  UNLINKED_IN_CHARGE:
+    '계정 가입되지 않은 교인을 교육 기수 담당자로 지정할 수 없습니다.',
+  INVALID_IN_CHARGE_MEMBER:
+    '관리자 권한의 교인만 교육 기수의 담당자로 지정할 수 있습니다.',
+
+  UPDATE_ERROR: '교육 기수 업데이트 도중 에러 발생',
+  DELETE_ERROR: '교육 기수 삭제 도중 에러 발생',
 };
 
 export const EducationEnrollmentException = {

--- a/backend/src/management/educations/const/swagger/education-term.swagger.ts
+++ b/backend/src/management/educations/const/swagger/education-term.swagger.ts
@@ -1,0 +1,43 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+export const ApiGetEducationTerms = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교육 기수 조회',
+    }),
+  );
+
+export const ApiPostEducationTerms = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교육 기수 생성',
+    }),
+  );
+
+export const ApiGetEducationTermById = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '특정 기수 조회',
+    }),
+  );
+
+export const ApiPatchEducationTerm = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교육 기수 수정',
+    }),
+  );
+
+export const ApiDeleteEducationTerm = () =>
+  applyDecorators(ApiOperation({ summary: '교육 기수 삭제' }));
+
+export const ApiSyncAttendance = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교육 기수의 출석 정보 동기화',
+      description:
+        '<h2>해당 기수의 누락된 출석 정보를 동기화합니다.</h2>' +
+        '<p>누락된 출석 정보가 없을 경우 BadRequestException</p>',
+    }),
+  );

--- a/backend/src/management/educations/controller/education-terms.controller.ts
+++ b/backend/src/management/educations/controller/education-terms.controller.ts
@@ -8,9 +8,10 @@ import {
   Patch,
   Post,
   Query,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { GetEducationTermDto } from '../dto/terms/get-education-term.dto';
 import { CreateEducationTermDto } from '../dto/terms/create-education-term.dto';
 import { UpdateEducationTermDto } from '../dto/terms/update-education-term.dto';
@@ -18,15 +19,26 @@ import { QueryRunner as QR } from 'typeorm';
 import { EducationTermService } from '../service/education-term.service';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
+import {
+  ApiDeleteEducationTerm,
+  ApiGetEducationTermById,
+  ApiGetEducationTerms,
+  ApiPatchEducationTerm,
+  ApiPostEducationTerms,
+  ApiSyncAttendance,
+} from '../const/swagger/education-term.swagger';
+import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
+import { ChurchManagerGuard } from '../../../churches/guard/church-guard.service';
+import { Token } from '../../../auth/decorator/jwt.decorator';
+import { AuthType } from '../../../auth/const/enum/auth-type.enum';
+import { JwtAccessPayload } from '../../../auth/type/jwt';
 
 @ApiTags('Management:Educations:Terms')
 @Controller('educations/:educationId/terms')
 export class EducationTermsController {
   constructor(private readonly educationTermService: EducationTermService) {}
 
-  @ApiOperation({
-    summary: '교육 기수 조회',
-  })
+  @ApiGetEducationTerms()
   @Get()
   getEducationTerms(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -40,18 +52,20 @@ export class EducationTermsController {
     );
   }
 
-  @ApiOperation({
-    summary: '교육 기수 생성',
-  })
+  @ApiPostEducationTerms()
   @Post()
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   @UseInterceptors(TransactionInterceptor)
   postEducationTerms(
-    @Param('churchId', ParseIntPipe) churchId: number,
+    @Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
+    @Param('churchId', ParseIntPipe)
+    churchId: number,
     @Param('educationId', ParseIntPipe) educationId: number,
     @Body() dto: CreateEducationTermDto,
     @QueryRunner() qr: QR,
   ) {
     return this.educationTermService.createEducationTerm(
+      accessPayload.id,
       churchId,
       educationId,
       dto,
@@ -59,9 +73,7 @@ export class EducationTermsController {
     );
   }
 
-  @ApiOperation({
-    summary: '특정 기수 조회',
-  })
+  @ApiGetEducationTermById()
   @Get(':educationTermId')
   getEducationTermById(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -75,9 +87,7 @@ export class EducationTermsController {
     );
   }
 
-  @ApiOperation({
-    summary: '교육 기수 수정',
-  })
+  @ApiPatchEducationTerm()
   @Patch(':educationTermId')
   @UseInterceptors(TransactionInterceptor)
   patchEducationTerm(
@@ -96,10 +106,10 @@ export class EducationTermsController {
     );
   }
 
-  @ApiOperation({ summary: '교육 기수 삭제' })
+  @ApiDeleteEducationTerm()
   @UseInterceptors(TransactionInterceptor)
   @Delete(':educationTermId')
-  deleteEducationTerm(
+  async deleteEducationTerm(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('educationId', ParseIntPipe) educationId: number,
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
@@ -113,12 +123,7 @@ export class EducationTermsController {
     );
   }
 
-  @ApiOperation({
-    summary: '교육 기수의 출석 정보 동기화',
-    description:
-      '<p><h2>해당 기수의 누락된 출석 정보를 동기화합니다.</h2></p>' +
-      '<p>누락된 출석 정보가 없을 경우 BadRequestException</p>',
-  })
+  @ApiSyncAttendance()
   @Post(':educationTermId/sync-attendance')
   @UseInterceptors(TransactionInterceptor)
   syncAttendance(

--- a/backend/src/management/educations/dto/enrollments/create-education-enrollment.dto.ts
+++ b/backend/src/management/educations/dto/enrollments/create-education-enrollment.dto.ts
@@ -9,7 +9,7 @@ import {
   MaxLength,
   Min,
 } from 'class-validator';
-import { EducationStatus } from '../../const/education-status.enum';
+import { EducationEnrollmentStatus } from '../../const/education-status.enum';
 import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
 
 @SanitizeDto()
@@ -26,13 +26,13 @@ export class CreateEducationEnrollmentDto extends PickType(
 
   @ApiProperty({
     description: '교육 상태 (수료중/수료/미수료)',
-    enum: EducationStatus,
-    default: EducationStatus.IN_PROGRESS,
+    enum: EducationEnrollmentStatus,
+    default: EducationEnrollmentStatus.IN_PROGRESS,
     required: false,
   })
   @IsOptional()
-  @IsEnum(EducationStatus)
-  status: EducationStatus = EducationStatus.IN_PROGRESS;
+  @IsEnum(EducationEnrollmentStatus)
+  status: EducationEnrollmentStatus = EducationEnrollmentStatus.IN_PROGRESS;
 
   @ApiProperty({
     description: '비고',

--- a/backend/src/management/educations/dto/enrollments/update-education-enrollment.dto.ts
+++ b/backend/src/management/educations/dto/enrollments/update-education-enrollment.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { EducationEnrollmentModel } from '../../entity/education-enrollment.entity';
-import { EducationStatus } from '../../const/education-status.enum';
+import { EducationEnrollmentStatus } from '../../const/education-status.enum';
 import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
@@ -12,12 +12,12 @@ export class UpdateEducationEnrollmentDto extends PickType(
 ) {
   @ApiProperty({
     description: '교육 이수 상태',
-    enum: EducationStatus,
+    enum: EducationEnrollmentStatus,
     required: false,
   })
-  @IsEnum(EducationStatus)
+  @IsEnum(EducationEnrollmentStatus)
   @IsOptional()
-  override status: EducationStatus;
+  override status: EducationEnrollmentStatus;
 
   @ApiProperty({
     description: '비고',

--- a/backend/src/management/educations/dto/terms/create-education-term.dto.ts
+++ b/backend/src/management/educations/dto/terms/create-education-term.dto.ts
@@ -1,16 +1,15 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { EducationTermModel } from '../../entity/education-term.entity';
-import { IsDate, IsNumber, IsOptional, Min, ValidateIf } from 'class-validator';
+import { IsDate, IsNumber, IsOptional, Min } from 'class-validator';
 import { IsAfterDate } from '../../../../common/decorator/validator/is-after-date.decorator';
-import { IsLessThanOrEqual } from '../../../../common/decorator/validator/is-less-or-equal-than.decorator';
 
 export class CreateEducationTermDto extends PickType(EducationTermModel, [
   'term',
-  'numberOfSessions',
-  'completionCriteria',
+  //'numberOfSessions',
+  //'completionCriteria',
   'startDate',
   'endDate',
-  'instructorId',
+  'inChargeId',
 ]) {
   @ApiProperty({
     description: '기수',
@@ -20,16 +19,16 @@ export class CreateEducationTermDto extends PickType(EducationTermModel, [
   @Min(1)
   term: number;
 
-  @ApiProperty({
+  /*@ApiProperty({
     description: '총 몇 회의 교육으로 이루어졌는지 (최소값: 1)',
     minimum: 1,
     default: 1,
   })
   @IsNumber()
   @Min(1)
-  override numberOfSessions: number = 1;
+  override numberOfSessions: number = 1;*/
 
-  @ApiProperty({
+  /*@ApiProperty({
     description: '수료 기준 출석 횟수 (선택값)',
     minimum: 1,
     required: false,
@@ -39,7 +38,7 @@ export class CreateEducationTermDto extends PickType(EducationTermModel, [
   @Min(1)
   @IsLessThanOrEqual('numberOfSessions')
   @IsOptional()
-  override completionCriteria: number;
+  override completionCriteria: number;*/
 
   @ApiProperty({
     description: '교육회차 시작일',
@@ -63,5 +62,5 @@ export class CreateEducationTermDto extends PickType(EducationTermModel, [
   @IsNumber()
   @Min(1)
   @IsOptional()
-  override instructorId: number;
+  override inChargeId: number;
 }

--- a/backend/src/management/educations/dto/terms/get-education-term.dto.ts
+++ b/backend/src/management/educations/dto/terms/get-education-term.dto.ts
@@ -1,26 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { EducationTermOrderEnum } from '../../const/order.enum';
-import { IsEnum, IsIn, IsNumber, IsOptional } from 'class-validator';
+import { IsEnum } from 'class-validator';
+import { BaseOffsetPaginationRequestDto } from '../../../../common/dto/request/base-offset-pagination-request.dto';
 
-export class GetEducationTermDto {
-  @ApiProperty({
-    description: '데이터 요청 개수',
-    default: 20,
-    required: false,
-  })
-  @IsOptional()
-  @IsNumber()
-  take: number = 20;
-
-  @ApiProperty({
-    description: '요청 페이지',
-    default: 1,
-    required: false,
-  })
-  @IsOptional()
-  @IsNumber()
-  page: number = 1;
-
+export class GetEducationTermDto extends BaseOffsetPaginationRequestDto<EducationTermOrderEnum> {
   @ApiProperty({
     description: '정렬 기준 (기본값: 기수)',
     enum: EducationTermOrderEnum,
@@ -30,11 +13,14 @@ export class GetEducationTermDto {
   @IsEnum(EducationTermOrderEnum)
   order: EducationTermOrderEnum = EducationTermOrderEnum.term;
 
-  @ApiProperty({
-    description: '정렬 내림차순 / 오름차순 (기본값: 오름차순)',
-    default: 'asc',
+  /*@ApiProperty({
+    description: '회차명',
     required: false,
   })
-  @IsIn(['asc', 'desc', 'ASC', 'DESC'])
-  orderDirection: 'asc' | 'desc' | 'ASC' | 'DESC' = 'asc';
+  @IsOptional()
+  @IsString()
+  @Length(2, 50)
+  @IsNoSpecialChar()
+  @RemoveSpaces()
+  sessionTitle: string;*/
 }

--- a/backend/src/management/educations/dto/terms/response/delete-education-term-response.dto.ts
+++ b/backend/src/management/educations/dto/terms/response/delete-education-term-response.dto.ts
@@ -1,0 +1,13 @@
+import { BaseDeleteResponseDto } from '../../../../../common/dto/reponse/base-delete-response.dto';
+
+export class DeleteEducationTermResponseDto extends BaseDeleteResponseDto {
+  constructor(
+    timestamp: Date,
+    id: number,
+    educationName: string,
+    term: number,
+    success: boolean,
+  ) {
+    super(timestamp, id, success);
+  }
+}

--- a/backend/src/management/educations/dto/terms/response/education-term-pagination-result.dto.ts
+++ b/backend/src/management/educations/dto/terms/response/education-term-pagination-result.dto.ts
@@ -1,5 +1,5 @@
-import { BaseOffsetPaginationResponseDto } from '../../../common/dto/reponse/base-offset-pagination-response.dto';
-import { EducationTermModel } from '../entity/education-term.entity';
+import { BaseOffsetPaginationResponseDto } from '../../../../../common/dto/reponse/base-offset-pagination-response.dto';
+import { EducationTermModel } from '../../../entity/education-term.entity';
 
 /*export interface EducationTermPaginationResultDto
   extends BaseOffsetPaginationResultDto<EducationTermModel> {

--- a/backend/src/management/educations/dto/terms/response/get-education-term-response.dto.ts
+++ b/backend/src/management/educations/dto/terms/response/get-education-term-response.dto.ts
@@ -1,0 +1,8 @@
+import { BaseGetResponseDto } from '../../../../../common/dto/reponse/base-get-response.dto';
+import { EducationTermModel } from '../../../entity/education-term.entity';
+
+export class GetEducationTermResponseDto extends BaseGetResponseDto<EducationTermModel> {
+  constructor(data: EducationTermModel) {
+    super(data);
+  }
+}

--- a/backend/src/management/educations/dto/terms/response/patch-education-term-response.dto.ts
+++ b/backend/src/management/educations/dto/terms/response/patch-education-term-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePatchResponseDto } from '../../../../../common/dto/reponse/base-patch-response.dto';
+import { EducationTermModel } from '../../../entity/education-term.entity';
+
+export class PatchEducationTermResponseDto extends BasePatchResponseDto<EducationTermModel> {
+  constructor(data: EducationTermModel) {
+    super(data);
+  }
+}

--- a/backend/src/management/educations/dto/terms/response/post-education-term-response.dto.ts
+++ b/backend/src/management/educations/dto/terms/response/post-education-term-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePostResponseDto } from '../../../../../common/dto/reponse/base-post-response.dto';
+import { EducationTermModel } from '../../../entity/education-term.entity';
+
+export class PostEducationTermResponseDto extends BasePostResponseDto<EducationTermModel> {
+  constructor(data: EducationTermModel) {
+    super(data);
+  }
+}

--- a/backend/src/management/educations/dto/terms/update-education-term.dto.ts
+++ b/backend/src/management/educations/dto/terms/update-education-term.dto.ts
@@ -1,9 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDate, IsNumber, IsOptional, Min } from 'class-validator';
-import { IsLessThanOrEqual } from '../../../../common/decorator/validator/is-less-or-equal-than.decorator';
+import { IsDate, IsEnum, IsNumber, IsOptional, Min } from 'class-validator';
 import { IsAfterDate } from '../../../../common/decorator/validator/is-after-date.decorator';
 import { TransformStartDate } from '../../../../member-history/decorator/transform-start-date.decorator';
 import { TransformEndDate } from '../../../../member-history/decorator/transform-end-date.decorator';
+import { EducationStatus } from '../../const/education-status.enum';
 
 export class UpdateEducationTermDto {
   @ApiProperty({
@@ -17,26 +17,13 @@ export class UpdateEducationTermDto {
   term: number;
 
   @ApiProperty({
-    description: '총 몇 회의 교육으로 이루어졌는지 (최소값: 1)',
-    minimum: 1,
-    default: 1,
-  })
-  @IsNumber()
-  @Min(1)
-  @IsOptional()
-  numberOfSessions: number;
-
-  @ApiProperty({
-    description: '수료 기준 출석 횟수 (선택값)',
-    minimum: 1,
+    description: '교육 진행 상태',
+    enum: EducationStatus,
     required: false,
   })
   @IsOptional()
-  @IsNumber()
-  @Min(1)
-  //@ValidateIf((o) => o.numberOfSessions !== undefined)
-  @IsLessThanOrEqual('numberOfSessions')
-  completionCriteria: number;
+  @IsEnum(EducationStatus)
+  status: EducationStatus;
 
   @ApiProperty({
     description: '교육회차 시작일',
@@ -52,7 +39,6 @@ export class UpdateEducationTermDto {
   @IsOptional()
   @IsDate()
   @TransformEndDate()
-  //@ValidateIf((o) => o.startDate !== undefined)
   @IsAfterDate('startDate')
   endDate: Date;
 
@@ -64,5 +50,27 @@ export class UpdateEducationTermDto {
   @IsNumber()
   @Min(1)
   @IsOptional()
-  instructorId: number;
+  inChargeId: number;
+
+  /*@ApiProperty({
+    description: '총 몇 회의 교육으로 이루어졌는지 (최소값: 1)',
+    minimum: 1,
+    default: 1,
+  })
+  @IsNumber()
+  @Min(1)
+  @IsOptional()
+  numberOfSessions: number;*/
+
+  /*@ApiProperty({
+    description: '수료 기준 출석 횟수 (선택값)',
+    minimum: 1,
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  //@ValidateIf((o) => o.numberOfSessions !== undefined)
+  @IsLessThanOrEqual('numberOfSessions')
+  completionCriteria: number;*/
 }

--- a/backend/src/management/educations/entity/education-enrollment.entity.ts
+++ b/backend/src/management/educations/entity/education-enrollment.entity.ts
@@ -1,6 +1,6 @@
 import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
 import { EducationTermModel } from './education-term.entity';
-import { EducationStatus } from '../const/education-status.enum';
+import { EducationEnrollmentStatus } from '../const/education-status.enum';
 import { SessionAttendanceModel } from './session-attendance.entity';
 import { BaseModel } from '../../../common/entity/base.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
@@ -23,11 +23,11 @@ export class EducationEnrollmentModel extends BaseModel {
 
   @Index()
   @Column({
-    enum: EducationStatus,
+    enum: EducationEnrollmentStatus,
     comment: '교육 상태 (수료중/수료/미수료)',
-    default: EducationStatus.IN_PROGRESS,
+    default: EducationEnrollmentStatus.IN_PROGRESS,
   })
-  status: EducationStatus;
+  status: EducationEnrollmentStatus;
 
   @Column({ default: 0, comment: '출석 횟수' })
   attendanceCount: number;

--- a/backend/src/management/educations/entity/education-term.entity.ts
+++ b/backend/src/management/educations/entity/education-term.entity.ts
@@ -2,8 +2,12 @@ import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
 import { EducationModel } from './education.entity';
 import { EducationSessionModel } from './education-session.entity';
 import { EducationEnrollmentModel } from './education-enrollment.entity';
-import { BaseModel } from '../../../common/entity/base.entity';
+import {
+  BaseModel,
+  BaseModelColumns,
+} from '../../../common/entity/base.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
+import { EducationStatus } from '../const/education-status.enum';
 
 @Entity()
 export class EducationTermModel extends BaseModel {
@@ -11,21 +15,27 @@ export class EducationTermModel extends BaseModel {
   @Index()
   educationId: number;
 
-  @Column({ comment: '교육 이름', nullable: true })
+  @Column({ comment: '교육 이름' })
   educationName: string;
 
   @ManyToOne(() => EducationModel, (education) => education.educationTerms)
   education!: EducationModel;
 
+  @Column({ nullable: true })
+  creatorId: number;
+
+  @ManyToOne(() => MemberModel)
+  creator: MemberModel;
+
   @Column({ comment: '교육 기수' })
   @Index()
   term: number; // 기수
 
-  @Column({ comment: '총 교육 회차' })
-  numberOfSessions: number; // 총 교육 회차
+  @Column({ default: EducationStatus.RESERVE })
+  status: EducationStatus;
 
-  @Column({ type: 'int', nullable: true, comment: '수료 기준 출석 횟수' })
-  completionCriteria: number | null;
+  @Column({ comment: '총 교육 회차', default: 0 })
+  numberOfSessions: number; // 총 교육 회차
 
   @Column({ type: 'timestamptz', comment: '기수 시작일' })
   startDate: Date;
@@ -35,10 +45,10 @@ export class EducationTermModel extends BaseModel {
 
   @Index()
   @Column({ type: 'int', comment: '교육 진행자 ID', nullable: true })
-  instructorId!: number | null;
+  inChargeId!: number | null;
 
-  @ManyToOne(() => MemberModel, (member) => member.instructingEducation)
-  instructor!: MemberModel;
+  @ManyToOne(() => MemberModel, (member) => member.inChargeEducationTerm)
+  inCharge!: MemberModel;
 
   @OneToMany(() => EducationSessionModel, (session) => session.educationTerm)
   educationSessions: EducationSessionModel[];
@@ -63,4 +73,30 @@ export class EducationTermModel extends BaseModel {
     (enrollment) => enrollment.educationTerm,
   )
   educationEnrollments: EducationEnrollmentModel[];
+
+  //@Column({ type: 'int', nullable: true, comment: '수료 기준 출석 횟수' })
+  //completionCriteria: number | null;
 }
+
+export const EducationTermColumns = {
+  ...BaseModelColumns,
+  educationId: 'educationId',
+  education: 'education',
+  educationName: 'educationName',
+  creatorId: 'creatorId',
+  creator: 'creator',
+  term: 'term',
+  status: 'status',
+  numberOfSessions: 'numberOfSessions',
+  startDate: 'startDate',
+  endDate: 'endDate',
+  inChargeId: 'inChargeId',
+  inCharge: 'inCharge',
+  educationSessions: 'educationSessions',
+  isDoneCount: 'isDoneCount',
+  enrollmentCount: 'enrollmentCount',
+  inProgressCount: 'inProgressCount',
+  completedCount: 'completedCount',
+  incompleteCount: 'incompleteCount',
+  educationEnrollments: 'educationEnrollments',
+};

--- a/backend/src/management/educations/service/education-domain/interface/education-term-domain.service.interface.ts
+++ b/backend/src/management/educations/service/education-domain/interface/education-term-domain.service.interface.ts
@@ -9,9 +9,8 @@ import {
 } from 'typeorm';
 import { EducationTermModel } from '../../../entity/education-term.entity';
 import { CreateEducationTermDto } from '../../../dto/terms/create-education-term.dto';
-import { EducationEnrollmentModel } from '../../../entity/education-enrollment.entity';
 import { UpdateEducationTermDto } from '../../../dto/terms/update-education-term.dto';
-import { EducationStatus } from '../../../const/education-status.enum';
+import { EducationEnrollmentStatus } from '../../../const/education-status.enum';
 import { MemberModel } from '../../../../../members/entity/member.entity';
 
 export const IEDUCATION_TERM_DOMAIN_SERVICE = Symbol(
@@ -43,8 +42,8 @@ export interface IEducationTermDomainService {
   ): Promise<EducationTermModel>;
 
   createEducationTerm(
-    //church: ChurchModel,
     education: EducationModel,
+    creator: MemberModel,
     instructor: MemberModel | null,
     dto: CreateEducationTermDto,
     qr: QueryRunner,
@@ -52,13 +51,11 @@ export interface IEducationTermDomainService {
 
   updateEducationTerm(
     education: EducationModel,
-    educationTerm: EducationTermModel & {
-      educationEnrollments: EducationEnrollmentModel[];
-    },
+    educationTerm: EducationTermModel,
     newInstructor: MemberModel | null,
     dto: UpdateEducationTermDto,
     qr: QueryRunner,
-  ): Promise<EducationTermModel>;
+  ): Promise<UpdateResult>;
 
   deleteEducationTerm(
     educationTerm: EducationTermModel,
@@ -83,13 +80,13 @@ export interface IEducationTermDomainService {
 
   incrementEducationStatusCount(
     educationTerm: EducationTermModel,
-    status: EducationStatus,
+    status: EducationEnrollmentStatus,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 
   decrementEducationStatusCount(
     educationTerm: EducationTermModel,
-    status: EducationStatus,
+    status: EducationEnrollmentStatus,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 

--- a/backend/src/management/educations/service/education-term.service.ts
+++ b/backend/src/management/educations/service/education-term.service.ts
@@ -27,11 +27,15 @@ import {
   IMEMBERS_DOMAIN_SERVICE,
   IMembersDomainService,
 } from '../../../members/member-domain/interface/members-domain.service.interface';
-import { EducationTermPaginationResultDto } from '../dto/education-term-pagination-result.dto';
+import { EducationTermPaginationResultDto } from '../dto/terms/response/education-term-pagination-result.dto';
 import {
   IEDUCATION_ENROLLMENT_DOMAIN_SERVICE,
   IEducationEnrollmentsDomainService,
 } from './education-domain/interface/education-enrollment-domain.service.interface';
+import { DeleteEducationTermResponseDto } from '../dto/terms/response/delete-education-term-response.dto';
+import { PatchEducationTermResponseDto } from '../dto/terms/response/patch-education-term-response.dto';
+import { PostEducationTermResponseDto } from '../dto/terms/response/post-education-term-response.dto';
+import { GetEducationTermResponseDto } from '../dto/terms/response/get-education-term-response.dto';
 
 @Injectable()
 export class EducationTermService {
@@ -102,15 +106,19 @@ export class EducationTermService {
       qr,
     );
 
-    return this.educationTermDomainService.findEducationTermById(
-      church,
-      education,
-      educationTermId,
-      qr,
-    );
+    const educationTerm =
+      await this.educationTermDomainService.findEducationTermById(
+        church,
+        education,
+        educationTermId,
+        qr,
+      );
+
+    return new GetEducationTermResponseDto(educationTerm);
   }
 
   async createEducationTerm(
+    creatorUserId: number,
     churchId: number,
     educationId: number,
     dto: CreateEducationTermDto,
@@ -121,17 +129,25 @@ export class EducationTermService {
       qr,
     );
 
+    const creatorMember =
+      await this.membersDomainService.findMemberModelByUserId(
+        church,
+        creatorUserId,
+        qr,
+      );
+
     const education = await this.educationDomainService.findEducationModelById(
       church,
       educationId,
       qr,
     );
 
-    const instructor = dto.instructorId
+    const instructor = dto.inChargeId
       ? await this.membersDomainService.findMemberModelById(
           church,
-          dto.instructorId,
+          dto.inChargeId,
           qr,
+          { user: true },
         )
       : null;
 
@@ -139,19 +155,29 @@ export class EducationTermService {
       await this.educationTermDomainService.createEducationTerm(
         //church,
         education,
+        creatorMember,
         instructor,
         dto,
         qr,
       );
 
     // 회차에 맞게 EducationSession 생성
-    await this.educationSessionDomainService.createEducationSessions(
+    /*await this.educationSessionDomainService.createEducationSessions(
       educationTerm,
       educationTerm.numberOfSessions,
       qr,
-    );
+    );*/
 
-    return educationTerm;
+    //return educationTerm;
+    const createdEducationTerm =
+      await this.educationTermDomainService.findEducationTermById(
+        church,
+        education,
+        educationTerm.id,
+        qr,
+      );
+
+    return new PostEducationTermResponseDto(createdEducationTerm);
   }
 
   async updateEducationTerm(
@@ -193,41 +219,52 @@ export class EducationTermService {
       churchId,
       qr,
     );
+
     const education = await this.educationDomainService.findEducationModelById(
       church,
       educationId,
       qr,
     );
+
     const educationTerm =
       await this.educationTermDomainService.findEducationTermModelById(
         church,
         education,
         educationTermId,
         qr,
-        { educationSessions: true },
       );
 
-    const newInstructor = dto.instructorId
+    const newInstructor = dto.inChargeId
       ? await this.membersDomainService.findMemberModelById(
           church,
-          dto.instructorId,
+          dto.inChargeId,
           qr,
+          { user: true },
         )
       : null;
 
+    await this.educationTermDomainService.updateEducationTerm(
+      education,
+      educationTerm,
+      newInstructor,
+      dto,
+      qr,
+    );
+
     const updatedEducationTerm =
-      await this.educationTermDomainService.updateEducationTerm(
+      await this.educationTermDomainService.findEducationTermById(
+        church,
         education,
-        educationTerm,
-        newInstructor,
-        dto,
+        educationTermId,
         qr,
       );
+
+    return new PatchEducationTermResponseDto(updatedEducationTerm);
 
     // 회차 수정 시
     // 회차 감소 --> 회차 삭제 X, 수동 삭제
     // 회차 증가 --> 회차 생성
-    if (
+    /*if (
       dto.numberOfSessions &&
       dto.numberOfSessions > educationTerm.educationSessions.length
     ) {
@@ -254,9 +291,9 @@ export class EducationTermService {
         enrollmentIds,
         qr,
       );
-    }
+    }*/
 
-    return updatedEducationTerm;
+    //return updatedEducationTerm;
   }
 
   async deleteEducationTerm(
@@ -301,13 +338,13 @@ export class EducationTermService {
       qr,
     );
 
-    return {
-      timestamp: new Date(),
-      id: educationTerm.id,
-      educationName: educationTerm.educationName,
-      term: educationTerm.term,
-      success: true,
-    };
+    return new DeleteEducationTermResponseDto(
+      new Date(),
+      educationTerm.id,
+      educationTerm.educationName,
+      educationTerm.term,
+      true,
+    );
   }
 
   async syncSessionAttendances(

--- a/backend/src/member-history/dto/education/get-education-history.dto.ts
+++ b/backend/src/member-history/dto/education/get-education-history.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsIn, IsNumber, IsOptional, Min } from 'class-validator';
-import { EducationStatus } from '../../../management/educations/const/education-status.enum';
+import { EducationEnrollmentStatus } from '../../../management/educations/const/education-status.enum';
 
 export class GetEducationHistoryDto {
   @ApiProperty({
@@ -34,10 +34,10 @@ export class GetEducationHistoryDto {
 
   @ApiProperty({
     description: '교육 상태',
-    enum: EducationStatus,
+    enum: EducationEnrollmentStatus,
     required: false,
   })
-  @IsEnum(EducationStatus)
+  @IsEnum(EducationEnrollmentStatus)
   @IsOptional()
-  status: EducationStatus;
+  status: EducationEnrollmentStatus;
 }

--- a/backend/src/member-history/service/education-history.service.ts
+++ b/backend/src/member-history/service/education-history.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { QueryRunner } from 'typeorm';
 import { GetEducationHistoryDto } from '../dto/education/get-education-history.dto';
 import { EducationEnrollmentModel } from '../../management/educations/entity/education-enrollment.entity';
-import { EducationStatus } from '../../management/educations/const/education-status.enum';
+import { EducationEnrollmentStatus } from '../../management/educations/const/education-status.enum';
 import {
   IEDUCATION_HISTORY_DOMAIN_SERVICE,
   IEducationHistoryDomainService,
@@ -73,13 +73,13 @@ export class EducationHistoryService {
       (acc, enrollment) => ({
         inProgressCount:
           acc.inProgressCount +
-          (enrollment.status === EducationStatus.IN_PROGRESS ? 1 : 0),
+          (enrollment.status === EducationEnrollmentStatus.IN_PROGRESS ? 1 : 0),
         completedCount:
           acc.completedCount +
-          (enrollment.status === EducationStatus.COMPLETED ? 1 : 0),
+          (enrollment.status === EducationEnrollmentStatus.COMPLETED ? 1 : 0),
         incompleteCount:
           acc.incompleteCount +
-          (enrollment.status === EducationStatus.INCOMPLETE ? 1 : 0),
+          (enrollment.status === EducationEnrollmentStatus.INCOMPLETE ? 1 : 0),
       }),
       { inProgressCount: 0, completedCount: 0, incompleteCount: 0 },
     );

--- a/backend/src/members/const/default-find-options.const.ts
+++ b/backend/src/members/const/default-find-options.const.ts
@@ -107,7 +107,7 @@ export const HardDeleteMemberRelationOptions: FindOptionsRelations<MemberModel> 
   {
     ...DefaultMemberRelationOption,
     guiding: true,
-    instructingEducation: true,
+    inChargeEducationTerm: true,
     ministryHistory: true,
     officerHistory: true,
     groupHistory: true,

--- a/backend/src/members/const/exception/member.exception.ts
+++ b/backend/src/members/const/exception/member.exception.ts
@@ -11,4 +11,6 @@ export const MemberException = {
   NOT_LINKED_MEMBER: '계정 연동이 되어있지 않은 교인입니다.',
 
   SAME_ROLE: '이미 동일한 권한입니다.',
+
+  USER_ERROR: '교인의 계정 정보 불러오기 실패',
 };

--- a/backend/src/members/dto/get-member.dto.ts
+++ b/backend/src/members/dto/get-member.dto.ts
@@ -21,7 +21,7 @@ import {
 import { MarriageOptions } from '../member-domain/const/marriage-options.const';
 import { QueryBoolean } from '../../common/decorator/transformer/query-boolean.decorator';
 import { RemoveSpaces } from '../../common/decorator/transformer/remove-spaces';
-import { EducationStatus } from '../../management/educations/const/education-status.enum';
+import { EducationEnrollmentStatus } from '../../management/educations/const/education-status.enum';
 
 export class GetMemberDto {
   @ApiProperty({
@@ -356,14 +356,14 @@ export class GetMemberDto {
 
   @ApiProperty({
     description: '교육이수 상태',
-    enum: EducationStatus,
+    enum: EducationEnrollmentStatus,
     required: false,
     isArray: true,
   })
   @TransformStringArray()
-  @IsEnum(EducationStatus, { each: true })
+  @IsEnum(EducationEnrollmentStatus, { each: true })
   @IsOptional()
-  educationStatus?: EducationStatus[];
+  educationStatus?: EducationEnrollmentStatus[];
 
   @ApiProperty({
     name: 'baptism',

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -173,8 +173,8 @@ export class MemberModel extends BaseModel {
   )
   educations: EducationEnrollmentModel[];
 
-  @OneToMany(() => EducationTermModel, (term) => term.instructor)
-  instructingEducation: EducationTermModel[];
+  @OneToMany(() => EducationTermModel, (term) => term.inCharge)
+  inChargeEducationTerm: EducationTermModel[];
 
   @Index()
   @Column({ comment: '그룹 ID', nullable: true })


### PR DESCRIPTION
## 주요 내용
교육 기수(EducationTerm)의 구조와 로직을 전면적으로 리팩토링하였습니다.
불필요한 필드 제거, 필드 명칭 통일, 상태 관리 속성 추가, 자동 생성 로직 제거 등
도메인 간 일관성과 명확한 역할 분리를 위한 개선이 반영되었습니다.

## 세부 내용

### 🔧 필드 및 자동 생성 로직 변경
- `completionCriteria` 필드 제거
  - 생성/수정 시 해당 값을 받지 않음
- `numberOfSession` 기능 변경
  - 사용자가 직접 수정할 수 없음
  - 실제 하위 Session 개수에 따라 자동 계산됨
  - 기수 생성/수정 시 `numberOfSession` 기반 Session 자동 생성 기능 제거

### 📘 필드 명칭 통일
- 담당자 관련 용어 변경 (`instructor` → `inCharge`)
  - `instructorId` → `inChargeId`
  - `instructor` → `inCharge`
  - 다른 도메인(Task, Visitation 등)과 용어 통일

### ✅ 상태 속성 추가
- `status` 필드 추가로 기수 상태 관리
  - `reserve` (예정), `inProgress` (진행중), `done` (완료), `pending` (지연)
  - 기수 생성 시 기본값은 `reserve`
  - 수정 가능

### 👤 생성자 정보 및 권한 검증
- `creator` 필드 추가
  - 해당 기수를 생성한 교인 정보 저장
- 기수 생성 시 로그인된 사용자 필요 (manager 이상 권한 요구)
- 담당자(`inCharge`) 지정 시 검증 로직 추가
  - 미가입 교인을 지정할 경우 → `UnauthorizedException`
  - 일반 교인을 지정할 경우 → `ConflictException`

이번 구조 개편을 통해 교육 기수 관리의 명확성이 향상되었으며,
도메인 간 필드 명칭 및 권한 체계도 일관되게 정비되었습니다.