### PR TITLE
feat: 매니저 권한 범위 관리 기능 및 수정 API 추가

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -57,6 +57,7 @@ import { PermissionTemplateModel } from './permission/entity/permission-template
 import { ManagerModule } from './manager/manager.module';
 import { ChurchUserModule } from './church-user/church-user.module';
 import { ChurchUserModel } from './church-user/entity/church-user.entity';
+import { PermissionScopeModel } from './permission/entity/permission-scope.entity';
 
 @Module({
   imports: [
@@ -167,6 +168,7 @@ import { ChurchUserModel } from './church-user/entity/church-user.entity';
           // 권한 관련
           PermissionUnitModel,
           PermissionTemplateModel,
+          PermissionScopeModel,
         ],
         synchronize: true,
       }),

--- a/backend/src/church-user/entity/church-user.entity.ts
+++ b/backend/src/church-user/entity/church-user.entity.ts
@@ -5,6 +5,7 @@ import {
   Index,
   JoinColumn,
   ManyToOne,
+  OneToMany,
   OneToOne,
 } from 'typeorm';
 import { ChurchModel } from '../../churches/entity/church.entity';
@@ -12,6 +13,7 @@ import { UserModel } from '../../user/entity/user.entity';
 import { MemberModel } from '../../members/entity/member.entity';
 import { ChurchUserRole } from '../../user/const/user-role.enum';
 import { PermissionTemplateModel } from '../../permission/entity/permission-template.entity';
+import { PermissionScopeModel } from '../../permission/entity/permission-scope.entity';
 
 @Entity()
 export class ChurchUserModel extends BaseModel {
@@ -49,6 +51,12 @@ export class ChurchUserModel extends BaseModel {
   @ManyToOne(() => PermissionTemplateModel)
   @JoinColumn({ name: 'permissionTemplateId' })
   permissionTemplate: PermissionTemplateModel;
+
+  @OneToMany(
+    () => PermissionScopeModel,
+    (permissionScope) => permissionScope.churchUser,
+  )
+  permissionScopes: PermissionScopeModel[];
 
   @Column({ default: false })
   isPermissionActive: boolean;

--- a/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
+++ b/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
@@ -37,6 +37,13 @@ export interface IGroupsDomainService {
     qr?: QueryRunner,
   ): Promise<GroupModel>;
 
+  findGroupModelsByIds(
+    church: ChurchModel,
+    groupIds: number[],
+    qr?: QueryRunner,
+    relationsOptions?: FindOptionsRelations<GroupModel>,
+  ): Promise<GroupModel[]>;
+
   findGroupModelById(
     church: ChurchModel,
     groupId: number,

--- a/backend/src/management/groups/groups-domain/service/groups-domain.service.ts
+++ b/backend/src/management/groups/groups-domain/service/groups-domain.service.ts
@@ -15,6 +15,7 @@ import { CreateGroupDto } from '../../dto/group/create-group.dto';
 import {
   FindOptionsOrder,
   FindOptionsRelations,
+  In,
   IsNull,
   QueryRunner,
   Repository,
@@ -114,6 +115,29 @@ export class GroupsDomainService implements IGroupsDomainService {
     }
 
     return group;
+  }
+
+  async findGroupModelsByIds(
+    church: ChurchModel,
+    groupIds: number[],
+    qr?: QueryRunner,
+    relationsOptions?: FindOptionsRelations<GroupModel>,
+  ) {
+    const groupRepository = this.getGroupsRepository(qr);
+
+    const groups = await groupRepository.find({
+      where: {
+        churchId: church.id,
+        id: In(groupIds),
+      },
+      relations: relationsOptions,
+    });
+
+    if (groups.length !== groupIds.length) {
+      throw new NotFoundException(GroupException.NOT_FOUND);
+    }
+
+    return groups;
   }
 
   async findGroupById(

--- a/backend/src/manager/const/manager-find-options.const.ts
+++ b/backend/src/manager/const/manager-find-options.const.ts
@@ -10,6 +10,7 @@ export const ManagersFindOptionsRelations: FindOptionsRelations<ChurchUserModel>
     member: MemberSummarizedRelation,
     user: true,
     permissionTemplate: true,
+    permissionScopes: { group: true },
   };
 
 export const ManagersFindOptionsSelect: FindOptionsSelect<ChurchUserModel> = {
@@ -23,6 +24,14 @@ export const ManagersFindOptionsSelect: FindOptionsSelect<ChurchUserModel> = {
     id: true,
     title: true,
   },
+  permissionScopes: {
+    id: true,
+    isAllGroups: true,
+    group: {
+      id: true,
+      name: true,
+    },
+  },
 };
 
 export const ManagerFindOptionsRelations: FindOptionsRelations<ChurchUserModel> =
@@ -30,6 +39,7 @@ export const ManagerFindOptionsRelations: FindOptionsRelations<ChurchUserModel> 
     member: MemberSummarizedRelation,
     permissionTemplate: { permissionUnits: true },
     user: true,
+    permissionScopes: { group: true },
   };
 
 export const ManagerFindOptionsSelect: FindOptionsSelect<ChurchUserModel> = {
@@ -38,5 +48,13 @@ export const ManagerFindOptionsSelect: FindOptionsSelect<ChurchUserModel> = {
     id: true,
     name: true,
     mobilePhone: true,
+  },
+  permissionScopes: {
+    id: true,
+    isAllGroups: true,
+    group: {
+      id: true,
+      name: true,
+    },
   },
 };

--- a/backend/src/manager/controller/manager.controller.ts
+++ b/backend/src/manager/controller/manager.controller.ts
@@ -15,6 +15,7 @@ import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
 import { AssignPermissionTemplateDto } from '../dto/request/assign-permission-template.dto';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { UpdatePermissionScopeDto } from '../dto/request/update-permission-scope.dto';
 
 @ApiTags('Churches:Managers')
 @Controller('managers')
@@ -78,6 +79,22 @@ export class ManagerController {
     return this.managerService.unassignPermissionTemplate(
       churchId,
       managerId,
+      qr,
+    );
+  }
+
+  @Patch(':managerId/permission-scope')
+  @UseInterceptors(TransactionInterceptor)
+  patchPermissionScope(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('managerId', ParseIntPipe) managerId: number,
+    @Body() dto: UpdatePermissionScopeDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.managerService.patchPermissionScope(
+      churchId,
+      managerId,
+      dto,
       qr,
     );
   }

--- a/backend/src/manager/dto/request/update-permission-scope.dto.ts
+++ b/backend/src/manager/dto/request/update-permission-scope.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsBoolean, IsNumber, IsOptional } from 'class-validator';
+
+export class UpdatePermissionScopeDto {
+  @ApiProperty({
+    description: '권한 유형의 범위',
+    isArray: true,
+  })
+  @IsNumber({}, { each: true })
+  @IsArray()
+  groupIds: number[];
+
+  @ApiProperty({
+    description: '전체 범위',
+    default: false,
+    required: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isAllGroups: boolean = false;
+}

--- a/backend/src/manager/manager.module.ts
+++ b/backend/src/manager/manager.module.ts
@@ -6,6 +6,7 @@ import { ManagerService } from './service/manager.service';
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
 import { PermissionDomainModule } from '../permission/permission-domain/permission-domain.module';
 import { UserDomainModule } from '../user/user-domain/user-domain.module';
+import { GroupsDomainModule } from '../management/groups/groups-domain/groups-domain.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { UserDomainModule } from '../user/user-domain/user-domain.module';
     ChurchesDomainModule,
     PermissionDomainModule,
     ManagerDomainModule,
+    GroupsDomainModule,
   ],
   controllers: [ManagerController],
   providers: [ManagerService],

--- a/backend/src/manager/service/manager.service.ts
+++ b/backend/src/manager/service/manager.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { ConflictException, Inject, Injectable } from '@nestjs/common';
 import { GetManagersDto } from '../dto/request/get-managers.dto';
 import {
   ICHURCHES_DOMAIN_SERVICE,
@@ -17,6 +17,20 @@ import {
   IMANAGER_DOMAIN_SERVICE,
   IManagerDomainService,
 } from '../manager-domain/service/interface/manager-domain.service.interface';
+import { UpdatePermissionScopeDto } from '../dto/request/update-permission-scope.dto';
+import {
+  IGROUPS_DOMAIN_SERVICE,
+  IGroupsDomainService,
+} from '../../management/groups/groups-domain/interface/groups-domain.service.interface';
+import {
+  IPERMISSION_SCOPE_DOMAIN_SERVICE,
+  IPermissionScopeDomainService,
+} from '../../permission/permission-domain/service/interface/permission-scope-domain.service.interface';
+import { PermissionScopeModel } from '../../permission/entity/permission-scope.entity';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { ChurchUserRole } from '../../user/const/user-role.enum';
+import { PermissionScopeException } from '../../permission/exception/permission-scope.exception';
 
 @Injectable()
 export class ManagerService {
@@ -27,6 +41,10 @@ export class ManagerService {
     private readonly managerDomainService: IManagerDomainService,
     @Inject(IPERMISSION_DOMAIN_SERVICE)
     private readonly permissionDomainService: IPermissionDomainService,
+    @Inject(IPERMISSION_SCOPE_DOMAIN_SERVICE)
+    private readonly permissionScopeDomainService: IPermissionScopeDomainService,
+    @Inject(IGROUPS_DOMAIN_SERVICE)
+    private readonly groupsDomainService: IGroupsDomainService,
   ) {}
 
   async getManagers(churchId: number, dto: GetManagersDto) {
@@ -175,5 +193,128 @@ export class ManagerService {
     );
 
     return new PatchManagerResponseDto(updatedManager);
+  }
+
+  private async handleAllGroupScope(
+    manager: ChurchUserModel,
+    existingScope: PermissionScopeModel[],
+    qr: QueryRunner,
+  ) {
+    const toRemove: PermissionScopeModel[] = [];
+
+    // 기존 권한 범위 삭제
+    existingScope.forEach((scope) => {
+      if (!scope.isAllGroups) {
+        toRemove.push(scope);
+      }
+    });
+
+    if (toRemove.length > 0) {
+      await this.permissionScopeDomainService.deletePermissionScope(
+        toRemove,
+        qr,
+      );
+    }
+
+    // 기존 isAllGroups 가 존재하는지 확인
+    const exists = existingScope.find((s) => s.isAllGroups);
+
+    if (!exists) {
+      // isAllGroups 가 true 인 PermissionScope 생성
+      await this.permissionScopeDomainService.createAllGroupPermissionScope(
+        manager,
+        qr,
+      );
+    }
+  }
+
+  private async handlePermissionScopeChange(
+    church: ChurchModel,
+    manager: ChurchUserModel,
+    existingScope: PermissionScopeModel[],
+    dto: UpdatePermissionScopeDto,
+    qr: QueryRunner,
+  ) {
+    const toCreate: number[] = [];
+    const toRemove: PermissionScopeModel[] = [];
+
+    const existingMap = new Map<number, PermissionScopeModel>();
+
+    for (const scope of existingScope) {
+      if (!scope.isAllGroups && scope.groupId !== null) {
+        existingMap.set(scope.groupId, scope);
+      }
+    }
+
+    const newSet = new Set(dto.groupIds);
+
+    for (const [groupId, scope] of existingMap.entries()) {
+      if (!newSet.has(groupId)) toRemove.push(scope);
+    }
+
+    for (const groupId of newSet) {
+      if (!existingMap.has(groupId)) toCreate.push(groupId);
+    }
+
+    toRemove.push(...existingScope.filter((s) => s.isAllGroups));
+
+    const toCreateGroups =
+      toCreate.length > 0
+        ? await this.groupsDomainService.findGroupModelsByIds(
+            church,
+            toCreate,
+            qr,
+          )
+        : [];
+
+    await this.permissionScopeDomainService.applyPermissionScopeChange(
+      manager,
+      toCreateGroups,
+      toRemove,
+      qr,
+    );
+  }
+
+  async patchPermissionScope(
+    churchId: number,
+    managerId: number,
+    dto: UpdatePermissionScopeDto,
+    qr: QueryRunner,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const manager = await this.managerDomainService.findManagerById(
+      church,
+      managerId,
+      qr,
+    );
+
+    if (manager.role === ChurchUserRole.OWNER) {
+      throw new ConflictException(PermissionScopeException.OWNER);
+    }
+
+    const existingScope =
+      await this.permissionScopeDomainService.findPermissionScopeByChurchUserId(
+        manager,
+        qr,
+      );
+
+    // 전체 그룹 범위 지정
+    if (dto.isAllGroups) {
+      await this.handleAllGroupScope(manager, existingScope, qr);
+
+      return this.managerDomainService.findManagerById(church, managerId, qr);
+    } else {
+      await this.handlePermissionScopeChange(
+        church,
+        manager,
+        existingScope,
+        dto,
+        qr,
+      );
+
+      return this.managerDomainService.findManagerById(church, managerId, qr);
+    }
   }
 }

--- a/backend/src/permission/entity/permission-scope.entity.ts
+++ b/backend/src/permission/entity/permission-scope.entity.ts
@@ -1,0 +1,29 @@
+import { BaseModel } from '../../common/entity/base.entity';
+import { Check, Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { GroupModel } from '../../management/groups/entity/group.entity';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+
+@Entity()
+@Check(
+  `("isAllGroups" = true AND "groupId" IS NULL) OR ("isAllGroups" = false AND "groupId" IS NOT NULL)`,
+)
+export class PermissionScopeModel extends BaseModel {
+  @Index()
+  @Column()
+  churchUserId: number;
+
+  @ManyToOne(() => ChurchUserModel, (churchUser) => churchUser.permissionScopes)
+  @JoinColumn({ name: 'churchUserId' })
+  churchUser: ChurchUserModel;
+
+  @Column({ default: false })
+  isAllGroups: boolean;
+
+  @Index()
+  @Column({ nullable: true })
+  groupId: number;
+
+  @ManyToOne(() => GroupModel, { nullable: true })
+  @JoinColumn({ name: 'groupId' })
+  group: GroupModel;
+}

--- a/backend/src/permission/exception/permission-scope.exception.ts
+++ b/backend/src/permission/exception/permission-scope.exception.ts
@@ -1,0 +1,4 @@
+export const PermissionScopeException = {
+  DELETE_ERROR: '권한 범위 삭제 도중 에러 발생',
+  OWNER: '소유자 권한 관리자는 권한 범위를 설정할 수 없습니다.',
+};

--- a/backend/src/permission/permission-domain/permission-domain.module.ts
+++ b/backend/src/permission/permission-domain/permission-domain.module.ts
@@ -5,15 +5,30 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { PermissionUnitModel } from '../entity/permission-unit.entity';
 import { PermissionUnitSeederService } from './service/permission-unit-seeder.service';
 import { PermissionTemplateModel } from '../entity/permission-template.entity';
+import { PermissionScopeModel } from '../entity/permission-scope.entity';
+import { IPERMISSION_SCOPE_DOMAIN_SERVICE } from './service/interface/permission-scope-domain.service.interface';
+import { PermissionScopeDomainService } from './service/permission-scope-domain.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([PermissionUnitModel, PermissionTemplateModel]),
+    TypeOrmModule.forFeature([
+      PermissionUnitModel,
+      PermissionTemplateModel,
+      PermissionScopeModel,
+    ]),
   ],
   providers: [
     PermissionUnitSeederService,
     { provide: IPERMISSION_DOMAIN_SERVICE, useClass: PermissionDomainService },
+    {
+      provide: IPERMISSION_SCOPE_DOMAIN_SERVICE,
+      useClass: PermissionScopeDomainService,
+    },
   ],
-  exports: [PermissionUnitSeederService, IPERMISSION_DOMAIN_SERVICE],
+  exports: [
+    PermissionUnitSeederService,
+    IPERMISSION_DOMAIN_SERVICE,
+    IPERMISSION_SCOPE_DOMAIN_SERVICE,
+  ],
 })
 export class PermissionDomainModule {}

--- a/backend/src/permission/permission-domain/service/interface/permission-scope-domain.service.interface.ts
+++ b/backend/src/permission/permission-domain/service/interface/permission-scope-domain.service.interface.ts
@@ -1,0 +1,39 @@
+import { ChurchUserModel } from '../../../../church-user/entity/church-user.entity';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
+import { PermissionScopeModel } from '../../../entity/permission-scope.entity';
+import { GroupModel } from '../../../../management/groups/entity/group.entity';
+
+export const IPERMISSION_SCOPE_DOMAIN_SERVICE = Symbol(
+  'IPERMISSION_SCOPE_DOMAIN_SERVICE',
+);
+
+export interface IPermissionScopeDomainService {
+  findPermissionScopeByChurchUserId(
+    churchUser: ChurchUserModel,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<PermissionScopeModel>,
+  ): Promise<PermissionScopeModel[]>;
+
+  createAllGroupPermissionScope(
+    churchUser: ChurchUserModel,
+    qr: QueryRunner,
+  ): Promise<PermissionScopeModel>;
+
+  createPermissionScope(
+    churchUser: ChurchUserModel,
+    groups: GroupModel[],
+    qr: QueryRunner,
+  ): Promise<PermissionScopeModel[]>;
+
+  deletePermissionScope(
+    toRemove: PermissionScopeModel[],
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  applyPermissionScopeChange(
+    churchUser: ChurchUserModel,
+    toCreate: GroupModel[],
+    toRemove: PermissionScopeModel[],
+    qr: QueryRunner,
+  ): Promise<void>;
+}

--- a/backend/src/permission/permission-domain/service/permission-scope-domain.service.ts
+++ b/backend/src/permission/permission-domain/service/permission-scope-domain.service.ts
@@ -1,0 +1,116 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { IPermissionScopeDomainService } from './interface/permission-scope-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { PermissionScopeModel } from '../../entity/permission-scope.entity';
+import {
+  FindOptionsRelations,
+  QueryRunner,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
+import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
+import { GroupModel } from '../../../management/groups/entity/group.entity';
+import { PermissionScopeException } from '../../exception/permission-scope.exception';
+
+@Injectable()
+export class PermissionScopeDomainService
+  implements IPermissionScopeDomainService
+{
+  constructor(
+    @InjectRepository(PermissionScopeModel)
+    private readonly permissionScopeRepository: Repository<PermissionScopeModel>,
+  ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(PermissionScopeModel)
+      : this.permissionScopeRepository;
+  }
+
+  async findPermissionScopeByChurchUserId(
+    churchUser: ChurchUserModel,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<PermissionScopeModel>,
+  ) {
+    const repository = this.getRepository(qr);
+
+    return repository.find({
+      where: {
+        churchUserId: churchUser.id,
+      },
+      relations: relationOptions,
+    });
+  }
+
+  async createAllGroupPermissionScope(
+    churchUser: ChurchUserModel,
+    qr: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    return repository.save({
+      churchUserId: churchUser.id,
+      isAllGroups: true,
+    });
+  }
+
+  async createPermissionScope(
+    churchUser: ChurchUserModel,
+    groups: GroupModel[],
+    qr: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    const permissionScopes = this.permissionScopeRepository.create(
+      groups.map((group) => ({
+        churchUserId: churchUser.id,
+        groupId: group.id,
+        isAllGroups: false,
+      })),
+    );
+
+    return repository.save(permissionScopes);
+  }
+
+  async deletePermissionScope(
+    toRemove: PermissionScopeModel[],
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    const result = await repository.softDelete(toRemove.map((t) => t.id));
+
+    if (result.affected !== toRemove.length) {
+      throw new InternalServerErrorException(
+        PermissionScopeException.DELETE_ERROR,
+      );
+    }
+
+    return result;
+  }
+
+  async applyPermissionScopeChange(
+    churchUser: ChurchUserModel,
+    toCreate: GroupModel[],
+    toRemove: PermissionScopeModel[],
+    qr: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    if (toRemove && toRemove.length > 0) {
+      await repository.softRemove(toRemove);
+    }
+
+    const newScopes = toCreate.map((group) =>
+      repository.create({
+        churchUserId: churchUser.id,
+        isAllGroups: false,
+        groupId: group.id,
+      }),
+    );
+
+    if (newScopes.length > 0) {
+      await repository.save(newScopes);
+    }
+  }
+}


### PR DESCRIPTION
## 주요 내용
매니저(ChurchUser)의 그룹 단위 권한 범위를 설정/갱신할 수 있는 PermissionScopeModel 도입 및 관련 엔드포인트 구현

## 세부 내용

### 모델 정의
- PermissionScopeModel 생성
  - ChurchUser와 Group 간의 중간 테이블 역할
  - 전체 그룹 유효 여부를 나타내는 isAllGroups 플래그 추가
  - groupId는 nullable이며 isAllGroups=true일 경우 null로 설정됨
  - groupId와 isAllGroups의 조합 정합성을 보장하는 DB 체크 제약 추가

### 엔드포인트
- PATCH /churches/{churchId}/managers/{managerId}/permission-scope
  - 요청 프로퍼티: { groupIds: number[], isAllGroups: boolean }
  - isAllGroups가 true일 경우 groupIds는 무시됨
  - 기존 PermissionScope를 삭제한 후 최종적으로 적용할 스코프만 남김

### 내부 처리 로직
- Application 레이어에서 기존과 요청된 groupId를 비교하여 삭제/생성 대상 판단
- 도메인 서비스에서 판단 결과 기반으로 PermissionScope 삭제 및 생성 실행

## 목적 및 효과
- 매니저가 접근 가능한 권한 범위를 명확하게 그룹 단위로 설정 가능
- 전체 그룹 범위와 특정 그룹 범위를 유연하게 관리
- 스코프 변경 로직의 정합성과 확장성 확보