### PR TITLE
fix: 교육 세션 보고 다중 생성 문제 해결 및 목록 조회 검색 기능 확장

### DIFF
--- a/backend/src/common/decorator/validator/is-no-special-char.validator.ts
+++ b/backend/src/common/decorator/validator/is-no-special-char.validator.ts
@@ -1,7 +1,7 @@
 import { Matches } from 'class-validator';
 
 export function IsNoSpecialChar() {
-  return Matches(/^[a-zA-Z0-9가-힣 \-]+$/, {
+  return Matches(/^[a-zA-Z0-9ㄱ-힣 \-]+$/, {
     message: '특수문자는 사용할 수 없습니다.',
   });
 }

--- a/backend/src/common/dto/request/base-offset-pagination-request.dto.ts
+++ b/backend/src/common/dto/request/base-offset-pagination-request.dto.ts
@@ -41,5 +41,5 @@ export abstract class BaseOffsetPaginationRequestDto<TOrder> {
   })
   @IsIn(['asc', 'desc', 'ASC', 'DESC'])
   @IsOptional()
-  orderDirection: 'asc' | 'desc' | 'ASC' | 'DESC';
+  orderDirection: 'ASC' | 'DESC' | 'asc' | 'desc';
 }

--- a/backend/src/management/educations/const/swagger/education-session.swagger.ts
+++ b/backend/src/management/educations/const/swagger/education-session.swagger.ts
@@ -1,0 +1,161 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export const ApiGetEducationSessions = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교육 회차 조회',
+      description:
+        '<h2>교육 기수 하위의 세션을 조회합니다.</h2>' +
+        '<p>정렬 기준: 회차 / 생성일 / 수정일</p>',
+    }),
+  );
+
+export const ApiPostEducationSessions = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교육 회차 생성',
+      description:
+        '<h2>교육 기수 하위의 세션을 생성합니다.</h2>' +
+        '<p><b>name:</b> 세션의 이름  [한글, 알파벳, 숫자, - 사용 가능, 최대 50자 (그 외 특수문자 불가)]</p>' +
+        '<p><b>startDate:</b> 세션의 시작 날짜+시간</p>' +
+        '<p><b>endDate:</b> 세션의 종료 날짜+시간 [startDate 보다 앞설 수 없음]</p>' +
+        '<p><b>inChargeId:</b> 담당자 교인 ID [관리자 권한의 교인만 설정 가능] 선택값</p>' +
+        '<p><b>content:</b> 세션 내용 [서식 제외 순수 텍스트 1000자, html 태그로 서식 지정 가능]</p>' +
+        '<p><b>status:</b> 세션 진행 상태 [reserve, done, pending]</p>' +
+        '<p><b>receiverIds:</b> 보고 대상자 교인 ID 배열 [관리자 권한의 교인만 설정 가능]</p>',
+    }),
+  );
+
+export const ApiGetEducationSessionById = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '특정 교육 회차 조회',
+      description: '<h2>교육 세션의 상세 내용을 조회합니다.</h2>',
+    }),
+    ApiResponse({
+      example: {
+        data: {
+          id: 50,
+          createdAt: '2025-05-20T05:38:43.949Z',
+          updatedAt: '2025-05-21T08:07:33.466Z',
+          educationTermId: 9,
+          session: 4,
+          name: '보고 테스트',
+          content: '',
+          startDate: '2025-05-20T14:34:02.234Z',
+          endDate: '2025-05-20T14:34:02.234Z',
+          status: 'reserve',
+          inChargeId: 4,
+          creatorId: 1,
+          inCharge: {
+            id: 4,
+            name: '최종희',
+            officer: {
+              id: 3,
+              name: '집사',
+            },
+            group: null,
+            groupRole: null,
+          },
+          creator: {
+            id: 1,
+            name: '김홍남',
+            officer: {
+              id: 3,
+              name: '집사',
+            },
+            group: {
+              id: 5,
+              name: '청년부2',
+            },
+            groupRole: null,
+          },
+          reports: [
+            {
+              id: 26,
+              isRead: true,
+              isConfirmed: false,
+              receiver: {
+                id: 1,
+                name: '김홍남',
+                officer: {
+                  id: 3,
+                  name: '집사',
+                },
+                group: {
+                  id: 5,
+                  name: '청년부2',
+                },
+                groupRole: null,
+              },
+            },
+            {
+              id: 24,
+              isRead: false,
+              isConfirmed: false,
+              receiver: {
+                id: 2,
+                name: '권우주',
+                officer: {
+                  id: 1,
+                  name: '장로',
+                },
+                group: null,
+                groupRole: null,
+              },
+            },
+          ],
+        },
+        timestamp: '2025-05-21T17:07:45.867Z',
+      },
+    }),
+  );
+
+export const ApiPatchEducationSession = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교육 세션 수정',
+      description:
+        '<h2>교육 세션을 수정합니다.</h2>' +
+        '<p><b>name:</b> 세션의 이름 (string) [한글, 알파벳, 숫자, - 사용 가능, 최대 50자 (그 외 특수문자 불가)]</p>' +
+        '<p><b>startDate:</b> 세션의 시작 날짜+시간 (Date) [기존 endDate 보다 늦을 수 없음]</p>' +
+        '<p><b>endDate:</b> 세션의 종료 날짜+시간 (Date) [기존 startDate 보다 앞설 수 없음]</p>' +
+        '<p><b>inChargeId:</b> 담당자 교인 ID (number) [관리자 권한의 교인만 설정 가능, 담당자 삭제 시 null] 선택값</p>' +
+        '<p><b>content:</b> 세션 내용 (string) [서식 제외 순수 텍스트 1000자, html 태그로 서식 지정 가능]</p>' +
+        '<p><b>status:</b> 세션 진행 상태 (enum) [reserve, done, pending]</p>',
+    }),
+  );
+
+export const ApiDeleteEducationSession = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교육 세션 삭제',
+      description:
+        '<h2>교육 세션을 삭제합니다.</h2>' +
+        '<p>회차 삭제 시 다른 회차들의 넘버링 자동 수정, 해당 기수의 회차 개수 자동 수정</p>' +
+        '<p>해당 세션의 보고 삭제</p>',
+    }),
+  );
+
+export const ApiAddReportReceivers = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '보고 대상자 추가',
+      description:
+        '<h2>교육 세션의 보고 대상자를 추가합니다.</h2>' +
+        '<p>recevierIds: 추가할 대상자 교인 ID 배열 (number[]) [관리자 권한의 교인만 설정 가능, 중복된 ID 존재 시 중복 내용 제거]</p>' +
+        '<p>이미 등록된 교인을 추가 불가능</p>',
+    }),
+  );
+
+export const ApiDeleteReportReceivers = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '보고 대상자 삭제',
+      description:
+        '<h2>교육 세션의 보고 대상자를 삭제합니다.</h2>' +
+        '<p>receiverIds: 삭제할 대상자 교인 ID 배열 (number[]) [중복된 ID 존재 시 중복 내용 제거]</p>' +
+        '<p>등록되지 않은 교인 삭제 불가능</p>',
+    }),
+  );

--- a/backend/src/management/educations/controller/education-sessions.controller.ts
+++ b/backend/src/management/educations/controller/education-sessions.controller.ts
@@ -11,7 +11,7 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { QueryRunner as QR } from 'typeorm/query-runner/QueryRunner';
 import { UpdateEducationSessionDto } from '../dto/sessions/request/update-education-session.dto';
 import { EducationSessionService } from '../service/educaiton-session.service';
@@ -26,6 +26,15 @@ import { Token } from '../../../auth/decorator/jwt.decorator';
 import { GetEducationSessionDto } from '../dto/sessions/request/get-education-session.dto';
 import { AddEducationSessionReportDto } from '../../../report/dto/education-report/session/request/add-education-session-report.dto';
 import { DeleteEducationSessionReportDto } from '../../../report/dto/education-report/session/request/delete-education-session-report.dto';
+import {
+  ApiAddReportReceivers,
+  ApiDeleteEducationSession,
+  ApiDeleteReportReceivers,
+  ApiGetEducationSessionById,
+  ApiGetEducationSessions,
+  ApiPatchEducationSession,
+  ApiPostEducationSessions,
+} from '../const/swagger/education-session.swagger';
 
 @ApiTags('Management:Educations:Sessions')
 @Controller('educations/:educationId/terms/:educationTermId/sessions')
@@ -34,7 +43,7 @@ export class EducationSessionsController {
     private readonly educationSessionsService: EducationSessionService,
   ) {}
 
-  @ApiOperation({ summary: '교육 회차 조회' })
+  @ApiGetEducationSessions()
   @Get()
   getEducationSessions(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -50,7 +59,7 @@ export class EducationSessionsController {
     );
   }
 
-  @ApiOperation({ summary: '교육 회차 생성' })
+  @ApiPostEducationSessions()
   @Post()
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   @UseInterceptors(TransactionInterceptor)
@@ -74,7 +83,7 @@ export class EducationSessionsController {
     );
   }
 
-  @ApiOperation({ summary: '특정 교육 회차 조회' })
+  @ApiGetEducationSessionById()
   @Get(':educationSessionId')
   getEducationSessionById(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -90,7 +99,7 @@ export class EducationSessionsController {
     );
   }
 
-  @ApiOperation({ summary: '교육 진행 내용 업데이트' })
+  @ApiPatchEducationSession()
   @Patch(':educationSessionId')
   @UseInterceptors(TransactionInterceptor)
   patchEducationSession(
@@ -111,11 +120,7 @@ export class EducationSessionsController {
     );
   }
 
-  @ApiOperation({
-    summary: '교육 회차 삭제',
-    description:
-      '회차 삭제 시 다른 회차들의 넘버링 자동 수정, 해당 기수의 회차 개수 자동 수정',
-  })
+  @ApiDeleteEducationSession()
   @Delete(':educationSessionId')
   @UseInterceptors(TransactionInterceptor)
   deleteEducationSession(
@@ -134,7 +139,7 @@ export class EducationSessionsController {
     );
   }
 
-  @ApiOperation({})
+  @ApiAddReportReceivers()
   @UseInterceptors(TransactionInterceptor)
   @Patch(':educationSessionId/add-receivers')
   addReportReceivers(
@@ -155,7 +160,7 @@ export class EducationSessionsController {
     );
   }
 
-  @ApiOperation({})
+  @ApiDeleteReportReceivers()
   @UseInterceptors(TransactionInterceptor)
   @Patch(':educationSessionId/delete-receivers')
   deleteReportReceivers(

--- a/backend/src/management/educations/dto/education/get-education.dto.ts
+++ b/backend/src/management/educations/dto/education/get-education.dto.ts
@@ -1,6 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsIn, IsNumber, IsOptional } from 'class-validator';
+import {
+  IsEnum,
+  IsIn,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Length,
+} from 'class-validator';
 import { EducationOrderEnum } from '../../const/order.enum';
+import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
+import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import { RemoveSpaces } from '../../../../common/decorator/transformer/remove-spaces';
 
 export class GetEducationDto {
   @ApiProperty({
@@ -39,4 +49,15 @@ export class GetEducationDto {
   @IsIn(['asc', 'desc', 'ASC', 'DESC'])
   @IsOptional()
   orderDirection: 'asc' | 'desc' | 'ASC' | 'DESC' = 'asc';
+
+  @ApiProperty({
+    description: '교육명',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @Length(2, 50)
+  @IsNoSpecialChar()
+  @RemoveSpaces()
+  name?: string;
 }

--- a/backend/src/management/educations/dto/enrollments/get-education-enrollment.dto.ts
+++ b/backend/src/management/educations/dto/enrollments/get-education-enrollment.dto.ts
@@ -1,6 +1,15 @@
-import { IsEnum, IsIn, IsNumber, IsOptional, Min } from 'class-validator';
+import {
+  IsEnum,
+  IsIn,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
 import { EducationEnrollmentOrderEnum } from '../../const/order.enum';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
 
 export class GetEducationEnrollmentDto {
   @ApiProperty({
@@ -41,4 +50,13 @@ export class GetEducationEnrollmentDto {
   @IsOptional()
   @IsIn(['asc', 'desc', 'ASC', 'DESC'])
   orderDirection: 'asc' | 'desc' | 'ASC' | 'DESC' = 'asc';
+
+  @ApiProperty({
+    description: '수강 교인 이름',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @IsNotEmpty()
+  memberName?: string;
 }

--- a/backend/src/management/educations/dto/terms/request/get-education-term.dto.ts
+++ b/backend/src/management/educations/dto/terms/request/get-education-term.dto.ts
@@ -1,7 +1,17 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { EducationTermOrderEnum } from '../../../const/order.enum';
-import { IsEnum } from 'class-validator';
+import {
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Length,
+  Min,
+} from 'class-validator';
 import { BaseOffsetPaginationRequestDto } from '../../../../../common/dto/request/base-offset-pagination-request.dto';
+import { IsNoSpecialChar } from '../../../../../common/decorator/validator/is-no-special-char.validator';
+import { RemoveSpaces } from '../../../../../common/decorator/transformer/remove-spaces';
+import { IsOptionalNotNull } from '../../../../../common/decorator/validator/is-optional-not.null.validator';
 
 export class GetEducationTermDto extends BaseOffsetPaginationRequestDto<EducationTermOrderEnum> {
   @ApiProperty({
@@ -13,14 +23,32 @@ export class GetEducationTermDto extends BaseOffsetPaginationRequestDto<Educatio
   @IsEnum(EducationTermOrderEnum)
   order: EducationTermOrderEnum = EducationTermOrderEnum.term;
 
-  /*@ApiProperty({
-    description: '회차명',
+  @ApiProperty({
+    description: '기수 담당자 ID',
     required: false,
   })
   @IsOptional()
+  @IsNumber()
+  @Min(1)
+  termInChargeId?: number;
+
+  @ApiProperty({
+    description: '세션명',
+    required: false,
+  })
+  @IsOptionalNotNull()
   @IsString()
   @Length(2, 50)
   @IsNoSpecialChar()
   @RemoveSpaces()
-  sessionTitle: string;*/
+  sessionName?: string;
+
+  @ApiProperty({
+    description: '세션 담당자 ID',
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  sessionInChargeId?: number;
 }

--- a/backend/src/management/educations/service/education-domain/service/educaiton-term-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/educaiton-term-domain.service.ts
@@ -15,6 +15,8 @@ import {
 import {
   FindOptionsRelations,
   FindOptionsSelect,
+  ILike,
+  In,
   QueryRunner,
   Repository,
   UpdateResult,
@@ -34,12 +36,15 @@ import {
 } from '../../../../../members/const/member-find-options.const';
 import { UserRole } from '../../../../../user/const/user-role.enum';
 import { MemberException } from '../../../../../members/const/exception/member.exception';
+import { EducationSessionModel } from '../../../entity/education-session.entity';
 
 @Injectable()
 export class EducationTermDomainService implements IEducationTermDomainService {
   constructor(
     @InjectRepository(EducationTermModel)
     private readonly educationTermsRepository: Repository<EducationTermModel>,
+    @InjectRepository(EducationSessionModel)
+    private readonly educationSessionsRepository: Repository<EducationSessionModel>,
   ) {}
 
   private CountColumnMap = {
@@ -54,6 +59,12 @@ export class EducationTermDomainService implements IEducationTermDomainService {
     return qr
       ? qr.manager.getRepository(EducationTermModel)
       : this.educationTermsRepository;
+  }
+
+  private getEducationSessionRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(EducationSessionModel)
+      : this.educationSessionsRepository;
   }
 
   private assertValidateInChargeMember(member: MemberModel) {
@@ -94,6 +105,24 @@ export class EducationTermDomainService implements IEducationTermDomainService {
     return !!educationTerm;
   }
 
+  private async getTermIdsBySession(
+    dto: GetEducationTermDto,
+    qr?: QueryRunner,
+  ) {
+    const educationSessionRepository = this.getEducationSessionRepository(qr);
+
+    const sessions = await educationSessionRepository.find({
+      where: {
+        inChargeId: dto.sessionInChargeId,
+        name: dto.sessionName && ILike(`%${dto.sessionName}%`),
+      },
+    });
+
+    return Array.from(
+      new Set(sessions.map((session) => session.educationTermId)),
+    );
+  }
+
   async findEducationTerms(
     church: ChurchModel,
     education: EducationModel,
@@ -112,13 +141,17 @@ export class EducationTermDomainService implements IEducationTermDomainService {
       order.createdAt = 'desc';
     }
 
+    const termIds = await this.getTermIdsBySession(dto, qr);
+
     const [result, totalCount] = await Promise.all([
       educationTermsRepository.find({
         where: {
+          id: termIds ? In(termIds) : undefined,
           education: {
             churchId: church.id,
           },
           educationId: education.id,
+          inChargeId: dto.termInChargeId,
         },
         order,
         select: {
@@ -149,10 +182,12 @@ export class EducationTermDomainService implements IEducationTermDomainService {
       }),
       educationTermsRepository.count({
         where: {
+          id: termIds ? In(termIds) : undefined,
           education: {
             churchId: church.id,
           },
           educationId: education.id,
+          inChargeId: dto.termInChargeId,
         },
       }),
     ]);

--- a/backend/src/management/educations/service/education-domain/service/education-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/education-domain.service.ts
@@ -6,7 +6,13 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EducationModel } from '../../../entity/education.entity';
-import { FindOptionsRelations, IsNull, QueryRunner, Repository } from 'typeorm';
+import {
+  FindOptionsRelations,
+  ILike,
+  IsNull,
+  QueryRunner,
+  Repository,
+} from 'typeorm';
 import { ChurchModel } from '../../../../../churches/entity/church.entity';
 import { GetEducationDto } from '../../../dto/education/get-education.dto';
 import { EducationOrderEnum } from '../../../const/order.enum';
@@ -72,6 +78,7 @@ export class EducationDomainService implements IEducationDomainService {
       educationsRepository.find({
         where: {
           churchId: church.id,
+          name: dto.name && ILike(`%${dto.name}%`),
         },
         select: {
           id: true,
@@ -89,6 +96,7 @@ export class EducationDomainService implements IEducationDomainService {
       educationsRepository.count({
         where: {
           churchId: church.id,
+          name: dto.name && ILike(`%${dto.name}%`),
         },
       }),
     ]);

--- a/backend/src/management/educations/service/education-domain/service/education-enrollments-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/education-enrollments-domain.service.ts
@@ -9,6 +9,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { EducationEnrollmentModel } from '../../../entity/education-enrollment.entity';
 import {
   FindOptionsRelations,
+  ILike,
   In,
   IsNull,
   QueryRunner,
@@ -84,6 +85,9 @@ export class EducationEnrollmentsDomainService
       educationEnrollmentsRepository.find({
         where: {
           educationTermId: educationTerm.id,
+          member: {
+            name: dto.memberName && ILike(`%${dto.memberName}%`),
+          },
         },
         relations: {
           member: DefaultMemberRelationOptions,
@@ -104,6 +108,9 @@ export class EducationEnrollmentsDomainService
       educationEnrollmentsRepository.count({
         where: {
           educationTermId: educationTerm.id,
+          member: {
+            name: dto.memberName && ILike(`%${dto.memberName}%`),
+          },
         },
       }),
     ]);

--- a/backend/src/report/const/exception/education-session-report.exception.ts
+++ b/backend/src/report/const/exception/education-session-report.exception.ts
@@ -11,4 +11,7 @@ export const EducationSessionReportException = {
 
   EXCEED_RECEIVERS: (maxReceiver: number = MAX_RECEIVER_COUNT) =>
     `피보고자는 최대 ${maxReceiver}명까지 등록할 수 있습니다.`,
+  INVALID_RECEIVER_AUTHORIZATION: '피보고자로 등록할 수 없는 교인입니다.',
+
+  FAIL_ADD_REPORT_RECEIVERS: '피보고자 추가 실패',
 };

--- a/backend/src/report/const/swagger/education-session-report.swagger.ts
+++ b/backend/src/report/const/swagger/education-session-report.swagger.ts
@@ -1,0 +1,30 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+export const ApiGetEducationSessionReports = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교육 세션 보고 목록 조회',
+    }),
+  );
+
+export const ApiGetEducationSessionReportById = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교육 세션 보고 단건 조회',
+    }),
+  );
+
+export const ApiPatchEducationSessionReport = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교육 세션 보고 수정',
+    }),
+  );
+
+export const ApiDeleteEducationSessionReport = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교육 세션 보고 삭제',
+    }),
+  );

--- a/backend/src/report/controller/education-session-report.controller.ts
+++ b/backend/src/report/controller/education-session-report.controller.ts
@@ -12,6 +12,12 @@ import { EducationSessionReportService } from '../service/education-session-repo
 import { GetEducationSessionReportDto } from '../dto/education-report/session/request/get-education-session-report.dto';
 import { UpdateEducationSessionReportDto } from '../dto/education-report/session/request/update-education-session-report.dto';
 import { ApiTags } from '@nestjs/swagger';
+import {
+  ApiDeleteEducationSessionReport,
+  ApiGetEducationSessionReportById,
+  ApiGetEducationSessionReports,
+  ApiPatchEducationSessionReport,
+} from '../const/swagger/education-session-report.swagger';
 
 @ApiTags('Churches:Members:Reports:Education-Sessions')
 @Controller('education-session')
@@ -20,6 +26,7 @@ export class EducationSessionReportController {
     private readonly educationSessionReportService: EducationSessionReportService,
   ) {}
 
+  @ApiGetEducationSessionReports()
   @Get()
   getEducationSessionReport(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -33,6 +40,7 @@ export class EducationSessionReportController {
     );
   }
 
+  @ApiGetEducationSessionReportById()
   @Get(':educationSessionReportId')
   getEducationSessionReportById(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -46,6 +54,7 @@ export class EducationSessionReportController {
     );
   }
 
+  @ApiPatchEducationSessionReport()
   @Patch(':educationSessionReportId')
   patchEducationSessionReport(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -61,6 +70,7 @@ export class EducationSessionReportController {
     );
   }
 
+  @ApiDeleteEducationSessionReport()
   @Delete(':educationSessionReportId')
   deleteEducationSessionReport(
     @Param('churchId', ParseIntPipe) churchId: number,

--- a/backend/src/report/report-domain/interface/education-session-report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/education-session-report-domain.service.interface.ts
@@ -32,13 +32,13 @@ export interface IEducationSessionReportDomainService {
     relationOptions?: FindOptionsRelations<EducationSessionReportModel>,
   ): Promise<EducationSessionReportModel>;
 
-  createSingleReport(
+  /*createSingleReport(
     education: EducationModel,
     educationTerm: EducationTermModel,
     educationSession: EducationSessionModel,
     receiver: MemberModel,
     qr: QueryRunner,
-  ): Promise<EducationSessionReportModel>;
+  ): Promise<EducationSessionReportModel>;*/
 
   createEducationSessionReports(
     education: EducationModel,
@@ -50,6 +50,12 @@ export interface IEducationSessionReportDomainService {
 
   deleteEducationSessionReports(
     deleteReports: EducationSessionReportModel[],
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  delete(
+    educationSessionId: number,
+    deleteReceiverIds: number[],
     qr?: QueryRunner,
   ): Promise<UpdateResult>;
 


### PR DESCRIPTION
## 주요 내용
1. 교육 세션 생성 시 다중 피보고자(receiverIds)에 대해 보고가 한 개만 생성되던 문제를 해결하였고,
2. 교육, 교육 등록, 교육 기수 목록 조회 시 다양한 검색 조건을 지원하도록 기능을 확장하였습니다.

## 세부 내용

### 🛠️ 버그 수정
- `EducationSession` 생성 시 `receiverIds` 배열에 여러 교인이 포함되어 있어도 각 교인에 대해 개별 `EducationSessionReport`가 생성되도록 로직 수정

### 🔍 목록 조회 검색 기능 확장
- `Education` 목록 조회
  - `name`(교육명) 기반 검색 기능 추가 (`GET /educations?name=...`)

- `EducationEnrollment` 목록 조회
  - 교인 이름 기반 검색 기능 추가 (`GET /education-enrollments?memberName=...`)

- `EducationTerm` 목록 조회
  - 다음 조건 중 하나 이상으로 검색 가능:
    - 해당 기수의 담당자 이름
    - 하위 `EducationSession`의 교육명
    - 하위 `EducationSession`의 담당자 이름

이번 수정 및 기능 추가를 통해 보고 생성 로직의 신뢰성을 확보하였고,
다양한 필터 조건을 통한 유연한 교육 데이터 조회가 가능해졌습니다.