### PR TITLE
refactor: 교육 관련 도메인의 생성자 및 담당자 지정 시 ChurchUser 기반으로 변경

### DIFF
--- a/backend/src/management/educations/service/education-domain/interface/education-domain.service.interface.ts
+++ b/backend/src/management/educations/service/education-domain/interface/education-domain.service.interface.ts
@@ -4,7 +4,7 @@ import { FindOptionsRelations, QueryRunner } from 'typeorm';
 import { EducationModel } from '../../../entity/education.entity';
 import { CreateEducationDto } from '../../../dto/education/create-education.dto';
 import { UpdateEducationDto } from '../../../dto/education/update-education.dto';
-import { MemberModel } from '../../../../../members/entity/member.entity';
+import { ChurchUserModel } from '../../../../../church-user/entity/church-user.entity';
 
 export const IEDUCATION_DOMAIN_SERVICE = Symbol('IEDUCATION_DOMAIN_SERVICE');
 
@@ -30,7 +30,8 @@ export interface IEducationDomainService {
 
   createEducation(
     church: ChurchModel,
-    creatorMember: MemberModel,
+    //creatorMember: MemberModel,
+    creatorMember: ChurchUserModel,
     dto: CreateEducationDto,
     qr?: QueryRunner,
   ): Promise<EducationModel>;

--- a/backend/src/management/educations/service/education-domain/interface/education-session-domain.service.interface.ts
+++ b/backend/src/management/educations/service/education-domain/interface/education-session-domain.service.interface.ts
@@ -3,9 +3,9 @@ import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { EducationSessionModel } from '../../../entity/education-session.entity';
 import { UpdateEducationSessionDto } from '../../../dto/sessions/request/update-education-session.dto';
 import { CreateEducationSessionDto } from '../../../dto/sessions/request/create-education-session.dto';
-import { MemberModel } from '../../../../../members/entity/member.entity';
 import { EducationSessionDomainPaginationResultDto } from '../dto/sessions/education-session-domain-pagination-result.dto';
 import { GetEducationSessionDto } from '../../../dto/sessions/request/get-education-session.dto';
+import { ChurchUserModel } from '../../../../../church-user/entity/church-user.entity';
 
 export const IEDUCATION_SESSION_DOMAIN_SERVICE = Symbol(
   'IEDUCATION_SESSION_DOMAIN_SERVICE',
@@ -45,16 +45,16 @@ export interface IEducationSessionDomainService {
 
   createSingleEducationSession(
     educationTerm: EducationTermModel,
-    creatorMember: MemberModel,
+    creatorMember: ChurchUserModel, //MemberModel,
     dto: CreateEducationSessionDto,
-    inCharge: MemberModel | null,
+    inCharge: ChurchUserModel | null, //MemberModel | null,
     qr: QueryRunner,
   ): Promise<EducationSessionModel>;
 
   updateEducationSession(
     educationSession: EducationSessionModel,
     dto: UpdateEducationSessionDto,
-    inCharge: MemberModel | null,
+    inCharge: ChurchUserModel | null, //MemberModel | null,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 

--- a/backend/src/management/educations/service/education-domain/interface/education-term-domain.service.interface.ts
+++ b/backend/src/management/educations/service/education-domain/interface/education-term-domain.service.interface.ts
@@ -11,8 +11,8 @@ import { EducationTermModel } from '../../../entity/education-term.entity';
 import { CreateEducationTermDto } from '../../../dto/terms/request/create-education-term.dto';
 import { UpdateEducationTermDto } from '../../../dto/terms/request/update-education-term.dto';
 import { EducationEnrollmentStatus } from '../../../const/education-status.enum';
-import { MemberModel } from '../../../../../members/entity/member.entity';
 import { GetInProgressEducationTermDto } from '../../../dto/terms/request/get-in-progress-education-term.dto';
+import { ChurchUserModel } from '../../../../../church-user/entity/church-user.entity';
 
 export const IEDUCATION_TERM_DOMAIN_SERVICE = Symbol(
   'IEDUCATION_TERM_DOMAIN_SERVICE',
@@ -44,8 +44,8 @@ export interface IEducationTermDomainService {
 
   createEducationTerm(
     education: EducationModel,
-    creator: MemberModel,
-    instructor: MemberModel | null,
+    creator: ChurchUserModel, //MemberModel,
+    instructor: ChurchUserModel | null, //MemberModel | null,
     dto: CreateEducationTermDto,
     qr: QueryRunner,
   ): Promise<EducationTermModel>;
@@ -53,7 +53,7 @@ export interface IEducationTermDomainService {
   updateEducationTerm(
     education: EducationModel,
     educationTerm: EducationTermModel,
-    newInstructor: MemberModel | null,
+    newInstructor: ChurchUserModel | null, //MemberModel | null,
     dto: UpdateEducationTermDto,
     qr: QueryRunner,
   ): Promise<UpdateResult>;

--- a/backend/src/management/educations/service/education-domain/service/educaiton-term-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/educaiton-term-domain.service.ts
@@ -5,7 +5,6 @@ import {
   Injectable,
   InternalServerErrorException,
   NotFoundException,
-  UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
@@ -33,15 +32,14 @@ import {
   EducationEnrollmentStatus,
   EducationTermStatus,
 } from '../../../const/education-status.enum';
-import { MemberModel } from '../../../../../members/entity/member.entity';
 import {
   MemberSummarizedRelation,
   MemberSummarizedSelect,
 } from '../../../../../members/const/member-find-options.const';
-import { UserRole } from '../../../../../user/const/user-role.enum';
-import { MemberException } from '../../../../../members/const/exception/member.exception';
+import { ChurchUserRole } from '../../../../../user/const/user-role.enum';
 import { EducationSessionModel } from '../../../entity/education-session.entity';
 import { GetInProgressEducationTermDto } from '../../../dto/terms/request/get-in-progress-education-term.dto';
+import { ChurchUserModel } from '../../../../../church-user/entity/church-user.entity';
 
 @Injectable()
 export class EducationTermDomainService implements IEducationTermDomainService {
@@ -72,8 +70,19 @@ export class EducationTermDomainService implements IEducationTermDomainService {
       : this.educationSessionsRepository;
   }
 
-  private assertValidateInChargeMember(member: MemberModel) {
-    if (!member.userId) {
+  private assertValidateInChargeMember(
+    member: ChurchUserModel /*MemberModel*/,
+  ) {
+    if (
+      member.role !== ChurchUserRole.MANAGER &&
+      member.role !== ChurchUserRole.OWNER
+    ) {
+      throw new ConflictException(
+        EducationTermException.INVALID_IN_CHARGE_ROLE,
+      );
+    }
+
+    /*if (!member.userId) {
       throw new UnauthorizedException(
         EducationTermException.UNLINKED_IN_CHARGE,
       );
@@ -90,7 +99,7 @@ export class EducationTermDomainService implements IEducationTermDomainService {
       throw new ConflictException(
         EducationTermException.INVALID_IN_CHARGE_ROLE,
       );
-    }
+    }*/
   }
 
   private async isExistEducationTerm(
@@ -336,8 +345,8 @@ export class EducationTermDomainService implements IEducationTermDomainService {
 
   async createEducationTerm(
     education: EducationModel,
-    creator: MemberModel,
-    inCharge: MemberModel | null,
+    creator: ChurchUserModel, //MemberModel,
+    inCharge: ChurchUserModel | null, //MemberModel | null,
     dto: CreateEducationTermDto,
     qr: QueryRunner,
   ): Promise<EducationTermModel> {
@@ -353,14 +362,14 @@ export class EducationTermDomainService implements IEducationTermDomainService {
       throw new BadRequestException(EducationTermException.ALREADY_EXIST);
     }
 
-    //inCharge && this.assertValidateInChargeMember(inCharge);
+    inCharge && this.assertValidateInChargeMember(inCharge);
 
     return educationTermsRepository.save({
       educationId: education.id,
       educationName: education.name,
-      creatorId: creator.id,
+      creatorId: creator.member.id,
       ...dto,
-      inChargeId: inCharge ? inCharge.id : undefined,
+      inChargeId: inCharge ? inCharge.member.id : undefined,
     });
   }
 
@@ -408,7 +417,7 @@ export class EducationTermDomainService implements IEducationTermDomainService {
   async updateEducationTerm(
     education: EducationModel,
     educationTerm: EducationTermModel,
-    newInCharge: MemberModel | null,
+    newInCharge: ChurchUserModel | null, //MemberModel | null,
     dto: UpdateEducationTermDto,
     qr: QueryRunner,
   ) {
@@ -432,7 +441,7 @@ export class EducationTermDomainService implements IEducationTermDomainService {
       },
       {
         ...dto,
-        inChargeId: newInCharge ? newInCharge.id : undefined,
+        inChargeId: newInCharge ? newInCharge.member.id : undefined,
       },
     );
 

--- a/backend/src/management/educations/service/education-domain/service/education-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/education-domain.service.ts
@@ -20,11 +20,12 @@ import { EducationException } from '../../../const/exception/education.exception
 import { CreateEducationDto } from '../../../dto/education/create-education.dto';
 import { UpdateEducationDto } from '../../../dto/education/update-education.dto';
 import { IEducationDomainService } from '../interface/education-domain.service.interface';
-import { MemberModel } from '../../../../../members/entity/member.entity';
 import {
   MemberSummarizedRelation,
   MemberSummarizedSelect,
 } from '../../../../../members/const/member-find-options.const';
+import { ChurchUserModel } from '../../../../../church-user/entity/church-user.entity';
+import { MemberException } from '../../../../../members/const/exception/member.exception';
 
 @Injectable()
 export class EducationDomainService implements IEducationDomainService {
@@ -159,7 +160,8 @@ export class EducationDomainService implements IEducationDomainService {
 
   async createEducation(
     church: ChurchModel,
-    creatorMember: MemberModel,
+    //creatorMember: MemberModel,
+    creatorMember: ChurchUserModel,
     dto: CreateEducationDto,
     qr?: QueryRunner,
   ) {
@@ -171,10 +173,14 @@ export class EducationDomainService implements IEducationDomainService {
       throw new BadRequestException(EducationException.ALREADY_EXIST);
     }
 
+    if (!creatorMember.member) {
+      throw new InternalServerErrorException(MemberException.USER_ERROR);
+    }
+
     return educationsRepository.save({
       name: dto.name,
       description: dto.description,
-      creatorId: creatorMember.id,
+      creatorId: creatorMember.member.id,
       churchId: church.id,
     });
   }

--- a/backend/src/management/educations/service/education-domain/service/education-session-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/education-session-domain.service.ts
@@ -14,14 +14,11 @@ import {
   ConflictException,
   InternalServerErrorException,
   NotFoundException,
-  UnauthorizedException,
 } from '@nestjs/common';
 import { EducationSessionException } from '../../../const/exception/education.exception';
 import { UpdateEducationSessionDto } from '../../../dto/sessions/request/update-education-session.dto';
 import { CreateEducationSessionDto } from '../../../dto/sessions/request/create-education-session.dto';
-import { MemberModel } from '../../../../../members/entity/member.entity';
-import { MemberException } from '../../../../../members/const/exception/member.exception';
-import { UserRole } from '../../../../../user/const/user-role.enum';
+import { ChurchUserRole } from '../../../../../user/const/user-role.enum';
 import {
   MemberSummarizedRelation,
   MemberSummarizedSelect,
@@ -29,6 +26,7 @@ import {
 import { GetEducationSessionDto } from '../../../dto/sessions/request/get-education-session.dto';
 import { EducationSessionDomainPaginationResultDto } from '../dto/sessions/education-session-domain-pagination-result.dto';
 import { EducationSessionOrderEnum } from '../../../const/order.enum';
+import { ChurchUserModel } from '../../../../../church-user/entity/church-user.entity';
 
 export class EducationSessionDomainService
   implements IEducationSessionDomainService
@@ -190,8 +188,17 @@ export class EducationSessionDomainService
     );
   }
 
-  private assertValidInCharge(inCharge: MemberModel) {
-    if (!inCharge.userId) {
+  private assertValidInCharge(inCharge: ChurchUserModel /*MemberModel*/) {
+    if (
+      inCharge.role !== ChurchUserRole.MANAGER &&
+      inCharge.role !== ChurchUserRole.OWNER
+    ) {
+      throw new ConflictException(
+        EducationSessionException.INVALID_IN_CHARGE_ROLE,
+      );
+    }
+
+    /*if (!inCharge.userId) {
       throw new UnauthorizedException(
         EducationSessionException.UNLINKED_IN_CHARGE,
       );
@@ -209,14 +216,14 @@ export class EducationSessionDomainService
       throw new ConflictException(
         EducationSessionException.INVALID_IN_CHARGE_ROLE,
       );
-    }
+    }*/
   }
 
   async createSingleEducationSession(
     educationTerm: EducationTermModel,
-    creatorMember: MemberModel,
+    creatorMember: ChurchUserModel, //MemberModel,
     dto: CreateEducationSessionDto,
-    inCharge: MemberModel | null,
+    inCharge: ChurchUserModel | null, //MemberModel | null,
     qr: QueryRunner,
   ) {
     const educationSessionsRepository = this.getEducationSessionsRepository(qr);
@@ -241,13 +248,13 @@ export class EducationSessionDomainService
     inCharge && this.assertValidInCharge(inCharge);
 
     return educationSessionsRepository.save({
-      creatorId: creatorMember.id,
+      creatorId: creatorMember.member.id,
       educationTermId: educationTerm.id,
       session: newSessionNumber,
       title: dto.title,
       startDate: dto.startDate,
       endDate: dto.endDate,
-      inChargeId: inCharge ? inCharge.id : undefined,
+      inChargeId: inCharge ? inCharge.member.id : undefined,
       content: dto.content,
       status: dto.status,
     });
@@ -276,7 +283,7 @@ export class EducationSessionDomainService
   async updateEducationSession(
     educationSession: EducationSessionModel,
     dto: UpdateEducationSessionDto,
-    inCharge: MemberModel | null,
+    inCharge: ChurchUserModel | null, //MemberModel | null,
     qr: QueryRunner,
   ) {
     const educationSessionsRepository = this.getEducationSessionsRepository(qr);
@@ -284,16 +291,13 @@ export class EducationSessionDomainService
     this.assertValidateSessionDate(educationSession, dto);
     inCharge && this.assertValidInCharge(inCharge);
 
-    const inChargeId =
-      dto.inChargeId === undefined ? undefined : dto.inChargeId;
-
     const result = await educationSessionsRepository.update(
       {
         id: educationSession.id,
       },
       {
         ...dto,
-        inChargeId,
+        inChargeId: inCharge ? inCharge.member.id : undefined,
       },
     );
 

--- a/backend/src/management/educations/service/education-term.service.ts
+++ b/backend/src/management/educations/service/education-term.service.ts
@@ -158,13 +158,11 @@ export class EducationTermService {
       qr,
     );
 
-    const creatorMember = (
-      await this.managerDomainService.findManagerByUserId(
-        church,
-        creatorUserId,
-        qr,
-      )
-    ).member;
+    const creatorMember = await this.managerDomainService.findManagerByUserId(
+      church,
+      creatorUserId,
+      qr,
+    );
     /*await this.membersDomainService.findMemberModelByUserId(
         church,
         creatorUserId,
@@ -184,13 +182,11 @@ export class EducationTermService {
           qr,
           { user: true },
         )*/
-        (
-          await this.managerDomainService.findManagerById(
-            church,
-            dto.inChargeId,
-            qr,
-          )
-        ).member
+        await this.managerDomainService.findManagerById(
+          church,
+          dto.inChargeId,
+          qr,
+        )
       : null;
 
     const educationTerm =
@@ -283,13 +279,11 @@ export class EducationTermService {
           qr,
           { user: true },
         )*/
-        (
-          await this.managerDomainService.findManagerModelById(
-            church,
-            dto.inChargeId,
-            qr,
-          )
-        ).member
+        await this.managerDomainService.findManagerModelById(
+          church,
+          dto.inChargeId,
+          qr,
+        )
       : null;
 
     await this.educationTermDomainService.updateEducationTerm(

--- a/backend/src/management/educations/service/educations.service.ts
+++ b/backend/src/management/educations/service/educations.service.ts
@@ -27,8 +27,6 @@ export class EducationsService {
   constructor(
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchDomainService: IChurchesDomainService,
-    /*@Inject(IMEMBERS_DOMAIN_SERVICE)
-    private readonly membersDomainService: IMembersDomainService,*/
     @Inject(IMANAGER_DOMAIN_SERVICE)
     private readonly managerDomainService: IManagerDomainService,
 
@@ -88,14 +86,11 @@ export class EducationsService {
       qr,
     );
 
-    const creatorMember = (
-      await this.managerDomainService.findManagerByUserId(church, userId, qr)
-    ).member;
-    /*await this.membersDomainService.findMemberModelByUserId(
-        church,
-        userId,
-        qr,
-      );*/
+    const creatorMember = await this.managerDomainService.findManagerByUserId(
+      church,
+      userId,
+      qr,
+    );
 
     return this.educationDomainService.createEducation(
       church,


### PR DESCRIPTION
## 주요 내용
Education, EducationTerm, EducationSession 생성 시의 생성자(creator), 담당자(inCharge) 지정 로직을 ChurchUser 기반으로 재구성하였습니다. 실제 엔티티는 기존처럼 MemberModel 을 참조하되, 메소드 파라미터는 ChurchUserModel 을 기준으로 받도록 변경했습니다.

## 세부 내용

### ✏️ 생성/담당자 지정 방식 변경
- 교육(Education), 교육 기수(EducationTerm), 교육 세션(EducationSession)의 `creator`, `inCharge` 지정 시 ChurchUserModel 인스턴스를 파라미터로 받도록 변경
- 내부적으로 ChurchUser 에 연결된 MemberModel 을 추출하여 엔티티에 할당
