### PR TITLE
feat: 교육 보고(EducationSessionReport) 모듈 기본 설계 및 구조 구성

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -49,6 +49,7 @@ import { ChurchJoinRequestStatModel } from './churches/entity/church-join-reques
 import { TaskModule } from './task/task.module';
 import { TaskModel } from './task/entity/task.entity';
 import { TaskReportModel } from './report/entity/task-report.entity';
+import { EducationSessionReportModel } from './report/entity/education-session-report.entity';
 
 @Module({
   imports: [
@@ -152,6 +153,7 @@ import { TaskReportModel } from './report/entity/task-report.entity';
           ReportModel,
           VisitationReportModel,
           TaskReportModel,
+          EducationSessionReportModel,
           // 업무 관련 엔티티
           TaskModel,
         ],

--- a/backend/src/management/educations/dto/sessions/request/create-education-session.dto.ts
+++ b/backend/src/management/educations/dto/sessions/request/create-education-session.dto.ts
@@ -77,4 +77,13 @@ export class CreateEducationSessionDto extends PickType(EducationSessionModel, [
   })
   @IsEnum(EducationSessionStatus)
   override status: EducationSessionStatus = EducationSessionStatus.RESERVE;
+
+  @ApiProperty({
+    description: '피보고자 ID',
+    isArray: true,
+  })
+  @IsOptional()
+  @IsNumber({}, { each: true })
+  @Min(1, { each: true })
+  receiverIds: number[];
 }

--- a/backend/src/management/educations/educations.module.ts
+++ b/backend/src/management/educations/educations.module.ts
@@ -14,6 +14,7 @@ import { MemberEducationEventHandler } from './service/member-education-event-ha
 import { EducationDomainModule } from './service/education-domain/education-domain.module';
 import { ChurchesDomainModule } from '../../churches/churches-domain/churches-domain.module';
 import { MembersDomainModule } from '../../members/member-domain/members-domain.module';
+import { EducationSessionReportDomainModule } from '../../report/report-domain/education-session-report-domain.module';
 
 @Module({
   imports: [
@@ -27,6 +28,8 @@ import { MembersDomainModule } from '../../members/member-domain/members-domain.
     MembersDomainModule,
     ChurchesDomainModule,
     EducationDomainModule,
+
+    EducationSessionReportDomainModule,
   ],
   controllers: [
     EducationsController,

--- a/backend/src/management/educations/entity/education-session.entity.ts
+++ b/backend/src/management/educations/entity/education-session.entity.ts
@@ -4,6 +4,8 @@ import { SessionAttendanceModel } from './session-attendance.entity';
 import { BaseModel } from '../../../common/entity/base.entity';
 import { EducationSessionStatus } from '../const/education-status.enum';
 import { MemberModel } from '../../../members/entity/member.entity';
+import { EducationSessionReportModel } from '../../../report/entity/education-session-report.entity';
+import { MAX_RECEIVER_COUNT } from '../../../report/const/report.constraints';
 
 @Entity()
 export class EducationSessionModel extends BaseModel {
@@ -62,4 +64,14 @@ export class EducationSessionModel extends BaseModel {
 
   @ManyToOne(() => MemberModel)
   creator: MemberModel;
+
+  @OneToMany(
+    () => EducationSessionReportModel,
+    (report) => report.educationSession,
+  )
+  reports: EducationSessionReportModel[];
+
+  canAddReport(newReceivers: number[] | MemberModel[]) {
+    return this.reports.length + newReceivers.length > MAX_RECEIVER_COUNT;
+  }
 }

--- a/backend/src/management/educations/service/educaiton-session.service.ts
+++ b/backend/src/management/educations/service/educaiton-session.service.ts
@@ -37,6 +37,10 @@ import { GetEducationSessionResponseDto } from '../dto/sessions/response/get-edu
 import { EducationSessionStatus } from '../const/education-status.enum';
 import { PatchEducationSessionResponseDto } from '../dto/sessions/response/patch-education-session-response.dto';
 import { DeleteSessionResponseDto } from '../dto/sessions/response/delete-education-session-response.dto';
+import {
+  IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE,
+  IEducationSessionReportDomainService,
+} from '../../../report/report-domain/interface/education-session-report-domain.service.interface';
 
 @Injectable()
 export class EducationSessionService {
@@ -56,6 +60,9 @@ export class EducationSessionService {
     private readonly educationEnrollmentsDomainService: IEducationEnrollmentsDomainService,
     @Inject(ISESSION_ATTENDANCE_DOMAIN_SERVICE)
     private readonly sessionAttendanceDomainService: ISessionAttendanceDomainService,
+
+    @Inject(IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE)
+    private readonly educationSessionReportDomainService: IEducationSessionReportDomainService,
   ) {}
 
   private async getEducationTerm(
@@ -220,6 +227,23 @@ export class EducationSessionService {
         newSession.id,
         qr,
       );
+
+    if (dto.receiverIds.length > 0) {
+      const receiver = await this.membersDomainService.findMemberModelById(
+        church,
+        dto.receiverIds[0],
+        qr,
+        { user: true },
+      );
+
+      await this.educationSessionReportDomainService.createSingleReport(
+        education,
+        educationTerm,
+        session,
+        receiver,
+        qr,
+      );
+    }
 
     return new PostEducationSessionResponseDto(session);
   }

--- a/backend/src/management/educations/service/education-domain/service/education-session-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/education-session-domain.service.ts
@@ -135,10 +135,19 @@ export class EducationSessionDomainService
       relations: {
         inCharge: MemberSummarizedRelation,
         creator: MemberSummarizedRelation,
+        reports: {
+          receiver: MemberSummarizedRelation,
+        },
       },
       select: {
         inCharge: MemberSummarizedSelect,
         creator: MemberSummarizedSelect,
+        reports: {
+          id: true,
+          isRead: true,
+          isConfirmed: true,
+          receiver: MemberSummarizedSelect,
+        },
       },
     });
 

--- a/backend/src/report/const/exception/education-session-report.exception.ts
+++ b/backend/src/report/const/exception/education-session-report.exception.ts
@@ -1,0 +1,10 @@
+import { MAX_RECEIVER_COUNT } from '../report.constraints';
+
+export const EducationSessionReportException = {
+  NOT_FOUND: '해당 교육 보고를 찾을 수 없습니다.',
+
+  REPORT_LOAD_FAIL: '교육 회차의 보고 정보 불러오기 실패',
+
+  EXCEED_RECEIVERS: (maxReceiver: number = MAX_RECEIVER_COUNT) =>
+    `피보고자는 최대 ${maxReceiver}명까지 등록할 수 있습니다.`,
+};

--- a/backend/src/report/controller/education-session-report.controller.ts
+++ b/backend/src/report/controller/education-session-report.controller.ts
@@ -1,0 +1,43 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+} from '@nestjs/common';
+import { EducationSessionReportService } from '../service/education-session-report.service';
+
+@Controller('education-session')
+export class EducationSessionReportController {
+  constructor(
+    private readonly educationSessionReportService: EducationSessionReportService,
+  ) {}
+
+  @Get()
+  getEducationSessionReport(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Body() dto: any,
+  ) {}
+
+  @Get(':educationSessionReportId')
+  getEducationSessionReportById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Param('educationSessionReportId', ParseIntPipe) reportId: number,
+  ) {
+    return this.educationSessionReportService.getEducationSessionReportById(
+      churchId,
+      memberId,
+      reportId,
+    );
+  }
+
+  @Patch(':educationSessionReportId')
+  patchEducationSessionReport() {}
+
+  @Delete(':educationSessionReportId')
+  deleteEducationSessionReport() {}
+}

--- a/backend/src/report/entity/education-session-report.entity.ts
+++ b/backend/src/report/entity/education-session-report.entity.ts
@@ -1,0 +1,32 @@
+import { ChildEntity, Column, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { ReportModel } from './report.entity';
+import { EducationSessionModel } from '../../management/educations/entity/education-session.entity';
+import { EducationModel } from '../../management/educations/entity/education.entity';
+import { EducationTermModel } from '../../management/educations/entity/education-term.entity';
+
+@ChildEntity('EDUCATIONSESSION')
+export class EducationSessionReportModel extends ReportModel {
+  @Index()
+  @Column()
+  educationSessionId: number;
+
+  @ManyToOne(() => EducationSessionModel, (session) => session.reports)
+  @JoinColumn({ name: 'educationSessionId' })
+  educationSession: EducationSessionModel;
+
+  @Index()
+  @Column()
+  educationId: number;
+
+  @ManyToOne(() => EducationModel)
+  @JoinColumn({ name: 'educationId' })
+  education: EducationModel;
+
+  @Index()
+  @Column()
+  educationTermId: number;
+
+  @ManyToOne(() => EducationTermModel)
+  @JoinColumn({ name: 'educationTermId' })
+  educationTerm: EducationTermModel;
+}

--- a/backend/src/report/entity/report.entity.ts
+++ b/backend/src/report/entity/report.entity.ts
@@ -5,12 +5,12 @@ import { Column, Entity, Index, ManyToOne, TableInheritance } from 'typeorm';
 @Entity()
 @TableInheritance({ column: { type: 'varchar', name: 'reportType' } })
 export abstract class ReportModel extends BaseModel {
-  @Index()
+  /*@Index()
   @Column({ nullable: true })
   senderId: number;
 
   @ManyToOne(() => MemberModel)
-  sender: MemberModel;
+  sender: MemberModel;*/
 
   @Index()
   @Column()
@@ -19,7 +19,7 @@ export abstract class ReportModel extends BaseModel {
   @ManyToOne(() => MemberModel)
   receiver: MemberModel;
 
-  @Column({ type: 'timestamp', default: new Date() })
+  @Column({ type: 'timestamptz', default: new Date() })
   reportedAt: Date;
 
   @Column({ default: false })

--- a/backend/src/report/report-domain/education-session-report-domain.module.ts
+++ b/backend/src/report/report-domain/education-session-report-domain.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { EducationSessionReportModel } from '../entity/education-session-report.entity';
+import { IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE } from './interface/education-session-report-domain.service.interface';
+import { EducationSessionReportDomainService } from './service/education-session-report-domain.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([EducationSessionReportModel])],
+  providers: [
+    {
+      provide: IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE,
+      useClass: EducationSessionReportDomainService,
+    },
+  ],
+  exports: [IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE],
+})
+export class EducationSessionReportDomainModule {}

--- a/backend/src/report/report-domain/interface/education-session-report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/education-session-report-domain.service.interface.ts
@@ -1,0 +1,27 @@
+import { QueryRunner } from 'typeorm';
+import { MemberModel } from '../../../members/entity/member.entity';
+import { EducationSessionReportModel } from '../../entity/education-session-report.entity';
+import { EducationModel } from '../../../management/educations/entity/education.entity';
+import { EducationTermModel } from '../../../management/educations/entity/education-term.entity';
+import { EducationSessionModel } from '../../../management/educations/entity/education-session.entity';
+
+export const IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE = Symbol(
+  'IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE',
+);
+
+export interface IEducationSessionReportDomainService {
+  findEducationSessionReportById(
+    receiver: MemberModel,
+    reportId: number,
+    checkIsRead: boolean,
+    qr?: QueryRunner,
+  ): Promise<EducationSessionReportModel>;
+
+  createSingleReport(
+    education: EducationModel,
+    educationTerm: EducationTermModel,
+    educationSession: EducationSessionModel,
+    receiver: MemberModel,
+    qr: QueryRunner,
+  ): Promise<EducationSessionReportModel>;
+}

--- a/backend/src/report/report-domain/interface/task-report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/task-report-domain.service.interface.ts
@@ -18,7 +18,7 @@ export interface ITaskReportDomainService {
 
   createTaskReports(
     task: TaskModel,
-    sender: MemberModel,
+    //sender: MemberModel,
     receivers: MemberModel[],
     qr: QueryRunner,
   ): Promise<TaskReportModel[]>;

--- a/backend/src/report/report-domain/interface/visitation-report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/visitation-report-domain.service.interface.ts
@@ -18,7 +18,7 @@ export interface IVisitationReportDomainService {
 
   createVisitationReport(
     visitation: VisitationMetaModel,
-    sender: MemberModel,
+    //sender: MemberModel,
     receiver: MemberModel,
     qr: QueryRunner,
   ): Promise<VisitationReportModel>;

--- a/backend/src/report/report-domain/service/education-session-report-domain.service.ts
+++ b/backend/src/report/report-domain/service/education-session-report-domain.service.ts
@@ -1,0 +1,195 @@
+import {
+  ConflictException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { IEducationSessionReportDomainService } from '../interface/education-session-report-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EducationSessionReportModel } from '../../entity/education-session-report.entity';
+import { QueryRunner, Repository } from 'typeorm';
+import { MemberModel } from '../../../members/entity/member.entity';
+import { EducationSessionReportException } from '../../const/exception/education-session-report.exception';
+import { EducationModel } from '../../../management/educations/entity/education.entity';
+import { EducationTermModel } from '../../../management/educations/entity/education-term.entity';
+import { EducationSessionModel } from '../../../management/educations/entity/education-session.entity';
+import { MAX_RECEIVER_COUNT } from '../../const/report.constraints';
+import { MemberException } from '../../../members/const/exception/member.exception';
+import { UserRole } from '../../../user/const/user-role.enum';
+import { AddConflictExceptionV2 } from '../../../common/exception/add-conflict.exception';
+
+@Injectable()
+export class EducationSessionReportDomainService
+  implements IEducationSessionReportDomainService
+{
+  constructor(
+    @InjectRepository(EducationSessionReportModel)
+    private readonly repository: Repository<EducationSessionReportModel>,
+  ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(EducationSessionReportModel)
+      : this.repository;
+  }
+
+  private assertCanAddReceivers(
+    educationSession: EducationSessionModel & {
+      reports: EducationSessionReportModel[];
+    },
+    newReceiverIds: number[] | MemberModel[],
+  ) {
+    let reports = educationSession.reports;
+
+    if (reports === undefined) {
+      throw new InternalServerErrorException(
+        EducationSessionReportException.REPORT_LOAD_FAIL,
+      );
+    }
+
+    if (reports.length + newReceiverIds.length > MAX_RECEIVER_COUNT) {
+      throw new ConflictException(
+        EducationSessionReportException.EXCEED_RECEIVERS(),
+      );
+    }
+  }
+
+  async createSingleReport(
+    education: EducationModel,
+    educationTerm: EducationTermModel,
+    educationSession: EducationSessionModel,
+    receiver: MemberModel,
+    qr: QueryRunner,
+  ) {
+    // 해당 교육에 피보고자 추가할 수 있는지
+    //educationSession.canAddReport([receiver]);
+    this.assertCanAddReceivers(educationSession, [receiver]);
+
+    if (!receiver.userId) {
+      throw new ConflictException('계정 가입되지 않음');
+    } else if (!receiver.user) {
+      throw new InternalServerErrorException('계정 정보 불러오기 실패');
+    } else if (
+      receiver.user.role !== UserRole.manager &&
+      receiver.user.role !== UserRole.mainAdmin
+    ) {
+      throw new ConflictException('관리자가 아님');
+    }
+
+    const repository = this.getRepository(qr);
+
+    const isExist = await repository.findOne({
+      where: {
+        receiverId: receiver.id,
+        educationSessionId: educationSession.id,
+      },
+    });
+
+    if (isExist) {
+      throw new ConflictException('이미 존재하는 피보고자');
+    }
+
+    return repository.save({
+      receiverId: receiver.id,
+      educationSessionId: educationSession.id,
+      educationTermId: educationTerm.id,
+      educationId: education.id,
+    });
+  }
+
+  async createEducationSessionReports(
+    education: EducationModel,
+    educationTerm: EducationTermModel,
+    educationSession: EducationSessionModel,
+    receivers: MemberModel[],
+    qr: QueryRunner,
+  ) {
+    educationSession.canAddReport(receivers);
+
+    const repository = this.getRepository(qr);
+
+    const failed: { receiverId: number; reason: string }[] = [];
+
+    const oldReceiverIds = new Set(
+      educationSession.reports.map((r) => r.receiverId),
+    );
+
+    for (const receiver of receivers) {
+      // 피보고자 중복 등록
+      if (oldReceiverIds.has(receiver.id)) {
+        failed.push({
+          receiverId: receiver.id,
+          reason: '이미 피보고자로 지정된 교인입니다.',
+        });
+      }
+
+      // 피보고자의 가입 여부
+      if (!receiver.userId) {
+        failed.push({
+          receiverId: receiver.id,
+          reason: '계정 가입되지 않은 교인입니다.',
+        });
+      }
+
+      if (!receiver.user) {
+        throw new InternalServerErrorException(MemberException.USER_ERROR);
+      }
+
+      if (
+        receiver.user.role !== UserRole.mainAdmin &&
+        receiver.user.role !== UserRole.manager
+      ) {
+        failed.push({
+          receiverId: receiver.id,
+          reason: '관리자 권한의 교인만 피보고자로 등록 가능',
+        });
+      }
+    }
+
+    if (failed.length > 0) {
+      throw new AddConflictExceptionV2('피보고자 추가 실패', failed);
+    }
+
+    const reports = receivers.map((receiver) =>
+      repository.create({
+        educationId: education.id,
+        educationTermId: educationTerm.id,
+        educationSession: educationSession,
+        receiver,
+        reportedAt: new Date(),
+        isRead: false,
+        isConfirmed: false,
+      }),
+    );
+
+    return repository.save(reports);
+  }
+
+  async findEducationSessionReportById(
+    receiver: MemberModel,
+    reportId: number,
+    checkIsRead: boolean,
+    qr?: QueryRunner,
+  ): Promise<EducationSessionReportModel> {
+    const repository = this.getRepository(qr);
+
+    const report = await repository.findOne({
+      where: {
+        receiverId: receiver.id,
+        id: reportId,
+      },
+    });
+
+    if (!report) {
+      throw new NotFoundException(EducationSessionReportException.NOT_FOUND);
+    }
+
+    // 읽음 처리
+    if (checkIsRead) {
+      report.isRead = true;
+      await repository.save(report);
+    }
+
+    return report;
+  }
+}

--- a/backend/src/report/report-domain/service/task-report-domain.service.ts
+++ b/backend/src/report/report-domain/service/task-report-domain.service.ts
@@ -52,13 +52,13 @@ export class TaskReportDomainService implements ITaskReportDomainService {
     }
 
     if (reports.length + newReceiverIds.length > MAX_RECEIVER_COUNT) {
-      throw new ConflictException(TaskReportException.EXCEED_RECEIVERS);
+      throw new ConflictException(TaskReportException.EXCEED_RECEIVERS());
     }
   }
 
   async createTaskReports(
     task: TaskModel,
-    sender: MemberModel,
+    //sender: MemberModel,
     receivers: MemberModel[],
     qr: QueryRunner,
   ) {
@@ -99,7 +99,7 @@ export class TaskReportDomainService implements ITaskReportDomainService {
     const reports = receivers.map((receiver) =>
       repository.create({
         task: task,
-        senderId: sender ? sender.id : undefined,
+        //senderId: sender ? sender.id : undefined,
         receiver,
         reportedAt: new Date(),
         isRead: false,
@@ -175,11 +175,11 @@ export class TaskReportDomainService implements ITaskReportDomainService {
         receiverId: receiver.id,
       },
       relations: {
-        sender: MemberSummarizedRelation,
+        //sender: MemberSummarizedRelation,
         task: { inCharge: MemberSummarizedRelation },
       },
       select: {
-        sender: MemberSummarizedSelect,
+        //sender: MemberSummarizedSelect,
         task: {
           title: true,
           taskStatus: true,
@@ -194,9 +194,10 @@ export class TaskReportDomainService implements ITaskReportDomainService {
       throw new NotFoundException(TaskReportException.NOT_FOUND);
     }
 
-    checkIsRead && (report.isRead = true);
-
-    checkIsRead && repository.save(report);
+    if (checkIsRead) {
+      report.isRead = true;
+      await repository.save(report);
+    }
 
     return report;
   }

--- a/backend/src/report/report-domain/service/visitation-report-domain.service.ts
+++ b/backend/src/report/report-domain/service/visitation-report-domain.service.ts
@@ -33,7 +33,7 @@ export class VisitationReportDomainService
 
   createVisitationReport(
     visitation: VisitationMetaModel,
-    sender: MemberModel,
+    //sender: MemberModel,
     receiver: MemberModel,
     qr: QueryRunner,
   ) {
@@ -41,7 +41,7 @@ export class VisitationReportDomainService
 
     return repository.save({
       visitation,
-      senderId: sender ? sender.id : undefined,
+      //senderId: sender ? sender.id : undefined,
       receiver,
       reportedAt: new Date(),
       isRead: false,
@@ -116,11 +116,11 @@ export class VisitationReportDomainService
         id: reportId,
       },
       relations: {
-        sender: {
+        /*sender: {
           officer: true,
           group: true,
           groupRole: true,
-        },
+        },*/
         visitation: {
           instructor: true,
           members: true,
@@ -132,9 +132,14 @@ export class VisitationReportDomainService
       throw new NotFoundException(VisitationReportException.NOT_FOUND);
     }
 
-    isRead && (report.isRead = true);
+    if (isRead) {
+      report.isRead = true;
+      await repository.save(report);
+    }
 
-    isRead && repository.save(report);
+    /*isRead && (report.isRead = true);
+
+    isRead && repository.save(report);*/
 
     return report;
   }

--- a/backend/src/report/report.module.ts
+++ b/backend/src/report/report.module.ts
@@ -8,6 +8,9 @@ import { VisitationReportService } from './service/visitation-report.service';
 import { TaskReportController } from './controller/task-report.controller';
 import { TaskReportService } from './service/task-report.service';
 import { TaskReportDomainModule } from './report-domain/task-report-domain.module';
+import { EducationSessionReportController } from './controller/education-session-report.controller';
+import { EducationSessionReportService } from './service/education-session-report.service';
+import { EducationSessionReportDomainModule } from './report-domain/education-session-report-domain.module';
 
 @Module({
   imports: [
@@ -21,9 +24,18 @@ import { TaskReportDomainModule } from './report-domain/task-report-domain.modul
     MembersDomainModule,
     VisitationReportDomainModule,
     TaskReportDomainModule,
+    EducationSessionReportDomainModule,
   ],
-  controllers: [VisitationReportController, TaskReportController],
-  providers: [VisitationReportService, TaskReportService],
+  controllers: [
+    VisitationReportController,
+    TaskReportController,
+    EducationSessionReportController,
+  ],
+  providers: [
+    VisitationReportService,
+    TaskReportService,
+    EducationSessionReportService,
+  ],
   exports: [],
 })
 export class ReportModule {}

--- a/backend/src/report/service/education-session-report.service.ts
+++ b/backend/src/report/service/education-session-report.service.ts
@@ -1,0 +1,45 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IMEMBERS_DOMAIN_SERVICE,
+  IMembersDomainService,
+} from '../../members/member-domain/interface/members-domain.service.interface';
+import {
+  IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE,
+  IEducationSessionReportDomainService,
+} from '../report-domain/interface/education-session-report-domain.service.interface';
+
+@Injectable()
+export class EducationSessionReportService {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,
+
+    @Inject(IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE)
+    private readonly educationSessionReportDomainService: IEducationSessionReportDomainService,
+  ) {}
+
+  async getEducationSessionReportById(
+    churchId: number,
+    receiverId: number,
+    reportId: number,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+    const receiver = await this.membersDomainService.findMemberModelById(
+      church,
+      receiverId,
+    );
+
+    return this.educationSessionReportDomainService.findEducationSessionReportById(
+      receiver,
+      reportId,
+      true,
+    );
+  }
+}

--- a/backend/src/task/service/task.service.ts
+++ b/backend/src/task/service/task.service.ts
@@ -243,7 +243,7 @@ export class TaskService {
       taskId,
       TaskTreeEnum.none,
       qr,
-      { inCharge: true, reports: true },
+      { /* inCharge: true, */ reports: true },
     );
 
     const newReceivers = await this.membersDomainService.findMembersById(
@@ -255,7 +255,7 @@ export class TaskService {
 
     await this.taskReportDomainService.createTaskReports(
       task,
-      task.inCharge,
+      //task.inCharge,
       newReceivers,
       qr,
     );

--- a/backend/src/visitation/service/visitation.service.ts
+++ b/backend/src/visitation/service/visitation.service.ts
@@ -165,7 +165,7 @@ export class VisitationService {
     if (dto.receiverIds && dto.receiverIds.length > 0) {
       await this.createVisitationReports(
         church,
-        instructor,
+        //instructor,
         dto.receiverIds,
         visitationMeta,
         qr,
@@ -177,7 +177,7 @@ export class VisitationService {
 
   private async createVisitationReports(
     church: ChurchModel,
-    sender: MemberModel,
+    //sender: MemberModel,
     receiverIds: number[],
     visitationMeta: VisitationMetaModel,
     qr: QueryRunner,
@@ -201,7 +201,7 @@ export class VisitationService {
 
         return this.visitationReportDomainService.createVisitationReport(
           visitationMeta,
-          sender,
+          //sender,
           receiver,
           qr,
         );
@@ -601,7 +601,7 @@ export class VisitationService {
         church,
         visitationId,
         qr,
-        { instructor: true, reports: true },
+        { /*instructor: true,*/ reports: true },
       );
 
     const reports = visitation.reports;
@@ -641,7 +641,7 @@ export class VisitationService {
       newReceivers.map((receiver) => {
         return this.visitationReportDomainService.createVisitationReport(
           visitation,
-          visitation.instructor,
+          //visitation.instructor,
           receiver,
           qr,
         );


### PR DESCRIPTION
## 주요 내용
교육 회차 보고 기능을 위한 `EducationSessionReport` 모듈을 도입하고, Controller → Service → DomainService → Repository 계층 구조를 기반으로 기본 저장 흐름과 구조를 설계하였습니다.

## 세부 내용

### 🧱 기본 구조 구성
- `EducationSessionReportController` 생성
- `EducationSessionReportService` 및 `EducationSessionReportDomainService` 정의
- 도메인 기반의 책임 분리 구조 적용
  - 서비스: 유스케이스 로직 담당
  - 도메인 서비스: 도메인 규칙 및 검증 담당
  - 리포지토리: DB 접근

### 📝 보고 저장 시 포함 정보
- 보고 생성 시 다음 ID 정보 함께 저장:
  - `educationId`, `educationTermId`, `educationSessionId`
  - 교육 회차 정보를 효율적으로 조회하기 위함

### 🧹 ReportModel 구조 정리
- 공통 `ReportModel`에서 `sender`(보고자) 필드 제거
  - 보고 대상 엔티티의 `inCharge` 또는 `instructor` 필드를 통해 담당자 확인
  - Education, Task, Visitation 등에서 일관된 방식 적용

이번 설계는 교육 보고 기능의 기반을 마련하는 단계로,
도메인 계층 중심의 확장성과 일관된 보고 흐름 구현을 위한 구조적 준비 작업입니다.