### PR TITLE
feat: 교육 회차 보고(EducationSessionReport) 기능 구현 및 피보고자 관리 기능 추가

### DIFF
--- a/backend/src/management/educations/controller/education-sessions.controller.ts
+++ b/backend/src/management/educations/controller/education-sessions.controller.ts
@@ -24,6 +24,8 @@ import { AuthType } from '../../../auth/const/enum/auth-type.enum';
 import { JwtAccessPayload } from '../../../auth/type/jwt';
 import { Token } from '../../../auth/decorator/jwt.decorator';
 import { GetEducationSessionDto } from '../dto/sessions/request/get-education-session.dto';
+import { AddEducationSessionReportDto } from '../../../report/dto/education-report/session/request/add-education-session-report.dto';
+import { DeleteEducationSessionReportDto } from '../../../report/dto/education-report/session/request/delete-education-session-report.dto';
 
 @ApiTags('Management:Educations:Sessions')
 @Controller('educations/:educationId/terms/:educationTermId/sessions')
@@ -128,6 +130,48 @@ export class EducationSessionsController {
       educationId,
       educationTermId,
       educationSessionId,
+      qr,
+    );
+  }
+
+  @ApiOperation({})
+  @UseInterceptors(TransactionInterceptor)
+  @Patch(':educationSessionId/add-receivers')
+  addReportReceivers(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('educationId', ParseIntPipe) educationId: number,
+    @Param('educationTermId', ParseIntPipe) educationTermId: number,
+    @Param('educationSessionId', ParseIntPipe) educationSessionId: number,
+    @Body() dto: AddEducationSessionReportDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.educationSessionsService.addReportReceivers(
+      churchId,
+      educationId,
+      educationTermId,
+      educationSessionId,
+      dto,
+      qr,
+    );
+  }
+
+  @ApiOperation({})
+  @UseInterceptors(TransactionInterceptor)
+  @Patch(':educationSessionId/delete-receivers')
+  deleteReportReceivers(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('educationId', ParseIntPipe) educationId: number,
+    @Param('educationTermId', ParseIntPipe) educationTermId: number,
+    @Param('educationSessionId', ParseIntPipe) educationSessionId: number,
+    @Body() dto: DeleteEducationSessionReportDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.educationSessionsService.deleteEducationSessionReportReceivers(
+      churchId,
+      educationId,
+      educationTermId,
+      educationSessionId,
+      dto,
       qr,
     );
   }

--- a/backend/src/report/const/education-session-report-order.enum.ts
+++ b/backend/src/report/const/education-session-report-order.enum.ts
@@ -1,0 +1,4 @@
+export enum EducationSessionReportOrderEnum {
+  createdAt = 'createdAt',
+  updatedAt = 'updatedAt',
+}

--- a/backend/src/report/const/exception/education-session-report.exception.ts
+++ b/backend/src/report/const/exception/education-session-report.exception.ts
@@ -2,8 +2,12 @@ import { MAX_RECEIVER_COUNT } from '../report.constraints';
 
 export const EducationSessionReportException = {
   NOT_FOUND: '해당 교육 보고를 찾을 수 없습니다.',
+  ALREADY_REPORTED_MEMBER: '이미 피보고자로 등록된 교인입니다.',
+  NOT_EXIST_REPORTED_MEMBER: '피보고자로 등록되지 않은 교인입니다.',
 
   REPORT_LOAD_FAIL: '교육 회차의 보고 정보 불러오기 실패',
+  UPDATE_ERROR: '교육 회차 보고 업데이트 도중 에러 발생',
+  DELETE_ERROR: '교육 회차 보고 삭제 도중 에러 발생',
 
   EXCEED_RECEIVERS: (maxReceiver: number = MAX_RECEIVER_COUNT) =>
     `피보고자는 최대 ${maxReceiver}명까지 등록할 수 있습니다.`,

--- a/backend/src/report/controller/education-session-report.controller.ts
+++ b/backend/src/report/controller/education-session-report.controller.ts
@@ -6,9 +6,14 @@ import {
   Param,
   ParseIntPipe,
   Patch,
+  Query,
 } from '@nestjs/common';
 import { EducationSessionReportService } from '../service/education-session-report.service';
+import { GetEducationSessionReportDto } from '../dto/education-report/session/request/get-education-session-report.dto';
+import { UpdateEducationSessionReportDto } from '../dto/education-report/session/request/update-education-session-report.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('Churches:Members:Reports:Education-Sessions')
 @Controller('education-session')
 export class EducationSessionReportController {
   constructor(
@@ -19,8 +24,14 @@ export class EducationSessionReportController {
   getEducationSessionReport(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
-    @Body() dto: any,
-  ) {}
+    @Query() dto: GetEducationSessionReportDto,
+  ) {
+    return this.educationSessionReportService.getEducationSessionReports(
+      churchId,
+      memberId,
+      dto,
+    );
+  }
 
   @Get(':educationSessionReportId')
   getEducationSessionReportById(
@@ -36,8 +47,30 @@ export class EducationSessionReportController {
   }
 
   @Patch(':educationSessionReportId')
-  patchEducationSessionReport() {}
+  patchEducationSessionReport(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Param('educationSessionReportId', ParseIntPipe) reportId: number,
+    @Body() dto: UpdateEducationSessionReportDto,
+  ) {
+    return this.educationSessionReportService.patchEducationSessionReport(
+      churchId,
+      memberId,
+      reportId,
+      dto,
+    );
+  }
 
   @Delete(':educationSessionReportId')
-  deleteEducationSessionReport() {}
+  deleteEducationSessionReport(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Param('educationSessionReportId', ParseIntPipe) reportId: number,
+  ) {
+    return this.educationSessionReportService.deleteEducationSessionReport(
+      churchId,
+      memberId,
+      reportId,
+    );
+  }
 }

--- a/backend/src/report/dto/education-report/session/request/add-education-session-report.dto.ts
+++ b/backend/src/report/dto/education-report/session/request/add-education-session-report.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsNumber, Min } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class AddEducationSessionReportDto {
+  @ApiProperty({
+    description: '피보고자 ID 배열',
+    isArray: true,
+  })
+  @Transform(({ value }) => {
+    return Array.isArray(value) ? Array.from(new Set(value)) : value;
+  })
+  @IsArray()
+  @IsNumber({}, { each: true })
+  @Min(1, { each: true })
+  receiverIds: number[];
+}

--- a/backend/src/report/dto/education-report/session/request/delete-education-session-report.dto.ts
+++ b/backend/src/report/dto/education-report/session/request/delete-education-session-report.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsNumber, Min } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class DeleteEducationSessionReportDto {
+  @ApiProperty({
+    description: '업무 피보고자 ID',
+    isArray: true,
+  })
+  @Transform(({ value }) =>
+    Array.isArray(value) ? Array.from(new Set(value)) : value,
+  )
+  @IsArray()
+  @IsNumber({}, { each: true })
+  @Min(1, { each: true })
+  receiverIds: number[];
+}

--- a/backend/src/report/dto/education-report/session/request/get-education-session-report.dto.ts
+++ b/backend/src/report/dto/education-report/session/request/get-education-session-report.dto.ts
@@ -1,0 +1,36 @@
+import { BaseOffsetPaginationRequestDto } from '../../../../../common/dto/request/base-offset-pagination-request.dto';
+import { EducationSessionReportOrderEnum } from '../../../../const/education-session-report-order.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsEnum, IsOptional } from 'class-validator';
+import { QueryBoolean } from '../../../../../common/decorator/transformer/query-boolean.decorator';
+
+export class GetEducationSessionReportDto extends BaseOffsetPaginationRequestDto<EducationSessionReportOrderEnum> {
+  @ApiProperty({
+    description: '정렬 기준',
+    enum: EducationSessionReportOrderEnum,
+    default: EducationSessionReportOrderEnum.createdAt,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(EducationSessionReportOrderEnum)
+  order: EducationSessionReportOrderEnum =
+    EducationSessionReportOrderEnum.createdAt;
+
+  @ApiProperty({
+    description: '읽은 보고 or 읽지 않은 보고',
+    required: false,
+  })
+  @IsOptional()
+  @QueryBoolean()
+  @IsBoolean()
+  isRead?: boolean;
+
+  @ApiProperty({
+    description: '확인 처리한 보고 or 하지 않은 보고',
+    required: false,
+  })
+  @IsOptional()
+  @QueryBoolean()
+  @IsBoolean()
+  isConfirmed?: boolean;
+}

--- a/backend/src/report/dto/education-report/session/request/update-education-session-report.dto.ts
+++ b/backend/src/report/dto/education-report/session/request/update-education-session-report.dto.ts
@@ -1,0 +1,3 @@
+import { BaseUpdateReportDto } from '../../../base-update-report.dto';
+
+export class UpdateEducationSessionReportDto extends BaseUpdateReportDto {}

--- a/backend/src/report/dto/education-report/session/response/delete-education-session-report-response.dto.ts
+++ b/backend/src/report/dto/education-report/session/response/delete-education-session-report-response.dto.ts
@@ -1,0 +1,15 @@
+import { BaseDeleteResponseDto } from '../../../../../common/dto/reponse/base-delete-response.dto';
+
+export class DeleteEducationSessionReportResponseDto extends BaseDeleteResponseDto {
+  constructor(
+    public readonly timestamp: Date,
+    public readonly id: number,
+    public readonly educationId: number,
+    public readonly educationTermId: number,
+    public readonly educationSessionId: number,
+    public readonly educationSessionName: string,
+    public readonly success: boolean,
+  ) {
+    super(timestamp, id, success);
+  }
+}

--- a/backend/src/report/dto/education-report/session/response/education-session-report-domain-pagination-result.dto.ts
+++ b/backend/src/report/dto/education-report/session/response/education-session-report-domain-pagination-result.dto.ts
@@ -1,0 +1,8 @@
+import { BaseDomainOffsetPaginationResultDto } from '../../../../../common/dto/base-domain-offset-pagination-result.dto';
+import { EducationSessionReportModel } from '../../../../entity/education-session-report.entity';
+
+export class EducationSessionReportDomainPaginationResultDto extends BaseDomainOffsetPaginationResultDto<EducationSessionReportModel> {
+  constructor(data: EducationSessionReportModel[], totalCount: number) {
+    super(data, totalCount);
+  }
+}

--- a/backend/src/report/dto/education-report/session/response/education-session-report-pagination-result.dto.ts
+++ b/backend/src/report/dto/education-report/session/response/education-session-report-pagination-result.dto.ts
@@ -1,0 +1,14 @@
+import { BaseOffsetPaginationResponseDto } from '../../../../../common/dto/reponse/base-offset-pagination-response.dto';
+import { EducationSessionReportModel } from '../../../../entity/education-session-report.entity';
+
+export class EducationSessionReportPaginationResultDto extends BaseOffsetPaginationResponseDto<EducationSessionReportModel> {
+  constructor(
+    data: EducationSessionReportModel[],
+    totalCount: number,
+    count: number,
+    page: number,
+    totalPage: number,
+  ) {
+    super(data, totalCount, count, page, totalPage);
+  }
+}

--- a/backend/src/report/dto/education-report/session/response/get-education-session-report-response.dto.ts
+++ b/backend/src/report/dto/education-report/session/response/get-education-session-report-response.dto.ts
@@ -1,0 +1,8 @@
+import { BaseGetResponseDto } from '../../../../../common/dto/reponse/base-get-response.dto';
+import { EducationSessionReportModel } from '../../../../entity/education-session-report.entity';
+
+export class GetEducationSessionReportResponseDto extends BaseGetResponseDto<EducationSessionReportModel> {
+  constructor(data: EducationSessionReportModel) {
+    super(data);
+  }
+}

--- a/backend/src/report/dto/education-report/session/response/patch-education-session-report-response.dto.ts
+++ b/backend/src/report/dto/education-report/session/response/patch-education-session-report-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePatchResponseDto } from '../../../../../common/dto/reponse/base-patch-response.dto';
+import { EducationSessionReportModel } from '../../../../entity/education-session-report.entity';
+
+export class PatchEducationSessionReportResponseDto extends BasePatchResponseDto<EducationSessionReportModel> {
+  constructor(data: EducationSessionReportModel) {
+    super(data);
+  }
+}

--- a/backend/src/report/report-domain/interface/education-session-report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/education-session-report-domain.service.interface.ts
@@ -1,20 +1,35 @@
-import { QueryRunner } from 'typeorm';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { EducationSessionReportModel } from '../../entity/education-session-report.entity';
 import { EducationModel } from '../../../management/educations/entity/education.entity';
 import { EducationTermModel } from '../../../management/educations/entity/education-term.entity';
 import { EducationSessionModel } from '../../../management/educations/entity/education-session.entity';
+import { EducationSessionReportDomainPaginationResultDto } from '../../dto/education-report/session/response/education-session-report-domain-pagination-result.dto';
+import { GetEducationSessionReportDto } from '../../dto/education-report/session/request/get-education-session-report.dto';
+import { UpdateEducationSessionReportDto } from '../../dto/education-report/session/request/update-education-session-report.dto';
 
 export const IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE = Symbol(
   'IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE',
 );
 
 export interface IEducationSessionReportDomainService {
+  findEducationSessionReports(
+    receiver: MemberModel,
+    dto: GetEducationSessionReportDto,
+  ): Promise<EducationSessionReportDomainPaginationResultDto>;
+
   findEducationSessionReportById(
     receiver: MemberModel,
     reportId: number,
     checkIsRead: boolean,
     qr?: QueryRunner,
+  ): Promise<EducationSessionReportModel>;
+
+  findEducationSessionReportModelById(
+    receiver: MemberModel,
+    reportId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<EducationSessionReportModel>,
   ): Promise<EducationSessionReportModel>;
 
   createSingleReport(
@@ -24,4 +39,23 @@ export interface IEducationSessionReportDomainService {
     receiver: MemberModel,
     qr: QueryRunner,
   ): Promise<EducationSessionReportModel>;
+
+  createEducationSessionReports(
+    education: EducationModel,
+    educationTerm: EducationTermModel,
+    educationSession: EducationSessionModel,
+    receivers: MemberModel[],
+    qr: QueryRunner,
+  ): Promise<EducationSessionReportModel[]>;
+
+  deleteEducationSessionReports(
+    deleteReports: EducationSessionReportModel[],
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  updateEducationSessionReport(
+    targetReport: EducationSessionReportModel,
+    dto: UpdateEducationSessionReportDto,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
 }

--- a/backend/src/report/service/education-session-report.service.ts
+++ b/backend/src/report/service/education-session-report.service.ts
@@ -11,6 +11,13 @@ import {
   IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE,
   IEducationSessionReportDomainService,
 } from '../report-domain/interface/education-session-report-domain.service.interface';
+import { GetEducationSessionReportDto } from '../dto/education-report/session/request/get-education-session-report.dto';
+import { EducationSessionReportPaginationResultDto } from '../dto/education-report/session/response/education-session-report-pagination-result.dto';
+import { UpdateEducationSessionReportDto } from '../dto/education-report/session/request/update-education-session-report.dto';
+import { PatchEducationSessionReportResponseDto } from '../dto/education-report/session/response/patch-education-session-report-response.dto';
+import { GetEducationSessionReportResponseDto } from '../dto/education-report/session/response/get-education-session-report-response.dto';
+import { QueryRunner } from 'typeorm';
+import { DeleteEducationSessionReportResponseDto } from '../dto/education-report/session/response/delete-education-session-report-response.dto';
 
 @Injectable()
 export class EducationSessionReportService {
@@ -24,6 +31,33 @@ export class EducationSessionReportService {
     private readonly educationSessionReportDomainService: IEducationSessionReportDomainService,
   ) {}
 
+  async getEducationSessionReports(
+    churchId: number,
+    memberId: number,
+    dto: GetEducationSessionReportDto,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+    const receiver = await this.membersDomainService.findMemberModelById(
+      church,
+      memberId,
+    );
+
+    const { data, totalCount } =
+      await this.educationSessionReportDomainService.findEducationSessionReports(
+        receiver,
+        dto,
+      );
+
+    return new EducationSessionReportPaginationResultDto(
+      data,
+      totalCount,
+      data.length,
+      dto.page,
+      Math.ceil(totalCount / dto.take),
+    );
+  }
+
   async getEducationSessionReportById(
     churchId: number,
     receiverId: number,
@@ -36,9 +70,84 @@ export class EducationSessionReportService {
       receiverId,
     );
 
-    return this.educationSessionReportDomainService.findEducationSessionReportById(
-      receiver,
+    const report =
+      await this.educationSessionReportDomainService.findEducationSessionReportById(
+        receiver,
+        reportId,
+        true,
+      );
+
+    return new GetEducationSessionReportResponseDto(report);
+  }
+
+  async patchEducationSessionReport(
+    churchId: number,
+    memberId: number,
+    reportId: number,
+    dto: UpdateEducationSessionReportDto,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+    const receiver = await this.membersDomainService.findMemberModelById(
+      church,
+      memberId,
+    );
+
+    const targetReport =
+      await this.educationSessionReportDomainService.findEducationSessionReportModelById(
+        receiver,
+        reportId,
+      );
+
+    await this.educationSessionReportDomainService.updateEducationSessionReport(
+      targetReport,
+      dto,
+    );
+
+    const updatedReport =
+      await this.educationSessionReportDomainService.findEducationSessionReportById(
+        receiver,
+        reportId,
+        false,
+      );
+
+    return new PatchEducationSessionReportResponseDto(updatedReport);
+  }
+
+  async deleteEducationSessionReport(
+    churchId: number,
+    receiverId: number,
+    reportId: number,
+    qr?: QueryRunner,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const receiver = await this.membersDomainService.findMemberModelById(
+      church,
+      receiverId,
+    );
+
+    const deleteTarget =
+      await this.educationSessionReportDomainService.findEducationSessionReportModelById(
+        receiver,
+        reportId,
+        qr,
+        { educationSession: true },
+      );
+
+    await this.educationSessionReportDomainService.deleteEducationSessionReports(
+      [deleteTarget],
+      qr,
+    );
+
+    return new DeleteEducationSessionReportResponseDto(
+      new Date(),
       reportId,
+      deleteTarget.educationId,
+      deleteTarget.educationTermId,
+      deleteTarget.educationSessionId,
+      deleteTarget.educationSession.name,
       true,
     );
   }


### PR DESCRIPTION
## 주요 내용

교육 회차(EducationSession)에 피보고자(receiver)를 추가하고,
보고(EducationSessionReport)를 생성 및 관리할 수 있는 기능을 구현하였습니다. 보고 흐름과 API 구조는 기존 Visitation 및 Task 보고와 동일한 패턴을 따릅니다.

## 세부 내용

### 피보고자 관리 기능

- 교육 회차 생성 시 `receiverIds` 전달 가능 → 보고 자동 생성
- 생성 이후에도 피보고자 추가/삭제 가능
  - 추가: `PATCH /churches/{churchId}/management/educations/{educationId}/terms/{educationTermId}/sessions/{educationSessionId}/add-receivers`
  - 삭제: `PATCH /churches/{churchId}/management/educations/{educationId}/terms/{educationTermId}/sessions/{educationSessionId}/delete-receivers`
- 예외 처리:
  - 이미 피보고자인 교인을 추가할 경우 → `ConflictException`
  - 미가입자 또는 권한 없는 교인을 추가할 경우 → `UnauthorizedException`
  - 등록되지 않은 교인을 삭제할 경우 → `ConflictException`

### 개인 보고 관리 기능

- 로그인한 사용자가 받은 교육 회차 보고 목록 조회
- 단건 조회, `isRead`, `isConfirmed` 수정 가능
- 보고 삭제 기능 포함
- API 구조 및 응답 형식은 `VisitationReport`, `TaskReport`와 동일

이번 기능 추가를 통해 교육 회차 단위에서도 체계적인 보고 및 확인 절차가 가능해졌으며,
보고 대상자 관리 흐름이 다른 도메인과 일관되게 통합되었습니다.