### PR TITLE
fix: EducationTerm 목록 조회 시 세션 조건 미사용 시에도 정상 조회되도록 수정

### DIFF
--- a/backend/src/management/educations/service/education-domain/service/educaiton-term-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/educaiton-term-domain.service.ts
@@ -141,7 +141,10 @@ export class EducationTermDomainService implements IEducationTermDomainService {
       order.createdAt = 'desc';
     }
 
-    const termIds = await this.getTermIdsBySession(dto, qr);
+    const termIds =
+      dto.sessionInChargeId || dto.sessionName
+        ? await this.getTermIdsBySession(dto, qr)
+        : undefined;
 
     const [result, totalCount] = await Promise.all([
       educationTermsRepository.find({


### PR DESCRIPTION
## 주요 내용
교육 기수(EducationTerm) 목록 조회 시, 세션(Session) 관련 조건이 없더라도 세션 연관 조회 로직이 무조건 실행되어, 세션이 아직 생성되지 않은 기수가 누락되는 문제를 수정하였습니다.

## 세부 내용
- 기존 로직: `sessionName`, `sessionInChargeId` 조건이 없어도 내부적으로 세션 검색 쿼리가 실행됨 → 세션이 존재하지 않는 기수는 필터링되어 결과에서 제외됨
- 수정 후: `sessionName` 또는 `sessionInChargeId`가 **존재하는 경우에만** 세션 기반 조건 검색을 수행하도록 로직 분기 처리
- 세션 관련 조건이 없는 경우에는 기수(EducationTerm) 목록을 그대로 조회

이번 수정으로 인해 세션이 아직 생성되지 않은 교육 기수들도 정상적으로 목록 조회에 포함되며, 불필요한 쿼리 수행 및 데이터 누락 문제가 해소되었습니다.