### PR TITLE
refactor: VisitationReport 피보고자 지정 시 ChurchUser 기반 유효성 검증 도입

### DIFF
--- a/backend/src/report/const/exception/visitation-report.exception.ts
+++ b/backend/src/report/const/exception/visitation-report.exception.ts
@@ -1,5 +1,9 @@
+import { MAX_RECEIVER_COUNT } from '../report.constraints';
+
 export const VisitationReportException = {
   NOT_FOUND: '해당 심방 보고를 찾을 수 없습니다.',
   UPDATE_ERROR: '심방 보고 업데이트 도중 에러 발생',
   DELETE_ERROR: '심방 보고 삭제 도중 에러 발생',
+  EXCEED_RECEIVERS: `피보고자는 최대 ${MAX_RECEIVER_COUNT}명까지 등록할 수 있습니다.`,
+  NOT_EXIST_REPORTED_MEMBER: '피보고자로 등록되지 않은 교인입니다.',
 };

--- a/backend/src/report/report-domain/interface/visitation-report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/visitation-report-domain.service.interface.ts
@@ -4,6 +4,7 @@ import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { VisitationReportModel } from '../../entity/visitation-report.entity';
 import { GetVisitationReportDto } from '../../dto/visitation-report/get-visitation-report.dto';
 import { UpdateVisitationReportDto } from '../../dto/visitation-report/update-visitation-report.dto';
+import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 
 export const IVISITATION_REPORT_DOMAIN_SERVICE = Symbol(
   'IVISITATION_REPORT_DOMAIN_SERVICE',
@@ -16,12 +17,11 @@ export interface IVisitationReportDomainService {
     qr?: QueryRunner,
   ): Promise<{ data: VisitationReportModel[]; totalCount: number }>;
 
-  createVisitationReport(
+  createVisitationReports(
     visitation: VisitationMetaModel,
-    //sender: MemberModel,
-    receiver: MemberModel,
+    newReceivers: ChurchUserModel[],
     qr: QueryRunner,
-  ): Promise<VisitationReportModel>;
+  ): Promise<VisitationReportModel[]>;
 
   findVisitationReportModelById(
     receiver: MemberModel,
@@ -48,8 +48,14 @@ export interface IVisitationReportDomainService {
     qr?: QueryRunner,
   ): Promise<UpdateResult>;
 
+  deleteVisitationReportCascade(
+    visitation: VisitationMetaModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
   deleteVisitationReports(
-    visitationReports: VisitationReportModel[],
+    visitation: VisitationMetaModel,
+    receiverIds: number[],
     qr?: QueryRunner,
   ): Promise<UpdateResult>;
 }

--- a/backend/src/report/report-domain/service/task-report-domain.service.ts
+++ b/backend/src/report/report-domain/service/task-report-domain.service.ts
@@ -65,9 +65,9 @@ export class TaskReportDomainService implements ITaskReportDomainService {
 
     // 피보고자 중복 체크
     for (const receiver of receivers) {
-      if (oldReceiverIds.has(receiver.id)) {
+      if (oldReceiverIds.has(receiver.member.id)) {
         failed.push({
-          receiverId: receiver.id,
+          receiverId: receiver.member.id,
           reason: TaskReportException.ALREADY_REPORTED_MEMBER,
         });
       }

--- a/backend/src/report/report-domain/service/visitation-report-domain.service.ts
+++ b/backend/src/report/report-domain/service/visitation-report-domain.service.ts
@@ -4,6 +4,7 @@ import { VisitationReportModel } from '../../entity/visitation-report.entity';
 import {
   FindOptionsOrder,
   FindOptionsRelations,
+  In,
   QueryRunner,
   Repository,
   UpdateResult,
@@ -12,12 +13,12 @@ import { VisitationMetaModel } from '../../../visitation/entity/visitation-meta.
 import { MemberModel } from '../../../members/entity/member.entity';
 import { GetVisitationReportDto } from '../../dto/visitation-report/get-visitation-report.dto';
 import {
+  ConflictException,
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
 import { VisitationReportException } from '../../const/exception/visitation-report.exception';
 import { UpdateVisitationReportDto } from '../../dto/visitation-report/update-visitation-report.dto';
-import { ReportModel } from '../../entity/report.entity';
 import { VisitationReportOrderEnum } from '../../const/visitation-report-order.enum';
 import {
   VisitationReportFindOptionsRelation,
@@ -25,6 +26,11 @@ import {
   VisitationReportsFindOptionsRelation,
   VisitationReportsFindOptionsSelect,
 } from '../../const/report-find-options.const';
+import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
+import { MAX_RECEIVER_COUNT } from '../../const/report.constraints';
+import { TaskReportException } from '../../const/exception/task-report.exception';
+import { AddConflictExceptionV2 } from '../../../common/exception/add-conflict.exception';
+import { RemoveConflictException } from '../../../common/exception/remove-conflict.exception';
 
 export class VisitationReportDomainService
   implements IVisitationReportDomainService
@@ -39,22 +45,50 @@ export class VisitationReportDomainService
       ? qr.manager.getRepository(VisitationReportModel)
       : this.visitationReportRepository;
 
-  createVisitationReport(
+  async createVisitationReports(
     visitation: VisitationMetaModel,
-    //sender: MemberModel,
-    receiver: MemberModel,
+    newReceivers: ChurchUserModel[],
     qr: QueryRunner,
-  ) {
+  ): Promise<VisitationReportModel[]> {
     const repository = this.getRepository(qr);
 
-    return repository.save({
-      visitation,
-      //senderId: sender ? sender.id : undefined,
-      receiver,
-      reportedAt: new Date(),
-      isRead: false,
-      isConfirmed: false,
+    const oldReports = await repository.find({
+      where: { visitationId: visitation.id },
     });
+    const oldReceiverIds = new Set(
+      oldReports.map((report) => report.receiverId),
+    );
+
+    if (oldReports.length + newReceivers.length > MAX_RECEIVER_COUNT) {
+      throw new ConflictException(VisitationReportException.EXCEED_RECEIVERS);
+    }
+
+    const failed: { receiverId: number; reason: string }[] = [];
+
+    for (const receiver of newReceivers) {
+      if (oldReceiverIds.has(receiver.member.id)) {
+        failed.push({
+          receiverId: receiver.member.id,
+          reason: TaskReportException.ALREADY_REPORTED_MEMBER,
+        });
+      }
+    }
+
+    if (failed.length > 0) {
+      throw new AddConflictExceptionV2('피보고자 추가 실패', failed);
+    }
+
+    const reports = newReceivers.map((receiver) =>
+      repository.create({
+        visitation: visitation,
+        receiver: receiver.member,
+        reportedAt: new Date(),
+        isRead: false,
+        isConfirmed: false,
+      }),
+    );
+
+    return repository.save(reports);
   }
 
   async findVisitationReportsByReceiver(
@@ -189,14 +223,52 @@ export class VisitationReportDomainService
     return result;
   }
 
-  async deleteVisitationReports(
-    visitationReports: ReportModel[],
-    qr?: QueryRunner,
-  ) {
+  deleteVisitationReportCascade(
+    visitation: VisitationMetaModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
     const repository = this.getRepository(qr);
 
-    const reportIds = visitationReports.map((r) => r.id);
+    return repository.softDelete({ visitationId: visitation.id });
+  }
 
-    return repository.softDelete(reportIds);
+  async deleteVisitationReports(
+    visitation: VisitationMetaModel,
+    receiverIds: number[],
+    qr?: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    const reports = await repository.find({
+      where: {
+        visitationId: visitation.id,
+      },
+    });
+
+    const oldReceiverIds = new Set(reports.map((report) => report.receiverId));
+
+    const notExistReceiverIds = receiverIds.filter(
+      (id) => !oldReceiverIds.has(id),
+    );
+
+    if (notExistReceiverIds.length > 0) {
+      throw new RemoveConflictException(
+        VisitationReportException.NOT_EXIST_REPORTED_MEMBER,
+        notExistReceiverIds,
+      );
+    }
+
+    const result = await repository.softDelete({
+      visitationId: visitation.id,
+      receiverId: In(receiverIds),
+    });
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        VisitationReportException.DELETE_ERROR,
+      );
+    }
+
+    return result;
   }
 }


### PR DESCRIPTION
## 주요 내용
VisitationReport 생성 시 피보고자(receiver)의 유효성을 판단하는 기준을 MemberModel 단독에서 ChurchUserModel 기반으로 변경하여, 계정 가입 여부와 권한 조건을 보다 명확하게 검증하도록 개선하였습니다.

## 세부 내용

### ✅ 유효성 체크 로직 강화
- 피보고자는 `ChurchUserRole`이 `manager` 또는 `owner`인 경우만 허용
- 단순히 교회에 등록된 교인(Member)이 아닌, **교회에 계정으로 가입된 ChurchUser**인지 여부 검증
- 비계정 교인(Member만 존재, ChurchUser 없음)은 피보고자로 지정 불가

### 🧱 참조 구조 유지
- `VisitationReportModel.receiver` 필드는 기존대로 `MemberModel`을 참조
- 다만, 서비스 로직에서는 ChurchUser를 통해 연결된 Member를 추출해 설정