### PR TITLE
refactor: EducationStatus enum 이름을 EducationTermStatus로 명확하게 변경

### DIFF
--- a/backend/src/management/educations/const/education-status.enum.ts
+++ b/backend/src/management/educations/const/education-status.enum.ts
@@ -4,7 +4,7 @@ export enum EducationEnrollmentStatus {
   INCOMPLETE = 'incomplete',
 }
 
-export enum EducationStatus {
+export enum EducationTermStatus {
   RESERVE = 'reserve',
   IN_PROGRESS = 'inProgress',
   DONE = 'done',

--- a/backend/src/management/educations/dto/terms/request/update-education-term.dto.ts
+++ b/backend/src/management/educations/dto/terms/request/update-education-term.dto.ts
@@ -10,7 +10,7 @@ import {
 import { IsAfterDate } from '../../../../../common/decorator/validator/is-after-date.decorator';
 import { TransformStartDate } from '../../../../../member-history/decorator/transform-start-date.decorator';
 import { TransformEndDate } from '../../../../../member-history/decorator/transform-end-date.decorator';
-import { EducationStatus } from '../../../const/education-status.enum';
+import { EducationTermStatus } from '../../../const/education-status.enum';
 import { PlainTextMaxLength } from '../../../../../common/decorator/validator/plain-text-max-length.validator';
 import { SanitizeDto } from '../../../../../common/decorator/sanitize-target.decorator';
 import { IsOptionalNotNull } from '../../../../../common/decorator/validator/is-optional-not.null.validator';
@@ -38,12 +38,12 @@ export class UpdateEducationTermDto {
 
   @ApiProperty({
     description: '교육 진행 상태',
-    enum: EducationStatus,
+    enum: EducationTermStatus,
     required: false,
   })
   @IsOptional()
-  @IsEnum(EducationStatus)
-  status: EducationStatus;
+  @IsEnum(EducationTermStatus)
+  status: EducationTermStatus;
 
   @ApiProperty({
     description: '교육회차 시작일',

--- a/backend/src/management/educations/entity/education-term.entity.ts
+++ b/backend/src/management/educations/entity/education-term.entity.ts
@@ -7,7 +7,7 @@ import {
   BaseModelColumns,
 } from '../../../common/entity/base.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
-import { EducationStatus } from '../const/education-status.enum';
+import { EducationTermStatus } from '../const/education-status.enum';
 import { EducationConstraints } from '../const/education-constraints.const';
 
 @Entity()
@@ -35,8 +35,8 @@ export class EducationTermModel extends BaseModel {
   @Index()
   term: number; // 기수
 
-  @Column({ default: EducationStatus.RESERVE })
-  status: EducationStatus;
+  @Column({ default: EducationTermStatus.RESERVE })
+  status: EducationTermStatus;
 
   @Column({ comment: '총 교육 회차', default: 0 })
   numberOfSessions: number; // 총 교육 회차


### PR DESCRIPTION
## 주요 내용
기존 교육 기수(EducationTerm)의 상태를 나타내던 `EducationStatus` enum의 명칭을 `EducationTermStatus`로 변경하여 도메인 간 의미를 더 명확하게 표현하였습니다.

## 세부 내용
- `EducationStatus` → `EducationTermStatus`로 enum 이름 변경
- 해당 enum을 사용하는 모든 필드, DTO, 서비스, 조건문 등에서 이름 변경 반영
- 용어 혼동을 방지하고, 교육(Education)과 교육 기수(EducationTerm) 간 책임을 구분하기 위함