### PR TITLE
feat: 권한 범위 설정용 그룹 검색 API 추가

### DIFF
--- a/backend/src/management/groups/const/swagger/group.swagger.ts
+++ b/backend/src/management/groups/const/swagger/group.swagger.ts
@@ -70,3 +70,10 @@ export const ApiGetChildGroupIds = () =>
       description: '<h2>해당 그룹의 하위 그룹들의 id 값을 조회합니다.</h2>',
     }),
   );
+
+export const ApiGetGroupsByName = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '그룹 이름으로 검색',
+    }),
+  );

--- a/backend/src/management/groups/controller/groups.controller.ts
+++ b/backend/src/management/groups/controller/groups.controller.ts
@@ -22,10 +22,12 @@ import {
   ApiGetChildGroupIds,
   ApiGetGroupById,
   ApiGetGroups,
+  ApiGetGroupsByName,
   ApiPatchGroup,
   ApiPostGroups,
 } from '../const/swagger/group.swagger';
 import { GetGroupDto } from '../dto/group/get-group.dto';
+import { GetGroupByNameDto } from '../dto/group/get-group-by-name.dto';
 
 @ApiTags('Management:Groups')
 @Controller('groups')
@@ -39,6 +41,15 @@ export class GroupsController {
     @Query() dto: GetGroupDto,
   ) {
     return this.groupsService.getGroups(churchId, dto);
+  }
+
+  @ApiGetGroupsByName()
+  @Get('search')
+  getGroupsByName(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetGroupByNameDto,
+  ) {
+    return this.groupsService.getGroupsByName(churchId, dto);
   }
 
   @ApiPostGroups()

--- a/backend/src/management/groups/dto/group/get-group-by-name.dto.ts
+++ b/backend/src/management/groups/dto/group/get-group-by-name.dto.ts
@@ -1,0 +1,30 @@
+import { BaseOffsetPaginationRequestDto } from '../../../../common/dto/request/base-offset-pagination-request.dto';
+import { GroupOrderEnum } from '../../const/group-order.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import { Transform } from 'class-transformer';
+import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
+
+export class GetGroupByNameDto extends BaseOffsetPaginationRequestDto<GroupOrderEnum> {
+  @ApiProperty({
+    description: '정렬 기준',
+    enum: GroupOrderEnum,
+    default: GroupOrderEnum.createdAt,
+    required: false,
+  })
+  @IsEnum(GroupOrderEnum)
+  @IsOptional()
+  order: GroupOrderEnum = GroupOrderEnum.createdAt;
+
+  @ApiProperty({
+    description: '검색 이름',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @IsNotEmpty()
+  @IsNoSpecialChar()
+  @Transform(({ value }) => value.replaceAll(' ', ''))
+  name: string;
+}

--- a/backend/src/management/groups/groups-domain/dto/group-domain-pagination-result.dto.ts
+++ b/backend/src/management/groups/groups-domain/dto/group-domain-pagination-result.dto.ts
@@ -1,0 +1,8 @@
+import { BaseDomainOffsetPaginationResultDto } from '../../../../common/dto/base-domain-offset-pagination-result.dto';
+import { GroupModel } from '../../entity/group.entity';
+
+export class GroupDomainPaginationResultDto extends BaseDomainOffsetPaginationResultDto<GroupModel> {
+  constructor(data: GroupModel[], totalCount: number) {
+    super(data, totalCount);
+  }
+}

--- a/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
+++ b/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
@@ -4,6 +4,8 @@ import { FindOptionsRelations, QueryRunner } from 'typeorm';
 import { CreateGroupDto } from '../../dto/group/create-group.dto';
 import { UpdateGroupDto } from '../../dto/group/update-group.dto';
 import { GetGroupDto } from '../../dto/group/get-group.dto';
+import { GetGroupByNameDto } from '../../dto/group/get-group-by-name.dto';
+import { GroupDomainPaginationResultDto } from '../dto/group-domain-pagination-result.dto';
 
 export interface ParentGroup {
   id: number;
@@ -29,7 +31,13 @@ export interface IGroupsDomainService {
   findGroups(
     church: ChurchModel,
     dto: GetGroupDto,
-  ): Promise<{ data: GroupModel[]; totalCount: number }>;
+  ): Promise<GroupDomainPaginationResultDto>;
+
+  findGroupsByName(
+    church: ChurchModel,
+    dto: GetGroupByNameDto,
+    qr?: QueryRunner,
+  ): Promise<GroupDomainPaginationResultDto>;
 
   findGroupById(
     church: ChurchModel,

--- a/backend/src/management/groups/service/groups.service.ts
+++ b/backend/src/management/groups/service/groups.service.ts
@@ -14,6 +14,7 @@ import {
 import { GetGroupDto } from '../dto/group/get-group.dto';
 import { GroupPaginationResultDto } from '../dto/response/group-pagination-result.dto';
 import { GroupDeleteResponseDto } from '../dto/response/group-delete-response.dto';
+import { GetGroupByNameDto } from '../dto/group/get-group-by-name.dto';
 
 @Injectable()
 export class GroupsService {
@@ -172,5 +173,27 @@ export class GroupsService {
     );
 
     return this.groupsDomainService.findChildGroups(group, qr);
+  }
+
+  async getGroupsByName(
+    churchId: number,
+    dto: GetGroupByNameDto,
+    qr?: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const { data, totalCount } =
+      await this.groupsDomainService.findGroupsByName(church, dto, qr);
+
+    return new GroupPaginationResultDto(
+      data,
+      totalCount,
+      data.length,
+      dto.page,
+      Math.ceil(totalCount / dto.take),
+    );
   }
 }


### PR DESCRIPTION
## 주요 내용
매니저 권한 범위 설정 시 사용할 수 있도록, 그룹 이름 기반 검색 엔드포인트 추가

## 세부 내용

### 엔드포인트
- GET /churches/{churchId}/management/groups/search

### 쿼리 파라미터
- take: 조회할 데이터 개수
- page: 조회할 페이지 번호
- order: 정렬 기준 (createdAt, updatedAt, name) — 기본값: createdAt
- orderDirection: 정렬 방향 (asc, desc) — 기본값: asc
- name: 그룹명 검색 키워드 (optional, 부분 일치)

### 기능
- 교회 내 그룹을 이름으로 검색 및 정렬
- 권한 범위 설정 시 그룹을 선택할 수 있도록 데이터 제공

## 목적 및 효과
- 권한 관리 시 그룹 선택 UX 개선
- 대규모 그룹 구성에서도 빠르고 정확한 검색 지원