### PR TITLE
feat: TaskGuard 및 TaskPermissionService 추가로 작업 권한 체크 기능 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -57,6 +57,7 @@ import { PermissionTemplateModel } from './permission/entity/permission-template
 import { ManagerModule } from './manager/manager.module';
 import { ChurchUserModule } from './church-user/church-user.module';
 import { ChurchUserModel } from './church-user/entity/church-user.entity';
+import { PermissionScopeModel } from './permission/entity/permission-scope.entity';
 
 @Module({
   imports: [
@@ -167,6 +168,7 @@ import { ChurchUserModel } from './church-user/entity/church-user.entity';
           // 권한 관련
           PermissionUnitModel,
           PermissionTemplateModel,
+          PermissionScopeModel,
         ],
         synchronize: true,
       }),

--- a/backend/src/church-user/church-user-domain/service/interface/church-user-domain.service.interface.ts
+++ b/backend/src/church-user/church-user-domain/service/interface/church-user-domain.service.interface.ts
@@ -33,6 +33,7 @@ export interface IChurchUserDomainService {
     qr?: QueryRunner,
   ): Promise<boolean>;
 
+  // 권한 인증용
   findChurchUserByUserId(
     userId: number,
     qr?: QueryRunner,
@@ -44,9 +45,9 @@ export interface IChurchUserDomainService {
     qr?: QueryRunner,
   ): Promise<ChurchUserDomainPaginationResultDto>;
 
-  findChurchUserByMember(
+  findChurchUserById(
     church: ChurchModel,
-    member: MemberModel,
+    churchUserId: number,
     qr?: QueryRunner,
   ): Promise<ChurchUserModel>;
 

--- a/backend/src/church-user/controller/church-user.controller.ts
+++ b/backend/src/church-user/controller/church-user.controller.ts
@@ -32,12 +32,12 @@ export class ChurchUserController {
   @ApiOperation({
     summary: '교회 가입 계정(교인) 단건 조회',
   })
-  @Get(':userId')
+  @Get(':churchUserId')
   getChurchUserById(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('userId', ParseIntPipe) userId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
   ) {
-    return this.churchUserService.getChurchUserByUserId(churchId, userId);
+    return this.churchUserService.getChurchUserByUserId(churchId, churchUserId);
   }
 
   @ApiOperation({
@@ -48,10 +48,10 @@ export class ChurchUserController {
       '<h2>교회에 가입한 교인의 role 을 변경합니다.</h2>' +
       '<p>변경 가능한 role: manager, member</p>',
   })
-  @Patch(':userId/role')
+  @Patch(':churchUserId/role')
   patchUserRole(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('userId', ParseIntPipe) userId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
     @Body() dto: UpdateChurchUserRoleDto,
   ) {
     throw new BadRequestException('현재 개발 범위 외의 기능');
@@ -62,7 +62,7 @@ export class ChurchUserController {
   @ApiOperation({
     summary: '계정 - 교인 정보 연결',
   })
-  @Patch(':userId/link-member')
+  @Patch(':churchUserId/link-member')
   linkMember() {
     return '개발 전';
   }
@@ -70,7 +70,7 @@ export class ChurchUserController {
   @ApiOperation({
     summary: '계정 - 교인 정보 연결 해제',
   })
-  @Patch(':userId/unlink-member')
+  @Patch(':churchUserId/unlink-member')
   unlinkMember() {
     return '개발 전';
   }
@@ -78,7 +78,7 @@ export class ChurchUserController {
   @ApiOperation({
     summary: '교회 계정 가입 취소',
   })
-  @Patch(':userId/leave-church')
+  @Patch(':churchUserId/leave-church')
   leaveChurch() {
     return '개발 전';
   }

--- a/backend/src/church-user/dto/response/church-user-pagination-response.dto.ts
+++ b/backend/src/church-user/dto/response/church-user-pagination-response.dto.ts
@@ -1,0 +1,14 @@
+import { BaseOffsetPaginationResponseDto } from '../../../common/dto/reponse/base-offset-pagination-response.dto';
+import { ChurchUserModel } from '../../entity/church-user.entity';
+
+export class ChurchUserPaginationResponseDto extends BaseOffsetPaginationResponseDto<ChurchUserModel> {
+  constructor(
+    data: ChurchUserModel[],
+    totalCount: number,
+    count: number,
+    page: number,
+    totalPage: number,
+  ) {
+    super(data, totalCount, count, page, totalPage);
+  }
+}

--- a/backend/src/church-user/dto/response/get-church-user-response.dto.ts
+++ b/backend/src/church-user/dto/response/get-church-user-response.dto.ts
@@ -1,0 +1,8 @@
+import { BaseGetResponseDto } from '../../../common/dto/reponse/base-get-response.dto';
+import { ChurchUserModel } from '../../entity/church-user.entity';
+
+export class GetChurchUserResponseDto extends BaseGetResponseDto<ChurchUserModel> {
+  constructor(data: ChurchUserModel) {
+    super(data);
+  }
+}

--- a/backend/src/church-user/dto/response/patch-church-user-response.dto.ts
+++ b/backend/src/church-user/dto/response/patch-church-user-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePatchResponseDto } from '../../../common/dto/reponse/base-patch-response.dto';
+import { ChurchUserModel } from '../../entity/church-user.entity';
+
+export class PatchChurchUserResponseDto extends BasePatchResponseDto<ChurchUserModel> {
+  constructor(data: ChurchUserModel) {
+    super(data);
+  }
+}

--- a/backend/src/church-user/entity/church-user.entity.ts
+++ b/backend/src/church-user/entity/church-user.entity.ts
@@ -5,6 +5,7 @@ import {
   Index,
   JoinColumn,
   ManyToOne,
+  OneToMany,
   OneToOne,
 } from 'typeorm';
 import { ChurchModel } from '../../churches/entity/church.entity';
@@ -12,6 +13,7 @@ import { UserModel } from '../../user/entity/user.entity';
 import { MemberModel } from '../../members/entity/member.entity';
 import { ChurchUserRole } from '../../user/const/user-role.enum';
 import { PermissionTemplateModel } from '../../permission/entity/permission-template.entity';
+import { PermissionScopeModel } from '../../permission/entity/permission-scope.entity';
 
 @Entity()
 export class ChurchUserModel extends BaseModel {
@@ -49,6 +51,12 @@ export class ChurchUserModel extends BaseModel {
   @ManyToOne(() => PermissionTemplateModel)
   @JoinColumn({ name: 'permissionTemplateId' })
   permissionTemplate: PermissionTemplateModel;
+
+  @OneToMany(
+    () => PermissionScopeModel,
+    (permissionScope) => permissionScope.churchUser,
+  )
+  permissionScopes: PermissionScopeModel[];
 
   @Column({ default: false })
   isPermissionActive: boolean;

--- a/backend/src/church-user/exception/church-user.exception.ts
+++ b/backend/src/church-user/exception/church-user.exception.ts
@@ -1,0 +1,6 @@
+export const ChurchUserException = {
+  OWNER_CANNOT_LEAVE: '교회 소유자는 교회에서 탈퇴할 수 없습니다.',
+  NOT_FOUND: '해당 교회 가입 정보를 찾을 수 없습니다.',
+  UPDATE_ERROR: '교회 가입 정보 업데이트 도중 에러 발생',
+  DELETE_ERROR: '교회 가입 정보 삭제 도중 에러 발생',
+};

--- a/backend/src/church-user/service/church-user.service.ts
+++ b/backend/src/church-user/service/church-user.service.ts
@@ -18,6 +18,9 @@ import {
   IUSER_DOMAIN_SERVICE,
   IUserDomainService,
 } from '../../user/user-domain/interface/user-domain.service.interface';
+import { GetChurchUserResponseDto } from '../dto/response/get-church-user-response.dto';
+import { ChurchUserPaginationResponseDto } from '../dto/response/church-user-pagination-response.dto';
+import { PatchChurchUserResponseDto } from '../dto/response/patch-church-user-response.dto';
 
 @Injectable()
 export class ChurchUserService {
@@ -46,17 +49,18 @@ export class ChurchUserService {
     const { data, totalCount } =
       await this.churchUserDomainService.findChurchUsers(church, dto);
 
-    return {
+    return new ChurchUserPaginationResponseDto(
       data,
       totalCount,
-      count: data.length,
-      totalPage: Math.ceil(totalCount / dto.take),
-    };
+      data.length,
+      dto.page,
+      Math.ceil(totalCount / dto.take),
+    );
   }
 
   async getChurchUserByUserId(
     churchId: number,
-    userId: number,
+    churchUserId: number,
     qr?: QueryRunner,
   ) {
     const church = await this.churchesDomainService.findChurchModelById(
@@ -64,20 +68,18 @@ export class ChurchUserService {
       qr,
     );
 
-    const user = await this.userDomainService.findUserById(userId, qr);
-
-    const churchUser = await this.churchUserDomainService.findChurchUserByUser(
+    const churchUser = await this.churchUserDomainService.findChurchUserById(
       church,
-      user,
+      churchUserId,
       qr,
     );
 
-    return churchUser;
+    return new GetChurchUserResponseDto(churchUser);
   }
 
   async patchChurchUserRole(
     churchId: number,
-    userId: number,
+    churchUserId: number,
     dto: UpdateChurchUserRoleDto,
     qr?: QueryRunner,
   ) {
@@ -86,11 +88,9 @@ export class ChurchUserService {
       qr,
     );
 
-    const user = await this.userDomainService.findUserById(userId, qr);
-
-    const churchUser = await this.churchUserDomainService.findChurchUserByUser(
+    const churchUser = await this.churchUserDomainService.findChurchUserById(
       church,
-      user,
+      churchUserId,
       qr,
     );
 
@@ -101,8 +101,12 @@ export class ChurchUserService {
     );
 
     const updatedChurchUser =
-      await this.churchUserDomainService.findChurchUserByUser(church, user, qr);
+      await this.churchUserDomainService.findChurchUserById(
+        church,
+        churchUserId,
+        qr,
+      );
 
-    return updatedChurchUser;
+    return new PatchChurchUserResponseDto(updatedChurchUser);
   }
 }

--- a/backend/src/churches/dto/transfer-owner.dto.ts
+++ b/backend/src/churches/dto/transfer-owner.dto.ts
@@ -3,9 +3,9 @@ import { IsNumber, Min } from 'class-validator';
 
 export class TransferOwnerDto {
   @ApiProperty({
-    description: '새로운 owner 가 될 교인의 ID',
+    description: '새로운 owner 가 될 교인의 Church User ID',
   })
   @IsNumber()
   @Min(1)
-  newOwnerMemberId: number;
+  newOwnerChurchUserId: number;
 }

--- a/backend/src/churches/service/churches.service.ts
+++ b/backend/src/churches/service/churches.service.ts
@@ -146,12 +146,6 @@ export class ChurchesService {
       qr,
     );
 
-    const newOwnerMember = await this.membersDomainService.findMemberModelById(
-      church,
-      dto.newOwnerMemberId,
-      qr,
-    );
-
     const oldOwnerChurchUser =
       await this.churchUserDomainService.findChurchUserByUser(
         church,
@@ -160,9 +154,9 @@ export class ChurchesService {
       );
 
     const newOwnerChurchUser =
-      await this.churchUserDomainService.findChurchUserByMember(
+      await this.churchUserDomainService.findChurchUserById(
         church,
-        newOwnerMember,
+        dto.newOwnerChurchUserId,
         qr,
       );
 

--- a/backend/src/common/filter/typeorm-exception.filter.ts
+++ b/backend/src/common/filter/typeorm-exception.filter.ts
@@ -20,7 +20,7 @@ export class TypeOrmExceptionFilter implements ExceptionFilter {
     const error: any = exception;
 
     let statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
-    let message = '데이터 저장 실패';
+    let message = '데이터베이스 에러';
     let errorType = 'Internal Server Error';
 
     if (error.code === '23505') {

--- a/backend/src/management/educations/service/educaiton-session.service.ts
+++ b/backend/src/management/educations/service/educaiton-session.service.ts
@@ -187,14 +187,14 @@ export class EducationSessionService {
         { educationEnrollments: true },
       );
 
-    const creatorMember = await this.managerDomainService.findManagerById(
+    const creatorMember = await this.managerDomainService.findManagerByMemberId(
       church,
       creatorMemberId,
       qr,
     );
 
     const inCharge = dto.inChargeId
-      ? await this.managerDomainService.findManagerById(
+      ? await this.managerDomainService.findManagerByMemberId(
           church,
           dto.inChargeId,
           qr,
@@ -271,7 +271,7 @@ export class EducationSessionService {
       );
 
     const inCharge = dto.inChargeId
-      ? await this.managerDomainService.findManagerById(
+      ? await this.managerDomainService.findManagerByMemberId(
           church,
           dto.inChargeId,
           qr,
@@ -458,11 +458,12 @@ export class EducationSessionService {
     newReceiverIds: number[],
     qr: QueryRunner,
   ) {
-    const newReceivers = await this.managerDomainService.findManagersByIds(
-      church,
-      newReceiverIds,
-      qr,
-    );
+    const newReceivers =
+      await this.managerDomainService.findManagersByMemberIds(
+        church,
+        newReceiverIds,
+        qr,
+      );
 
     await this.educationSessionReportDomainService.createEducationSessionReports(
       education,

--- a/backend/src/management/educations/service/education-term.service.ts
+++ b/backend/src/management/educations/service/education-term.service.ts
@@ -182,7 +182,7 @@ export class EducationTermService {
           qr,
           { user: true },
         )*/
-        await this.managerDomainService.findManagerById(
+        await this.managerDomainService.findManagerByMemberId(
           church,
           dto.inChargeId,
           qr,
@@ -273,13 +273,7 @@ export class EducationTermService {
       );
 
     const newInCharge = dto.inChargeId
-      ? /*await this.membersDomainService.findMemberModelById(
-          church,
-          dto.inChargeId,
-          qr,
-          { user: true },
-        )*/
-        await this.managerDomainService.findManagerModelById(
+      ? await this.managerDomainService.findManagerByMemberId(
           church,
           dto.inChargeId,
           qr,

--- a/backend/src/management/groups/const/swagger/group.swagger.ts
+++ b/backend/src/management/groups/const/swagger/group.swagger.ts
@@ -70,3 +70,10 @@ export const ApiGetChildGroupIds = () =>
       description: '<h2>해당 그룹의 하위 그룹들의 id 값을 조회합니다.</h2>',
     }),
   );
+
+export const ApiGetGroupsByName = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '그룹 이름으로 검색',
+    }),
+  );

--- a/backend/src/management/groups/controller/groups.controller.ts
+++ b/backend/src/management/groups/controller/groups.controller.ts
@@ -22,10 +22,12 @@ import {
   ApiGetChildGroupIds,
   ApiGetGroupById,
   ApiGetGroups,
+  ApiGetGroupsByName,
   ApiPatchGroup,
   ApiPostGroups,
 } from '../const/swagger/group.swagger';
 import { GetGroupDto } from '../dto/group/get-group.dto';
+import { GetGroupByNameDto } from '../dto/group/get-group-by-name.dto';
 
 @ApiTags('Management:Groups')
 @Controller('groups')
@@ -39,6 +41,15 @@ export class GroupsController {
     @Query() dto: GetGroupDto,
   ) {
     return this.groupsService.getGroups(churchId, dto);
+  }
+
+  @ApiGetGroupsByName()
+  @Get('search')
+  getGroupsByName(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetGroupByNameDto,
+  ) {
+    return this.groupsService.getGroupsByName(churchId, dto);
   }
 
   @ApiPostGroups()

--- a/backend/src/management/groups/dto/group/get-group-by-name.dto.ts
+++ b/backend/src/management/groups/dto/group/get-group-by-name.dto.ts
@@ -1,0 +1,30 @@
+import { BaseOffsetPaginationRequestDto } from '../../../../common/dto/request/base-offset-pagination-request.dto';
+import { GroupOrderEnum } from '../../const/group-order.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import { Transform } from 'class-transformer';
+import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
+
+export class GetGroupByNameDto extends BaseOffsetPaginationRequestDto<GroupOrderEnum> {
+  @ApiProperty({
+    description: '정렬 기준',
+    enum: GroupOrderEnum,
+    default: GroupOrderEnum.createdAt,
+    required: false,
+  })
+  @IsEnum(GroupOrderEnum)
+  @IsOptional()
+  order: GroupOrderEnum = GroupOrderEnum.createdAt;
+
+  @ApiProperty({
+    description: '검색 이름',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @IsNotEmpty()
+  @IsNoSpecialChar()
+  @Transform(({ value }) => value.replaceAll(' ', ''))
+  name: string;
+}

--- a/backend/src/management/groups/groups-domain/dto/group-domain-pagination-result.dto.ts
+++ b/backend/src/management/groups/groups-domain/dto/group-domain-pagination-result.dto.ts
@@ -1,0 +1,8 @@
+import { BaseDomainOffsetPaginationResultDto } from '../../../../common/dto/base-domain-offset-pagination-result.dto';
+import { GroupModel } from '../../entity/group.entity';
+
+export class GroupDomainPaginationResultDto extends BaseDomainOffsetPaginationResultDto<GroupModel> {
+  constructor(data: GroupModel[], totalCount: number) {
+    super(data, totalCount);
+  }
+}

--- a/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
+++ b/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
@@ -37,6 +37,13 @@ export interface IGroupsDomainService {
     qr?: QueryRunner,
   ): Promise<GroupModel>;
 
+  findGroupModelsByIds(
+    church: ChurchModel,
+    groupIds: number[],
+    qr?: QueryRunner,
+    relationsOptions?: FindOptionsRelations<GroupModel>,
+  ): Promise<GroupModel[]>;
+
   findGroupModelById(
     church: ChurchModel,
     groupId: number,

--- a/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
+++ b/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
@@ -4,6 +4,8 @@ import { FindOptionsRelations, QueryRunner } from 'typeorm';
 import { CreateGroupDto } from '../../dto/group/create-group.dto';
 import { UpdateGroupDto } from '../../dto/group/update-group.dto';
 import { GetGroupDto } from '../../dto/group/get-group.dto';
+import { GetGroupByNameDto } from '../../dto/group/get-group-by-name.dto';
+import { GroupDomainPaginationResultDto } from '../dto/group-domain-pagination-result.dto';
 
 export interface ParentGroup {
   id: number;
@@ -29,7 +31,13 @@ export interface IGroupsDomainService {
   findGroups(
     church: ChurchModel,
     dto: GetGroupDto,
-  ): Promise<{ data: GroupModel[]; totalCount: number }>;
+  ): Promise<GroupDomainPaginationResultDto>;
+
+  findGroupsByName(
+    church: ChurchModel,
+    dto: GetGroupByNameDto,
+    qr?: QueryRunner,
+  ): Promise<GroupDomainPaginationResultDto>;
 
   findGroupById(
     church: ChurchModel,

--- a/backend/src/management/groups/groups-domain/service/groups-domain.service.ts
+++ b/backend/src/management/groups/groups-domain/service/groups-domain.service.ts
@@ -15,6 +15,7 @@ import { CreateGroupDto } from '../../dto/group/create-group.dto';
 import {
   FindOptionsOrder,
   FindOptionsRelations,
+  In,
   IsNull,
   QueryRunner,
   Repository,
@@ -114,6 +115,29 @@ export class GroupsDomainService implements IGroupsDomainService {
     }
 
     return group;
+  }
+
+  async findGroupModelsByIds(
+    church: ChurchModel,
+    groupIds: number[],
+    qr?: QueryRunner,
+    relationsOptions?: FindOptionsRelations<GroupModel>,
+  ) {
+    const groupRepository = this.getGroupsRepository(qr);
+
+    const groups = await groupRepository.find({
+      where: {
+        churchId: church.id,
+        id: In(groupIds),
+      },
+      relations: relationsOptions,
+    });
+
+    if (groups.length !== groupIds.length) {
+      throw new NotFoundException(GroupException.NOT_FOUND);
+    }
+
+    return groups;
   }
 
   async findGroupById(

--- a/backend/src/management/groups/service/groups.service.ts
+++ b/backend/src/management/groups/service/groups.service.ts
@@ -14,6 +14,7 @@ import {
 import { GetGroupDto } from '../dto/group/get-group.dto';
 import { GroupPaginationResultDto } from '../dto/response/group-pagination-result.dto';
 import { GroupDeleteResponseDto } from '../dto/response/group-delete-response.dto';
+import { GetGroupByNameDto } from '../dto/group/get-group-by-name.dto';
 
 @Injectable()
 export class GroupsService {
@@ -172,5 +173,27 @@ export class GroupsService {
     );
 
     return this.groupsDomainService.findChildGroups(group, qr);
+  }
+
+  async getGroupsByName(
+    churchId: number,
+    dto: GetGroupByNameDto,
+    qr?: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const { data, totalCount } =
+      await this.groupsDomainService.findGroupsByName(church, dto, qr);
+
+    return new GroupPaginationResultDto(
+      data,
+      totalCount,
+      data.length,
+      dto.page,
+      Math.ceil(totalCount / dto.take),
+    );
   }
 }

--- a/backend/src/manager/const/manager-find-options.const.ts
+++ b/backend/src/manager/const/manager-find-options.const.ts
@@ -10,6 +10,7 @@ export const ManagersFindOptionsRelations: FindOptionsRelations<ChurchUserModel>
     member: MemberSummarizedRelation,
     user: true,
     permissionTemplate: true,
+    permissionScopes: { group: true },
   };
 
 export const ManagersFindOptionsSelect: FindOptionsSelect<ChurchUserModel> = {
@@ -23,6 +24,14 @@ export const ManagersFindOptionsSelect: FindOptionsSelect<ChurchUserModel> = {
     id: true,
     title: true,
   },
+  permissionScopes: {
+    id: true,
+    isAllGroups: true,
+    group: {
+      id: true,
+      name: true,
+    },
+  },
 };
 
 export const ManagerFindOptionsRelations: FindOptionsRelations<ChurchUserModel> =
@@ -30,6 +39,7 @@ export const ManagerFindOptionsRelations: FindOptionsRelations<ChurchUserModel> 
     member: MemberSummarizedRelation,
     permissionTemplate: { permissionUnits: true },
     user: true,
+    permissionScopes: { group: true },
   };
 
 export const ManagerFindOptionsSelect: FindOptionsSelect<ChurchUserModel> = {
@@ -38,5 +48,13 @@ export const ManagerFindOptionsSelect: FindOptionsSelect<ChurchUserModel> = {
     id: true,
     name: true,
     mobilePhone: true,
+  },
+  permissionScopes: {
+    id: true,
+    isAllGroups: true,
+    group: {
+      id: true,
+      name: true,
+    },
   },
 };

--- a/backend/src/manager/controller/manager.controller.ts
+++ b/backend/src/manager/controller/manager.controller.ts
@@ -32,68 +32,72 @@ export class ManagerController {
   }
 
   @ApiOperation({ summary: '관리자 단건 조회' })
-  @Get(':managerId')
+  @Get(':churchUserId')
   getManagerById(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('managerId', ParseIntPipe) managerId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
   ) {
-    return this.managerService.getManagerById(churchId, managerId);
+    return this.managerService.getManagerById(churchId, churchUserId);
   }
 
   @ApiOperation({ summary: '관리자 활성 상태 온오프' })
-  @Patch(':managerId/toggle-permission-activity')
+  @Patch(':churchUserId/toggle-permission-activity')
   @UseInterceptors(TransactionInterceptor)
   toggleManagerPermissionActive(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('managerId', ParseIntPipe) managerId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
     @QueryRunner() qr: QR,
   ) {
-    return this.managerService.togglePermissionActive(churchId, managerId, qr);
+    return this.managerService.togglePermissionActive(
+      churchId,
+      churchUserId,
+      qr,
+    );
   }
 
   @ApiOperation({ summary: '권한 유형 부여' })
-  @Patch(':managerId/assign-permission-template')
+  @Patch(':churchUserId/assign-permission-template')
   @UseInterceptors(TransactionInterceptor)
   assignPermissionTemplate(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('managerId', ParseIntPipe) managerId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
     @Body() dto: AssignPermissionTemplateDto,
     @QueryRunner() qr: QR,
   ) {
     return this.managerService.assignPermissionTemplate(
       churchId,
-      managerId,
+      churchUserId,
       dto,
       qr,
     );
   }
 
   @ApiOperation({ summary: '권한 유형 해제' })
-  @Patch(':managerId/unassign-permission-template')
+  @Patch(':churchUserId/unassign-permission-template')
   @UseInterceptors(TransactionInterceptor)
   unassignPermissionTemplate(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('managerId', ParseIntPipe) managerId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
     @QueryRunner() qr: QR,
   ) {
     return this.managerService.unassignPermissionTemplate(
       churchId,
-      managerId,
+      churchUserId,
       qr,
     );
   }
 
-  @Patch(':managerId/permission-scope')
+  @Patch(':churchUserId/permission-scope')
   @UseInterceptors(TransactionInterceptor)
   patchPermissionScope(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('managerId', ParseIntPipe) managerId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
     @Body() dto: UpdatePermissionScopeDto,
     @QueryRunner() qr: QR,
   ) {
     return this.managerService.patchPermissionScope(
       churchId,
-      managerId,
+      churchUserId,
       dto,
       qr,
     );

--- a/backend/src/manager/controller/manager.controller.ts
+++ b/backend/src/manager/controller/manager.controller.ts
@@ -15,6 +15,7 @@ import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
 import { AssignPermissionTemplateDto } from '../dto/request/assign-permission-template.dto';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { UpdatePermissionScopeDto } from '../dto/request/update-permission-scope.dto';
 
 @ApiTags('Churches:Managers')
 @Controller('managers')
@@ -78,6 +79,22 @@ export class ManagerController {
     return this.managerService.unassignPermissionTemplate(
       churchId,
       managerId,
+      qr,
+    );
+  }
+
+  @Patch(':managerId/permission-scope')
+  @UseInterceptors(TransactionInterceptor)
+  patchPermissionScope(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('managerId', ParseIntPipe) managerId: number,
+    @Body() dto: UpdatePermissionScopeDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.managerService.patchPermissionScope(
+      churchId,
+      managerId,
+      dto,
       qr,
     );
   }

--- a/backend/src/manager/dto/request/update-permission-scope.dto.ts
+++ b/backend/src/manager/dto/request/update-permission-scope.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsBoolean, IsNumber, IsOptional } from 'class-validator';
+
+export class UpdatePermissionScopeDto {
+  @ApiProperty({
+    description: '권한 유형의 범위',
+    isArray: true,
+  })
+  @IsNumber({}, { each: true })
+  @IsArray()
+  groupIds: number[];
+
+  @ApiProperty({
+    description: '전체 범위',
+    default: false,
+    required: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isAllGroups: boolean = false;
+}

--- a/backend/src/manager/exception/manager.exception.ts
+++ b/backend/src/manager/exception/manager.exception.ts
@@ -1,5 +1,6 @@
 export const ManagerException = {
   NOT_FOUND: '해당 관리자를 찾을 수 없습니다.',
+  FORBIDDEN: '해당 교회 관리자만 접근할 수 있습니다.',
 
   CANNOT_CHANGE_ACTIVITY:
     '관리자 권한의 교인만 활성 상태를 변경할 수 있습니다.',

--- a/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
+++ b/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
@@ -15,13 +15,6 @@ export interface IManagerDomainService {
     qr?: QueryRunner,
   ): Promise<ManagerDomainPaginationResultDto>;
 
-  findManagerModelById(
-    church: ChurchModel,
-    managerId: number,
-    qr?: QueryRunner,
-    relationOptions?: FindOptionsRelations<ChurchUserModel>,
-  ): Promise<ChurchUserModel>;
-
   findManagersByPermissionTemplate(
     church: ChurchModel,
     permissionTemplate: PermissionTemplateModel,
@@ -29,19 +22,57 @@ export interface IManagerDomainService {
     qr?: QueryRunner,
   ): Promise<ManagerDomainPaginationResultDto>;
 
+  findManagerById(
+    church: ChurchModel,
+    churchUserId: number,
+    qr?: QueryRunner,
+  ): Promise<ChurchUserModel>;
+
+  findManagerModelById(
+    church: ChurchModel,
+    churchUserId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<ChurchUserModel>,
+  ): Promise<ChurchUserModel>;
+
+  /**
+   * 생성자의 권한 확인용
+   * @param church
+   * @param userId
+   * @param qr
+   */
   findManagerByUserId(
     church: ChurchModel,
     userId: number,
     qr?: QueryRunner,
   ): Promise<ChurchUserModel>;
 
-  findManagerById(
+  /**
+   * inCharge 로 지정된 교인의 권한 확인용
+   * @param church
+   * @param managerId
+   * @param qr
+   */
+  findManagerByMemberId(
     church: ChurchModel,
     managerId: number,
     qr?: QueryRunner,
   ): Promise<ChurchUserModel>;
 
-  findManagersByIds(
+  findManagerModelByMemberId(
+    church: ChurchModel,
+    managerId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<ChurchUserModel>,
+  ): Promise<ChurchUserModel>;
+
+  /**
+   * receiver 로 지정된 교인의 권한 확인용
+   * @param church
+   * @param managerIds
+   * @param qr
+   */
+  findManagersByMemberIds(
     church: ChurchModel,
     managerIds: number[],
     qr?: QueryRunner,

--- a/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
+++ b/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
@@ -47,6 +47,12 @@ export interface IManagerDomainService {
     qr?: QueryRunner,
   ): Promise<ChurchUserModel>;
 
+  findManagerForPermissionCheck(
+    church: ChurchModel,
+    userId: number,
+    qr?: QueryRunner,
+  ): Promise<ChurchUserModel>;
+
   /**
    * inCharge 로 지정된 교인의 권한 확인용
    * @param church

--- a/backend/src/manager/manager.module.ts
+++ b/backend/src/manager/manager.module.ts
@@ -6,6 +6,7 @@ import { ManagerService } from './service/manager.service';
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
 import { PermissionDomainModule } from '../permission/permission-domain/permission-domain.module';
 import { UserDomainModule } from '../user/user-domain/user-domain.module';
+import { GroupsDomainModule } from '../management/groups/groups-domain/groups-domain.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { UserDomainModule } from '../user/user-domain/user-domain.module';
     ChurchesDomainModule,
     PermissionDomainModule,
     ManagerDomainModule,
+    GroupsDomainModule,
   ],
   controllers: [ManagerController],
   providers: [ManagerService],

--- a/backend/src/manager/service/manager.service.ts
+++ b/backend/src/manager/service/manager.service.ts
@@ -67,7 +67,7 @@ export class ManagerService {
 
   async togglePermissionActive(
     churchId: number,
-    managerId: number,
+    churchUserId: number,
     qr: QueryRunner,
   ) {
     const church = await this.churchesDomainService.findChurchModelById(
@@ -77,7 +77,7 @@ export class ManagerService {
 
     const targetManager = await this.managerDomainService.findManagerModelById(
       church,
-      managerId,
+      churchUserId,
       qr,
     );
 
@@ -89,20 +89,20 @@ export class ManagerService {
 
     const updatedManager = await this.managerDomainService.findManagerById(
       church,
-      managerId,
+      churchUserId,
       qr,
     );
 
     return new PatchManagerResponseDto(updatedManager);
   }
 
-  async getManagerById(churchId: number, managerId: number) {
+  async getManagerById(churchId: number, churchUserId: number) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
     const manager = await this.managerDomainService.findManagerById(
       church,
-      managerId,
+      churchUserId,
     );
 
     return new GetManagerResponseDto(manager);
@@ -110,7 +110,7 @@ export class ManagerService {
 
   async assignPermissionTemplate(
     churchId: number,
-    managerId: number,
+    churchUserId: number,
     dto: AssignPermissionTemplateDto,
     qr: QueryRunner,
   ) {
@@ -128,7 +128,7 @@ export class ManagerService {
 
     const manager = await this.managerDomainService.findManagerModelById(
       church,
-      managerId,
+      churchUserId,
       qr,
       { permissionTemplate: true },
     );
@@ -154,7 +154,7 @@ export class ManagerService {
 
     const updatedManager = await this.managerDomainService.findManagerById(
       church,
-      managerId,
+      churchUserId,
       qr,
     );
 
@@ -163,7 +163,7 @@ export class ManagerService {
 
   async unassignPermissionTemplate(
     churchId: number,
-    managerId: number,
+    churchUserId: number,
     qr: QueryRunner,
   ) {
     const church = await this.churchesDomainService.findChurchModelById(
@@ -173,7 +173,7 @@ export class ManagerService {
 
     const manager = await this.managerDomainService.findManagerModelById(
       church,
-      managerId,
+      churchUserId,
       qr,
       { permissionTemplate: true },
     );
@@ -188,7 +188,7 @@ export class ManagerService {
 
     const updatedManager = await this.managerDomainService.findManagerById(
       church,
-      managerId,
+      churchUserId,
       qr,
     );
 
@@ -277,7 +277,7 @@ export class ManagerService {
 
   async patchPermissionScope(
     churchId: number,
-    managerId: number,
+    churchUserId: number,
     dto: UpdatePermissionScopeDto,
     qr: QueryRunner,
   ) {
@@ -286,7 +286,7 @@ export class ManagerService {
 
     const manager = await this.managerDomainService.findManagerById(
       church,
-      managerId,
+      churchUserId,
       qr,
     );
 
@@ -304,7 +304,11 @@ export class ManagerService {
     if (dto.isAllGroups) {
       await this.handleAllGroupScope(manager, existingScope, qr);
 
-      return this.managerDomainService.findManagerById(church, managerId, qr);
+      return this.managerDomainService.findManagerById(
+        church,
+        churchUserId,
+        qr,
+      );
     } else {
       await this.handlePermissionScopeChange(
         church,
@@ -314,7 +318,11 @@ export class ManagerService {
         qr,
       );
 
-      return this.managerDomainService.findManagerById(church, managerId, qr);
+      return this.managerDomainService.findManagerById(
+        church,
+        churchUserId,
+        qr,
+      );
     }
   }
 }

--- a/backend/src/manager/service/manager.service.ts
+++ b/backend/src/manager/service/manager.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { ConflictException, Inject, Injectable } from '@nestjs/common';
 import { GetManagersDto } from '../dto/request/get-managers.dto';
 import {
   ICHURCHES_DOMAIN_SERVICE,
@@ -17,6 +17,20 @@ import {
   IMANAGER_DOMAIN_SERVICE,
   IManagerDomainService,
 } from '../manager-domain/service/interface/manager-domain.service.interface';
+import { UpdatePermissionScopeDto } from '../dto/request/update-permission-scope.dto';
+import {
+  IGROUPS_DOMAIN_SERVICE,
+  IGroupsDomainService,
+} from '../../management/groups/groups-domain/interface/groups-domain.service.interface';
+import {
+  IPERMISSION_SCOPE_DOMAIN_SERVICE,
+  IPermissionScopeDomainService,
+} from '../../permission/permission-domain/service/interface/permission-scope-domain.service.interface';
+import { PermissionScopeModel } from '../../permission/entity/permission-scope.entity';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { ChurchUserRole } from '../../user/const/user-role.enum';
+import { PermissionScopeException } from '../../permission/exception/permission-scope.exception';
 
 @Injectable()
 export class ManagerService {
@@ -27,6 +41,10 @@ export class ManagerService {
     private readonly managerDomainService: IManagerDomainService,
     @Inject(IPERMISSION_DOMAIN_SERVICE)
     private readonly permissionDomainService: IPermissionDomainService,
+    @Inject(IPERMISSION_SCOPE_DOMAIN_SERVICE)
+    private readonly permissionScopeDomainService: IPermissionScopeDomainService,
+    @Inject(IGROUPS_DOMAIN_SERVICE)
+    private readonly groupsDomainService: IGroupsDomainService,
   ) {}
 
   async getManagers(churchId: number, dto: GetManagersDto) {
@@ -175,5 +193,128 @@ export class ManagerService {
     );
 
     return new PatchManagerResponseDto(updatedManager);
+  }
+
+  private async handleAllGroupScope(
+    manager: ChurchUserModel,
+    existingScope: PermissionScopeModel[],
+    qr: QueryRunner,
+  ) {
+    const toRemove: PermissionScopeModel[] = [];
+
+    // 기존 권한 범위 삭제
+    existingScope.forEach((scope) => {
+      if (!scope.isAllGroups) {
+        toRemove.push(scope);
+      }
+    });
+
+    if (toRemove.length > 0) {
+      await this.permissionScopeDomainService.deletePermissionScope(
+        toRemove,
+        qr,
+      );
+    }
+
+    // 기존 isAllGroups 가 존재하는지 확인
+    const exists = existingScope.find((s) => s.isAllGroups);
+
+    if (!exists) {
+      // isAllGroups 가 true 인 PermissionScope 생성
+      await this.permissionScopeDomainService.createAllGroupPermissionScope(
+        manager,
+        qr,
+      );
+    }
+  }
+
+  private async handlePermissionScopeChange(
+    church: ChurchModel,
+    manager: ChurchUserModel,
+    existingScope: PermissionScopeModel[],
+    dto: UpdatePermissionScopeDto,
+    qr: QueryRunner,
+  ) {
+    const toCreate: number[] = [];
+    const toRemove: PermissionScopeModel[] = [];
+
+    const existingMap = new Map<number, PermissionScopeModel>();
+
+    for (const scope of existingScope) {
+      if (!scope.isAllGroups && scope.groupId !== null) {
+        existingMap.set(scope.groupId, scope);
+      }
+    }
+
+    const newSet = new Set(dto.groupIds);
+
+    for (const [groupId, scope] of existingMap.entries()) {
+      if (!newSet.has(groupId)) toRemove.push(scope);
+    }
+
+    for (const groupId of newSet) {
+      if (!existingMap.has(groupId)) toCreate.push(groupId);
+    }
+
+    toRemove.push(...existingScope.filter((s) => s.isAllGroups));
+
+    const toCreateGroups =
+      toCreate.length > 0
+        ? await this.groupsDomainService.findGroupModelsByIds(
+            church,
+            toCreate,
+            qr,
+          )
+        : [];
+
+    await this.permissionScopeDomainService.applyPermissionScopeChange(
+      manager,
+      toCreateGroups,
+      toRemove,
+      qr,
+    );
+  }
+
+  async patchPermissionScope(
+    churchId: number,
+    managerId: number,
+    dto: UpdatePermissionScopeDto,
+    qr: QueryRunner,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const manager = await this.managerDomainService.findManagerById(
+      church,
+      managerId,
+      qr,
+    );
+
+    if (manager.role === ChurchUserRole.OWNER) {
+      throw new ConflictException(PermissionScopeException.OWNER);
+    }
+
+    const existingScope =
+      await this.permissionScopeDomainService.findPermissionScopeByChurchUserId(
+        manager,
+        qr,
+      );
+
+    // 전체 그룹 범위 지정
+    if (dto.isAllGroups) {
+      await this.handleAllGroupScope(manager, existingScope, qr);
+
+      return this.managerDomainService.findManagerById(church, managerId, qr);
+    } else {
+      await this.handlePermissionScopeChange(
+        church,
+        manager,
+        existingScope,
+        dto,
+        qr,
+      );
+
+      return this.managerDomainService.findManagerById(church, managerId, qr);
+    }
   }
 }

--- a/backend/src/permission/entity/permission-scope.entity.ts
+++ b/backend/src/permission/entity/permission-scope.entity.ts
@@ -1,0 +1,29 @@
+import { BaseModel } from '../../common/entity/base.entity';
+import { Check, Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { GroupModel } from '../../management/groups/entity/group.entity';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+
+@Entity()
+@Check(
+  `("isAllGroups" = true AND "groupId" IS NULL) OR ("isAllGroups" = false AND "groupId" IS NOT NULL)`,
+)
+export class PermissionScopeModel extends BaseModel {
+  @Index()
+  @Column()
+  churchUserId: number;
+
+  @ManyToOne(() => ChurchUserModel, (churchUser) => churchUser.permissionScopes)
+  @JoinColumn({ name: 'churchUserId' })
+  churchUser: ChurchUserModel;
+
+  @Column({ default: false })
+  isAllGroups: boolean;
+
+  @Index()
+  @Column({ nullable: true })
+  groupId: number;
+
+  @ManyToOne(() => GroupModel, { nullable: true })
+  @JoinColumn({ name: 'groupId' })
+  group: GroupModel;
+}

--- a/backend/src/permission/exception/permission-scope.exception.ts
+++ b/backend/src/permission/exception/permission-scope.exception.ts
@@ -1,0 +1,4 @@
+export const PermissionScopeException = {
+  DELETE_ERROR: '권한 범위 삭제 도중 에러 발생',
+  OWNER: '소유자 권한 관리자는 권한 범위를 설정할 수 없습니다.',
+};

--- a/backend/src/permission/permission-domain/permission-domain.module.ts
+++ b/backend/src/permission/permission-domain/permission-domain.module.ts
@@ -5,15 +5,30 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { PermissionUnitModel } from '../entity/permission-unit.entity';
 import { PermissionUnitSeederService } from './service/permission-unit-seeder.service';
 import { PermissionTemplateModel } from '../entity/permission-template.entity';
+import { PermissionScopeModel } from '../entity/permission-scope.entity';
+import { IPERMISSION_SCOPE_DOMAIN_SERVICE } from './service/interface/permission-scope-domain.service.interface';
+import { PermissionScopeDomainService } from './service/permission-scope-domain.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([PermissionUnitModel, PermissionTemplateModel]),
+    TypeOrmModule.forFeature([
+      PermissionUnitModel,
+      PermissionTemplateModel,
+      PermissionScopeModel,
+    ]),
   ],
   providers: [
     PermissionUnitSeederService,
     { provide: IPERMISSION_DOMAIN_SERVICE, useClass: PermissionDomainService },
+    {
+      provide: IPERMISSION_SCOPE_DOMAIN_SERVICE,
+      useClass: PermissionScopeDomainService,
+    },
   ],
-  exports: [PermissionUnitSeederService, IPERMISSION_DOMAIN_SERVICE],
+  exports: [
+    PermissionUnitSeederService,
+    IPERMISSION_DOMAIN_SERVICE,
+    IPERMISSION_SCOPE_DOMAIN_SERVICE,
+  ],
 })
 export class PermissionDomainModule {}

--- a/backend/src/permission/permission-domain/service/interface/permission-scope-domain.service.interface.ts
+++ b/backend/src/permission/permission-domain/service/interface/permission-scope-domain.service.interface.ts
@@ -1,0 +1,39 @@
+import { ChurchUserModel } from '../../../../church-user/entity/church-user.entity';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
+import { PermissionScopeModel } from '../../../entity/permission-scope.entity';
+import { GroupModel } from '../../../../management/groups/entity/group.entity';
+
+export const IPERMISSION_SCOPE_DOMAIN_SERVICE = Symbol(
+  'IPERMISSION_SCOPE_DOMAIN_SERVICE',
+);
+
+export interface IPermissionScopeDomainService {
+  findPermissionScopeByChurchUserId(
+    churchUser: ChurchUserModel,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<PermissionScopeModel>,
+  ): Promise<PermissionScopeModel[]>;
+
+  createAllGroupPermissionScope(
+    churchUser: ChurchUserModel,
+    qr: QueryRunner,
+  ): Promise<PermissionScopeModel>;
+
+  createPermissionScope(
+    churchUser: ChurchUserModel,
+    groups: GroupModel[],
+    qr: QueryRunner,
+  ): Promise<PermissionScopeModel[]>;
+
+  deletePermissionScope(
+    toRemove: PermissionScopeModel[],
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  applyPermissionScopeChange(
+    churchUser: ChurchUserModel,
+    toCreate: GroupModel[],
+    toRemove: PermissionScopeModel[],
+    qr: QueryRunner,
+  ): Promise<void>;
+}

--- a/backend/src/permission/permission-domain/service/permission-scope-domain.service.ts
+++ b/backend/src/permission/permission-domain/service/permission-scope-domain.service.ts
@@ -1,0 +1,116 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { IPermissionScopeDomainService } from './interface/permission-scope-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { PermissionScopeModel } from '../../entity/permission-scope.entity';
+import {
+  FindOptionsRelations,
+  QueryRunner,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
+import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
+import { GroupModel } from '../../../management/groups/entity/group.entity';
+import { PermissionScopeException } from '../../exception/permission-scope.exception';
+
+@Injectable()
+export class PermissionScopeDomainService
+  implements IPermissionScopeDomainService
+{
+  constructor(
+    @InjectRepository(PermissionScopeModel)
+    private readonly permissionScopeRepository: Repository<PermissionScopeModel>,
+  ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(PermissionScopeModel)
+      : this.permissionScopeRepository;
+  }
+
+  async findPermissionScopeByChurchUserId(
+    churchUser: ChurchUserModel,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<PermissionScopeModel>,
+  ) {
+    const repository = this.getRepository(qr);
+
+    return repository.find({
+      where: {
+        churchUserId: churchUser.id,
+      },
+      relations: relationOptions,
+    });
+  }
+
+  async createAllGroupPermissionScope(
+    churchUser: ChurchUserModel,
+    qr: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    return repository.save({
+      churchUserId: churchUser.id,
+      isAllGroups: true,
+    });
+  }
+
+  async createPermissionScope(
+    churchUser: ChurchUserModel,
+    groups: GroupModel[],
+    qr: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    const permissionScopes = this.permissionScopeRepository.create(
+      groups.map((group) => ({
+        churchUserId: churchUser.id,
+        groupId: group.id,
+        isAllGroups: false,
+      })),
+    );
+
+    return repository.save(permissionScopes);
+  }
+
+  async deletePermissionScope(
+    toRemove: PermissionScopeModel[],
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    const result = await repository.softDelete(toRemove.map((t) => t.id));
+
+    if (result.affected !== toRemove.length) {
+      throw new InternalServerErrorException(
+        PermissionScopeException.DELETE_ERROR,
+      );
+    }
+
+    return result;
+  }
+
+  async applyPermissionScopeChange(
+    churchUser: ChurchUserModel,
+    toCreate: GroupModel[],
+    toRemove: PermissionScopeModel[],
+    qr: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    if (toRemove && toRemove.length > 0) {
+      await repository.softRemove(toRemove);
+    }
+
+    const newScopes = toCreate.map((group) =>
+      repository.create({
+        churchUserId: churchUser.id,
+        isAllGroups: false,
+        groupId: group.id,
+      }),
+    );
+
+    if (newScopes.length > 0) {
+      await repository.save(newScopes);
+    }
+  }
+}

--- a/backend/src/task/controller/task.controller.ts
+++ b/backend/src/task/controller/task.controller.ts
@@ -36,6 +36,8 @@ import {
 } from '../const/swagger/task.swagger';
 import { AddTaskReportReceiverDto } from '../../report/dto/task-report/request/add-task-report-receiver.dto';
 import { DeleteTaskReportReceiverDto } from '../../report/dto/task-report/request/delete-task-report-receiver.dto';
+import { TaskGuard } from '../guard/task.guard';
+import { DomainAction } from '../../permission/const/domain-action.enum';
 
 @ApiTags('Tasks')
 @Controller()
@@ -43,6 +45,7 @@ export class TaskController {
   constructor(private readonly taskService: TaskService) {}
 
   @ApiGetTasks()
+  @UseGuards(AccessTokenGuard, TaskGuard(DomainAction.READ))
   @Get()
   getTasks(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -52,6 +55,7 @@ export class TaskController {
   }
 
   @ApiPostTask()
+  @UseGuards(AccessTokenGuard, TaskGuard(DomainAction.WRITE))
   @Post()
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   @UseInterceptors(TransactionInterceptor)
@@ -65,6 +69,7 @@ export class TaskController {
   }
 
   @ApiGetTaskById()
+  @UseGuards(AccessTokenGuard, TaskGuard(DomainAction.READ))
   @Get(':taskId')
   async getTaskById(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -74,6 +79,7 @@ export class TaskController {
   }
 
   @ApiGetSubTasks()
+  @UseGuards(AccessTokenGuard, TaskGuard(DomainAction.READ))
   @Get(':taskId/sub-tasks')
   async getSubTasks(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -83,6 +89,7 @@ export class TaskController {
   }
 
   @ApiPatchTask()
+  @UseGuards(AccessTokenGuard, TaskGuard(DomainAction.WRITE))
   @Patch(':taskId')
   @UseInterceptors(TransactionInterceptor)
   patchTask(
@@ -95,6 +102,7 @@ export class TaskController {
   }
 
   @ApiDeleteTask()
+  @UseGuards(AccessTokenGuard, TaskGuard(DomainAction.WRITE))
   @Delete(':taskId')
   @UseInterceptors(TransactionInterceptor)
   deleteTask(
@@ -106,6 +114,7 @@ export class TaskController {
   }
 
   @ApiAddReportReceivers()
+  @UseGuards(AccessTokenGuard, TaskGuard(DomainAction.WRITE))
   @Patch(':taskId/add-receivers')
   @UseInterceptors(TransactionInterceptor)
   addReportReceivers(
@@ -118,6 +127,7 @@ export class TaskController {
   }
 
   @ApiDeleteReportReceiver()
+  @UseGuards(AccessTokenGuard, TaskGuard(DomainAction.WRITE))
   @Patch(':taskId/delete-receivers')
   @UseInterceptors(TransactionInterceptor)
   deleteReportReceivers(

--- a/backend/src/task/guard/task.guard.ts
+++ b/backend/src/task/guard/task.guard.ts
@@ -1,0 +1,51 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  InternalServerErrorException,
+  mixin,
+  Type,
+} from '@nestjs/common';
+import { DomainAction } from '../../permission/const/domain-action.enum';
+import { TaskPermissionService } from '../service/task-permission.service';
+
+export function TaskGuard(domainAction: DomainAction): Type<CanActivate> {
+  @Injectable()
+  class TaskPermissionGuard implements CanActivate {
+    constructor(
+      private readonly taskPermissionService: TaskPermissionService,
+    ) {}
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+      const req = context.switchToHttp().getRequest();
+
+      const token = req.tokenPayload;
+
+      if (!token) {
+        throw new InternalServerErrorException('JWT 처리 과정 누락');
+      }
+
+      const churchId = parseInt(req.params.churchId);
+
+      const requestUserId = token.id;
+
+      const hasPermission = await this.taskPermissionService.hasTaskPermission(
+        churchId,
+        requestUserId,
+        domainAction,
+      );
+
+      if (!hasPermission) {
+        const actionText = domainAction === DomainAction.READ ? '읽기' : '쓰기';
+
+        throw new ForbiddenException(
+          `업무 기능에 대한 ${actionText} 권한이 없습니다.`,
+        );
+      }
+
+      return hasPermission;
+    }
+  }
+  return mixin(TaskPermissionGuard);
+}

--- a/backend/src/task/service/task-permission.service.ts
+++ b/backend/src/task/service/task-permission.service.ts
@@ -1,0 +1,54 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IMANAGER_DOMAIN_SERVICE,
+  IManagerDomainService,
+} from '../../manager/manager-domain/service/interface/manager-domain.service.interface';
+import { ChurchUserRole } from '../../user/const/user-role.enum';
+import { DomainType } from '../../permission/const/domain-type.enum';
+import { DomainAction } from '../../permission/const/domain-action.enum';
+
+@Injectable()
+export class TaskPermissionService {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IMANAGER_DOMAIN_SERVICE)
+    private readonly managerDomainService: IManagerDomainService,
+  ) {}
+
+  async hasTaskPermission(
+    churchId: number,
+    requestUserId: number,
+    domainAction: DomainAction,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    if (requestManager.role === ChurchUserRole.OWNER) {
+      return true;
+    }
+
+    const permissionTemplate = requestManager.permissionTemplate;
+
+    for (const permissionUnit of permissionTemplate.permissionUnits) {
+      if (
+        permissionUnit.domain === DomainType.TASK &&
+        permissionUnit.action === domainAction
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/backend/src/task/service/task.service.ts
+++ b/backend/src/task/service/task.service.ts
@@ -100,7 +100,7 @@ export class TaskService {
     );
 
     const inCharge = dto.inChargeId
-      ? await this.managerDomainService.findManagerById(
+      ? await this.managerDomainService.findManagerByMemberId(
           church,
           dto.inChargeId,
           qr,
@@ -162,7 +162,7 @@ export class TaskService {
     );
 
     const newInChargeMember = dto.inChargeId
-      ? await this.managerDomainService.findManagerById(
+      ? await this.managerDomainService.findManagerByMemberId(
           church,
           dto.inChargeId,
           qr,
@@ -247,11 +247,12 @@ export class TaskService {
     newReceiverIds: number[],
     qr: QueryRunner,
   ) {
-    const newReceivers = await this.managerDomainService.findManagersByIds(
-      church,
-      newReceiverIds,
-      qr,
-    );
+    const newReceivers =
+      await this.managerDomainService.findManagersByMemberIds(
+        church,
+        newReceiverIds,
+        qr,
+      );
 
     await this.taskReportDomainService.createTaskReports(
       task,

--- a/backend/src/task/task.module.ts
+++ b/backend/src/task/task.module.ts
@@ -7,6 +7,7 @@ import { TaskService } from './service/task.service';
 import { TaskDomainModule } from './task-domain/task-domain.module';
 import { TaskReportDomainModule } from '../report/report-domain/task-report-domain.module';
 import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
+import { TaskPermissionService } from './service/task-permission.service';
 
 @Module({
   imports: [
@@ -21,6 +22,6 @@ import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.mo
     TaskReportDomainModule,
   ],
   controllers: [TaskController],
-  providers: [TaskService],
+  providers: [TaskService, TaskPermissionService],
 })
 export class TaskModule {}

--- a/backend/src/user/const/user-role.enum.ts
+++ b/backend/src/user/const/user-role.enum.ts
@@ -1,3 +1,5 @@
+import { In } from 'typeorm';
+
 export enum UserRole {
   OWNER = 'owner', // 교회 생성자, 결제, 교회 삭제를 포함한 모든 권한, 교회 당 1명만 부여
   MANAGER = 'manager', // 관리자, 상위 관리자가 부여한 권한
@@ -16,3 +18,8 @@ export enum ChurchUserRole {
   MEMBER = 'member', // 교회 일반 교인
   NONE = 'none',
 }
+
+export const ChurchUserManagers = In([
+  ChurchUserRole.MANAGER,
+  ChurchUserRole.OWNER,
+]);

--- a/backend/src/visitation/service/visitation.service.ts
+++ b/backend/src/visitation/service/visitation.service.ts
@@ -113,7 +113,7 @@ export class VisitationService {
       qr,
     );
 
-    const inCharge = await this.managerDomainService.findManagerById(
+    const inCharge = await this.managerDomainService.findManagerByMemberId(
       church,
       dto.inChargeId,
       qr,
@@ -220,7 +220,7 @@ export class VisitationService {
     // 심방 진행자 변경 시
     const newInstructor =
       dto.inChargeId && dto.inChargeId !== targetMetaData.inChargeId
-        ? await this.managerDomainService.findManagerById(
+        ? await this.managerDomainService.findManagerByMemberId(
             church,
             dto.inChargeId,
             qr,
@@ -330,11 +330,12 @@ export class VisitationService {
     newReceiverIds: number[],
     qr: QueryRunner,
   ) {
-    const newReceivers = await this.managerDomainService.findManagersByIds(
-      church,
-      newReceiverIds,
-      qr,
-    );
+    const newReceivers =
+      await this.managerDomainService.findManagersByMemberIds(
+        church,
+        newReceiverIds,
+        qr,
+      );
 
     await this.visitationReportDomainService.createVisitationReports(
       visitation,


### PR DESCRIPTION
## 주요 내용
작업(Task) 도메인에 대한 요청 시 권한을 검증하기 위한 TaskGuard와 TaskPermissionService를 도입함

## 세부 내용

### TaskGuard
- `@UseGuards(TaskGuard(DomainAction.READ or WRITE))` 형태로 사용
- 요청 유저의 churchUserId 및 churchId를 기준으로 권한 보유 여부 판단
- 단순 추출 및 흐름 제어만 담당하고, 실제 검증은 서비스에 위임

### TaskPermissionService
- 주어진 ChurchUser가 특정 DomainAction(Task.READ, Task.WRITE 등)에 대한 권한을 보유하고 있는지 판단
- OWNER 권한 보유 시 무조건 허용
- PermissionTemplate 내 PermissionUnit 목록을 기반으로 도메인 및 액션 매칭

## 목적 및 효과
- 도메인별 가드 및 권한 로직 분리 구조의 시작점으로서 Task 전용 권한 체크 구현
- 도메인 정책은 서비스에서, 요청 흐름 제어는 Guard에서 책임지는 구조 확립
