### PR TITLE
feat: 교인 모델에 프로필 이미지 URL 컬럼 추가

### DIFF
--- a/backend/src/members/const/default-find-options.const.ts
+++ b/backend/src/members/const/default-find-options.const.ts
@@ -14,7 +14,7 @@ export const DefaultMemberRelationOption: FindOptionsRelations<MemberModel> = {
   },
   group: true,
   groupRole: true,
-  user: true,
+  //user: true,
 };
 
 export const DefaultMemberSelectOption: FindOptionsSelect<MemberModel> = {
@@ -47,9 +47,9 @@ export const DefaultMemberSelectOption: FindOptionsSelect<MemberModel> = {
     id: true,
     role: true,
   },
-  user: {
+  /*user: {
     role: true,
-  },
+  },*/
 };
 
 export const DefaultMembersRelationOption: FindOptionsRelations<MemberModel> = {
@@ -60,11 +60,12 @@ export const DefaultMembersRelationOption: FindOptionsRelations<MemberModel> = {
     educationTerm: true,
   },
   officer: true,
-  user: true,
+  //user: true,
 };
 
 export const DefaultMembersSelectOption: FindOptionsSelect<MemberModel> = {
   id: true,
+  profileImageUrl: true,
   name: true,
   createdAt: true,
   updatedAt: true,
@@ -98,9 +99,9 @@ export const DefaultMembersSelectOption: FindOptionsSelect<MemberModel> = {
     id: true,
     name: true,
   },
-  user: {
+  /*user: {
     role: true,
-  },
+  },*/
 };
 
 export const HardDeleteMemberRelationOptions: FindOptionsRelations<MemberModel> =

--- a/backend/src/members/const/member-find-options.const.ts
+++ b/backend/src/members/const/member-find-options.const.ts
@@ -10,6 +10,7 @@ export const MemberSummarizedRelation: FindOptionsRelations<MemberModel> = {
 export const MemberSummarizedSelect: FindOptionsSelect<MemberModel> = {
   id: true,
   name: true,
+  profileImageUrl: true,
   officer: {
     id: true,
     name: true,

--- a/backend/src/members/dto/request/create-member.dto.ts
+++ b/backend/src/members/dto/request/create-member.dto.ts
@@ -10,6 +10,7 @@ import {
   IsNumber,
   IsOptional,
   IsString,
+  IsUrl,
   Length,
   Matches,
   MaxLength,
@@ -31,6 +32,14 @@ export class CreateMemberDto {
   @IsDate()
   @IsOptional()
   registeredAt?: Date = new Date();
+
+  @ApiProperty({
+    description: '프로필 이미지 url',
+    required: false,
+  })
+  @IsOptional()
+  @IsUrl()
+  profileImageUrl?: string;
 
   @ApiProperty({
     name: 'name',

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -15,7 +15,6 @@ import { FamilyRelationModel } from '../../family-relation/entity/family-relatio
 import { MarriageOptions } from '../member-domain/const/marriage-options.const';
 import { Exclude } from 'class-transformer';
 import { BaseModel } from '../../common/entity/base.entity';
-import { UserModel } from '../../user/entity/user.entity';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { MinistryModel } from '../../management/ministries/entity/ministry.entity';
 import { OfficerModel } from '../../management/officers/entity/officer.entity';
@@ -35,13 +34,13 @@ import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 
 @Entity()
 export class MemberModel extends BaseModel {
-  @Index()
+  /*@Index()
   @Column({ nullable: true })
   userId: number;
 
   @OneToOne(() => UserModel, (user) => user.member)
   @JoinColumn({ name: 'userId' })
-  user: UserModel;
+  user: UserModel;*/
 
   @OneToOne(() => ChurchUserModel, (churchUser) => churchUser.member)
   churchUser: ChurchUserModel;
@@ -61,6 +60,9 @@ export class MemberModel extends BaseModel {
   @Index()
   @Column({ default: new Date() })
   registeredAt: Date;
+
+  @Column({ default: '' })
+  profileImageUrl: string;
 
   @Column({ length: 30, comment: '교인 이름' })
   @Index()

--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -65,12 +65,12 @@ export interface IMembersDomainService {
     relationOptions?: FindOptionsRelations<MemberModel>,
   ): Promise<MemberModel>;
 
-  findMemberModelByUserId(
+  /*findMemberModelByUserId(
     church: ChurchModel,
     userId: number,
     qr?: QueryRunner,
     relationOptions?: FindOptionsRelations<MemberModel>,
-  ): Promise<MemberModel>;
+  ): Promise<MemberModel>;*/
 
   /*linkUserToMember(
     member: MemberModel,

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -32,7 +32,6 @@ import { OfficerModel } from '../../../management/officers/entity/officer.entity
 import { MinistryModel } from '../../../management/ministries/entity/ministry.entity';
 import { GroupModel } from '../../../management/groups/entity/group.entity';
 import { GroupRoleModel } from '../../../management/groups/entity/group-role.entity';
-import { UserModel } from '../../../user/entity/user.entity';
 import { MembersDomainPaginationResultDto } from '../dto/members-domain-pagination-result.dto';
 import { GetSimpleMembersDto } from '../../dto/request/get-simple-members.dto';
 import {
@@ -195,7 +194,7 @@ export class MembersDomainService implements IMembersDomainService {
     return member;
   }
 
-  async findMemberModelByUserId(
+  /*async findMemberModelByUserId(
     church: ChurchModel,
     userId: number,
     qr?: QueryRunner,
@@ -216,9 +215,9 @@ export class MembersDomainService implements IMembersDomainService {
     }
 
     return member;
-  }
+  }*/
 
-  async linkUserToMember(
+  /*async linkUserToMember(
     member: MemberModel,
     user: UserModel,
     qr?: QueryRunner,
@@ -240,7 +239,7 @@ export class MembersDomainService implements IMembersDomainService {
     }
 
     return result;
-  }
+  }*/
 
   async findMemberModelById(
     church: ChurchModel,

--- a/backend/src/members/service/search-members.service.ts
+++ b/backend/src/members/service/search-members.service.ts
@@ -228,6 +228,7 @@ export class SearchMembersService implements ISearchMembersService {
     return {
       id: true,
       registeredAt: true,
+      profileImageUrl: true,
       name: true,
       [dto.order]: this.isChurchManagementColumn(dto.order)
         ? { id: true, name: true }

--- a/backend/src/report/service/task-report.service.ts
+++ b/backend/src/report/service/task-report.service.ts
@@ -42,7 +42,7 @@ export class TaskReportService {
       church,
       memberId,
       undefined,
-      { user: true },
+      //{ user: true },
     );
 
     const { data, totalCount } =
@@ -74,7 +74,7 @@ export class TaskReportService {
       church,
       memberId,
       qr,
-      { user: true },
+      //{ user: true },
     );
 
     const report = await this.taskReportDomainService.findTaskReportById(

--- a/backend/src/report/service/visitation-report.service.ts
+++ b/backend/src/report/service/visitation-report.service.ts
@@ -39,7 +39,7 @@ export class VisitationReportService {
       church,
       memberId,
       undefined,
-      { user: true },
+      //{ user: true },
     );
 
     const { data, totalCount } =
@@ -82,7 +82,7 @@ export class VisitationReportService {
       church,
       memberId,
       qr,
-      { user: true },
+      //{ user: true },
     );
 
     return this.visitationReportDomainService.findVisitationReportById(

--- a/backend/src/user/entity/user.entity.ts
+++ b/backend/src/user/entity/user.entity.ts
@@ -2,7 +2,6 @@ import { Column, Entity, Index, OneToMany, OneToOne } from 'typeorm';
 import { BaseModel } from '../../common/entity/base.entity';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { UserRole } from '../const/user-role.enum';
-import { MemberModel } from '../../members/entity/member.entity';
 import { ChurchJoinRequestModel } from '../../churches/entity/church-join-request.entity';
 import { Exclude } from 'class-transformer';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
@@ -46,6 +45,6 @@ export class UserModel extends BaseModel {
   @OneToMany(() => ChurchJoinRequestModel, (joinRequest) => joinRequest.user)
   joinRequest: ChurchJoinRequestModel;
 
-  @OneToOne(() => MemberModel, (member) => member.user)
-  member: MemberModel;
+  /*@OneToOne(() => MemberModel, (member) => member.user)
+  member: MemberModel;*/
 }


### PR DESCRIPTION
## 주요 내용
교인(MemberModel)에 프로필 이미지를 나타내는 profileImageUrl 컬럼을 추가함

## 세부 내용

### MemberModel 변경
- profileImageUrl: string 컬럼 추가
  - S3 등 외부 저장소에 업로드한 이미지의 접근 URL 저장
  - 기본값은 빈 문자열('')로 설정

## 목적 및 효과
- 교인의 프로필 이미지를 저장하고 표시할 수 있는 기능 확장
- UI 상에서 교인 식별 및 개인화 요소 제공 가능