### PR TITLE
refactor: 심방(Visitation) 관련 로직 ChurchUser 적용 및 세부 기능 개선

### DIFF
--- a/backend/src/manager/exception/manager.exception.ts
+++ b/backend/src/manager/exception/manager.exception.ts
@@ -4,6 +4,9 @@ export const ManagerException = {
   CANNOT_CHANGE_ACTIVITY:
     '관리자 권한의 교인만 활성 상태를 변경할 수 있습니다.',
 
+  MISSING_MEMBER_DATA: (domain: string = '') =>
+    `교인 데이터와 연결이 끊겼습니다. (에러 발생 위치: ${domain})`,
+
   UPDATE_ERROR: '관리자 업데이트 도중 에러 발생',
   DELETE_ERROR: '관리자 삭제 도중 에러 발생',
   CANNOT_ASSIGN_PERMISSION:

--- a/backend/src/visitation/const/exception/visitation.exception.ts
+++ b/backend/src/visitation/const/exception/visitation.exception.ts
@@ -1,6 +1,7 @@
 export const VisitationException = {
   NOT_FOUND: '심방 데이터를 찾을 수 없습니다.',
-  INVALID_INSTRUCTOR: '심방 진행자로 등록할 수 없는 교인입니다.',
+  INVALID_CREATOR: '심방을 생성할 권한이 없습니다.',
+  INVALID_IN_CHARGE: '심방 진행자로 등록할 수 없는 교인입니다.',
   INVALID_RECEIVER: '심방 피보고자로 등록할 수 없는 교인입니다.',
   UPDATE_ERROR: '심방 데이터 업데이트 도중 에러 발생',
   DELETE_ERROR: '심방 데이터 삭제 도중 에러 발생',

--- a/backend/src/visitation/const/swagger/visitation.swagger.ts
+++ b/backend/src/visitation/const/swagger/visitation.swagger.ts
@@ -64,8 +64,7 @@ export const ApiPatchVisitationMeta = () =>
         '<p>3. 심방 제목</p>' +
         '<p>4. 심방 진행자</p>' +
         '<p>5. 심방 진행 날짜</p>' +
-        '<p>6. 추가할 심방 대상자</p>' +
-        '<p>7. 삭제할 심방 대상자</p>',
+        '<p>6. 최종적으로 포함되어야 할 심방 대상자</p>',
     }),
     ApiNotFoundResponse({
       description: [

--- a/backend/src/visitation/const/visitation-find-options.const.ts
+++ b/backend/src/visitation/const/visitation-find-options.const.ts
@@ -26,6 +26,13 @@ export const VisitationRelationOptions: FindOptionsRelations<VisitationMetaModel
         groupRole: true,
       },
     },
+    visitationDetails: {
+      member: {
+        group: true,
+        groupRole: true,
+        officer: true,
+      },
+    },
   };
 
 export const VisitationSelectOptions: FindOptionsSelect<VisitationMetaModel> = {
@@ -82,6 +89,29 @@ export const VisitationSelectOptions: FindOptionsSelect<VisitationMetaModel> = {
     isRead: true,
     isConfirmed: true,
     receiver: {
+      id: true,
+      name: true,
+      officer: {
+        id: true,
+        name: true,
+      },
+      group: {
+        id: true,
+        name: true,
+      },
+      groupRole: {
+        id: true,
+        role: true,
+      },
+    },
+  },
+  visitationDetails: {
+    id: true,
+    createdAt: true,
+    updatedAt: true,
+    visitationPray: true,
+    visitationContent: true,
+    member: {
       id: true,
       name: true,
       officer: {

--- a/backend/src/visitation/controller/visitation-detail.controller.ts
+++ b/backend/src/visitation/controller/visitation-detail.controller.ts
@@ -3,24 +3,27 @@ import { ApiPatchVisitationDetail } from '../const/swagger/visitation.swagger';
 import { UpdateVisitationDetailDto } from '../dto/internal/detail/update-visitation-detail.dto';
 import { VisitationService } from '../service/visitation.service';
 import { ApiTags } from '@nestjs/swagger';
+import { VisitationDetailService } from '../service/visitation-detail.service';
 
 @ApiTags('Visitations:Details')
 @Controller('visitations/:visitationId/details')
 export class VisitationDetailController {
-  constructor(private readonly visitationService: VisitationService) {}
+  constructor(
+    private readonly visitationDetailService: VisitationDetailService,
+  ) {}
 
   @ApiPatchVisitationDetail()
-  @Patch(':detailId')
+  @Patch(':memberId')
   patchVisitationDetail(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('visitationId', ParseIntPipe) visitationId: number,
-    @Param('detailId', ParseIntPipe) detailId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
     @Body() dto: UpdateVisitationDetailDto,
   ) {
-    return this.visitationService.updateVisitationDetail(
+    return this.visitationDetailService.updateVisitationDetail(
       churchId,
       visitationId,
-      detailId,
+      memberId,
       dto,
     );
   }

--- a/backend/src/visitation/controller/visitation.controller.ts
+++ b/backend/src/visitation/controller/visitation.controller.ts
@@ -60,7 +60,7 @@ export class VisitationController {
     @QueryRunner() qr: QR,
   ) {
     return this.visitationService.createVisitation(
-      accessPayload,
+      accessPayload.id,
       churchId,
       dto,
       qr,

--- a/backend/src/visitation/dto/internal/meta/create-visitation-meta.dto.ts
+++ b/backend/src/visitation/dto/internal/meta/create-visitation-meta.dto.ts
@@ -1,7 +1,7 @@
 import { VisitationMethod } from '../../../const/visitation-method.enum';
 import { VisitationType } from '../../../const/visitation-type.enum';
 import { VisitationStatus } from '../../../const/visitation-status.enum';
-import { MemberModel } from '../../../../members/entity/member.entity';
+import { ChurchUserModel } from '../../../../church-user/entity/church-user.entity';
 
 export class CreateVisitationMetaDto {
   status: VisitationStatus;
@@ -12,11 +12,11 @@ export class CreateVisitationMetaDto {
 
   title: string;
 
-  inCharge: MemberModel;
+  inCharge: ChurchUserModel; //MemberModel;
 
   startDate: Date;
 
   endDate: Date;
 
-  creator: MemberModel;
+  creator: ChurchUserModel; //MemberModel;
 }

--- a/backend/src/visitation/dto/internal/meta/update-visitation-meta.dto.ts
+++ b/backend/src/visitation/dto/internal/meta/update-visitation-meta.dto.ts
@@ -1,7 +1,7 @@
 import { VisitationStatus } from '../../../const/visitation-status.enum';
 import { VisitationMethod } from '../../../const/visitation-method.enum';
 import { VisitationType } from '../../../const/visitation-type.enum';
-import { MemberModel } from '../../../../members/entity/member.entity';
+import { ChurchUserModel } from '../../../../church-user/entity/church-user.entity';
 
 export class UpdateVisitationMetaDto {
   status?: VisitationStatus;
@@ -12,7 +12,7 @@ export class UpdateVisitationMetaDto {
 
   title?: string;
 
-  inCharge?: MemberModel;
+  inCharge?: ChurchUserModel;
 
   startDate?: Date;
   endDate?: Date;

--- a/backend/src/visitation/dto/response/delete-visitation-response.dto.ts
+++ b/backend/src/visitation/dto/response/delete-visitation-response.dto.ts
@@ -1,0 +1,12 @@
+import { BaseDeleteResponseDto } from '../../../common/dto/reponse/base-delete-response.dto';
+
+export class DeleteVisitationResponseDto extends BaseDeleteResponseDto {
+  constructor(
+    public readonly timestamp: Date,
+    public readonly id: number,
+    public readonly title: string,
+    public readonly success: boolean,
+  ) {
+    super(timestamp, id, success);
+  }
+}

--- a/backend/src/visitation/dto/response/get-visitation-response.dto.ts
+++ b/backend/src/visitation/dto/response/get-visitation-response.dto.ts
@@ -1,0 +1,8 @@
+import { BaseGetResponseDto } from '../../../common/dto/reponse/base-get-response.dto';
+import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
+
+export class GetVisitationResponseDto extends BaseGetResponseDto<VisitationMetaModel> {
+  constructor(data: VisitationMetaModel) {
+    super(data);
+  }
+}

--- a/backend/src/visitation/dto/response/patch-visitation-response.dto.ts
+++ b/backend/src/visitation/dto/response/patch-visitation-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePatchResponseDto } from '../../../common/dto/reponse/base-patch-response.dto';
+import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
+
+export class PatchVisitationResponseDto extends BasePatchResponseDto<VisitationMetaModel> {
+  constructor(data: VisitationMetaModel) {
+    super(data);
+  }
+}

--- a/backend/src/visitation/dto/response/post-visitation-response.dto.ts
+++ b/backend/src/visitation/dto/response/post-visitation-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePostResponseDto } from '../../../common/dto/reponse/base-post-response.dto';
+import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
+
+export class PostVisitationResponseDto extends BasePostResponseDto<VisitationMetaModel> {
+  constructor(data: VisitationMetaModel) {
+    super(data);
+  }
+}

--- a/backend/src/visitation/dto/update-visitation.dto.ts
+++ b/backend/src/visitation/dto/update-visitation.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
+  ArrayMaxSize,
   IsArray,
   IsDate,
   IsEnum,
@@ -71,10 +72,10 @@ export class UpdateVisitationDto {
   })
   @IsOptionalNotNull()
   @IsDate()
-  @IsAfterDate('visitationStartDate')
+  @IsAfterDate('startDate')
   endDate?: Date;
 
-  @ApiProperty({
+  /*@ApiProperty({
     description: '심방 대상자 추가할 교인 ID 들',
     isArray: true,
     required: false,
@@ -92,5 +93,16 @@ export class UpdateVisitationDto {
   @IsOptional()
   @IsArray()
   @TransformNumberArray()
-  deleteMemberIds?: number[];
+  deleteMemberIds?: number[];*/
+
+  @ApiProperty({
+    description: '심방 대상자 교인 ID',
+    isArray: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(30)
+  @TransformNumberArray()
+  memberIds?: number[];
 }

--- a/backend/src/visitation/entity/visitation-detail.entity.ts
+++ b/backend/src/visitation/entity/visitation-detail.entity.ts
@@ -24,9 +24,9 @@ export class VisitationDetailModel extends BaseModel {
   @JoinColumn({ name: 'memberId' })
   member: MemberModel;
 
-  @Column({ nullable: true })
+  @Column({ default: '' })
   visitationContent: string;
 
-  @Column({ nullable: true })
+  @Column({ default: '' })
   visitationPray: string;
 }

--- a/backend/src/visitation/service/visitation-detail.service.ts
+++ b/backend/src/visitation/service/visitation-detail.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import {
   IVISITATION_DETAIL_DOMAIN_SERVICE,
   IVisitationDetailDomainService,
@@ -7,12 +7,30 @@ import { VisitationMetaModel } from '../entity/visitation-meta.entity';
 import { MemberModel } from '../../members/entity/member.entity';
 import { CreateVisitationDto } from '../dto/create-visitation.dto';
 import { QueryRunner } from 'typeorm';
-import { MemberException } from '../../members/const/exception/member.exception';
-import { VisitationDetailDto } from '../dto/visittion-detail.dto';
+import {
+  IVISITATION_META_DOMAIN_SERVICE,
+  IVisitationMetaDomainService,
+} from '../visitation-domain/interface/visitation-meta-domain.service.interface';
+import { UpdateVisitationDetailDto } from '../dto/internal/detail/update-visitation-detail.dto';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IMEMBERS_DOMAIN_SERVICE,
+  IMembersDomainService,
+} from '../../members/member-domain/interface/members-domain.service.interface';
+import { ChurchModel } from '../../churches/entity/church.entity';
 
 @Injectable()
 export class VisitationDetailService {
   constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,
+    @Inject(IVISITATION_META_DOMAIN_SERVICE)
+    private readonly visitationMetaDomainService: IVisitationMetaDomainService,
     @Inject(IVISITATION_DETAIL_DOMAIN_SERVICE)
     private readonly visitationDetailDomainService: IVisitationDetailDomainService,
   ) {}
@@ -23,25 +41,92 @@ export class VisitationDetailService {
     dto: CreateVisitationDto,
     qr: QueryRunner,
   ) {
-    return Promise.all(
-      dto.visitationDetails.map(
-        async (visitationDetailDto: VisitationDetailDto) => {
-          const visitationMember = members.find(
-            (member) => member.id === visitationDetailDto.memberId,
-          );
+    return this.visitationDetailDomainService.createVisitationDetails(
+      visitationMeta,
+      members,
+      dto.visitationDetails,
+      qr,
+    );
+  }
 
-          if (!visitationMember) {
-            throw new NotFoundException(MemberException.NOT_FOUND);
-          }
+  async updateVisitationDetail(
+    churchId: number,
+    visitationId: number,
+    memberId: number,
+    dto: UpdateVisitationDetailDto,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
 
-          return this.visitationDetailDomainService.createVisitationDetail(
-            visitationMeta,
-            visitationMember,
-            visitationDetailDto,
-            qr,
-          );
-        },
+    const [metaData, member] = await Promise.all([
+      this.visitationMetaDomainService.findVisitationMetaModelById(
+        church,
+        visitationId,
       ),
+      this.membersDomainService.findMemberModelById(church, memberId),
+    ]);
+
+    const detailData =
+      await this.visitationDetailDomainService.findVisitationDetailByMetaAndMemberId(
+        metaData,
+        member,
+      );
+
+    await this.visitationDetailDomainService.updateVisitationDetail(
+      metaData,
+      detailData,
+      dto,
+    );
+
+    return this.visitationDetailDomainService.findVisitationDetailByMetaAndMemberId(
+      metaData,
+      member,
+    );
+  }
+
+  async handleUpdateVisitationMembers(
+    church: ChurchModel,
+    visitationMeta: VisitationMetaModel,
+    newMemberIds: number[],
+    qr: QueryRunner,
+  ) {
+    const oldVisitationDetails =
+      await this.visitationDetailDomainService.findVisitationDetailsByMetaId(
+        visitationMeta,
+        qr,
+      );
+
+    // 기존 대상자 memberId
+    const oldMemberIds = oldVisitationDetails.map((detail) => detail.memberId);
+
+    // 삭제될 detail 의 memberId
+    const newMemberIdsSet = new Set(newMemberIds);
+    const removedMemberIds = oldMemberIds.filter(
+      (oldMemberId) => !newMemberIdsSet.has(oldMemberId),
+    );
+
+    // 새로 생성될 detail 의 memberId
+    const oldMemberIdsSet = new Set(oldMemberIds);
+    const addedMemberIds = newMemberIds.filter(
+      (newMemberId) => !oldMemberIdsSet.has(newMemberId),
+    );
+
+    await this.visitationDetailDomainService.deleteRemovedMemberDetails(
+      visitationMeta,
+      removedMemberIds,
+      qr,
+    );
+
+    const addedMembers = await this.membersDomainService.findMembersById(
+      church,
+      addedMemberIds,
+      qr,
+    );
+
+    await this.visitationDetailDomainService.createAddedMemberDetails(
+      visitationMeta,
+      addedMembers,
+      qr,
     );
   }
 }

--- a/backend/src/visitation/service/visitation.service.ts
+++ b/backend/src/visitation/service/visitation.service.ts
@@ -3,7 +3,6 @@ import {
   ForbiddenException,
   Inject,
   Injectable,
-  InternalServerErrorException,
 } from '@nestjs/common';
 import {
   IVISITATION_META_DOMAIN_SERVICE,
@@ -24,7 +23,6 @@ import {
 import { UserRole } from '../../user/const/user-role.enum';
 import { UpdateVisitationMetaDto } from '../dto/internal/meta/update-visitation-meta.dto';
 import { QueryRunner } from 'typeorm';
-import { VisitationDetailModel } from '../entity/visitation-detail.entity';
 import { VisitationMetaModel } from '../entity/visitation-meta.entity';
 import { CreateVisitationDto } from '../dto/create-visitation.dto';
 import { JwtAccessPayload } from '../../auth/type/jwt';
@@ -32,11 +30,9 @@ import { VisitationException } from '../const/exception/visitation.exception';
 import { CreateVisitationMetaDto } from '../dto/internal/meta/create-visitation-meta.dto';
 import { GetVisitationDto } from '../dto/get-visitation.dto';
 import { VisitationType } from '../const/visitation-type.enum';
-import { UpdateVisitationDetailDto } from '../dto/internal/detail/update-visitation-detail.dto';
 import { UpdateVisitationDto } from '../dto/update-visitation.dto';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { MemberModel } from '../../members/entity/member.entity';
-import { VisitationDetailDto } from '../dto/visittion-detail.dto';
 import {
   IVISITATION_REPORT_DOMAIN_SERVICE,
   IVisitationReportDomainService,
@@ -45,6 +41,15 @@ import { AddConflictException } from '../../common/exception/add-conflict.except
 import { RemoveConflictException } from '../../common/exception/remove-conflict.exception';
 import { VisitationPaginationResultDto } from '../dto/visitation-pagination-result.dto';
 import { VisitationDetailService } from './visitation-detail.service';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import {
+  IMANAGER_DOMAIN_SERVICE,
+  IManagerDomainService,
+} from '../../manager/manager-domain/service/interface/manager-domain.service.interface';
+import { GetVisitationResponseDto } from '../dto/response/get-visitation-response.dto';
+import { PostVisitationResponseDto } from '../dto/response/post-visitation-response.dto';
+import { PatchVisitationResponseDto } from '../dto/response/patch-visitation-response.dto';
+import { DeleteVisitationResponseDto } from '../dto/response/delete-visitation-response.dto';
 
 @Injectable()
 export class VisitationService {
@@ -53,6 +58,8 @@ export class VisitationService {
     private readonly churchesDomainService: IChurchesDomainService,
     @Inject(IMEMBERS_DOMAIN_SERVICE)
     private readonly membersDomainService: IMembersDomainService,
+    @Inject(IMANAGER_DOMAIN_SERVICE)
+    private readonly managerDomainService: IManagerDomainService,
 
     @Inject(IVISITATION_META_DOMAIN_SERVICE)
     private readonly visitationMetaDomainService: IVisitationMetaDomainService,
@@ -89,29 +96,18 @@ export class VisitationService {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    const visitationMeta =
+    const visitation =
       await this.visitationMetaDomainService.findVisitationMetaById(
         church,
         visitingMetaDataId,
         qr,
       );
 
-    const visitationDetails: VisitationDetailModel[] =
-      await this.visitationDetailDomainService.findVisitationDetailsByMetaId(
-        visitationMeta,
-        qr,
-      );
-
-    const visitation: VisitationMetaModel = {
-      ...visitationMeta,
-      visitationDetails,
-    };
-
-    return visitation;
+    return new GetVisitationResponseDto(visitation);
   }
 
   async createVisitation(
-    accessPayload: JwtAccessPayload,
+    creatorId: number,
     churchId: number,
     dto: CreateVisitationDto,
     qr: QueryRunner,
@@ -121,22 +117,17 @@ export class VisitationService {
       qr,
     );
 
-    const creatorMember =
-      await this.membersDomainService.findMemberModelByUserId(
-        church,
-        accessPayload.id,
-        qr,
-      );
+    const creator = await this.managerDomainService.findManagerByUserId(
+      church,
+      creatorId,
+      qr,
+    );
 
-    const instructor = await this.membersDomainService.findMemberModelById(
+    const inCharge = await this.managerDomainService.findManagerById(
       church,
       dto.inChargeId,
       qr,
-      { user: true },
     );
-
-    // 심방 진행자 검증
-    this.checkVisitationAuthorization(instructor);
 
     const memberIds = dto.visitationDetails.map((detail) => detail.memberId);
 
@@ -148,8 +139,8 @@ export class VisitationService {
 
     const visitationMeta = await this.createVisitationMeta(
       church,
-      creatorMember,
-      instructor,
+      creator,
+      inCharge,
       members,
       dto,
       qr,
@@ -165,19 +156,181 @@ export class VisitationService {
     if (dto.receiverIds && dto.receiverIds.length > 0) {
       await this.createVisitationReports(
         church,
-        //instructor,
         dto.receiverIds,
         visitationMeta,
         qr,
       );
     }
 
-    return this.getVisitationById(churchId, visitationMeta.id, qr);
+    const newVisitation =
+      await this.visitationMetaDomainService.findVisitationMetaById(
+        church,
+        visitationMeta.id,
+        qr,
+      );
+
+    return new PostVisitationResponseDto(newVisitation);
+  }
+
+  /**
+   * 심방 생성 시 심방의 메타 데이터 생성
+   * @param church 교회 엔티티
+   * @param creator 심방 생성 교인
+   * @param inCharge 심방 진행자
+   * @param members 심방 대상자 (교인 엔티티 배열)
+   * @param dto 심방 생성 DTO
+   * @param qr 트랜잭션을 위한 QueryRunner
+   * @private
+   */
+  private async createVisitationMeta(
+    church: ChurchModel,
+    creator: ChurchUserModel,
+    inCharge: ChurchUserModel,
+    members: MemberModel[],
+    dto: CreateVisitationDto,
+    qr: QueryRunner,
+  ) {
+    const createVisitationMetaDto: CreateVisitationMetaDto = {
+      creator,
+      inCharge: inCharge,
+      status: dto.status,
+      visitationMethod: dto.visitationMethod,
+      title: dto.title,
+      startDate: dto.startDate,
+      endDate: dto.endDate,
+      visitationType:
+        members.length > 1 ? VisitationType.GROUP : VisitationType.SINGLE,
+    };
+
+    return this.visitationMetaDomainService.createVisitationMetaData(
+      church,
+      createVisitationMetaDto,
+      members,
+      qr,
+    );
+  }
+
+  async updateVisitationData(
+    churchId: number,
+    visitationMetaDataId: number,
+    dto: UpdateVisitationDto,
+    qr: QueryRunner,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const targetMetaData =
+      await this.visitationMetaDomainService.findVisitationMetaModelById(
+        church,
+        visitationMetaDataId,
+        qr,
+        { members: true },
+      );
+
+    // 심방 진행자 변경 시
+    const newInstructor =
+      dto.inChargeId && dto.inChargeId !== targetMetaData.inChargeId
+        ? await this.managerDomainService.findManagerById(
+            church,
+            dto.inChargeId,
+            qr,
+          )
+        : undefined;
+
+    // 심방 대상자 변경
+    let visitationType: VisitationType = targetMetaData.visitationType;
+
+    if (dto.memberIds) {
+      const newVisitationMembers =
+        await this.membersDomainService.findMembersById(
+          church,
+          dto.memberIds,
+          qr,
+        );
+
+      visitationType =
+        newVisitationMembers.length > 1
+          ? VisitationType.GROUP
+          : VisitationType.SINGLE;
+
+      // 변경된 대상자에 맞게 심방 디테일 생성/삭제
+      await this.visitationDetailService.handleUpdateVisitationMembers(
+        church,
+        targetMetaData,
+        dto.memberIds,
+        qr,
+      );
+
+      // 심방 메타 데이터의 대상자 수정
+      await this.visitationMetaDomainService.updateVisitationMember(
+        targetMetaData,
+        newVisitationMembers,
+        qr,
+      );
+    }
+
+    const updateVisitationMetaDto: UpdateVisitationMetaDto = {
+      startDate: dto.startDate,
+      endDate: dto.endDate,
+      visitationMethod: dto.visitationMethod,
+      visitationType,
+      status: dto.status,
+      title: dto.title,
+      inCharge: newInstructor,
+    };
+
+    await this.visitationMetaDomainService.updateVisitationMetaData(
+      targetMetaData,
+      updateVisitationMetaDto,
+      qr,
+    );
+
+    const updatedVisitation =
+      await this.visitationMetaDomainService.findVisitationMetaById(
+        church,
+        visitationMetaDataId,
+        qr,
+      );
+
+    return new PatchVisitationResponseDto(updatedVisitation);
+  }
+
+  async deleteVisitation(
+    churchId: number,
+    visitationMetaDataId: number,
+    qr: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const metaData =
+      await this.visitationMetaDomainService.findVisitationMetaModelById(
+        church,
+        visitationMetaDataId,
+        qr,
+      );
+
+    // 메타 데이터 삭제
+    await this.visitationMetaDomainService.deleteVisitationMeta(metaData, qr);
+
+    // 심방 디테일 삭제
+    await this.visitationDetailDomainService.deleteVisitationDetailsCascade(
+      metaData,
+      qr,
+    );
+
+    return new DeleteVisitationResponseDto(
+      new Date(),
+      metaData.id,
+      metaData.title,
+      true,
+    );
   }
 
   private async createVisitationReports(
     church: ChurchModel,
-    //sender: MemberModel,
     receiverIds: number[],
     visitationMeta: VisitationMetaModel,
     qr: QueryRunner,
@@ -209,382 +362,6 @@ export class VisitationService {
     );
   }
 
-  /**
-   * 심방 생성 시 대상자들의 심방 세부 데이터 생성
-   * @param visitationMeta 사전에 생성된 심방 메타 데이터
-   * @param members 심방 대상자 교인 엔티티 배열
-   * @param dto 심방 생성 DTO
-   * @param qr 트랜잭션을 위한 QueryRunner
-   * @private
-   */
-  /*private async createVisitationDetails(
-    visitationMeta: VisitationMetaModel,
-    members: MemberModel[],
-    dto: CreateVisitationDto,
-    qr: QueryRunner,
-  ) {
-    return Promise.all(
-      dto.visitationDetails.map(async (visitationDetailDto) => {
-        const visitationMember = members.find(
-          (member) => member.id === visitationDetailDto.memberId,
-        );
-
-        if (!visitationMember) {
-          throw new NotFoundException(MemberException.NOT_FOUND);
-        }
-
-        return this.visitationDetailDomainService.createVisitationDetail(
-          visitationMeta,
-          visitationMember,
-          visitationDetailDto,
-          qr,
-        );
-      }),
-    );
-  }*/
-
-  /**
-   * 심방 생성 시 심방의 메타 데이터 생성
-   * @param church 교회 엔티티
-   * @param creator 심방 생성 교인
-   * @param instructor 심방 진행자
-   * @param members 심방 대상자 (교인 엔티티 배열)
-   * @param dto 심방 생성 DTO
-   * @param qr 트랜잭션을 위한 QueryRunner
-   * @private
-   */
-  private async createVisitationMeta(
-    church: ChurchModel,
-    creator: MemberModel,
-    instructor: MemberModel,
-    members: MemberModel[],
-    dto: CreateVisitationDto,
-    qr: QueryRunner,
-  ) {
-    const createVisitationMetaDto: CreateVisitationMetaDto = {
-      creator,
-      inCharge: instructor,
-      status: dto.status,
-      visitationMethod: dto.visitationMethod,
-      title: dto.title,
-      startDate: dto.startDate,
-      endDate: dto.endDate,
-      visitationType:
-        members.length > 1 ? VisitationType.GROUP : VisitationType.SINGLE,
-    };
-
-    return this.visitationMetaDomainService.createVisitationMetaData(
-      church,
-      createVisitationMetaDto,
-      members,
-      qr,
-    );
-  }
-
-  private checkVisitationAuthorization(instructor: MemberModel) {
-    if (
-      !instructor.user ||
-      (instructor.user.role !== UserRole.OWNER &&
-        instructor.user.role !== UserRole.MANAGER)
-    ) {
-      throw new ForbiddenException(VisitationException.INVALID_INSTRUCTOR);
-    }
-  }
-
-  private async updateVisitationMembers(
-    church: ChurchModel,
-    visitationMeta: VisitationMetaModel,
-    dto: UpdateVisitationDto,
-    qr: QueryRunner,
-  ) {
-    if (!visitationMeta.members) {
-      throw new InternalServerErrorException(
-        VisitationException.MEMBER_RELATION_ERROR,
-      );
-    }
-
-    let visitationMembers = [...visitationMeta.members];
-
-    // 교인이 추가되는 경우 추가할 수 있는지 확인
-    if (dto.addMemberIds) {
-      if (visitationMembers.length + dto.addMemberIds.length > 30) {
-        throw new BadRequestException(
-          VisitationException.EXCEED_VISITATION_MEMBER,
-        );
-      }
-
-      await this.handleAddVisitationMembers(
-        church,
-        visitationMeta,
-        dto.addMemberIds,
-        visitationMembers,
-        qr,
-      );
-    }
-
-    // 교인이 삭제되는 경우 삭제할 수 있는지 확인
-    if (dto.deleteMemberIds) {
-      await this.handleDeleteVisitationMembers(
-        church,
-        visitationMeta,
-        dto.deleteMemberIds,
-        //visitationMembers,
-        qr,
-      );
-
-      // 삭제되지 않고 남은 교인들
-      visitationMembers = visitationMembers.filter(
-        (member) => !dto.deleteMemberIds?.includes(member.id),
-      );
-    }
-
-    await this.visitationMetaDomainService.updateVisitationMember(
-      visitationMeta,
-      visitationMembers,
-      qr,
-    );
-
-    return visitationMembers;
-  }
-
-  private async handleDeleteVisitationMembers(
-    church: ChurchModel,
-    visitationMeta: VisitationMetaModel,
-    deleteMemberIds: number[],
-    //visitationMembers: MemberModel[],
-    qr: QueryRunner,
-  ) {
-    const visitationMemberIdSet = new Set(
-      visitationMeta.members.map((member) => member.id),
-    );
-
-    const notExistMember = deleteMemberIds.filter(
-      (id) => !visitationMemberIdSet.has(id),
-    );
-
-    if (notExistMember.length > 0) {
-      throw new RemoveConflictException(
-        VisitationException.NOT_EXIST_DELETE_TARGET_MEMBER,
-        notExistMember,
-      );
-    }
-
-    await Promise.all(
-      deleteMemberIds.map(async (memberId) => {
-        const member = await this.membersDomainService.findMemberModelById(
-          church,
-          memberId,
-          qr,
-        );
-
-        const deleteTarget =
-          await this.visitationDetailDomainService.findVisitationDetailByMetaAndMemberId(
-            visitationMeta,
-            member,
-            qr,
-          );
-
-        return this.visitationDetailDomainService.deleteVisitationDetail(
-          deleteTarget,
-          qr,
-        );
-      }),
-    );
-  }
-
-  private async handleAddVisitationMembers(
-    church: ChurchModel,
-    visitationMeta: VisitationMetaModel,
-    addMemberIds: number[],
-    visitationMembers: MemberModel[],
-    qr: QueryRunner,
-  ) {
-    const visitationMemberIdSet = new Set(
-      visitationMeta.members.map((member) => member.id),
-    );
-
-    const duplicatedIds = addMemberIds.filter((id) =>
-      visitationMemberIdSet.has(id),
-    );
-
-    if (duplicatedIds.length > 0) {
-      throw new AddConflictException(
-        VisitationException.ALREADY_EXIST_TARGET_MEMBER,
-        duplicatedIds,
-      );
-    }
-
-    const newMembers = await this.membersDomainService.findMembersById(
-      church,
-      addMemberIds,
-      qr,
-    );
-
-    // 새 심방 대상자 추가
-    visitationMembers.push(...newMembers);
-
-    // 심방 세부 정보 생성 (VisitationDetailModel)
-    await Promise.all(
-      addMemberIds.map(async (memberId) => {
-        const member = await this.membersDomainService.findMemberModelById(
-          church,
-          memberId,
-          qr,
-        );
-
-        const detailDto: VisitationDetailDto = {
-          memberId: memberId,
-        };
-
-        return this.visitationDetailDomainService.createVisitationDetail(
-          visitationMeta,
-          member,
-          detailDto,
-          qr,
-        );
-      }),
-    );
-  }
-
-  async updateVisitationData(
-    churchId: number,
-    visitationMetaDataId: number,
-    dto: UpdateVisitationDto,
-    qr: QueryRunner,
-  ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
-    const targetMetaData =
-      await this.visitationMetaDomainService.findVisitationMetaModelById(
-        church,
-        visitationMetaDataId,
-        qr,
-        { members: true },
-      );
-
-    // 심방 종료날짜만 변경하는 경우
-    if (!dto.startDate && dto.endDate) {
-      if (dto.endDate < targetMetaData.startDate) {
-        throw new BadRequestException(VisitationException.INVALID_END_DATE);
-      }
-    }
-    // 심방 시작날짜만 변경하는 경우
-    if (dto.startDate && !dto.endDate) {
-      if (dto.startDate > targetMetaData.endDate) {
-        throw new BadRequestException(VisitationException.INVALID_START_DATE);
-      }
-    }
-
-    // 심방 진행자 변경 시
-    const newInstructor =
-      dto.inChargeId && dto.inChargeId !== targetMetaData.inChargeId
-        ? await this.membersDomainService.findMemberModelById(
-            church,
-            dto.inChargeId,
-            qr,
-            { user: true },
-          )
-        : undefined;
-
-    // 새로운 심방 진행자의 권한 확인
-    if (newInstructor) {
-      this.checkVisitationAuthorization(newInstructor);
-    }
-
-    // 심방 대상자 변경
-    let visitationType: VisitationType = targetMetaData.visitationType;
-
-    if (dto.addMemberIds || dto.deleteMemberIds) {
-      const newVisitationMembers = await this.updateVisitationMembers(
-        church,
-        targetMetaData,
-        dto,
-        qr,
-      );
-
-      visitationType =
-        newVisitationMembers.length > 1
-          ? VisitationType.GROUP
-          : VisitationType.SINGLE;
-    }
-
-    const updateVisitationMetaDto: UpdateVisitationMetaDto = {
-      startDate: dto.startDate,
-      endDate: dto.endDate,
-      visitationMethod: dto.visitationMethod,
-      visitationType,
-      status: dto.status,
-      title: dto.title,
-      inCharge: newInstructor,
-    };
-
-    await this.visitationMetaDomainService.updateVisitationMetaData(
-      targetMetaData,
-      updateVisitationMetaDto,
-      qr,
-    );
-
-    return this.visitationMetaDomainService.findVisitationMetaById(
-      church,
-      visitationMetaDataId,
-      qr,
-    );
-  }
-
-  async deleteVisitation(
-    churchId: number,
-    visitationMetaDataId: number,
-    qr: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const metaData =
-      await this.visitationMetaDomainService.findVisitationMetaModelById(
-        church,
-        visitationMetaDataId,
-        qr,
-      );
-
-    await this.visitationMetaDomainService.deleteVisitationMeta(metaData, qr);
-
-    await this.visitationDetailDomainService.deleteVisitationDetailsCascade(
-      metaData,
-      qr,
-    );
-  }
-
-  async updateVisitationDetail(
-    churchId: number,
-    visitationId: number,
-    detailId: number,
-    dto: UpdateVisitationDetailDto,
-  ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
-    const metaData =
-      await this.visitationMetaDomainService.findVisitationMetaModelById(
-        church,
-        visitationId,
-      );
-
-    const detailData =
-      await this.visitationDetailDomainService.findVisitationDetailModelById(
-        metaData,
-        detailId,
-      );
-
-    return this.visitationDetailDomainService.updateVisitationDetail(
-      metaData,
-      detailData,
-      dto,
-    );
-  }
-
   async addReportReceivers(
     churchId: number,
     visitationId: number,
@@ -601,7 +378,7 @@ export class VisitationService {
         church,
         visitationId,
         qr,
-        { /*instructor: true,*/ reports: true },
+        { reports: true },
       );
 
     const reports = visitation.reports;
@@ -641,7 +418,6 @@ export class VisitationService {
       newReceivers.map((receiver) => {
         return this.visitationReportDomainService.createVisitationReport(
           visitation,
-          //visitation.instructor,
           receiver,
           qr,
         );

--- a/backend/src/visitation/visitation-domain/interface/visitation-detail-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/interface/visitation-detail-domain.service.interface.ts
@@ -1,5 +1,5 @@
 import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
-import { QueryRunner, UpdateResult } from 'typeorm';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { VisitationDetailModel } from '../../entity/visitation-detail.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { UpdateVisitationDetailDto } from '../../dto/internal/detail/update-visitation-detail.dto';
@@ -10,12 +10,26 @@ export const IVISITATION_DETAIL_DOMAIN_SERVICE = Symbol(
 );
 
 export interface IVisitationDetailDomainService {
-  createVisitationDetail(
+  createAddedMemberDetails(
     metaData: VisitationMetaModel,
-    memberModel: MemberModel,
-    dto: VisitationDetailDto,
+    //memberIds: number[],
+    members: MemberModel[],
     qr: QueryRunner,
-  ): Promise<VisitationDetailModel>;
+  ): Promise<void>;
+
+  deleteRemovedMemberDetails(
+    metaData: VisitationMetaModel,
+    memberIds: number[],
+    //members: MemberModel[],
+    qr: QueryRunner,
+  ): Promise<void>;
+
+  createVisitationDetails(
+    metaData: VisitationMetaModel,
+    members: MemberModel[],
+    dto: VisitationDetailDto[],
+    qr: QueryRunner,
+  ): Promise<VisitationDetailModel[]>;
 
   findVisitationDetailByMetaAndMemberId(
     metaData: VisitationMetaModel,
@@ -26,34 +40,24 @@ export interface IVisitationDetailDomainService {
   findVisitationDetailsByMetaId(
     metaData: VisitationMetaModel,
     qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<VisitationDetailModel>,
   ): Promise<VisitationDetailModel[]>;
 
-  findVisitationDetailById(
+  /*findVisitationDetailById(
     visitationMeta: VisitationMetaModel,
     visitationDetailId: number,
     qr?: QueryRunner,
-  ): Promise<VisitationDetailModel>;
-
-  findVisitationDetailModelById(
-    visitationMeta: VisitationMetaModel,
-    visitationDetailId: number,
-    qr?: QueryRunner,
-  ): Promise<VisitationDetailModel>;
+  ): Promise<VisitationDetailModel>;*/
 
   updateVisitationDetail(
     visitationMeta: VisitationMetaModel,
     visitationDetail: VisitationDetailModel,
     dto: UpdateVisitationDetailDto,
     qr?: QueryRunner,
-  ): Promise<VisitationDetailModel>;
+  ): Promise<UpdateResult>;
 
   deleteVisitationDetailsCascade(
     metaData: VisitationMetaModel,
     qr: QueryRunner,
-  ): Promise<UpdateResult>;
-
-  deleteVisitationDetail(
-    visitationDetail: VisitationDetailModel,
-    qr?: QueryRunner,
   ): Promise<UpdateResult>;
 }

--- a/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
@@ -6,7 +6,13 @@ import {
 import { IVisitationDetailDomainService } from '../interface/visitation-detail-domain.service.interface';
 import { InjectRepository } from '@nestjs/typeorm';
 import { VisitationDetailModel } from '../../entity/visitation-detail.entity';
-import { QueryRunner, Repository, UpdateResult } from 'typeorm';
+import {
+  FindOptionsRelations,
+  In,
+  QueryRunner,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
 import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
 import {
@@ -32,20 +38,63 @@ export class VisitationDetailDomainService
       : this.repository;
   }
 
-  async createVisitationDetail(
+  async createAddedMemberDetails(
     metaData: VisitationMetaModel,
-    member: MemberModel,
-    dto: VisitationDetailDto,
+    //memberIds: number[],
+    members: MemberModel[],
     qr: QueryRunner,
   ) {
     const repository = this.getRepository(qr);
 
-    return repository.save({
-      visitationMeta: metaData,
-      member,
-      visitationContent: dto.visitationContent,
-      visitationPray: dto.visitationPray,
+    const details = repository.create(
+      members.map((member) => ({
+        visitationMeta: metaData,
+        memberId: member.id,
+      })),
+    );
+
+    await repository.save(details);
+  }
+
+  async deleteRemovedMemberDetails(
+    metaData: VisitationMetaModel,
+    memberIds: number[],
+    qr: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    await repository.softDelete({
+      visitationMetaId: metaData.id,
+      memberId: In(memberIds),
     });
+  }
+
+  async createVisitationDetails(
+    metaData: VisitationMetaModel,
+    members: MemberModel[],
+    dto: VisitationDetailDto[],
+    qr: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    const details = repository.create(
+      members.map((member) => {
+        const detail = dto.find((detail) => detail.memberId === member.id);
+
+        if (!detail) {
+          throw new InternalServerErrorException();
+        }
+
+        return {
+          visitationMetaId: metaData.id,
+          memberId: member.id,
+          visitationContent: detail.visitationContent,
+          visitationPray: detail.visitationPray,
+        };
+      }),
+    );
+
+    return repository.save(details);
   }
 
   async findVisitationDetailByMetaAndMemberId(
@@ -60,6 +109,8 @@ export class VisitationDetailDomainService
         memberId: member.id,
         visitationMetaId: metaData.id,
       },
+      relations: VisitationDetailRelationOptions,
+      select: VisitationDetailSelectOptions,
     });
 
     if (!detailData) {
@@ -72,6 +123,7 @@ export class VisitationDetailDomainService
   async findVisitationDetailsByMetaId(
     metaData: VisitationMetaModel,
     qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<VisitationDetailModel>,
   ) {
     const repository = this.getRepository(qr);
 
@@ -79,53 +131,8 @@ export class VisitationDetailDomainService
       where: {
         visitationMetaId: metaData.id,
       },
-      relations: VisitationDetailRelationOptions,
-      select: VisitationDetailSelectOptions,
+      relations: relationOptions,
     });
-  }
-
-  async findVisitationDetailById(
-    visitationMeta: VisitationMetaModel,
-    visitationDetailId: number,
-    qr?: QueryRunner,
-  ): Promise<VisitationDetailModel> {
-    const repository = this.getRepository(qr);
-
-    const detail = await repository.findOne({
-      where: {
-        visitationMetaId: visitationMeta.id,
-        id: visitationDetailId,
-      },
-      relations: VisitationDetailRelationOptions,
-      select: VisitationDetailSelectOptions,
-    });
-
-    if (!detail) {
-      throw new NotFoundException(VisitationDetailException.NOT_FOUND);
-    }
-
-    return detail;
-  }
-
-  async findVisitationDetailModelById(
-    visitationMeta: VisitationMetaModel,
-    visitationDetailId: number,
-    qr?: QueryRunner,
-  ) {
-    const repository = this.getRepository(qr);
-
-    const visitationDetail = await repository.findOne({
-      where: {
-        visitationMetaId: visitationMeta.id,
-        id: visitationDetailId,
-      },
-    });
-
-    if (!visitationDetail) {
-      throw new NotFoundException(VisitationDetailException.NOT_FOUND);
-    }
-
-    return visitationDetail;
   }
 
   async updateVisitationDetail(
@@ -153,11 +160,7 @@ export class VisitationDetailDomainService
       );
     }
 
-    return this.findVisitationDetailById(
-      visitationMeta,
-      visitationDetail.id,
-      qr,
-    );
+    return result;
   }
 
   async deleteVisitationDetailsCascade(
@@ -169,22 +172,5 @@ export class VisitationDetailDomainService
     return repository.softDelete({
       visitationMetaId: metaData.id,
     });
-  }
-
-  async deleteVisitationDetail(
-    visitationDetail: VisitationDetailModel,
-    qr?: QueryRunner,
-  ) {
-    const repository = this.getRepository(qr);
-
-    const result = await repository.softDelete(visitationDetail.id);
-
-    if (result.affected === 0) {
-      throw new InternalServerErrorException(
-        VisitationDetailException.DELETE_ERROR,
-      );
-    }
-
-    return result;
   }
 }

--- a/backend/src/visitation/visitation.module.ts
+++ b/backend/src/visitation/visitation.module.ts
@@ -8,6 +8,7 @@ import { MembersDomainModule } from '../members/member-domain/members-domain.mod
 import { VisitationReportDomainModule } from '../report/report-domain/visitation-report-domain.module';
 import { VisitationDetailController } from './controller/visitation-detail.controller';
 import { VisitationDetailService } from './service/visitation-detail.service';
+import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { VisitationDetailService } from './service/visitation-detail.service';
       { path: 'churches/:churchId', module: VisitationModule },
     ]),
     ChurchesDomainModule,
+    ManagerDomainModule,
     MembersDomainModule,
 
     VisitationDomainModule,


### PR DESCRIPTION
## 주요 내용
Visitation 도메인 전반에 걸쳐 ChurchUser 기반의 권한 구조를 반영하였고, 심방 세부 정보 관리 로직을 명확하고 일관되게 재구성하였습니다.

## 세부 내용

### 🧩 ChurchUser 기반 구조 적용
- 심방 생성자, 담당자 지정 시 ChurchUser 를 사용하도록 변경
- 실제 엔티티에는 MemberModel 참조 유지
- 서비스/도메인 로직 파라미터 및 조회 흐름을 ChurchUser 중심으로 정리

### 📌 심방 세부 정보(VisitationDetail) 생성 방식 개선
- 기존: Promise.all 로 각각 생성
- 변경: 생성할 세부 정보 리스트를 먼저 구성하고 `save()` 메소드로 일괄 저장

### 🔁 대상자 수정 방식 개선
- 기존: `addMemberIds`, `deleteMemberIds` 방식
- 변경: `memberIds` 하나로 통합 → 최종적으로 포함되어야 할 대상자의 id 리스트만 전달
- 내부적으로 기존 데이터와 비교하여 삭제 및 생성 분기 처리

### ✍️ 심방 내용 작성 시 요청 방식 변경
- 기존: `visitationDetailId` 기반 요청
- 변경: `memberId` 기반으로 요청 → `/churches/{churchId}/visitations/{visitationId}/details/{memberId}`
- 이유: 클라이언트에서 `visitationDetailId` 조회가 불편하며, `visitationMetaId + memberId` 조합으로 유일한 세부 정보 식별 가능

이번 리팩토링을 통해 클라이언트와의 연동 편의성 향상 및
도메인 로직의 일관성과 명확성이 크게 개선되었습니다.