### PR TITLE
refactor: ChurchUser 및 Manager 모듈에서 churchUserId 기반 조회로 통일

### DIFF
--- a/backend/src/church-user/church-user-domain/service/interface/church-user-domain.service.interface.ts
+++ b/backend/src/church-user/church-user-domain/service/interface/church-user-domain.service.interface.ts
@@ -33,6 +33,7 @@ export interface IChurchUserDomainService {
     qr?: QueryRunner,
   ): Promise<boolean>;
 
+  // 권한 인증용
   findChurchUserByUserId(
     userId: number,
     qr?: QueryRunner,
@@ -44,9 +45,9 @@ export interface IChurchUserDomainService {
     qr?: QueryRunner,
   ): Promise<ChurchUserDomainPaginationResultDto>;
 
-  findChurchUserByMember(
+  findChurchUserById(
     church: ChurchModel,
-    member: MemberModel,
+    churchUserId: number,
     qr?: QueryRunner,
   ): Promise<ChurchUserModel>;
 

--- a/backend/src/church-user/controller/church-user.controller.ts
+++ b/backend/src/church-user/controller/church-user.controller.ts
@@ -32,12 +32,12 @@ export class ChurchUserController {
   @ApiOperation({
     summary: '교회 가입 계정(교인) 단건 조회',
   })
-  @Get(':userId')
+  @Get(':churchUserId')
   getChurchUserById(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('userId', ParseIntPipe) userId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
   ) {
-    return this.churchUserService.getChurchUserByUserId(churchId, userId);
+    return this.churchUserService.getChurchUserByUserId(churchId, churchUserId);
   }
 
   @ApiOperation({
@@ -48,10 +48,10 @@ export class ChurchUserController {
       '<h2>교회에 가입한 교인의 role 을 변경합니다.</h2>' +
       '<p>변경 가능한 role: manager, member</p>',
   })
-  @Patch(':userId/role')
+  @Patch(':churchUserId/role')
   patchUserRole(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('userId', ParseIntPipe) userId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
     @Body() dto: UpdateChurchUserRoleDto,
   ) {
     throw new BadRequestException('현재 개발 범위 외의 기능');
@@ -62,7 +62,7 @@ export class ChurchUserController {
   @ApiOperation({
     summary: '계정 - 교인 정보 연결',
   })
-  @Patch(':userId/link-member')
+  @Patch(':churchUserId/link-member')
   linkMember() {
     return '개발 전';
   }
@@ -70,7 +70,7 @@ export class ChurchUserController {
   @ApiOperation({
     summary: '계정 - 교인 정보 연결 해제',
   })
-  @Patch(':userId/unlink-member')
+  @Patch(':churchUserId/unlink-member')
   unlinkMember() {
     return '개발 전';
   }
@@ -78,7 +78,7 @@ export class ChurchUserController {
   @ApiOperation({
     summary: '교회 계정 가입 취소',
   })
-  @Patch(':userId/leave-church')
+  @Patch(':churchUserId/leave-church')
   leaveChurch() {
     return '개발 전';
   }

--- a/backend/src/church-user/dto/response/church-user-pagination-response.dto.ts
+++ b/backend/src/church-user/dto/response/church-user-pagination-response.dto.ts
@@ -1,0 +1,14 @@
+import { BaseOffsetPaginationResponseDto } from '../../../common/dto/reponse/base-offset-pagination-response.dto';
+import { ChurchUserModel } from '../../entity/church-user.entity';
+
+export class ChurchUserPaginationResponseDto extends BaseOffsetPaginationResponseDto<ChurchUserModel> {
+  constructor(
+    data: ChurchUserModel[],
+    totalCount: number,
+    count: number,
+    page: number,
+    totalPage: number,
+  ) {
+    super(data, totalCount, count, page, totalPage);
+  }
+}

--- a/backend/src/church-user/dto/response/get-church-user-response.dto.ts
+++ b/backend/src/church-user/dto/response/get-church-user-response.dto.ts
@@ -1,0 +1,8 @@
+import { BaseGetResponseDto } from '../../../common/dto/reponse/base-get-response.dto';
+import { ChurchUserModel } from '../../entity/church-user.entity';
+
+export class GetChurchUserResponseDto extends BaseGetResponseDto<ChurchUserModel> {
+  constructor(data: ChurchUserModel) {
+    super(data);
+  }
+}

--- a/backend/src/church-user/dto/response/patch-church-user-response.dto.ts
+++ b/backend/src/church-user/dto/response/patch-church-user-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePatchResponseDto } from '../../../common/dto/reponse/base-patch-response.dto';
+import { ChurchUserModel } from '../../entity/church-user.entity';
+
+export class PatchChurchUserResponseDto extends BasePatchResponseDto<ChurchUserModel> {
+  constructor(data: ChurchUserModel) {
+    super(data);
+  }
+}

--- a/backend/src/church-user/exception/church-user.exception.ts
+++ b/backend/src/church-user/exception/church-user.exception.ts
@@ -1,0 +1,6 @@
+export const ChurchUserException = {
+  OWNER_CANNOT_LEAVE: '교회 소유자는 교회에서 탈퇴할 수 없습니다.',
+  NOT_FOUND: '해당 교회 가입 정보를 찾을 수 없습니다.',
+  UPDATE_ERROR: '교회 가입 정보 업데이트 도중 에러 발생',
+  DELETE_ERROR: '교회 가입 정보 삭제 도중 에러 발생',
+};

--- a/backend/src/church-user/service/church-user.service.ts
+++ b/backend/src/church-user/service/church-user.service.ts
@@ -18,6 +18,9 @@ import {
   IUSER_DOMAIN_SERVICE,
   IUserDomainService,
 } from '../../user/user-domain/interface/user-domain.service.interface';
+import { GetChurchUserResponseDto } from '../dto/response/get-church-user-response.dto';
+import { ChurchUserPaginationResponseDto } from '../dto/response/church-user-pagination-response.dto';
+import { PatchChurchUserResponseDto } from '../dto/response/patch-church-user-response.dto';
 
 @Injectable()
 export class ChurchUserService {
@@ -46,17 +49,18 @@ export class ChurchUserService {
     const { data, totalCount } =
       await this.churchUserDomainService.findChurchUsers(church, dto);
 
-    return {
+    return new ChurchUserPaginationResponseDto(
       data,
       totalCount,
-      count: data.length,
-      totalPage: Math.ceil(totalCount / dto.take),
-    };
+      data.length,
+      dto.page,
+      Math.ceil(totalCount / dto.take),
+    );
   }
 
   async getChurchUserByUserId(
     churchId: number,
-    userId: number,
+    churchUserId: number,
     qr?: QueryRunner,
   ) {
     const church = await this.churchesDomainService.findChurchModelById(
@@ -64,20 +68,18 @@ export class ChurchUserService {
       qr,
     );
 
-    const user = await this.userDomainService.findUserById(userId, qr);
-
-    const churchUser = await this.churchUserDomainService.findChurchUserByUser(
+    const churchUser = await this.churchUserDomainService.findChurchUserById(
       church,
-      user,
+      churchUserId,
       qr,
     );
 
-    return churchUser;
+    return new GetChurchUserResponseDto(churchUser);
   }
 
   async patchChurchUserRole(
     churchId: number,
-    userId: number,
+    churchUserId: number,
     dto: UpdateChurchUserRoleDto,
     qr?: QueryRunner,
   ) {
@@ -86,11 +88,9 @@ export class ChurchUserService {
       qr,
     );
 
-    const user = await this.userDomainService.findUserById(userId, qr);
-
-    const churchUser = await this.churchUserDomainService.findChurchUserByUser(
+    const churchUser = await this.churchUserDomainService.findChurchUserById(
       church,
-      user,
+      churchUserId,
       qr,
     );
 
@@ -101,8 +101,12 @@ export class ChurchUserService {
     );
 
     const updatedChurchUser =
-      await this.churchUserDomainService.findChurchUserByUser(church, user, qr);
+      await this.churchUserDomainService.findChurchUserById(
+        church,
+        churchUserId,
+        qr,
+      );
 
-    return updatedChurchUser;
+    return new PatchChurchUserResponseDto(updatedChurchUser);
   }
 }

--- a/backend/src/churches/dto/transfer-owner.dto.ts
+++ b/backend/src/churches/dto/transfer-owner.dto.ts
@@ -3,9 +3,9 @@ import { IsNumber, Min } from 'class-validator';
 
 export class TransferOwnerDto {
   @ApiProperty({
-    description: '새로운 owner 가 될 교인의 ID',
+    description: '새로운 owner 가 될 교인의 Church User ID',
   })
   @IsNumber()
   @Min(1)
-  newOwnerMemberId: number;
+  newOwnerChurchUserId: number;
 }

--- a/backend/src/churches/service/churches.service.ts
+++ b/backend/src/churches/service/churches.service.ts
@@ -146,12 +146,6 @@ export class ChurchesService {
       qr,
     );
 
-    const newOwnerMember = await this.membersDomainService.findMemberModelById(
-      church,
-      dto.newOwnerMemberId,
-      qr,
-    );
-
     const oldOwnerChurchUser =
       await this.churchUserDomainService.findChurchUserByUser(
         church,
@@ -160,9 +154,9 @@ export class ChurchesService {
       );
 
     const newOwnerChurchUser =
-      await this.churchUserDomainService.findChurchUserByMember(
+      await this.churchUserDomainService.findChurchUserById(
         church,
-        newOwnerMember,
+        dto.newOwnerChurchUserId,
         qr,
       );
 

--- a/backend/src/management/educations/service/educaiton-session.service.ts
+++ b/backend/src/management/educations/service/educaiton-session.service.ts
@@ -187,14 +187,14 @@ export class EducationSessionService {
         { educationEnrollments: true },
       );
 
-    const creatorMember = await this.managerDomainService.findManagerById(
+    const creatorMember = await this.managerDomainService.findManagerByMemberId(
       church,
       creatorMemberId,
       qr,
     );
 
     const inCharge = dto.inChargeId
-      ? await this.managerDomainService.findManagerById(
+      ? await this.managerDomainService.findManagerByMemberId(
           church,
           dto.inChargeId,
           qr,
@@ -271,7 +271,7 @@ export class EducationSessionService {
       );
 
     const inCharge = dto.inChargeId
-      ? await this.managerDomainService.findManagerById(
+      ? await this.managerDomainService.findManagerByMemberId(
           church,
           dto.inChargeId,
           qr,
@@ -458,11 +458,12 @@ export class EducationSessionService {
     newReceiverIds: number[],
     qr: QueryRunner,
   ) {
-    const newReceivers = await this.managerDomainService.findManagersByIds(
-      church,
-      newReceiverIds,
-      qr,
-    );
+    const newReceivers =
+      await this.managerDomainService.findManagersByMemberIds(
+        church,
+        newReceiverIds,
+        qr,
+      );
 
     await this.educationSessionReportDomainService.createEducationSessionReports(
       education,

--- a/backend/src/management/educations/service/education-term.service.ts
+++ b/backend/src/management/educations/service/education-term.service.ts
@@ -182,7 +182,7 @@ export class EducationTermService {
           qr,
           { user: true },
         )*/
-        await this.managerDomainService.findManagerById(
+        await this.managerDomainService.findManagerByMemberId(
           church,
           dto.inChargeId,
           qr,
@@ -273,13 +273,7 @@ export class EducationTermService {
       );
 
     const newInCharge = dto.inChargeId
-      ? /*await this.membersDomainService.findMemberModelById(
-          church,
-          dto.inChargeId,
-          qr,
-          { user: true },
-        )*/
-        await this.managerDomainService.findManagerModelById(
+      ? await this.managerDomainService.findManagerByMemberId(
           church,
           dto.inChargeId,
           qr,

--- a/backend/src/manager/controller/manager.controller.ts
+++ b/backend/src/manager/controller/manager.controller.ts
@@ -32,68 +32,72 @@ export class ManagerController {
   }
 
   @ApiOperation({ summary: '관리자 단건 조회' })
-  @Get(':managerId')
+  @Get(':churchUserId')
   getManagerById(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('managerId', ParseIntPipe) managerId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
   ) {
-    return this.managerService.getManagerById(churchId, managerId);
+    return this.managerService.getManagerById(churchId, churchUserId);
   }
 
   @ApiOperation({ summary: '관리자 활성 상태 온오프' })
-  @Patch(':managerId/toggle-permission-activity')
+  @Patch(':churchUserId/toggle-permission-activity')
   @UseInterceptors(TransactionInterceptor)
   toggleManagerPermissionActive(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('managerId', ParseIntPipe) managerId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
     @QueryRunner() qr: QR,
   ) {
-    return this.managerService.togglePermissionActive(churchId, managerId, qr);
+    return this.managerService.togglePermissionActive(
+      churchId,
+      churchUserId,
+      qr,
+    );
   }
 
   @ApiOperation({ summary: '권한 유형 부여' })
-  @Patch(':managerId/assign-permission-template')
+  @Patch(':churchUserId/assign-permission-template')
   @UseInterceptors(TransactionInterceptor)
   assignPermissionTemplate(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('managerId', ParseIntPipe) managerId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
     @Body() dto: AssignPermissionTemplateDto,
     @QueryRunner() qr: QR,
   ) {
     return this.managerService.assignPermissionTemplate(
       churchId,
-      managerId,
+      churchUserId,
       dto,
       qr,
     );
   }
 
   @ApiOperation({ summary: '권한 유형 해제' })
-  @Patch(':managerId/unassign-permission-template')
+  @Patch(':churchUserId/unassign-permission-template')
   @UseInterceptors(TransactionInterceptor)
   unassignPermissionTemplate(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('managerId', ParseIntPipe) managerId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
     @QueryRunner() qr: QR,
   ) {
     return this.managerService.unassignPermissionTemplate(
       churchId,
-      managerId,
+      churchUserId,
       qr,
     );
   }
 
-  @Patch(':managerId/permission-scope')
+  @Patch(':churchUserId/permission-scope')
   @UseInterceptors(TransactionInterceptor)
   patchPermissionScope(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('managerId', ParseIntPipe) managerId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
     @Body() dto: UpdatePermissionScopeDto,
     @QueryRunner() qr: QR,
   ) {
     return this.managerService.patchPermissionScope(
       churchId,
-      managerId,
+      churchUserId,
       dto,
       qr,
     );

--- a/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
+++ b/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
@@ -15,13 +15,6 @@ export interface IManagerDomainService {
     qr?: QueryRunner,
   ): Promise<ManagerDomainPaginationResultDto>;
 
-  findManagerModelById(
-    church: ChurchModel,
-    managerId: number,
-    qr?: QueryRunner,
-    relationOptions?: FindOptionsRelations<ChurchUserModel>,
-  ): Promise<ChurchUserModel>;
-
   findManagersByPermissionTemplate(
     church: ChurchModel,
     permissionTemplate: PermissionTemplateModel,
@@ -29,19 +22,57 @@ export interface IManagerDomainService {
     qr?: QueryRunner,
   ): Promise<ManagerDomainPaginationResultDto>;
 
+  findManagerById(
+    church: ChurchModel,
+    churchUserId: number,
+    qr?: QueryRunner,
+  ): Promise<ChurchUserModel>;
+
+  findManagerModelById(
+    church: ChurchModel,
+    churchUserId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<ChurchUserModel>,
+  ): Promise<ChurchUserModel>;
+
+  /**
+   * 생성자의 권한 확인용
+   * @param church
+   * @param userId
+   * @param qr
+   */
   findManagerByUserId(
     church: ChurchModel,
     userId: number,
     qr?: QueryRunner,
   ): Promise<ChurchUserModel>;
 
-  findManagerById(
+  /**
+   * inCharge 로 지정된 교인의 권한 확인용
+   * @param church
+   * @param managerId
+   * @param qr
+   */
+  findManagerByMemberId(
     church: ChurchModel,
     managerId: number,
     qr?: QueryRunner,
   ): Promise<ChurchUserModel>;
 
-  findManagersByIds(
+  findManagerModelByMemberId(
+    church: ChurchModel,
+    managerId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<ChurchUserModel>,
+  ): Promise<ChurchUserModel>;
+
+  /**
+   * receiver 로 지정된 교인의 권한 확인용
+   * @param church
+   * @param managerIds
+   * @param qr
+   */
+  findManagersByMemberIds(
     church: ChurchModel,
     managerIds: number[],
     qr?: QueryRunner,

--- a/backend/src/manager/service/manager.service.ts
+++ b/backend/src/manager/service/manager.service.ts
@@ -67,7 +67,7 @@ export class ManagerService {
 
   async togglePermissionActive(
     churchId: number,
-    managerId: number,
+    churchUserId: number,
     qr: QueryRunner,
   ) {
     const church = await this.churchesDomainService.findChurchModelById(
@@ -77,7 +77,7 @@ export class ManagerService {
 
     const targetManager = await this.managerDomainService.findManagerModelById(
       church,
-      managerId,
+      churchUserId,
       qr,
     );
 
@@ -89,20 +89,20 @@ export class ManagerService {
 
     const updatedManager = await this.managerDomainService.findManagerById(
       church,
-      managerId,
+      churchUserId,
       qr,
     );
 
     return new PatchManagerResponseDto(updatedManager);
   }
 
-  async getManagerById(churchId: number, managerId: number) {
+  async getManagerById(churchId: number, churchUserId: number) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
     const manager = await this.managerDomainService.findManagerById(
       church,
-      managerId,
+      churchUserId,
     );
 
     return new GetManagerResponseDto(manager);
@@ -110,7 +110,7 @@ export class ManagerService {
 
   async assignPermissionTemplate(
     churchId: number,
-    managerId: number,
+    churchUserId: number,
     dto: AssignPermissionTemplateDto,
     qr: QueryRunner,
   ) {
@@ -128,7 +128,7 @@ export class ManagerService {
 
     const manager = await this.managerDomainService.findManagerModelById(
       church,
-      managerId,
+      churchUserId,
       qr,
       { permissionTemplate: true },
     );
@@ -154,7 +154,7 @@ export class ManagerService {
 
     const updatedManager = await this.managerDomainService.findManagerById(
       church,
-      managerId,
+      churchUserId,
       qr,
     );
 
@@ -163,7 +163,7 @@ export class ManagerService {
 
   async unassignPermissionTemplate(
     churchId: number,
-    managerId: number,
+    churchUserId: number,
     qr: QueryRunner,
   ) {
     const church = await this.churchesDomainService.findChurchModelById(
@@ -173,7 +173,7 @@ export class ManagerService {
 
     const manager = await this.managerDomainService.findManagerModelById(
       church,
-      managerId,
+      churchUserId,
       qr,
       { permissionTemplate: true },
     );
@@ -188,7 +188,7 @@ export class ManagerService {
 
     const updatedManager = await this.managerDomainService.findManagerById(
       church,
-      managerId,
+      churchUserId,
       qr,
     );
 
@@ -277,7 +277,7 @@ export class ManagerService {
 
   async patchPermissionScope(
     churchId: number,
-    managerId: number,
+    churchUserId: number,
     dto: UpdatePermissionScopeDto,
     qr: QueryRunner,
   ) {
@@ -286,7 +286,7 @@ export class ManagerService {
 
     const manager = await this.managerDomainService.findManagerById(
       church,
-      managerId,
+      churchUserId,
       qr,
     );
 
@@ -304,7 +304,11 @@ export class ManagerService {
     if (dto.isAllGroups) {
       await this.handleAllGroupScope(manager, existingScope, qr);
 
-      return this.managerDomainService.findManagerById(church, managerId, qr);
+      return this.managerDomainService.findManagerById(
+        church,
+        churchUserId,
+        qr,
+      );
     } else {
       await this.handlePermissionScopeChange(
         church,
@@ -314,7 +318,11 @@ export class ManagerService {
         qr,
       );
 
-      return this.managerDomainService.findManagerById(church, managerId, qr);
+      return this.managerDomainService.findManagerById(
+        church,
+        churchUserId,
+        qr,
+      );
     }
   }
 }

--- a/backend/src/task/service/task.service.ts
+++ b/backend/src/task/service/task.service.ts
@@ -100,7 +100,7 @@ export class TaskService {
     );
 
     const inCharge = dto.inChargeId
-      ? await this.managerDomainService.findManagerById(
+      ? await this.managerDomainService.findManagerByMemberId(
           church,
           dto.inChargeId,
           qr,
@@ -162,7 +162,7 @@ export class TaskService {
     );
 
     const newInChargeMember = dto.inChargeId
-      ? await this.managerDomainService.findManagerById(
+      ? await this.managerDomainService.findManagerByMemberId(
           church,
           dto.inChargeId,
           qr,
@@ -247,11 +247,12 @@ export class TaskService {
     newReceiverIds: number[],
     qr: QueryRunner,
   ) {
-    const newReceivers = await this.managerDomainService.findManagersByIds(
-      church,
-      newReceiverIds,
-      qr,
-    );
+    const newReceivers =
+      await this.managerDomainService.findManagersByMemberIds(
+        church,
+        newReceiverIds,
+        qr,
+      );
 
     await this.taskReportDomainService.createTaskReports(
       task,

--- a/backend/src/user/const/user-role.enum.ts
+++ b/backend/src/user/const/user-role.enum.ts
@@ -1,3 +1,5 @@
+import { In } from 'typeorm';
+
 export enum UserRole {
   OWNER = 'owner', // 교회 생성자, 결제, 교회 삭제를 포함한 모든 권한, 교회 당 1명만 부여
   MANAGER = 'manager', // 관리자, 상위 관리자가 부여한 권한
@@ -16,3 +18,8 @@ export enum ChurchUserRole {
   MEMBER = 'member', // 교회 일반 교인
   NONE = 'none',
 }
+
+export const ChurchUserManagers = In([
+  ChurchUserRole.MANAGER,
+  ChurchUserRole.OWNER,
+]);

--- a/backend/src/visitation/service/visitation.service.ts
+++ b/backend/src/visitation/service/visitation.service.ts
@@ -113,7 +113,7 @@ export class VisitationService {
       qr,
     );
 
-    const inCharge = await this.managerDomainService.findManagerById(
+    const inCharge = await this.managerDomainService.findManagerByMemberId(
       church,
       dto.inChargeId,
       qr,
@@ -220,7 +220,7 @@ export class VisitationService {
     // 심방 진행자 변경 시
     const newInstructor =
       dto.inChargeId && dto.inChargeId !== targetMetaData.inChargeId
-        ? await this.managerDomainService.findManagerById(
+        ? await this.managerDomainService.findManagerByMemberId(
             church,
             dto.inChargeId,
             qr,
@@ -330,11 +330,12 @@ export class VisitationService {
     newReceiverIds: number[],
     qr: QueryRunner,
   ) {
-    const newReceivers = await this.managerDomainService.findManagersByIds(
-      church,
-      newReceiverIds,
-      qr,
-    );
+    const newReceivers =
+      await this.managerDomainService.findManagersByMemberIds(
+        church,
+        newReceiverIds,
+        qr,
+      );
 
     await this.visitationReportDomainService.createVisitationReports(
       visitation,


### PR DESCRIPTION
## 주요 내용
기존에는 memberId를 사용해 ChurchUser 또는 매니저 ChurchUser를 조회하던 로직을 모두 churchUserId 기반으로 변경함

## 세부 내용

### 조회 방식 변경
- ChurchUserService, ManagerService 내 로직에서 memberId 기반 ChurchUser 조회 제거
- 모든 ChurchUser 관련 식별 및 조회 로직을 churchUserId 기준으로 통일
- 불필요한 memberId → churchUser 변환 로직 제거

## 목적 및 효과
- churchUserId를 명시적으로 사용하는 구조로 변경함으로써 명확한 식별자 사용
- 중복 조회 방지 및 로직 단순화
- 권한 및 스코프 처리 시 일관된 참조 구조 확보