### PR TITLE
refactor: 권한 단위(PermissionUnit)의 action 구조를 read/write 중심으로 간소화

### DIFF
--- a/backend/src/permission/const/domain-action.enum.ts
+++ b/backend/src/permission/const/domain-action.enum.ts
@@ -1,6 +1,7 @@
 export enum DomainAction {
-  CREATE = 'create',
+  //CREATE = 'create',
   READ = 'read',
-  UPDATE = 'update',
-  DELETE = 'delete',
+  //UPDATE = 'update',
+  //DELETE = 'delete',
+  WRITE = 'write',
 }

--- a/backend/src/permission/service/permission.service.ts
+++ b/backend/src/permission/service/permission.service.ts
@@ -136,14 +136,24 @@ export class PermissionService {
       qr,
     );
 
+    const educationUnits =
+      await this.permissionDomainService.findPermissionUnits(
+        DomainType.EDUCATION,
+      );
+
     const educationManager: CreatePermissionTemplateDto = {
       title: '교육 관리자(샘플)',
-      unitIds: [9, 10, 11, 12],
+      unitIds: educationUnits.map((unit) => unit.id),
     };
+
+    const visitationUnits =
+      await this.permissionDomainService.findPermissionUnits(
+        DomainType.VISITATION,
+      );
 
     const visitationManager: CreatePermissionTemplateDto = {
       title: '심방 관리자(샘플)',
-      unitIds: [5, 6, 7, 8],
+      unitIds: visitationUnits.map((unit) => unit.id),
     };
 
     const educationTemplate =


### PR DESCRIPTION
## 주요 내용
기존 `create`, `read`, `update`, `delete`로 세분화되어 있던 권한 단위의 `action` 필드를 `read`, `write` 두 가지로 통합하여 관리 방식과 정책 해석을 단순화했습니다.
`write` 권한은 실제로는 `create`, `update`, `delete` 권한을 포함하는 의미로 사용됩니다.

## 세부 내용

### 🧱 PermissionUnit 구조 변경
- action 값 변경:
  - 기존: `create`, `read`, `update`, `delete`
  - 변경: `read`, `write`
- 기존 템플릿 및 유닛 정의 로직 수정
  - `write` 권한 설정 시 내부적으로 모든 쓰기 관련 작업이 허용됨
- 관련 클라이언트 문서 및 권한 해석 로직 변경 필요

이번 구조 단순화를 통해 관리자가 권한 유형을 구성할 때 보다 직관적으로 접근할 수 있으며, 클라이언트에서 권한 단위 매핑 시 복잡도를 줄일 수 있습니다.