### PR TITLE
feat: 권한 유형별 매니저 조회 API 응답 형식 개선 및 권한 단위 갱신 버그 수정

### DIFF
--- a/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
+++ b/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
@@ -4,6 +4,7 @@ import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { PermissionTemplateModel } from '../../../../permission/entity/permission-template.entity';
 import { ManagerDomainPaginationResultDto } from '../../dto/manager-domain-pagination-result.dto';
 import { ChurchUserModel } from '../../../../church-user/entity/church-user.entity';
+import { GetManagersByPermissionTemplateDto } from '../../../../permission/dto/template/request/get-managers-by-permission-template.dto';
 
 export const IMANAGER_DOMAIN_SERVICE = Symbol('IMANAGER_DOMAIN_SERVICE');
 
@@ -20,6 +21,13 @@ export interface IManagerDomainService {
     qr?: QueryRunner,
     relationOptions?: FindOptionsRelations<ChurchUserModel>,
   ): Promise<ChurchUserModel>;
+
+  findManagersByPermissionTemplate(
+    church: ChurchModel,
+    permissionTemplate: PermissionTemplateModel,
+    dto: GetManagersByPermissionTemplateDto,
+    qr?: QueryRunner,
+  ): Promise<ManagerDomainPaginationResultDto>;
 
   findManagerByUserId(
     church: ChurchModel,

--- a/backend/src/permission/controller/permission.controller.ts
+++ b/backend/src/permission/controller/permission.controller.ts
@@ -19,6 +19,7 @@ import { CreatePermissionTemplateDto } from '../dto/template/request/create-perm
 import { UpdatePermissionTemplateDto } from '../dto/template/request/update-permission-template.dto';
 import {
   ApiDeletePermissionTemplate,
+  ApiGetManagersByPermissionTemplate,
   ApiGetPermissionTemplateById,
   ApiGetPermissionTemplates,
   ApiGetPermissionUnits,
@@ -29,6 +30,7 @@ import {
 import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
+import { GetManagersByPermissionTemplateDto } from '../dto/template/request/get-managers-by-permission-template.dto';
 
 @ApiTags('Churches:Permissions')
 @Controller('permissions')
@@ -82,6 +84,20 @@ export class PermissionController {
     return this.permissionService.getPermissionTemplateById(
       churchId,
       templateId,
+    );
+  }
+
+  @ApiGetManagersByPermissionTemplate()
+  @Get('templates/:templateId/managers')
+  getManagersByPermissionTemplate(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('templateId', ParseIntPipe) templateId: number,
+    @Query() dto: GetManagersByPermissionTemplateDto,
+  ) {
+    return this.permissionService.getManagersByPermissionTemplate(
+      churchId,
+      templateId,
+      dto,
     );
   }
 

--- a/backend/src/permission/dto/template/request/get-managers-by-permission-template.dto.ts
+++ b/backend/src/permission/dto/template/request/get-managers-by-permission-template.dto.ts
@@ -1,0 +1,15 @@
+import { BaseOffsetPaginationRequestDto } from '../../../../common/dto/request/base-offset-pagination-request.dto';
+import { ManagerOrder } from '../../../../manager/const/manager-order.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+
+export class GetManagersByPermissionTemplateDto extends BaseOffsetPaginationRequestDto<ManagerOrder> {
+  @ApiProperty({
+    description: '정렬 기준',
+    enum: ManagerOrder,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(ManagerOrder)
+  order: ManagerOrder = ManagerOrder.JOINED_AT;
+}

--- a/backend/src/permission/permission-domain/service/interface/permission-domain.service.interface.ts
+++ b/backend/src/permission/permission-domain/service/interface/permission-domain.service.interface.ts
@@ -43,7 +43,7 @@ export interface IPermissionDomainService {
     template: PermissionTemplateModel,
     dto: UpdatePermissionTemplateDto,
     qr?: QueryRunner,
-  ): Promise<UpdateResult>;
+  ): Promise<void>;
 
   deletePermissionTemplate(
     template: PermissionTemplateModel,

--- a/backend/src/permission/permission-domain/service/permission-domain.service.ts
+++ b/backend/src/permission/permission-domain/service/permission-domain.service.ts
@@ -238,11 +238,20 @@ export class PermissionDomainService implements IPermissionDomainService {
 
     if (dto.title) {
       await this.assertValidTemplateTitle(church, dto.title, qr);
+      template.title = dto.title;
+    }
+
+    if (units) {
+      template.permissionUnits = units;
     }
 
     const templateRepository = this.getTemplateRepository(qr);
 
-    const result = await templateRepository.update(
+    await templateRepository.save(template);
+
+    return;
+
+    /*const result = await templateRepository.update(
       {
         churchId: church.id,
         id: template.id,
@@ -257,7 +266,7 @@ export class PermissionDomainService implements IPermissionDomainService {
       throw new InternalServerErrorException(PermissionException.UPDATE_ERROR);
     }
 
-    return result;
+    return result;*/
   }
 
   async deletePermissionTemplate(

--- a/backend/src/permission/permission.module.ts
+++ b/backend/src/permission/permission.module.ts
@@ -4,6 +4,7 @@ import { PermissionController } from './controller/permission.controller';
 import { PermissionService } from './service/permission.service';
 import { PermissionDomainModule } from './permission-domain/permission-domain.module';
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
+import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
 
 @Module({
   imports: [
@@ -11,7 +12,7 @@ import { ChurchesDomainModule } from '../churches/churches-domain/churches-domai
       { path: 'churches/:churchId', module: PermissionModule },
     ]),
     ChurchesDomainModule,
-
+    ManagerDomainModule,
     PermissionDomainModule,
   ],
   controllers: [PermissionController],

--- a/backend/src/permission/swagger/permission.swagger.ts
+++ b/backend/src/permission/swagger/permission.swagger.ts
@@ -87,3 +87,11 @@ export const ApiDeletePermissionTemplate = () =>
         '<p><a href="https://test-khn.atlassian.net/wiki/x/iAD8Ag">세부 문서</a></p>',
     }),
   );
+
+export const ApiGetManagersByPermissionTemplate = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '권한 유형에 속한 매니저 목록 조회',
+      description: '해당 권한 유형에 속한 매니저 목록 조회',
+    }),
+  );


### PR DESCRIPTION
## 주요 내용
특정 권한 유형에 할당된 매니저 목록을 조회하는 엔드포인트를 추가하고,
응답 시 ChurchUser 가 아닌 연결된 MemberModel 을 기준으로 반환하도록 응답 포맷을 개선했습니다. 또한 권한 단위(permissionUnits)가 정상적으로 반영되지 않던 문제를 해결했습니다.

## 세부 내용

### ✅ 권한 유형별 매니저 목록 조회 API
- `GET /churches/{churchId}/permissions/templates/{templateId}/managers` 추가
- 조회 파라미터:
  - `take`, `page`
  - `order` (`joinedAt`, `role`, `createdAt`, `updatedAt`)
  - `orderDirection` (`ASC`, `DESC`)
- 응답 포맷: 매니저 ChurchUser 가 아닌, **연결된 MemberModel 정보**로 응답

### 🛠 권한 단위 갱신 버그 수정
- N:M 관계 필드(`permissionUnits`)에 대해 `update()` 사용 시 발생하던 예외 해결
- `save()` 방식으로 권한 단위가 정상 반영되도록 처리 방식 변경