### PR TITLE
refactor: Education 및 EducationTerm의 담당자/생성자 지정 로직을 ChurchUser 기반으로 변경

### DIFF
--- a/backend/src/management/educations/educations.module.ts
+++ b/backend/src/management/educations/educations.module.ts
@@ -15,6 +15,7 @@ import { EducationDomainModule } from './service/education-domain/education-doma
 import { ChurchesDomainModule } from '../../churches/churches-domain/churches-domain.module';
 import { MembersDomainModule } from '../../members/member-domain/members-domain.module';
 import { EducationSessionReportDomainModule } from '../../report/report-domain/education-session-report-domain.module';
+import { ManagerDomainModule } from '../../manager/manager-domain/manager-domain.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { EducationSessionReportDomainModule } from '../../report/report-domain/e
     //MembersModule,
     MembersDomainModule,
     ChurchesDomainModule,
+    ManagerDomainModule,
     EducationDomainModule,
 
     EducationSessionReportDomainModule,

--- a/backend/src/management/educations/service/education-domain/service/educaiton-term-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/educaiton-term-domain.service.ts
@@ -353,7 +353,7 @@ export class EducationTermDomainService implements IEducationTermDomainService {
       throw new BadRequestException(EducationTermException.ALREADY_EXIST);
     }
 
-    inCharge && this.assertValidateInChargeMember(inCharge);
+    //inCharge && this.assertValidateInChargeMember(inCharge);
 
     return educationTermsRepository.save({
       educationId: education.id,

--- a/backend/src/management/educations/service/education-term.service.ts
+++ b/backend/src/management/educations/service/education-term.service.ts
@@ -23,10 +23,6 @@ import {
   ISESSION_ATTENDANCE_DOMAIN_SERVICE,
   ISessionAttendanceDomainService,
 } from './education-domain/interface/session-attendance-domain.service.interface';
-import {
-  IMEMBERS_DOMAIN_SERVICE,
-  IMembersDomainService,
-} from '../../../members/member-domain/interface/members-domain.service.interface';
 import { EducationTermPaginationResultDto } from '../dto/terms/response/education-term-pagination-result.dto';
 import {
   IEDUCATION_ENROLLMENT_DOMAIN_SERVICE,
@@ -37,12 +33,18 @@ import { PatchEducationTermResponseDto } from '../dto/terms/response/patch-educa
 import { PostEducationTermResponseDto } from '../dto/terms/response/post-education-term-response.dto';
 import { GetEducationTermResponseDto } from '../dto/terms/response/get-education-term-response.dto';
 import { GetInProgressEducationTermDto } from '../dto/terms/request/get-in-progress-education-term.dto';
+import {
+  IMANAGER_DOMAIN_SERVICE,
+  IManagerDomainService,
+} from '../../../manager/manager-domain/service/interface/manager-domain.service.interface';
 
 @Injectable()
 export class EducationTermService {
   constructor(
-    @Inject(IMEMBERS_DOMAIN_SERVICE)
-    private readonly membersDomainService: IMembersDomainService,
+    /*@Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,*/
+    @Inject(IMANAGER_DOMAIN_SERVICE)
+    private readonly managerDomainService: IManagerDomainService,
 
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,
@@ -156,12 +158,18 @@ export class EducationTermService {
       qr,
     );
 
-    const creatorMember =
-      await this.membersDomainService.findMemberModelByUserId(
+    const creatorMember = (
+      await this.managerDomainService.findManagerByUserId(
         church,
         creatorUserId,
         qr,
-      );
+      )
+    ).member;
+    /*await this.membersDomainService.findMemberModelByUserId(
+        church,
+        creatorUserId,
+        qr,
+      );*/
 
     const education = await this.educationDomainService.findEducationModelById(
       church,
@@ -169,13 +177,20 @@ export class EducationTermService {
       qr,
     );
 
-    const instructor = dto.inChargeId
-      ? await this.membersDomainService.findMemberModelById(
+    const inCharge = dto.inChargeId
+      ? /*await this.membersDomainService.findMemberModelById(
           church,
           dto.inChargeId,
           qr,
           { user: true },
-        )
+        )*/
+        (
+          await this.managerDomainService.findManagerById(
+            church,
+            dto.inChargeId,
+            qr,
+          )
+        ).member
       : null;
 
     const educationTerm =
@@ -183,7 +198,7 @@ export class EducationTermService {
         //church,
         education,
         creatorMember,
-        instructor,
+        inCharge,
         dto,
         qr,
       );
@@ -261,19 +276,26 @@ export class EducationTermService {
         qr,
       );
 
-    const newInstructor = dto.inChargeId
-      ? await this.membersDomainService.findMemberModelById(
+    const newInCharge = dto.inChargeId
+      ? /*await this.membersDomainService.findMemberModelById(
           church,
           dto.inChargeId,
           qr,
           { user: true },
-        )
+        )*/
+        (
+          await this.managerDomainService.findManagerModelById(
+            church,
+            dto.inChargeId,
+            qr,
+          )
+        ).member
       : null;
 
     await this.educationTermDomainService.updateEducationTerm(
       education,
       educationTerm,
-      newInstructor,
+      newInCharge,
       dto,
       qr,
     );

--- a/backend/src/management/educations/service/educations.service.ts
+++ b/backend/src/management/educations/service/educations.service.ts
@@ -18,17 +18,20 @@ import {
 import { EducationPaginationResultDto } from '../dto/education-pagination-result.dto';
 import { EducationDeleteResponseDto } from '../dto/education/response/education-delete-response.dto';
 import {
-  IMEMBERS_DOMAIN_SERVICE,
-  IMembersDomainService,
-} from '../../../members/member-domain/interface/members-domain.service.interface';
+  IMANAGER_DOMAIN_SERVICE,
+  IManagerDomainService,
+} from '../../../manager/manager-domain/service/interface/manager-domain.service.interface';
 
 @Injectable()
 export class EducationsService {
   constructor(
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchDomainService: IChurchesDomainService,
-    @Inject(IMEMBERS_DOMAIN_SERVICE)
-    private readonly membersDomainService: IMembersDomainService,
+    /*@Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,*/
+    @Inject(IMANAGER_DOMAIN_SERVICE)
+    private readonly managerDomainService: IManagerDomainService,
+
     @Inject(IEDUCATION_DOMAIN_SERVICE)
     private readonly educationDomainService: IEducationDomainService,
     @Inject(IEDUCATION_TERM_DOMAIN_SERVICE)
@@ -85,12 +88,14 @@ export class EducationsService {
       qr,
     );
 
-    const creatorMember =
-      await this.membersDomainService.findMemberModelByUserId(
+    const creatorMember = (
+      await this.managerDomainService.findManagerByUserId(church, userId, qr)
+    ).member;
+    /*await this.membersDomainService.findMemberModelByUserId(
         church,
         userId,
         qr,
-      );
+      );*/
 
     return this.educationDomainService.createEducation(
       church,

--- a/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
+++ b/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
@@ -21,6 +21,12 @@ export interface IManagerDomainService {
     relationOptions?: FindOptionsRelations<ChurchUserModel>,
   ): Promise<ChurchUserModel>;
 
+  findManagerByUserId(
+    church: ChurchModel,
+    userId: number,
+    qr?: QueryRunner,
+  ): Promise<ChurchUserModel>;
+
   findManagerById(
     church: ChurchModel,
     managerId: number,

--- a/backend/src/manager/manager-domain/service/manager-domain.service.ts
+++ b/backend/src/manager/manager-domain/service/manager-domain.service.ts
@@ -92,9 +92,35 @@ export class ManagerDomainService implements IManagerDomainService {
       where: {
         churchId: church.id,
         memberId: managerId,
+        role: In([ChurchUserRole.MANAGER, ChurchUserRole.OWNER]),
         leftAt: IsNull(),
       },
       relations: relationOptions,
+    });
+
+    if (!churchUser) {
+      throw new NotFoundException(ManagerException.NOT_FOUND);
+    }
+
+    return churchUser;
+  }
+
+  async findManagerByUserId(
+    church: ChurchModel,
+    userId: number,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    const churchUser = await repository.findOne({
+      where: {
+        churchId: church.id,
+        userId: userId,
+        role: In([ChurchUserRole.MANAGER, ChurchUserRole.OWNER]),
+        leftAt: IsNull(),
+      },
+      relations: ManagerFindOptionsRelations,
+      select: ManagerFindOptionsSelect,
     });
 
     if (!churchUser) {
@@ -115,6 +141,7 @@ export class ManagerDomainService implements IManagerDomainService {
       where: {
         churchId: church.id,
         memberId: managerId,
+        role: In([ChurchUserRole.MANAGER, ChurchUserRole.OWNER]),
         leftAt: IsNull(),
       },
       relations: ManagerFindOptionsRelations,


### PR DESCRIPTION
## 주요 내용
기존에는 교육 및 교육 기수의 `creator`, `inCharge`를 지정할 때 MemberModel을 직접 조회하고, 여기에 연결된 UserModel의 `UserRole`을 통해 관리자 여부를 판단했습니다. 이제는 ChurchUserModel에서 관리자인지를 판단하고, ChurchUser에 연결된 MemberModel을 참조하도록 구조를 변경했습니다.

## 세부 내용

### 🧠 관리자 판단 로직 변경
- 기존: MemberModel → UserModel 참조 → UserRole 확인
- 변경: ChurchUserModel 기준으로 `role`(manager/owner) 확인

### 🔄 Member 지정 방식 변경
- 관리자 ChurchUser를 기준으로 연결된 MemberModel을 사용하여 `creator`, `inCharge`를 지정
- MemberModel에 직접 접근하지 않고 ChurchUser를 통해 간접 지정

### 🔐 검증 개선
- 담당자 지정 시 해당 ChurchUser의 소속 교회와 요청 교회가 일치하는지 검증
- ChurchUser가 manager 또는 owner가 아닌 경우 예외 처리

이번 변경을 통해 교육 도메인에서도 일관된 권한 체계와 계정 기반 검증 로직을 반영할 수 있도록 정비하였습니다.