### PR TITLE
feat: 권한 유형별 매니저 조회 시 Member 외 User 정보 포함 및 응답 포맷 확장

### DIFF
--- a/backend/src/manager/const/manager-find-options.const.ts
+++ b/backend/src/manager/const/manager-find-options.const.ts
@@ -8,11 +8,17 @@ import {
 export const ManagersFindOptionsRelations: FindOptionsRelations<ChurchUserModel> =
   {
     member: MemberSummarizedRelation,
+    user: true,
     permissionTemplate: true,
   };
 
 export const ManagersFindOptionsSelect: FindOptionsSelect<ChurchUserModel> = {
   member: MemberSummarizedSelect,
+  user: {
+    id: true,
+    name: true,
+    mobilePhone: true,
+  },
   permissionTemplate: {
     id: true,
     title: true,
@@ -23,8 +29,14 @@ export const ManagerFindOptionsRelations: FindOptionsRelations<ChurchUserModel> 
   {
     member: MemberSummarizedRelation,
     permissionTemplate: { permissionUnits: true },
+    user: true,
   };
 
 export const ManagerFindOptionsSelect: FindOptionsSelect<ChurchUserModel> = {
   member: MemberSummarizedSelect,
+  user: {
+    id: true,
+    name: true,
+    mobilePhone: true,
+  },
 };


### PR DESCRIPTION
## 주요 내용
권한 유형에 속한 매니저들을 조회할 때 응답에 ChurchUser 와 연결된 Member 정보뿐 아니라, 해당 ChurchUser 와 연결된 User 의 기본 정보(id, name, mobilePhone)도 함께 제공하도록 응답 형식을 확장했습니다.

## 세부 내용

### 📘 응답 포맷 확장
- 기존 응답: MemberModel 정보만 포함
- 변경 응답: MemberModel 정보 + User 요약 정보 포함
  - `user: { id: number, name: string, mobilePhone: string }`

### 🧩 목적 및 효과
- 프론트엔드에서 매니저 정보를 사용자 계정 기준으로 쉽게 식별 가능
- 교회 관리자 목록에 이름, 전화번호 등 계정 정보 노출 요구사항 충족