### PR TITLE
feat: 교육 도메인 권한 체크 로직 및 Guard 적용

### DIFF
--- a/backend/src/management/educations/controller/education-enrollments.controller.ts
+++ b/backend/src/management/educations/controller/education-enrollments.controller.ts
@@ -18,6 +18,8 @@ import { UpdateEducationEnrollmentDto } from '../dto/enrollments/update-educatio
 import { EducationEnrollmentService } from '../service/education-enrollment.service';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
+import { EducationReadGuard } from '../guard/education-read.guard';
+import { EducationWriteGuard } from '../guard/education-write.guard';
 
 @ApiTags('Management:Educations:Enrollments')
 @Controller('educations/:educationId/terms/:educationTermId/enrollments')
@@ -26,6 +28,7 @@ export class EducationEnrollmentsController {
     private readonly educationEnrollmentsService: EducationEnrollmentService,
   ) {}
 
+  @EducationReadGuard()
   @Get()
   getEducationEnrollments(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -41,6 +44,7 @@ export class EducationEnrollmentsController {
     );
   }
 
+  @EducationWriteGuard()
   @Post()
   @UseInterceptors(TransactionInterceptor)
   postEducationEnrollment(
@@ -59,6 +63,7 @@ export class EducationEnrollmentsController {
     );
   }
 
+  @EducationWriteGuard()
   @Patch(':educationEnrollmentId')
   @UseInterceptors(TransactionInterceptor)
   patchEducationEnrollment(
@@ -79,6 +84,7 @@ export class EducationEnrollmentsController {
     );
   }
 
+  @EducationWriteGuard()
   @Delete(':educationEnrollmentId')
   @UseInterceptors(TransactionInterceptor)
   deleteEducationEnrollment(

--- a/backend/src/management/educations/controller/education-sessions.controller.ts
+++ b/backend/src/management/educations/controller/education-sessions.controller.ts
@@ -35,6 +35,8 @@ import {
   ApiPatchEducationSession,
   ApiPostEducationSessions,
 } from '../const/swagger/education-session.swagger';
+import { EducationReadGuard } from '../guard/education-read.guard';
+import { EducationWriteGuard } from '../guard/education-write.guard';
 
 @ApiTags('Management:Educations:Sessions')
 @Controller('educations/:educationId/terms/:educationTermId/sessions')
@@ -44,6 +46,7 @@ export class EducationSessionsController {
   ) {}
 
   @ApiGetEducationSessions()
+  @EducationReadGuard()
   @Get()
   getEducationSessions(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -60,6 +63,7 @@ export class EducationSessionsController {
   }
 
   @ApiPostEducationSessions()
+  @EducationWriteGuard()
   @Post()
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   @UseInterceptors(TransactionInterceptor)
@@ -84,6 +88,7 @@ export class EducationSessionsController {
   }
 
   @ApiGetEducationSessionById()
+  @EducationReadGuard()
   @Get(':educationSessionId')
   getEducationSessionById(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -100,6 +105,7 @@ export class EducationSessionsController {
   }
 
   @ApiPatchEducationSession()
+  @EducationWriteGuard()
   @Patch(':educationSessionId')
   @UseInterceptors(TransactionInterceptor)
   patchEducationSession(
@@ -121,6 +127,7 @@ export class EducationSessionsController {
   }
 
   @ApiDeleteEducationSession()
+  @EducationWriteGuard()
   @Delete(':educationSessionId')
   @UseInterceptors(TransactionInterceptor)
   deleteEducationSession(
@@ -140,6 +147,7 @@ export class EducationSessionsController {
   }
 
   @ApiAddReportReceivers()
+  @EducationWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   @Patch(':educationSessionId/add-receivers')
   addReportReceivers(
@@ -161,6 +169,7 @@ export class EducationSessionsController {
   }
 
   @ApiDeleteReportReceivers()
+  @EducationWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   @Patch(':educationSessionId/delete-receivers')
   deleteReportReceivers(

--- a/backend/src/management/educations/controller/education-terms.controller.ts
+++ b/backend/src/management/educations/controller/education-terms.controller.ts
@@ -32,6 +32,8 @@ import { ChurchManagerGuard } from '../../../churches/guard/church-guard.service
 import { Token } from '../../../auth/decorator/jwt.decorator';
 import { AuthType } from '../../../auth/const/enum/auth-type.enum';
 import { JwtAccessPayload } from '../../../auth/type/jwt';
+import { EducationReadGuard } from '../guard/education-read.guard';
+import { EducationWriteGuard } from '../guard/education-write.guard';
 
 @ApiTags('Management:Educations:Terms')
 @Controller('educations/:educationId/terms')
@@ -39,6 +41,7 @@ export class EducationTermsController {
   constructor(private readonly educationTermService: EducationTermService) {}
 
   @ApiGetEducationTerms()
+  @EducationReadGuard()
   @Get()
   getEducationTerms(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -53,6 +56,7 @@ export class EducationTermsController {
   }
 
   @ApiPostEducationTerms()
+  @EducationWriteGuard()
   @Post()
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   @UseInterceptors(TransactionInterceptor)
@@ -74,6 +78,7 @@ export class EducationTermsController {
   }
 
   @ApiGetEducationTermById()
+  @EducationReadGuard()
   @Get(':educationTermId')
   getEducationTermById(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -88,6 +93,7 @@ export class EducationTermsController {
   }
 
   @ApiPatchEducationTerm()
+  @EducationWriteGuard()
   @Patch(':educationTermId')
   @UseInterceptors(TransactionInterceptor)
   patchEducationTerm(
@@ -107,6 +113,7 @@ export class EducationTermsController {
   }
 
   @ApiDeleteEducationTerm()
+  @EducationWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   @Delete(':educationTermId')
   async deleteEducationTerm(
@@ -124,6 +131,7 @@ export class EducationTermsController {
   }
 
   @ApiSyncAttendance()
+  @EducationWriteGuard()
   @Post(':educationTermId/sync-attendance')
   @UseInterceptors(TransactionInterceptor)
   syncAttendance(

--- a/backend/src/management/educations/controller/educations.controller.ts
+++ b/backend/src/management/educations/controller/educations.controller.ts
@@ -8,7 +8,6 @@ import {
   Patch,
   Post,
   Query,
-  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
@@ -26,13 +25,13 @@ import { QueryRunner as QR } from 'typeorm';
 import { UpdateEducationDto } from '../dto/education/update-education.dto';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
-import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
-import { ChurchManagerGuard } from '../../../churches/guard/church-guard.service';
 import { Token } from '../../../auth/decorator/jwt.decorator';
 import { AuthType } from '../../../auth/const/enum/auth-type.enum';
 import { JwtAccessPayload } from '../../../auth/type/jwt';
 import { EducationTermService } from '../service/education-term.service';
 import { GetInProgressEducationTermDto } from '../dto/terms/request/get-in-progress-education-term.dto';
+import { EducationReadGuard } from '../guard/education-read.guard';
+import { EducationWriteGuard } from '../guard/education-write.guard';
 
 @ApiTags('Management:Educations')
 @Controller('educations')
@@ -43,6 +42,7 @@ export class EducationsController {
   ) {}
 
   @ApiGetEducation()
+  @EducationReadGuard()
   @Get()
   getEducations(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -53,7 +53,7 @@ export class EducationsController {
 
   @ApiPostEducation()
   @Post()
-  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
+  @EducationWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   postEducation(
     @Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
@@ -66,6 +66,7 @@ export class EducationsController {
   }
 
   @Get('in-progress')
+  @EducationReadGuard()
   getInProgressEducations(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Query() dto: GetInProgressEducationTermDto,
@@ -74,6 +75,7 @@ export class EducationsController {
   }
 
   @ApiGetEducationById()
+  @EducationReadGuard()
   @Get(':educationId')
   getEducationById(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -83,6 +85,7 @@ export class EducationsController {
   }
 
   @ApiPatchEducation()
+  @EducationWriteGuard()
   @Patch(':educationId')
   @UseInterceptors(TransactionInterceptor)
   patchEducation(
@@ -100,6 +103,7 @@ export class EducationsController {
   }
 
   @ApiDeleteEducation()
+  @EducationWriteGuard()
   @Delete(':educationId')
   deleteEducation(
     @Param('churchId', ParseIntPipe) churchId: number,

--- a/backend/src/management/educations/controller/session-attendance.controller.ts
+++ b/backend/src/management/educations/controller/session-attendance.controller.ts
@@ -11,7 +11,6 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { EducationsService } from '../service/educations.service';
 import { QueryRunner as QR } from 'typeorm';
 import { UpdateAttendanceDto } from '../dto/attendance/update-attendance.dto';
 import { GetAttendanceDto } from '../dto/attendance/get-attendance.dto';
@@ -23,6 +22,8 @@ import {
 import { SessionAttendanceService } from '../service/session-attendance.service';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
+import { EducationReadGuard } from '../guard/education-read.guard';
+import { EducationWriteGuard } from '../guard/education-write.guard';
 
 @ApiTags('Management:Educations:Attendance')
 @Controller(
@@ -30,11 +31,11 @@ import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 )
 export class SessionAttendanceController {
   constructor(
-    private readonly educationsService: EducationsService,
     private readonly sessionAttendanceService: SessionAttendanceService,
   ) {}
 
   @ApiGetSessionAttendance()
+  @EducationReadGuard()
   @Get()
   getSessionAttendances(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -50,13 +51,6 @@ export class SessionAttendanceController {
       sessionId,
       dto,
     );
-    /*return this.educationsService.getSessionAttendance(
-      churchId,
-      educationId,
-      educationTermId,
-      sessionId,
-      dto,
-    );*/
   }
 
   @ApiLoadSessionAttendance()
@@ -78,6 +72,7 @@ export class SessionAttendanceController {
   }
 
   @ApiPatchSessionAttendance()
+  @EducationWriteGuard()
   @Patch(':attendanceId')
   @UseInterceptors(TransactionInterceptor)
   patchSessionAttendance(
@@ -98,14 +93,5 @@ export class SessionAttendanceController {
       dto,
       qr,
     );
-    /*return this.educationsService.updateSessionAttendance(
-      churchId,
-      educationId,
-      educationTermId,
-      sessionId,
-      attendanceId,
-      dto,
-      qr,
-    );*/
   }
 }

--- a/backend/src/management/educations/educations.module.ts
+++ b/backend/src/management/educations/educations.module.ts
@@ -16,6 +16,8 @@ import { ChurchesDomainModule } from '../../churches/churches-domain/churches-do
 import { MembersDomainModule } from '../../members/member-domain/members-domain.module';
 import { EducationSessionReportDomainModule } from '../../report/report-domain/education-session-report-domain.module';
 import { ManagerDomainModule } from '../../manager/manager-domain/manager-domain.module';
+import { IDOMAIN_PERMISSION_SERVICE } from '../../permission/service/domain-permission.service.interface';
+import { EducationPermissionService } from './service/education-permission.service';
 
 @Module({
   imports: [
@@ -49,6 +51,10 @@ import { ManagerDomainModule } from '../../manager/manager-domain/manager-domain
     EducationEnrollmentService,
     EducationTermService,
     SessionAttendanceService,
+    {
+      provide: IDOMAIN_PERMISSION_SERVICE,
+      useClass: EducationPermissionService,
+    },
   ],
   exports: [],
 })

--- a/backend/src/management/educations/guard/education-read.guard.ts
+++ b/backend/src/management/educations/guard/education-read.guard.ts
@@ -1,0 +1,18 @@
+import { applyDecorators, UseGuards } from '@nestjs/common';
+import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
+import { createDomainGuard } from '../../../permission/guard/generic-domain.guard';
+import { DomainType } from '../../../permission/const/domain-type.enum';
+import { DomainName } from '../../../permission/const/domain-name.enum';
+import { DomainAction } from '../../../permission/const/domain-action.enum';
+
+export const EducationReadGuard = () =>
+  applyDecorators(
+    UseGuards(
+      AccessTokenGuard,
+      createDomainGuard(
+        DomainType.EDUCATION,
+        DomainName.EDUCATION,
+        DomainAction.READ,
+      ),
+    ),
+  );

--- a/backend/src/management/educations/guard/education-write.guard.ts
+++ b/backend/src/management/educations/guard/education-write.guard.ts
@@ -1,0 +1,18 @@
+import { applyDecorators, UseGuards } from '@nestjs/common';
+import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
+import { createDomainGuard } from '../../../permission/guard/generic-domain.guard';
+import { DomainType } from '../../../permission/const/domain-type.enum';
+import { DomainName } from '../../../permission/const/domain-name.enum';
+import { DomainAction } from '../../../permission/const/domain-action.enum';
+
+export const EducationWriteGuard = () =>
+  applyDecorators(
+    UseGuards(
+      AccessTokenGuard,
+      createDomainGuard(
+        DomainType.EDUCATION,
+        DomainName.EDUCATION,
+        DomainAction.WRITE,
+      ),
+    ),
+  );

--- a/backend/src/management/educations/service/education-permission.service.ts
+++ b/backend/src/management/educations/service/education-permission.service.ts
@@ -1,0 +1,45 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DomainPermissionService } from '../../../permission/service/domain-permission.service';
+import { DomainAction } from '../../../permission/const/domain-action.enum';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IMANAGER_DOMAIN_SERVICE,
+  IManagerDomainService,
+} from '../../../manager/manager-domain/service/interface/manager-domain.service.interface';
+import { DomainType } from '../../../permission/const/domain-type.enum';
+
+@Injectable()
+export class EducationPermissionService extends DomainPermissionService {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IMANAGER_DOMAIN_SERVICE)
+    private readonly managerDomainService: IManagerDomainService,
+  ) {
+    super();
+  }
+
+  async hasPermission(
+    churchId: number,
+    requestUserId: number,
+    domainAction: DomainAction,
+  ): Promise<boolean> {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    return super.checkPermission(
+      DomainType.EDUCATION,
+      domainAction,
+      requestManager,
+    );
+  }
+}

--- a/backend/src/members/const/default-find-options.const.ts
+++ b/backend/src/members/const/default-find-options.const.ts
@@ -14,7 +14,7 @@ export const DefaultMemberRelationOption: FindOptionsRelations<MemberModel> = {
   },
   group: true,
   groupRole: true,
-  user: true,
+  //user: true,
 };
 
 export const DefaultMemberSelectOption: FindOptionsSelect<MemberModel> = {
@@ -47,9 +47,9 @@ export const DefaultMemberSelectOption: FindOptionsSelect<MemberModel> = {
     id: true,
     role: true,
   },
-  user: {
+  /*user: {
     role: true,
-  },
+  },*/
 };
 
 export const DefaultMembersRelationOption: FindOptionsRelations<MemberModel> = {
@@ -60,11 +60,12 @@ export const DefaultMembersRelationOption: FindOptionsRelations<MemberModel> = {
     educationTerm: true,
   },
   officer: true,
-  user: true,
+  //user: true,
 };
 
 export const DefaultMembersSelectOption: FindOptionsSelect<MemberModel> = {
   id: true,
+  profileImageUrl: true,
   name: true,
   createdAt: true,
   updatedAt: true,
@@ -98,9 +99,9 @@ export const DefaultMembersSelectOption: FindOptionsSelect<MemberModel> = {
     id: true,
     name: true,
   },
-  user: {
+  /*user: {
     role: true,
-  },
+  },*/
 };
 
 export const HardDeleteMemberRelationOptions: FindOptionsRelations<MemberModel> =

--- a/backend/src/members/const/member-find-options.const.ts
+++ b/backend/src/members/const/member-find-options.const.ts
@@ -10,6 +10,7 @@ export const MemberSummarizedRelation: FindOptionsRelations<MemberModel> = {
 export const MemberSummarizedSelect: FindOptionsSelect<MemberModel> = {
   id: true,
   name: true,
+  profileImageUrl: true,
   officer: {
     id: true,
     name: true,

--- a/backend/src/members/dto/request/create-member.dto.ts
+++ b/backend/src/members/dto/request/create-member.dto.ts
@@ -10,9 +10,11 @@ import {
   IsNumber,
   IsOptional,
   IsString,
+  IsUrl,
   Length,
   Matches,
   MaxLength,
+  ValidateIf,
 } from 'class-validator';
 import { GenderEnum } from '../../const/enum/gender.enum';
 import { IsValidVehicleNumber } from '../../decorator/is-valid-vehicle-number.decorator';
@@ -21,6 +23,7 @@ import { FamilyRelationConst } from '../../../family-relation/family-relation-do
 import { MarriageOptions } from '../../member-domain/const/marriage-options.const';
 import { RemoveSpaces } from '../../../common/decorator/transformer/remove-spaces';
 import { IsNoSpecialChar } from '../../../common/decorator/validator/is-no-special-char.validator';
+import { IsOptionalNotNull } from '../../../common/decorator/validator/is-optional-not.null.validator';
 
 export class CreateMemberDto {
   @ApiProperty({
@@ -30,7 +33,16 @@ export class CreateMemberDto {
   })
   @IsDate()
   @IsOptional()
-  registeredAt?: Date = new Date();
+  registeredAt?: Date;
+
+  @ApiProperty({
+    description: '프로필 이미지 url',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @ValidateIf((_, value) => typeof value === 'string' && value.length > 0)
+  @IsUrl()
+  profileImageUrl?: string;
 
   @ApiProperty({
     name: 'name',

--- a/backend/src/members/dto/request/create-member.dto.ts
+++ b/backend/src/members/dto/request/create-member.dto.ts
@@ -89,7 +89,7 @@ export class CreateMemberDto {
   @ApiProperty({
     name: 'relation',
     description: '가족 관계',
-    example: '어머니',
+    example: FamilyRelationConst.MOTHER,
     required: false,
   })
   @IsString()

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -15,7 +15,6 @@ import { FamilyRelationModel } from '../../family-relation/entity/family-relatio
 import { MarriageOptions } from '../member-domain/const/marriage-options.const';
 import { Exclude } from 'class-transformer';
 import { BaseModel } from '../../common/entity/base.entity';
-import { UserModel } from '../../user/entity/user.entity';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { MinistryModel } from '../../management/ministries/entity/ministry.entity';
 import { OfficerModel } from '../../management/officers/entity/officer.entity';
@@ -35,13 +34,13 @@ import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 
 @Entity()
 export class MemberModel extends BaseModel {
-  @Index()
+  /*@Index()
   @Column({ nullable: true })
   userId: number;
 
   @OneToOne(() => UserModel, (user) => user.member)
   @JoinColumn({ name: 'userId' })
-  user: UserModel;
+  user: UserModel;*/
 
   @OneToOne(() => ChurchUserModel, (churchUser) => churchUser.member)
   churchUser: ChurchUserModel;
@@ -61,6 +60,9 @@ export class MemberModel extends BaseModel {
   @Index()
   @Column({ default: new Date() })
   registeredAt: Date;
+
+  @Column({ default: '' })
+  profileImageUrl: string;
 
   @Column({ length: 30, comment: '교인 이름' })
   @Index()

--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -65,12 +65,12 @@ export interface IMembersDomainService {
     relationOptions?: FindOptionsRelations<MemberModel>,
   ): Promise<MemberModel>;
 
-  findMemberModelByUserId(
+  /*findMemberModelByUserId(
     church: ChurchModel,
     userId: number,
     qr?: QueryRunner,
     relationOptions?: FindOptionsRelations<MemberModel>,
-  ): Promise<MemberModel>;
+  ): Promise<MemberModel>;*/
 
   /*linkUserToMember(
     member: MemberModel,

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -32,7 +32,6 @@ import { OfficerModel } from '../../../management/officers/entity/officer.entity
 import { MinistryModel } from '../../../management/ministries/entity/ministry.entity';
 import { GroupModel } from '../../../management/groups/entity/group.entity';
 import { GroupRoleModel } from '../../../management/groups/entity/group-role.entity';
-import { UserModel } from '../../../user/entity/user.entity';
 import { MembersDomainPaginationResultDto } from '../dto/members-domain-pagination-result.dto';
 import { GetSimpleMembersDto } from '../../dto/request/get-simple-members.dto';
 import {
@@ -195,7 +194,7 @@ export class MembersDomainService implements IMembersDomainService {
     return member;
   }
 
-  async findMemberModelByUserId(
+  /*async findMemberModelByUserId(
     church: ChurchModel,
     userId: number,
     qr?: QueryRunner,
@@ -216,9 +215,9 @@ export class MembersDomainService implements IMembersDomainService {
     }
 
     return member;
-  }
+  }*/
 
-  async linkUserToMember(
+  /*async linkUserToMember(
     member: MemberModel,
     user: UserModel,
     qr?: QueryRunner,
@@ -240,7 +239,7 @@ export class MembersDomainService implements IMembersDomainService {
     }
 
     return result;
-  }
+  }*/
 
   async findMemberModelById(
     church: ChurchModel,

--- a/backend/src/members/service/search-members.service.ts
+++ b/backend/src/members/service/search-members.service.ts
@@ -228,6 +228,7 @@ export class SearchMembersService implements ISearchMembersService {
     return {
       id: true,
       registeredAt: true,
+      profileImageUrl: true,
       name: true,
       [dto.order]: this.isChurchManagementColumn(dto.order)
         ? { id: true, name: true }

--- a/backend/src/permission/const/domain-name.enum.ts
+++ b/backend/src/permission/const/domain-name.enum.ts
@@ -1,0 +1,7 @@
+export enum DomainName {
+  MEMBER = '교인 관리',
+  VISITATION = '심방',
+  EDUCATION = '교육',
+  TASK = '업무',
+  OFFICER = '직분 관리',
+}

--- a/backend/src/report/service/task-report.service.ts
+++ b/backend/src/report/service/task-report.service.ts
@@ -42,7 +42,7 @@ export class TaskReportService {
       church,
       memberId,
       undefined,
-      { user: true },
+      //{ user: true },
     );
 
     const { data, totalCount } =
@@ -74,7 +74,7 @@ export class TaskReportService {
       church,
       memberId,
       qr,
-      { user: true },
+      //{ user: true },
     );
 
     const report = await this.taskReportDomainService.findTaskReportById(

--- a/backend/src/report/service/visitation-report.service.ts
+++ b/backend/src/report/service/visitation-report.service.ts
@@ -39,7 +39,7 @@ export class VisitationReportService {
       church,
       memberId,
       undefined,
-      { user: true },
+      //{ user: true },
     );
 
     const { data, totalCount } =
@@ -82,7 +82,7 @@ export class VisitationReportService {
       church,
       memberId,
       qr,
-      { user: true },
+      //{ user: true },
     );
 
     return this.visitationReportDomainService.findVisitationReportById(

--- a/backend/src/task/controller/task.controller.ts
+++ b/backend/src/task/controller/task.controller.ts
@@ -36,10 +36,8 @@ import {
 } from '../const/swagger/task.swagger';
 import { AddTaskReportReceiverDto } from '../../report/dto/task-report/request/add-task-report-receiver.dto';
 import { DeleteTaskReportReceiverDto } from '../../report/dto/task-report/request/delete-task-report-receiver.dto';
-import { TaskGuard } from '../guard/task.guard';
-import { DomainAction } from '../../permission/const/domain-action.enum';
-import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
-import { DomainType } from '../../permission/const/domain-type.enum';
+import { TaskReadGuard } from '../guard/task-read.guard';
+import { TaskWriteGuard } from '../guard/task-write.guard';
 
 @ApiTags('Tasks')
 @Controller()
@@ -47,10 +45,7 @@ export class TaskController {
   constructor(private readonly taskService: TaskService) {}
 
   @ApiGetTasks()
-  @UseGuards(
-    AccessTokenGuard,
-    createDomainGuard(DomainType.TASK, '업무', DomainAction.READ),
-  )
+  @TaskReadGuard()
   @Get()
   getTasks(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -60,7 +55,7 @@ export class TaskController {
   }
 
   @ApiPostTask()
-  @UseGuards(AccessTokenGuard, TaskGuard(DomainAction.WRITE))
+  @TaskWriteGuard()
   @Post()
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   @UseInterceptors(TransactionInterceptor)
@@ -74,7 +69,7 @@ export class TaskController {
   }
 
   @ApiGetTaskById()
-  @UseGuards(AccessTokenGuard, TaskGuard(DomainAction.READ))
+  @TaskReadGuard()
   @Get(':taskId')
   async getTaskById(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -84,7 +79,8 @@ export class TaskController {
   }
 
   @ApiGetSubTasks()
-  @UseGuards(AccessTokenGuard, TaskGuard(DomainAction.READ))
+  //@UseGuards(AccessTokenGuard, TaskGuard(DomainAction.READ))
+  @TaskReadGuard()
   @Get(':taskId/sub-tasks')
   async getSubTasks(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -94,7 +90,8 @@ export class TaskController {
   }
 
   @ApiPatchTask()
-  @UseGuards(AccessTokenGuard, TaskGuard(DomainAction.WRITE))
+  //@UseGuards(AccessTokenGuard, TaskGuard(DomainAction.WRITE))
+  @TaskWriteGuard()
   @Patch(':taskId')
   @UseInterceptors(TransactionInterceptor)
   patchTask(
@@ -107,7 +104,8 @@ export class TaskController {
   }
 
   @ApiDeleteTask()
-  @UseGuards(AccessTokenGuard, TaskGuard(DomainAction.WRITE))
+  //@UseGuards(AccessTokenGuard, TaskGuard(DomainAction.WRITE))
+  @TaskWriteGuard()
   @Delete(':taskId')
   @UseInterceptors(TransactionInterceptor)
   deleteTask(
@@ -119,7 +117,8 @@ export class TaskController {
   }
 
   @ApiAddReportReceivers()
-  @UseGuards(AccessTokenGuard, TaskGuard(DomainAction.WRITE))
+  //@UseGuards(AccessTokenGuard, TaskGuard(DomainAction.WRITE))
+  @TaskWriteGuard()
   @Patch(':taskId/add-receivers')
   @UseInterceptors(TransactionInterceptor)
   addReportReceivers(
@@ -132,7 +131,8 @@ export class TaskController {
   }
 
   @ApiDeleteReportReceiver()
-  @UseGuards(AccessTokenGuard, TaskGuard(DomainAction.WRITE))
+  //@UseGuards(AccessTokenGuard, TaskGuard(DomainAction.WRITE))
+  @TaskWriteGuard()
   @Patch(':taskId/delete-receivers')
   @UseInterceptors(TransactionInterceptor)
   deleteReportReceivers(

--- a/backend/src/task/guard/task-read.guard.ts
+++ b/backend/src/task/guard/task-read.guard.ts
@@ -1,0 +1,14 @@
+import { applyDecorators, UseGuards } from '@nestjs/common';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
+import { DomainType } from '../../permission/const/domain-type.enum';
+import { DomainName } from '../../permission/const/domain-name.enum';
+import { DomainAction } from '../../permission/const/domain-action.enum';
+
+export const TaskReadGuard = () =>
+  applyDecorators(
+    UseGuards(
+      AccessTokenGuard,
+      createDomainGuard(DomainType.TASK, DomainName.TASK, DomainAction.READ),
+    ),
+  );

--- a/backend/src/task/guard/task-write.guard.ts
+++ b/backend/src/task/guard/task-write.guard.ts
@@ -1,0 +1,14 @@
+import { applyDecorators, UseGuards } from '@nestjs/common';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
+import { DomainType } from '../../permission/const/domain-type.enum';
+import { DomainName } from '../../permission/const/domain-name.enum';
+import { DomainAction } from '../../permission/const/domain-action.enum';
+
+export const TaskWriteGuard = () =>
+  applyDecorators(
+    UseGuards(
+      AccessTokenGuard,
+      createDomainGuard(DomainType.TASK, DomainName.TASK, DomainAction.WRITE),
+    ),
+  );

--- a/backend/src/user/entity/user.entity.ts
+++ b/backend/src/user/entity/user.entity.ts
@@ -2,7 +2,6 @@ import { Column, Entity, Index, OneToMany, OneToOne } from 'typeorm';
 import { BaseModel } from '../../common/entity/base.entity';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { UserRole } from '../const/user-role.enum';
-import { MemberModel } from '../../members/entity/member.entity';
 import { ChurchJoinRequestModel } from '../../churches/entity/church-join-request.entity';
 import { Exclude } from 'class-transformer';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
@@ -46,6 +45,6 @@ export class UserModel extends BaseModel {
   @OneToMany(() => ChurchJoinRequestModel, (joinRequest) => joinRequest.user)
   joinRequest: ChurchJoinRequestModel;
 
-  @OneToOne(() => MemberModel, (member) => member.user)
-  member: MemberModel;
+  /*@OneToOne(() => MemberModel, (member) => member.user)
+  member: MemberModel;*/
 }

--- a/backend/src/visitation/guard/visitation-read.guard.ts
+++ b/backend/src/visitation/guard/visitation-read.guard.ts
@@ -1,0 +1,18 @@
+import { applyDecorators, UseGuards } from '@nestjs/common';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
+import { DomainType } from '../../permission/const/domain-type.enum';
+import { DomainName } from '../../permission/const/domain-name.enum';
+import { DomainAction } from '../../permission/const/domain-action.enum';
+
+export const VisitationReadGuard = () =>
+  applyDecorators(
+    UseGuards(
+      AccessTokenGuard,
+      createDomainGuard(
+        DomainType.VISITATION,
+        DomainName.VISITATION,
+        DomainAction.READ,
+      ),
+    ),
+  );

--- a/backend/src/visitation/guard/visitation-write.guard.ts
+++ b/backend/src/visitation/guard/visitation-write.guard.ts
@@ -1,0 +1,18 @@
+import { applyDecorators, UseGuards } from '@nestjs/common';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
+import { DomainType } from '../../permission/const/domain-type.enum';
+import { DomainName } from '../../permission/const/domain-name.enum';
+import { DomainAction } from '../../permission/const/domain-action.enum';
+
+export const VisitationWriteGuard = () =>
+  applyDecorators(
+    UseGuards(
+      AccessTokenGuard,
+      createDomainGuard(
+        DomainType.VISITATION,
+        DomainName.VISITATION,
+        DomainAction.WRITE,
+      ),
+    ),
+  );


### PR DESCRIPTION
## 주요 내용
교육(Education) 도메인에 대한 권한 체크 기능을 구현하고, Guard를 통해 실제 요청에 적용함

## 세부 내용

### 권한 체크 서비스 구현
- abstract class DomainPermissionService 상속하여 EducationPermissionService 구현
- IDomainPermissionService 인터페이스 구현
- hasPermission(churchId, requestUserId, domainAction) 메서드에서 도메인 타입과 액션 기반으로 권한 판단
- 내부적으로 checkPermission(domainAction, manager) 공통 로직 재사용

### Guard 적용
- EducationGuard(domainAction: DomainAction) 형태의 Guard 팩토리 구현
- 요청된 유저가 교육 도메인에 대해 주어진 액션 권한을 가지고 있는지 검사
- 권한이 없을 경우 403 Forbidden 에러 반환

## 목적 및 효과
- 교육 도메인에 대한 접근 제어 정책 적용
- 공통된 추상 클래스 기반 권한 체계 확립
- 도메인별 Guard 구조 확장을 통한 요청 흐름 내 보안 강화
