### PR TITLE
feat: 업무(Task) 도메인에서 ChurchUser 기반 생성자/담당자 처리 및 하위 업무 조회 기능 추가

### DIFF
--- a/backend/src/task/const/exception-message/task.exception.ts
+++ b/backend/src/task/const/exception-message/task.exception.ts
@@ -6,9 +6,11 @@ export const TaskException = {
   DELETE_ERROR: '업무 삭제 도중 에러 발생',
   INVALID_CHANGE_PARENT_TASK: '하위 업무로 변경할 수 없는 업무입니다.',
   TASK_HAS_DEPENDENCIES: '하위 업무가 존재하는 업무는 삭제할 수 없습니다.',
+  INVALID_CREATOR: '업무를 생성할 권한이 없습니다.',
+  NOT_FOUND_PARENT: '해당 상위 업무를 찾을 수 없습니다.',
+  NOT_FOUND_SUB: '해당 하위 업무를 찾을 수 없습니다.',
 
-  NOT_FOUND: (purpose: string = '') =>
-    `해당 ${purpose}업무를 찾을 수 없습니다.`,
+  NOT_FOUND: '해당 업무를 찾을 수 없습니다.',
 
   INVALID_START_DATE: '시작 날짜는 종료 날짜를 넘어설 수 없습니다.',
   INVALID_END_DATE: '종료 날짜는 시작 날짜를 앞설 수 없습니다.',

--- a/backend/src/task/const/swagger/task.swagger.ts
+++ b/backend/src/task/const/swagger/task.swagger.ts
@@ -8,6 +8,13 @@ export const ApiGetTasks = () =>
     }),
   );
 
+export const ApiGetSubTasks = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '하위 업무 목록 조회',
+    }),
+  );
+
 export const ApiPostTask = () =>
   applyDecorators(
     ApiOperation({

--- a/backend/src/task/const/task-find-options.const.ts
+++ b/backend/src/task/const/task-find-options.const.ts
@@ -6,9 +6,9 @@ import {
 } from '../../members/const/member-find-options.const';
 
 export const TasksFindOptionsRelation: FindOptionsRelations<TaskModel> = {
-  subTasks: {
+  /*subTasks: {
     inCharge: MemberSummarizedRelation,
-  },
+  },*/
   inCharge: MemberSummarizedRelation,
 };
 
@@ -35,7 +35,7 @@ export const TasksFindOptionsSelect: FindOptionsSelect<TaskModel> = {
   status: true,
   startDate: true,
   endDate: true,
-  subTasks: SubTaskFindOptionsSelect,
+  //subTasks: SubTaskFindOptionsSelect,
   inCharge: MemberSummarizedSelect,
 };
 

--- a/backend/src/task/const/task-tree.enum.ts
+++ b/backend/src/task/const/task-tree.enum.ts
@@ -1,5 +1,0 @@
-export enum TaskTreeEnum {
-  parent = '상위 ',
-  child = '하위 ',
-  none = '',
-}

--- a/backend/src/task/controller/task.controller.ts
+++ b/backend/src/task/controller/task.controller.ts
@@ -28,6 +28,7 @@ import {
   ApiAddReportReceivers,
   ApiDeleteReportReceiver,
   ApiDeleteTask,
+  ApiGetSubTasks,
   ApiGetTaskById,
   ApiGetTasks,
   ApiPatchTask,
@@ -70,6 +71,15 @@ export class TaskController {
     @Param('taskId', ParseIntPipe) taskId: number,
   ) {
     return this.taskService.getTaskById(churchId, taskId);
+  }
+
+  @ApiGetSubTasks()
+  @Get(':taskId/sub-tasks')
+  async getSubTasks(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('taskId', ParseIntPipe) taskId: number,
+  ) {
+    return this.taskService.getSubTasks(churchId, taskId);
   }
 
   @ApiPatchTask()

--- a/backend/src/task/dto/response/get-sub-task-response.dto.ts
+++ b/backend/src/task/dto/response/get-sub-task-response.dto.ts
@@ -1,0 +1,11 @@
+import { BaseGetResponseDto } from '../../../common/dto/reponse/base-get-response.dto';
+import { TaskModel } from '../../entity/task.entity';
+
+export class GetSubTaskResponseDto extends BaseGetResponseDto<TaskModel[]> {
+  constructor(
+    public readonly data: TaskModel[],
+    public readonly parentTaskId: number,
+  ) {
+    super(data);
+  }
+}

--- a/backend/src/task/task-domain/interface/task-domain.service.interface.ts
+++ b/backend/src/task/task-domain/interface/task-domain.service.interface.ts
@@ -6,6 +6,7 @@ import { CreateTaskDto } from '../../dto/request/create-task.dto';
 import { GetTasksDto } from '../../dto/request/get-tasks.dto';
 import { TaskDomainPaginationResultDto } from '../../dto/task-domain-pagination-result.dto';
 import { UpdateTaskDto } from '../../dto/request/update-task.dto';
+import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 
 export const ITASK_DOMAIN_SERVICE = Symbol('ITASK_DOMAIN_SERVICE');
 
@@ -16,6 +17,12 @@ export interface ITaskDomainService {
     qr?: QueryRunner,
   ): Promise<TaskDomainPaginationResultDto>;
 
+  findSubTasks(
+    church: ChurchModel,
+    parentTask: TaskModel,
+    qr?: QueryRunner,
+  ): Promise<TaskModel[]>;
+
   findTaskById(
     church: ChurchModel,
     taskId: number,
@@ -25,25 +32,29 @@ export interface ITaskDomainService {
   findTaskModelById(
     church: ChurchModel,
     taskId: number,
-    purpose?: string,
     qr?: QueryRunner,
     relationOptions?: FindOptionsRelations<TaskModel>,
   ): Promise<TaskModel>;
 
-  assertValidInChargeMember(inChargeMember: MemberModel): void;
+  findParentTaskModelById(
+    church: ChurchModel,
+    taskId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<TaskModel>,
+  ): Promise<TaskModel>;
 
   createTask(
     church: ChurchModel,
-    creatorMember: MemberModel,
+    creatorMember: ChurchUserModel, //MemberModel,
     parentTask: TaskModel | null,
-    inChargeMember: MemberModel | null,
+    inChargeMember: ChurchUserModel | null, //MemberModel | null,
     dto: CreateTaskDto,
     qr: QueryRunner,
   ): Promise<TaskModel>;
 
   updateTask(
     targetTask: TaskModel,
-    newInChargeMember: MemberModel | null,
+    newInChargeMember: ChurchUserModel | null, //MemberModel | null,
     newParentTask: TaskModel | null,
     dto: UpdateTaskDto,
     qr: QueryRunner,

--- a/backend/src/task/task.module.ts
+++ b/backend/src/task/task.module.ts
@@ -6,6 +6,7 @@ import { TaskController } from './controller/task.controller';
 import { TaskService } from './service/task.service';
 import { TaskDomainModule } from './task-domain/task-domain.module';
 import { TaskReportDomainModule } from '../report/report-domain/task-report-domain.module';
+import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { TaskReportDomainModule } from '../report/report-domain/task-report-doma
       { path: 'churches/:churchId/tasks', module: TaskModule },
     ]),
     ChurchesDomainModule,
+    ManagerDomainModule,
     MembersDomainModule,
     TaskDomainModule,
 

--- a/backend/src/visitation/controller/visitation.controller.ts
+++ b/backend/src/visitation/controller/visitation.controller.ts
@@ -16,13 +16,13 @@ import { VisitationService } from '../service/visitation.service';
 import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
-import { CreateVisitationDto } from '../dto/create-visitation.dto';
+import { CreateVisitationDto } from '../dto/request/create-visitation.dto';
 import { ChurchManagerGuard } from '../../churches/guard/church-guard.service';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
 import { Token } from '../../auth/decorator/jwt.decorator';
 import { AuthType } from '../../auth/const/enum/auth-type.enum';
 import { JwtAccessPayload } from '../../auth/type/jwt';
-import { GetVisitationDto } from '../dto/get-visitation.dto';
+import { GetVisitationDto } from '../dto/request/get-visitation.dto';
 import {
   ApiDeleteVisitation,
   ApiGetVisitationById,
@@ -30,7 +30,7 @@ import {
   ApiPatchVisitationMeta,
   ApiPostVisitation,
 } from '../const/swagger/visitation.swagger';
-import { UpdateVisitationDto } from '../dto/update-visitation.dto';
+import { UpdateVisitationDto } from '../dto/request/update-visitation.dto';
 import { AddReceiverDto } from '../dto/receiever/add-receiver.dto';
 import { DeleteReceiverDto } from '../dto/receiever/delete-receiver.dto';
 

--- a/backend/src/visitation/decorator/visitation-detail.validator.ts
+++ b/backend/src/visitation/decorator/visitation-detail.validator.ts
@@ -5,7 +5,7 @@ import {
   ValidatorConstraint,
   ValidatorConstraintInterface,
 } from 'class-validator';
-import { VisitationDetailDto } from '../dto/visittion-detail.dto';
+import { VisitationDetailDto } from '../dto/internal/visittion-detail.dto';
 
 @ValidatorConstraint({ name: 'VisitationDetailValidator', async: false })
 export class VisitationDetailConstraint

--- a/backend/src/visitation/dto/internal/visittion-detail.dto.ts
+++ b/backend/src/visitation/dto/internal/visittion-detail.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsOptional, IsString, Min } from 'class-validator';
-import { SanitizeDto } from '../../common/decorator/sanitize-target.decorator';
+import { SanitizeDto } from '../../../common/decorator/sanitize-target.decorator';
 
 @SanitizeDto()
 export class VisitationDetailDto {

--- a/backend/src/visitation/dto/receiever/add-receiver.dto.ts
+++ b/backend/src/visitation/dto/receiever/add-receiver.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
-import { CreateVisitationDto } from '../create-visitation.dto';
+import { CreateVisitationDto } from '../request/create-visitation.dto';
 import { IsArray, IsNumber, IsOptional, Min } from 'class-validator';
 
 export class AddReceiverDto extends PickType(CreateVisitationDto, [

--- a/backend/src/visitation/dto/receiever/delete-receiver.dto.ts
+++ b/backend/src/visitation/dto/receiever/delete-receiver.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
-import { CreateVisitationDto } from '../create-visitation.dto';
+import { CreateVisitationDto } from '../request/create-visitation.dto';
 import { IsArray, IsNumber, IsOptional, Min } from 'class-validator';
 
 export class DeleteReceiverDto extends PickType(CreateVisitationDto, [

--- a/backend/src/visitation/dto/request/create-visitation.dto.ts
+++ b/backend/src/visitation/dto/request/create-visitation.dto.ts
@@ -10,17 +10,17 @@ import {
   Min,
   ValidateNested,
 } from 'class-validator';
-import { VisitationMethod } from '../const/visitation-method.enum';
+import { VisitationMethod } from '../../const/visitation-method.enum';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { VisitationStatus } from '../const/visitation-status.enum';
-import { VisitationDetailValidator } from '../decorator/visitation-detail.validator';
-import { VisitationDetailDto } from './visittion-detail.dto';
-import { RemoveSpaces } from '../../common/decorator/transformer/remove-spaces';
-import { SanitizeDto } from '../../common/decorator/sanitize-target.decorator';
-import { IsAfterDate } from '../../common/decorator/validator/is-after-date.decorator';
-import { VisitationException } from '../const/exception/visitation.exception';
-import { IsNoSpecialChar } from '../../common/decorator/validator/is-no-special-char.validator';
+import { VisitationStatus } from '../../const/visitation-status.enum';
+import { VisitationDetailValidator } from '../../decorator/visitation-detail.validator';
+import { VisitationDetailDto } from '../internal/visittion-detail.dto';
+import { RemoveSpaces } from '../../../common/decorator/transformer/remove-spaces';
+import { SanitizeDto } from '../../../common/decorator/sanitize-target.decorator';
+import { IsAfterDate } from '../../../common/decorator/validator/is-after-date.decorator';
+import { VisitationException } from '../../const/exception/visitation.exception';
+import { IsNoSpecialChar } from '../../../common/decorator/validator/is-no-special-char.validator';
 
 @SanitizeDto()
 export class CreateVisitationDto {

--- a/backend/src/visitation/dto/request/get-visitation.dto.ts
+++ b/backend/src/visitation/dto/request/get-visitation.dto.ts
@@ -8,12 +8,12 @@ import {
   IsString,
   Min,
 } from 'class-validator';
-import { VisitationStatus } from '../const/visitation-status.enum';
-import { TransformStringArray } from '../../common/decorator/transformer/transform-array';
-import { VisitationOrderEnum } from '../const/visitation-order.enum';
-import { VisitationMethod } from '../const/visitation-method.enum';
-import { VisitationType } from '../const/visitation-type.enum';
-import { IsAfterDate } from '../../common/decorator/validator/is-after-date.decorator';
+import { VisitationStatus } from '../../const/visitation-status.enum';
+import { TransformStringArray } from '../../../common/decorator/transformer/transform-array';
+import { VisitationOrderEnum } from '../../const/visitation-order.enum';
+import { VisitationMethod } from '../../const/visitation-method.enum';
+import { VisitationType } from '../../const/visitation-type.enum';
+import { IsAfterDate } from '../../../common/decorator/validator/is-after-date.decorator';
 
 export class GetVisitationDto {
   @ApiProperty({

--- a/backend/src/visitation/dto/request/update-visitation.dto.ts
+++ b/backend/src/visitation/dto/request/update-visitation.dto.ts
@@ -10,13 +10,13 @@ import {
   IsString,
   Length,
 } from 'class-validator';
-import { TransformNumberArray } from '../../common/decorator/transformer/transform-array';
-import { VisitationStatus } from '../const/visitation-status.enum';
-import { VisitationMethod } from '../const/visitation-method.enum';
-import { RemoveSpaces } from '../../common/decorator/transformer/remove-spaces';
-import { IsAfterDate } from '../../common/decorator/validator/is-after-date.decorator';
-import { IsNoSpecialChar } from '../../common/decorator/validator/is-no-special-char.validator';
-import { IsOptionalNotNull } from '../../common/decorator/validator/is-optional-not.null.validator';
+import { TransformNumberArray } from '../../../common/decorator/transformer/transform-array';
+import { VisitationStatus } from '../../const/visitation-status.enum';
+import { VisitationMethod } from '../../const/visitation-method.enum';
+import { RemoveSpaces } from '../../../common/decorator/transformer/remove-spaces';
+import { IsAfterDate } from '../../../common/decorator/validator/is-after-date.decorator';
+import { IsNoSpecialChar } from '../../../common/decorator/validator/is-no-special-char.validator';
+import { IsOptionalNotNull } from '../../../common/decorator/validator/is-optional-not.null.validator';
 
 export class UpdateVisitationDto {
   @ApiProperty({

--- a/backend/src/visitation/dto/response/visitation-pagination-result.dto.ts
+++ b/backend/src/visitation/dto/response/visitation-pagination-result.dto.ts
@@ -1,5 +1,5 @@
-import { BaseOffsetPaginationResponseDto } from '../../common/dto/reponse/base-offset-pagination-response.dto';
-import { VisitationMetaModel } from '../entity/visitation-meta.entity';
+import { BaseOffsetPaginationResponseDto } from '../../../common/dto/reponse/base-offset-pagination-response.dto';
+import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
 
 export class VisitationPaginationResultDto extends BaseOffsetPaginationResponseDto<VisitationMetaModel> {
   constructor(

--- a/backend/src/visitation/service/visitation-detail.service.ts
+++ b/backend/src/visitation/service/visitation-detail.service.ts
@@ -5,7 +5,7 @@ import {
 } from '../visitation-domain/interface/visitation-detail-domain.service.interface';
 import { VisitationMetaModel } from '../entity/visitation-meta.entity';
 import { MemberModel } from '../../members/entity/member.entity';
-import { CreateVisitationDto } from '../dto/create-visitation.dto';
+import { CreateVisitationDto } from '../dto/request/create-visitation.dto';
 import { QueryRunner } from 'typeorm';
 import {
   IVISITATION_META_DOMAIN_SERVICE,

--- a/backend/src/visitation/service/visitation.service.ts
+++ b/backend/src/visitation/service/visitation.service.ts
@@ -24,13 +24,13 @@ import { UserRole } from '../../user/const/user-role.enum';
 import { UpdateVisitationMetaDto } from '../dto/internal/meta/update-visitation-meta.dto';
 import { QueryRunner } from 'typeorm';
 import { VisitationMetaModel } from '../entity/visitation-meta.entity';
-import { CreateVisitationDto } from '../dto/create-visitation.dto';
+import { CreateVisitationDto } from '../dto/request/create-visitation.dto';
 import { JwtAccessPayload } from '../../auth/type/jwt';
 import { VisitationException } from '../const/exception/visitation.exception';
 import { CreateVisitationMetaDto } from '../dto/internal/meta/create-visitation-meta.dto';
-import { GetVisitationDto } from '../dto/get-visitation.dto';
+import { GetVisitationDto } from '../dto/request/get-visitation.dto';
 import { VisitationType } from '../const/visitation-type.enum';
-import { UpdateVisitationDto } from '../dto/update-visitation.dto';
+import { UpdateVisitationDto } from '../dto/request/update-visitation.dto';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { MemberModel } from '../../members/entity/member.entity';
 import {
@@ -39,7 +39,7 @@ import {
 } from '../../report/report-domain/interface/visitation-report-domain.service.interface';
 import { AddConflictException } from '../../common/exception/add-conflict.exception';
 import { RemoveConflictException } from '../../common/exception/remove-conflict.exception';
-import { VisitationPaginationResultDto } from '../dto/visitation-pagination-result.dto';
+import { VisitationPaginationResultDto } from '../dto/response/visitation-pagination-result.dto';
 import { VisitationDetailService } from './visitation-detail.service';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import {

--- a/backend/src/visitation/visitation-domain/interface/visitation-detail-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/interface/visitation-detail-domain.service.interface.ts
@@ -3,7 +3,7 @@ import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { VisitationDetailModel } from '../../entity/visitation-detail.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { UpdateVisitationDetailDto } from '../../dto/internal/detail/update-visitation-detail.dto';
-import { VisitationDetailDto } from '../../dto/visittion-detail.dto';
+import { VisitationDetailDto } from '../../dto/internal/visittion-detail.dto';
 
 export const IVISITATION_DETAIL_DOMAIN_SERVICE = Symbol(
   'IVISITATION_DETAIL_DOMAIN_SERVICE',

--- a/backend/src/visitation/visitation-domain/interface/visitation-meta-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/interface/visitation-meta-domain.service.interface.ts
@@ -3,7 +3,7 @@ import { MemberModel } from '../../../members/entity/member.entity';
 import { CreateVisitationMetaDto } from '../../dto/internal/meta/create-visitation-meta.dto';
 import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
-import { GetVisitationDto } from '../../dto/get-visitation.dto';
+import { GetVisitationDto } from '../../dto/request/get-visitation.dto';
 import { UpdateVisitationMetaDto } from '../../dto/internal/meta/update-visitation-meta.dto';
 
 export const IVISITATION_META_DOMAIN_SERVICE = Symbol(

--- a/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
@@ -21,7 +21,7 @@ import {
 } from '../../const/visitation-find-options.const';
 import { VisitationDetailException } from '../../const/exception/visitation.exception';
 import { UpdateVisitationDetailDto } from '../../dto/internal/detail/update-visitation-detail.dto';
-import { VisitationDetailDto } from '../../dto/visittion-detail.dto';
+import { VisitationDetailDto } from '../../dto/internal/visittion-detail.dto';
 
 @Injectable()
 export class VisitationDetailDomainService

--- a/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
@@ -25,7 +25,7 @@ import { CreateVisitationMetaDto } from '../../dto/internal/meta/create-visitati
 import { MemberModel } from '../../../members/entity/member.entity';
 import { VisitationException } from '../../const/exception/visitation.exception';
 import { UpdateVisitationMetaDto } from '../../dto/internal/meta/update-visitation-meta.dto';
-import { GetVisitationDto } from '../../dto/get-visitation.dto';
+import { GetVisitationDto } from '../../dto/request/get-visitation.dto';
 import {
   VisitationRelationOptions,
   VisitationSelectOptions,
@@ -34,7 +34,7 @@ import { ChurchUserRole } from '../../../user/const/user-role.enum';
 import { MemberException } from '../../../members/const/exception/member.exception';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { ManagerException } from '../../../manager/exception/manager.exception';
-import { UpdateVisitationDto } from '../../dto/update-visitation.dto';
+import { UpdateVisitationDto } from '../../dto/request/update-visitation.dto';
 
 @Injectable()
 export class VisitationMetaDomainService


### PR DESCRIPTION
## 주요 내용
업무(TaskModel) 생성자와 담당자 지정 시 ChurchUserModel 기반으로 권한을 확인하고 관련 MemberModel 을 참조하도록 변경하였습니다.
또한, 기존의 업무 목록 조회에서는 하위 업무가 제외되고
새로 추가된 하위 업무 전용 엔드포인트를 통해 하위 업무를 개별적으로 확인할 수 있도록 개선하였습니다.

## 세부 내용

### 👤 생성자 및 담당자 참조 구조 개선
- TaskModel 생성자(`creator`), 담당자(`inCharge`) 지정 시 ChurchUserModel 기준으로 권한 검증
- Entity 내 참조 대상은 기존처럼 MemberModel 유지
- 도메인 서비스에서 ChurchUser → Member 변환 방식으로 처리

### 📁 업무 목록 조회 분리
- GET /churches/{churchId}/tasks 목록 조회에서 상위 업무만 조회되도록 변경
- GET /churches/{churchId}/tasks/{taskId}/children 엔드포인트 추가
  - 특정 업무의 하위 업무(TaskModel)들만 조회 가능

이번 변경을 통해 교회 내 사용자 권한 체계와 업무 관리 구조 간의 일관성을 확보하고
클라이언트에서 업무 목록 처리 로직도 보다 명확하게 분리할 수 있도록 구성하였습니다.