### PR TITLE
feat: 현재 진행 중인 교육 기수 조회 엔드포인트 추가

### DIFF
--- a/backend/src/management/educations/controller/educations.controller.ts
+++ b/backend/src/management/educations/controller/educations.controller.ts
@@ -31,11 +31,16 @@ import { ChurchManagerGuard } from '../../../churches/guard/church-guard.service
 import { Token } from '../../../auth/decorator/jwt.decorator';
 import { AuthType } from '../../../auth/const/enum/auth-type.enum';
 import { JwtAccessPayload } from '../../../auth/type/jwt';
+import { EducationTermService } from '../service/education-term.service';
+import { GetInProgressEducationTermDto } from '../dto/terms/request/get-in-progress-education-term.dto';
 
 @ApiTags('Management:Educations')
 @Controller('educations')
 export class EducationsController {
-  constructor(private readonly educationsService: EducationsService) {}
+  constructor(
+    private readonly educationsService: EducationsService,
+    private readonly educationTermService: EducationTermService,
+  ) {}
 
   @ApiGetEducation()
   @Get()
@@ -58,6 +63,14 @@ export class EducationsController {
   ) {
     const userId = accessPayload.id;
     return this.educationsService.createEducation(userId, churchId, dto, qr);
+  }
+
+  @Get('in-progress')
+  getInProgressEducations(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetInProgressEducationTermDto,
+  ) {
+    return this.educationTermService.getInProgressEducationTerms(churchId, dto);
   }
 
   @ApiGetEducationById()

--- a/backend/src/management/educations/dto/terms/request/get-in-progress-education-term.dto.ts
+++ b/backend/src/management/educations/dto/terms/request/get-in-progress-education-term.dto.ts
@@ -1,0 +1,15 @@
+import { BaseOffsetPaginationRequestDto } from '../../../../../common/dto/request/base-offset-pagination-request.dto';
+import { EducationTermOrderEnum } from '../../../const/order.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+
+export class GetInProgressEducationTermDto extends BaseOffsetPaginationRequestDto<EducationTermOrderEnum> {
+  @ApiProperty({
+    description: '정렬 기준 (기본값: 기수)',
+    enum: EducationTermOrderEnum,
+    default: EducationTermOrderEnum.term,
+    required: false,
+  })
+  @IsEnum(EducationTermOrderEnum)
+  order: EducationTermOrderEnum = EducationTermOrderEnum.term;
+}

--- a/backend/src/management/educations/service/education-domain/interface/education-term-domain.service.interface.ts
+++ b/backend/src/management/educations/service/education-domain/interface/education-term-domain.service.interface.ts
@@ -12,6 +12,7 @@ import { CreateEducationTermDto } from '../../../dto/terms/request/create-educat
 import { UpdateEducationTermDto } from '../../../dto/terms/request/update-education-term.dto';
 import { EducationEnrollmentStatus } from '../../../const/education-status.enum';
 import { MemberModel } from '../../../../../members/entity/member.entity';
+import { GetInProgressEducationTermDto } from '../../../dto/terms/request/get-in-progress-education-term.dto';
 
 export const IEDUCATION_TERM_DOMAIN_SERVICE = Symbol(
   'IEDUCATION_TERM_DOMAIN_SERVICE',
@@ -109,4 +110,10 @@ export interface IEducationTermDomainService {
     educationTerm: EducationTermModel,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
+
+  findInProgressEducationTerms(
+    church: ChurchModel,
+    dto: GetInProgressEducationTermDto,
+    qr?: QueryRunner,
+  ): Promise<{ data: EducationTermModel[]; totalCount: number }>;
 }

--- a/backend/src/management/educations/service/education-domain/service/educaiton-term-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/educaiton-term-domain.service.ts
@@ -13,6 +13,7 @@ import {
   EducationTermModel,
 } from '../../../entity/education-term.entity';
 import {
+  FindOptionsOrder,
   FindOptionsRelations,
   FindOptionsSelect,
   ILike,
@@ -28,7 +29,10 @@ import { EducationTermOrderEnum } from '../../../const/order.enum';
 import { EducationTermException } from '../../../const/exception/education.exception';
 import { CreateEducationTermDto } from '../../../dto/terms/request/create-education-term.dto';
 import { UpdateEducationTermDto } from '../../../dto/terms/request/update-education-term.dto';
-import { EducationEnrollmentStatus } from '../../../const/education-status.enum';
+import {
+  EducationEnrollmentStatus,
+  EducationTermStatus,
+} from '../../../const/education-status.enum';
 import { MemberModel } from '../../../../../members/entity/member.entity';
 import {
   MemberSummarizedRelation,
@@ -37,6 +41,7 @@ import {
 import { UserRole } from '../../../../../user/const/user-role.enum';
 import { MemberException } from '../../../../../members/const/exception/member.exception';
 import { EducationSessionModel } from '../../../entity/education-session.entity';
+import { GetInProgressEducationTermDto } from '../../../dto/terms/request/get-in-progress-education-term.dto';
 
 @Injectable()
 export class EducationTermDomainService implements IEducationTermDomainService {
@@ -121,6 +126,72 @@ export class EducationTermDomainService implements IEducationTermDomainService {
     return Array.from(
       new Set(sessions.map((session) => session.educationTermId)),
     );
+  }
+
+  async findInProgressEducationTerms(
+    church: ChurchModel,
+    dto: GetInProgressEducationTermDto,
+    qr?: QueryRunner,
+  ): Promise<{
+    data: EducationTermModel[];
+    totalCount: number;
+  }> {
+    const educationTermsRepository = this.getEducationTermsRepository(qr);
+
+    const order: FindOptionsOrder<EducationTermModel> = {
+      [dto.order]: dto.orderDirection,
+    };
+
+    if (dto.order !== EducationTermOrderEnum.createdAt) {
+      order.createdAt = 'asc';
+    }
+
+    const [data, totalCount] = await Promise.all([
+      educationTermsRepository.find({
+        where: {
+          education: {
+            churchId: church.id,
+          },
+          status: EducationTermStatus.IN_PROGRESS,
+        },
+        order,
+        select: {
+          id: true,
+          createdAt: true,
+          updatedAt: true,
+          educationId: true,
+          educationName: true,
+          creatorId: true,
+          term: true,
+          status: true,
+          numberOfSessions: true,
+          startDate: true,
+          endDate: true,
+          inChargeId: true,
+          isDoneCount: true,
+          enrollmentCount: true,
+          inProgressCount: true,
+          completedCount: true,
+          incompleteCount: true,
+          inCharge: MemberSummarizedSelect,
+        },
+        relations: {
+          inCharge: MemberSummarizedRelation,
+        },
+        take: dto.take,
+        skip: dto.take * (dto.page - 1),
+      }),
+      educationTermsRepository.count({
+        where: {
+          education: {
+            churchId: church.id,
+          },
+          status: EducationTermStatus.IN_PROGRESS,
+        },
+      }),
+    ]);
+
+    return { data, totalCount };
   }
 
   async findEducationTerms(

--- a/backend/src/management/educations/service/education-term.service.ts
+++ b/backend/src/management/educations/service/education-term.service.ts
@@ -36,6 +36,7 @@ import { DeleteEducationTermResponseDto } from '../dto/terms/response/delete-edu
 import { PatchEducationTermResponseDto } from '../dto/terms/response/patch-education-term-response.dto';
 import { PostEducationTermResponseDto } from '../dto/terms/response/post-education-term-response.dto';
 import { GetEducationTermResponseDto } from '../dto/terms/response/get-education-term-response.dto';
+import { GetInProgressEducationTermDto } from '../dto/terms/request/get-in-progress-education-term.dto';
 
 @Injectable()
 export class EducationTermService {
@@ -77,6 +78,32 @@ export class EducationTermService {
       await this.educationTermDomainService.findEducationTerms(
         church,
         education,
+        dto,
+        qr,
+      );
+
+    return new EducationTermPaginationResultDto(
+      data,
+      totalCount,
+      data.length,
+      dto.page,
+      Math.ceil(totalCount / dto.take),
+    );
+  }
+
+  async getInProgressEducationTerms(
+    churchId: number,
+    dto: GetInProgressEducationTermDto,
+    qr?: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const { data, totalCount } =
+      await this.educationTermDomainService.findInProgressEducationTerms(
+        church,
         dto,
         qr,
       );

--- a/backend/src/report/const/report-find-options.const.ts
+++ b/backend/src/report/const/report-find-options.const.ts
@@ -33,6 +33,7 @@ export const TaskReportsFindOptionsRelation: FindOptionsRelations<TaskReportMode
 export const VisitationReportsFindOptionsRelation: FindOptionsRelations<VisitationReportModel> =
   {
     visitation: {
+      members: MemberSummarizedRelation,
       inCharge: MemberSummarizedRelation,
     },
   };
@@ -57,6 +58,7 @@ export const VisitationReportsFindOptionsSelect: FindOptionsSelect<VisitationRep
       endDate: true,
       title: true,
       inCharge: MemberSummarizedSelect,
+      members: MemberSummarizedSelect,
     },
   };
 

--- a/backend/src/task/task-domain/service/task-domain.service.ts
+++ b/backend/src/task/task-domain/service/task-domain.service.ts
@@ -200,7 +200,7 @@ export class TaskDomainService implements ITaskDomainService {
       inChargeId: inChargeMember ? inChargeMember.id : undefined,
       parentTaskId: parentTask ? parentTask.id : undefined,
       taskType: parentTask ? TaskType.subTask : TaskType.parent,
-      name: dto.title,
+      title: dto.title,
       status: dto.status,
       startDate: dto.startDate,
       endDate: dto.endDate,

--- a/backend/src/visitation/entity/visitation-meta.entity.ts
+++ b/backend/src/visitation/entity/visitation-meta.entity.ts
@@ -64,7 +64,7 @@ export class VisitationMetaModel extends BaseModel {
   inChargeId: number;
 
   @ManyToOne(() => MemberModel, (member) => member.inChargingVisitations)
-  @JoinColumn({ name: 'instructorId' })
+  @JoinColumn({ name: 'inChargeId' })
   inCharge: MemberModel;
 
   @Index()


### PR DESCRIPTION
## 주요 내용

- `/churches/{churchId}/educations/in-progress` 엔드포인트를 추가하여, status가 `inProgress`인 교육 기수만 조회할 수 있도록 기능을 구현했습니다.

## 세부 내용

### 신규 엔드포인트

- **GET** `/churches/{churchId}/educations/in-progress`
- 현재 진행 중인 교육 기수(`status === "inProgress"`)만 조회
- 정렬 및 페이징 쿼리 파라미터 지원:
  - `take`: 조회할 데이터 개수 (기본값: 50)
  - `page`: 조회할 페이지 번호 (기본값: 1)
  - `order`: 정렬 기준 (`term`, `createdAt`, `updatedAt`)
  - `orderDirection`: 정렬 방향 (`asc`, `desc`)

### 응답 예시

```json
{
  "data": [
    {
      "id": 9,
      "createdAt": "2025-05-18T03:44:31.023Z",
      "updatedAt": "2025-05-21T21:41:38.408Z",
      "educationId": 9,
      "educationName": "교육 회차 테스트",
      "creatorId": null,
      "term": 1,
      "status": "inProgress",
      "numberOfSessions": 6,
      "startDate": "2025-05-18T12:44:17.471Z",
      "endDate": "2025-06-18T12:44:17.471Z",
      "inChargeId": null,
      "isDoneCount": 1,
      "enrollmentCount": 2,
      "inProgressCount": 2,
      "completedCount": 0,
      "incompleteCount": 0,
      "inCharge": null
    },
    {
      "id": 5,
      "createdAt": "2025-04-23T15:52:59.007Z",
      "updatedAt": "2025-05-17T04:13:50.139Z",
      "educationId": 1,
      "educationName": "새신자 교육",
      "creatorId": null,
      "term": 3,
      "status": "inProgress",
      "numberOfSessions": 1,
      "startDate": "2025-04-24T00:52:39.036Z",
      "endDate": "2025-04-24T00:52:39.036Z",
      "inChargeId": null,
      "isDoneCount": 0,
      "enrollmentCount": 0,
      "inProgressCount": 0,
      "completedCount": 0,
      "incompleteCount": 0,
      "inCharge": null
    },
    {
      "id": 4,
      "createdAt": "2025-04-23T15:52:50.955Z",
      "updatedAt": "2025-05-17T04:13:50.139Z",
      "educationId": 1,
      "educationName": "새신자 교육",
      "creatorId": null,
      "term": 4,
      "status": "inProgress",
      "numberOfSessions": 1,
      "startDate": "2025-04-24T00:52:39.036Z",
      "endDate": "2025-04-24T00:52:39.036Z",
      "inChargeId": null,
      "isDoneCount": 0,
      "enrollmentCount": 0,
      "inProgressCount": 0,
      "completedCount": 0,
      "incompleteCount": 0,
      "inCharge": null
    }
  ],
  "totalCount": 3,
  "count": 3,
  "page": 1,
  "totalPage": 1,
  "timestamp": "2025-05-26T14:46:35.780Z"
}
```

프론트엔드에서 현재 진행 중인 교육 회차만 간편하게 필터링할 수 있도록 별도 전용 엔드포인트를 추가하였으며, 일관된 정렬 및 페이징 쿼리 파라미터를 그대로 지원하여 기존 조회 API와 사용성을 맞췄습니다.