### PR TITLE
fix: 교인 수정 시 등록일자 갱신되는 버그 수정 및 프로필 이미지 빈 문자열 허용

### DIFF
--- a/backend/src/members/dto/request/create-member.dto.ts
+++ b/backend/src/members/dto/request/create-member.dto.ts
@@ -14,6 +14,7 @@ import {
   Length,
   Matches,
   MaxLength,
+  ValidateIf,
 } from 'class-validator';
 import { GenderEnum } from '../../const/enum/gender.enum';
 import { IsValidVehicleNumber } from '../../decorator/is-valid-vehicle-number.decorator';
@@ -22,6 +23,7 @@ import { FamilyRelationConst } from '../../../family-relation/family-relation-do
 import { MarriageOptions } from '../../member-domain/const/marriage-options.const';
 import { RemoveSpaces } from '../../../common/decorator/transformer/remove-spaces';
 import { IsNoSpecialChar } from '../../../common/decorator/validator/is-no-special-char.validator';
+import { IsOptionalNotNull } from '../../../common/decorator/validator/is-optional-not.null.validator';
 
 export class CreateMemberDto {
   @ApiProperty({
@@ -31,13 +33,14 @@ export class CreateMemberDto {
   })
   @IsDate()
   @IsOptional()
-  registeredAt?: Date = new Date();
+  registeredAt?: Date;
 
   @ApiProperty({
     description: '프로필 이미지 url',
     required: false,
   })
-  @IsOptional()
+  @IsOptionalNotNull()
+  @ValidateIf((_, value) => typeof value === 'string' && value.length > 0)
   @IsUrl()
   profileImageUrl?: string;
 


### PR DESCRIPTION
## 주요 내용
교인 정보 수정 시 의도치 않게 등록일자(registeredAt)가 갱신되는 문제를 해결하고, profileImageUrl 컬럼에 빈 문자열이 허용되도록 변경함

## 세부 내용

### 등록일자 버그 수정
- MemberModel 수정 로직에서 registeredAt 필드가 업데이트되지 않도록 제외 처리

### 프로필 이미지 처리 개선
- profileImageUrl 컬럼에 빈 문자열 저장 허용
- 프로필 이미지가 없는 경우에도 명확하게 빈 문자열로 표현 가능

## 목적 및 효과
- 교인 수정 시 등록일자 변경 방지로 데이터 무결성 유지
- 프로필 이미지 필수 입력 조건 제거로 사용자 경험 개선