### PR TITLE
refactor: Visitation, Task, Education 목록 조회 필드명 정비

### DIFF
--- a/backend/src/management/educations/dto/terms/request/get-education-term.dto.ts
+++ b/backend/src/management/educations/dto/terms/request/get-education-term.dto.ts
@@ -41,7 +41,7 @@ export class GetEducationTermDto extends BaseOffsetPaginationRequestDto<Educatio
   @Length(2, 50)
   @IsNoSpecialChar()
   @RemoveSpaces()
-  sessionName?: string;
+  sessionTitle?: string;
 
   @ApiProperty({
     description: '세션 담당자 ID',

--- a/backend/src/management/educations/service/education-domain/service/educaiton-term-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/educaiton-term-domain.service.ts
@@ -114,7 +114,7 @@ export class EducationTermDomainService implements IEducationTermDomainService {
     const sessions = await educationSessionRepository.find({
       where: {
         inChargeId: dto.sessionInChargeId,
-        title: dto.sessionName && ILike(`%${dto.sessionName}%`),
+        title: dto.sessionTitle && ILike(`%${dto.sessionTitle}%`),
       },
     });
 
@@ -142,7 +142,7 @@ export class EducationTermDomainService implements IEducationTermDomainService {
     }
 
     const termIds =
-      dto.sessionInChargeId || dto.sessionName
+      dto.sessionInChargeId || dto.sessionTitle
         ? await this.getTermIdsBySession(dto, qr)
         : undefined;
 

--- a/backend/src/management/educations/service/education-domain/service/education-session-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/education-session-domain.service.ts
@@ -80,8 +80,6 @@ export class EducationSessionDomainService
           startDate: true,
           endDate: true,
           status: true,
-          //isDone: true,
-          //sessionDate: true,
         },
         order,
         take: dto.take,

--- a/backend/src/task/const/task-order.enum.ts
+++ b/backend/src/task/const/task-order.enum.ts
@@ -2,5 +2,5 @@ export enum TaskOrder {
   createdAt = 'createdAt',
   updatedAt = 'updatedAt',
   title = 'title',
-  taskStartDate = 'taskStartDate',
+  startDate = 'startDate',
 }

--- a/backend/src/task/dto/request/get-tasks.dto.ts
+++ b/backend/src/task/dto/request/get-tasks.dto.ts
@@ -18,12 +18,12 @@ export class GetTasksDto extends BaseOffsetPaginationRequestDto<TaskOrder> {
   @ApiProperty({
     description: '정렬 조건',
     enum: TaskOrder,
-    default: TaskOrder.taskStartDate,
+    default: TaskOrder.startDate,
     required: false,
   })
   @IsOptional()
   @IsEnum(TaskOrder)
-  order: TaskOrder = TaskOrder.taskStartDate;
+  order: TaskOrder = TaskOrder.startDate;
 
   @ApiProperty({
     description: '업무 제목',
@@ -41,7 +41,7 @@ export class GetTasksDto extends BaseOffsetPaginationRequestDto<TaskOrder> {
   })
   @IsOptional()
   @IsDate()
-  fromTaskStartDate?: Date;
+  fromStartDate?: Date;
 
   @ApiProperty({
     description: '업무 시작 날짜 ~ 까지',
@@ -50,7 +50,7 @@ export class GetTasksDto extends BaseOffsetPaginationRequestDto<TaskOrder> {
   @IsOptional()
   @IsDate()
   @IsAfterDate('fromTaskStartDate')
-  toTaskStartDate?: Date;
+  toStartDate?: Date;
 
   @ApiProperty({
     description: '업무 상태 (예정 / 진행중 / 완료 / 지연)',

--- a/backend/src/task/task-domain/service/task-domain.service.ts
+++ b/backend/src/task/task-domain/service/task-domain.service.ts
@@ -49,12 +49,12 @@ export class TaskDomainService implements ITaskDomainService {
   }
 
   private parseTaskDate(dto: GetTasksDto) {
-    if (dto.fromTaskStartDate && !dto.toTaskStartDate) {
-      return MoreThanOrEqual(dto.fromTaskStartDate);
-    } else if (!dto.fromTaskStartDate && dto.toTaskStartDate) {
-      return LessThanOrEqual(dto.toTaskStartDate);
-    } else if (dto.fromTaskStartDate && dto.toTaskStartDate) {
-      return Between(dto.fromTaskStartDate, dto.toTaskStartDate);
+    if (dto.fromStartDate && !dto.toStartDate) {
+      return MoreThanOrEqual(dto.fromStartDate);
+    } else if (!dto.fromStartDate && dto.toStartDate) {
+      return LessThanOrEqual(dto.toStartDate);
+    } else if (dto.fromStartDate && dto.toStartDate) {
+      return Between(dto.fromStartDate, dto.toStartDate);
     } else {
       return undefined;
     }

--- a/backend/src/visitation/const/visitation-order.enum.ts
+++ b/backend/src/visitation/const/visitation-order.enum.ts
@@ -1,5 +1,5 @@
 export enum VisitationOrderEnum {
-  visitationStartDate = 'visitationStartDate',
+  startDate = 'startDate',
   createdAt = 'createdAt',
   updatedAt = 'updatedAt',
 }

--- a/backend/src/visitation/dto/get-visitation.dto.ts
+++ b/backend/src/visitation/dto/get-visitation.dto.ts
@@ -39,12 +39,12 @@ export class GetVisitationDto {
   @ApiProperty({
     description: '정렬 기준',
     enum: VisitationOrderEnum,
-    default: VisitationOrderEnum.visitationStartDate,
+    default: VisitationOrderEnum.startDate,
     required: false,
   })
   @IsOptional()
   @IsEnum(VisitationOrderEnum)
-  order: VisitationOrderEnum = VisitationOrderEnum.visitationStartDate;
+  order: VisitationOrderEnum = VisitationOrderEnum.startDate;
 
   @ApiProperty({
     description: '정렬 오름차순 / 내림차순',
@@ -61,7 +61,7 @@ export class GetVisitationDto {
   })
   @IsOptional()
   @IsDate()
-  fromVisitationDate?: Date;
+  fromStartDate?: Date;
 
   @ApiProperty({
     description: '심방 날짜 ~ 까지',
@@ -70,7 +70,7 @@ export class GetVisitationDto {
   @IsOptional()
   @IsDate()
   @IsAfterDate('fromVisitationDate')
-  toVisitationDate?: Date;
+  toStartDate?: Date;
 
   @ApiProperty({
     description: '심방 상태 (예약 / 완료 / 지연)',
@@ -81,7 +81,7 @@ export class GetVisitationDto {
   @IsOptional()
   @TransformStringArray()
   @IsEnum(VisitationStatus, { each: true })
-  visitationStatus?: VisitationStatus[];
+  status?: VisitationStatus[];
 
   @ApiProperty({
     description: '심방 방식 (대면 / 비대면)',

--- a/backend/src/visitation/dto/update-visitation.dto.ts
+++ b/backend/src/visitation/dto/update-visitation.dto.ts
@@ -15,6 +15,7 @@ import { VisitationMethod } from '../const/visitation-method.enum';
 import { RemoveSpaces } from '../../common/decorator/transformer/remove-spaces';
 import { IsAfterDate } from '../../common/decorator/validator/is-after-date.decorator';
 import { IsNoSpecialChar } from '../../common/decorator/validator/is-no-special-char.validator';
+import { IsOptionalNotNull } from '../../common/decorator/validator/is-optional-not.null.validator';
 
 export class UpdateVisitationDto {
   @ApiProperty({
@@ -22,7 +23,7 @@ export class UpdateVisitationDto {
     enum: VisitationStatus,
     required: false,
   })
-  @IsOptional()
+  @IsOptionalNotNull()
   @IsEnum(VisitationStatus)
   status?: VisitationStatus;
 
@@ -31,7 +32,7 @@ export class UpdateVisitationDto {
     enum: VisitationMethod,
     required: false,
   })
-  @IsOptional()
+  @IsOptionalNotNull()
   @IsEnum(VisitationMethod)
   visitationMethod?: VisitationMethod;
 
@@ -40,7 +41,7 @@ export class UpdateVisitationDto {
     maxLength: 50,
     required: false,
   })
-  @IsOptional()
+  @IsOptionalNotNull()
   @IsString()
   @IsNotEmpty()
   @RemoveSpaces()
@@ -60,7 +61,7 @@ export class UpdateVisitationDto {
     description: '심방 날짜',
     required: false,
   })
-  @IsOptional()
+  @IsOptionalNotNull()
   @IsDate()
   startDate?: Date;
 
@@ -68,7 +69,7 @@ export class UpdateVisitationDto {
     description: '심방 종료 날짜',
     required: false,
   })
-  @IsOptional()
+  @IsOptionalNotNull()
   @IsDate()
   @IsAfterDate('visitationStartDate')
   endDate?: Date;
@@ -92,12 +93,4 @@ export class UpdateVisitationDto {
   @IsArray()
   @TransformNumberArray()
   deleteMemberIds?: number[];
-
-  /*@ApiProperty({
-    description: 'API 테스트 시 true (심방 진행자의 권한 체크 건너뛰기)',
-    default: false,
-  })
-  @IsOptional()
-  @IsBoolean()
-  isTest: boolean = false;*/
 }

--- a/backend/src/visitation/dto/visitation-pagination-result.dto.ts
+++ b/backend/src/visitation/dto/visitation-pagination-result.dto.ts
@@ -1,11 +1,6 @@
 import { BaseOffsetPaginationResponseDto } from '../../common/dto/reponse/base-offset-pagination-response.dto';
 import { VisitationMetaModel } from '../entity/visitation-meta.entity';
 
-/*export interface VisitationPaginationResultDto
-  extends BaseOffsetPaginationResultDto<VisitationMetaModel> {
-  totalPage: number;
-}*/
-
 export class VisitationPaginationResultDto extends BaseOffsetPaginationResponseDto<VisitationMetaModel> {
   constructor(
     public readonly data: VisitationMetaModel[],

--- a/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
@@ -9,6 +9,7 @@ import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
 import {
   Between,
   FindOptionsRelations,
+  FindOptionsWhere,
   ILike,
   In,
   LessThanOrEqual,
@@ -44,25 +45,27 @@ export class VisitationMetaDomainService
   }
 
   private parseVisitationDate(dto: GetVisitationDto) {
-    if (dto.fromVisitationDate && !dto.toVisitationDate) {
-      return MoreThanOrEqual(dto.fromVisitationDate);
-    } else if (!dto.fromVisitationDate && dto.toVisitationDate) {
-      return LessThanOrEqual(dto.toVisitationDate);
-    } else if (dto.fromVisitationDate && dto.toVisitationDate) {
-      return Between(dto.fromVisitationDate, dto.toVisitationDate);
+    if (dto.fromStartDate && !dto.toStartDate) {
+      return MoreThanOrEqual(dto.fromStartDate);
+    } else if (!dto.fromStartDate && dto.toStartDate) {
+      return LessThanOrEqual(dto.toStartDate);
+    } else if (dto.fromStartDate && dto.toStartDate) {
+      return Between(dto.fromStartDate, dto.toStartDate);
     } else {
       return undefined;
     }
   }
 
-  private parseWhereOptions(dto: GetVisitationDto) {
+  private parseWhereOptions(
+    dto: GetVisitationDto,
+  ): FindOptionsWhere<VisitationMetaModel> {
     return {
-      visitationStartDate: this.parseVisitationDate(dto),
-      visitationStatus: dto.visitationStatus && In(dto.visitationStatus),
+      startDate: this.parseVisitationDate(dto),
+      status: dto.status && In(dto.status),
       visitationMethod: dto.visitationMethod && In(dto.visitationMethod),
       visitationType: dto.visitationType && In(dto.visitationType),
-      visitationTitle: dto.title && ILike(`%${dto.title}%`),
-      instructorId: dto.inChargeId,
+      title: dto.title && ILike(`%${dto.title}%`),
+      inChargeId: dto.inChargeId,
     };
   }
 


### PR DESCRIPTION
## 주요 내용

- Visitation, Task 도메인의 목록 조회 시 사용되는 order enum 값 일부를 정비하였고,
- 각 도메인의 목록 조회 DTO 필드명을 일관된 네이밍으로 변경했습니다.

## 세부 내용

### Visitation 목록 조회 DTO 변경

- order enum 값 변경
  - `visiationStartDate` → `startDate`

- DTO 필드명 변경
  - `fromVisitationDate` → `fromStartDate`
  - `toVisitationDate` → `toStartDate`
  - `visitatiionStatus` → `status`

### Task 목록 조회 DTO 변경

- order enum 값 변경
  - `taskStartDate` → `startDate`

- DTO 필드명 변경
  - `fromTaskStartDate` → `fromStartDate`
  - `toTaskStartDate` → `toStartDate`

### EducationTerm 목록 조회 DTO 변경

- DTO 필드명 변경
  - `sessionName` → `sessionTitle`

각 도메인의 목록 조회 API에서 정렬 및 필터링 기준으로 사용되는 필드명을 정비함으로써, 프론트엔드와 백엔드 간 필드명 불일치로 인한 혼선을 줄이고, 공통 로직 재사용성을 향상시켰습니다.