### PR TITLE
feat: ChurchJoinModule 응답 DTO 정비 및 이미 연결된 교인에 대한 예외 처리 추가

### DIFF
--- a/backend/src/church-join/church-join-domain/dto/church-join-domain-pagination-result.dto.ts
+++ b/backend/src/church-join/church-join-domain/dto/church-join-domain-pagination-result.dto.ts
@@ -1,0 +1,8 @@
+import { BaseDomainOffsetPaginationResultDto } from '../../../common/dto/base-domain-offset-pagination-result.dto';
+import { ChurchJoinModel } from '../../entity/church-join.entity';
+
+export class ChurchJoinDomainPaginationResultDto extends BaseDomainOffsetPaginationResultDto<ChurchJoinModel> {
+  constructor(data: ChurchJoinModel[], totalCount: number) {
+    super(data, totalCount);
+  }
+}

--- a/backend/src/church-join/church-join-domain/interface/church-join-requests-domain.service.interface.ts
+++ b/backend/src/church-join/church-join-domain/interface/church-join-requests-domain.service.interface.ts
@@ -3,7 +3,8 @@ import { UserModel } from '../../../user/entity/user.entity';
 import { QueryRunner, UpdateResult } from 'typeorm';
 import { ChurchJoinModel } from '../../entity/church-join.entity';
 import { ChurchJoinRequestStatusEnum } from '../../const/church-join-request-status.enum';
-import { GetJoinRequestDto } from '../../dto/get-join-request.dto';
+import { GetJoinRequestDto } from '../../dto/request/get-join-request.dto';
+import { ChurchJoinDomainPaginationResultDto } from '../dto/church-join-domain-pagination-result.dto';
 
 export const ICHURCH_JOIN_REQUESTS_DOMAIN_SERVICE = Symbol(
   'ICHURCH_JOIN_REQUESTS_DOMAIN_SERVICE',
@@ -25,7 +26,7 @@ export interface IChurchJoinRequestDomainService {
     church: ChurchModel,
     dto: GetJoinRequestDto,
     qr?: QueryRunner,
-  ): Promise<{ data: ChurchJoinModel[]; totalCount: number }>;
+  ): Promise<ChurchJoinDomainPaginationResultDto>;
 
   findChurchJoinRequestById(
     church: ChurchModel,

--- a/backend/src/church-join/church-join-domain/service/church-join-requests-domain.service.ts
+++ b/backend/src/church-join/church-join-domain/service/church-join-requests-domain.service.ts
@@ -19,8 +19,9 @@ import {
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { UserModel } from '../../../user/entity/user.entity';
 import { ChurchJoinRequestStatusEnum } from '../../const/church-join-request-status.enum';
-import { GetJoinRequestDto } from '../../dto/get-join-request.dto';
+import { GetJoinRequestDto } from '../../dto/request/get-join-request.dto';
 import { ChurchJoinException } from '../../exception/church-join.exception';
+import { ChurchJoinDomainPaginationResultDto } from '../dto/church-join-domain-pagination-result.dto';
 
 @Injectable()
 export class ChurchJoinRequestsDomainService
@@ -64,13 +65,13 @@ export class ChurchJoinRequestsDomainService
   ) {
     const repository = this.getRepository(qr);
 
-    const newRequest = await repository.save({
+    return repository.save({
       church,
       user,
       status: ChurchJoinRequestStatusEnum.PENDING,
     });
 
-    return this.findMyChurchJoinRequestById(user, newRequest.id, qr);
+    //return this.findMyChurchJoinRequestById(user, newRequest.id, qr);
   }
 
   private parseCreatedAt(dto: GetJoinRequestDto) {
@@ -123,7 +124,7 @@ export class ChurchJoinRequestsDomainService
       }),
     ]);
 
-    return { data, totalCount };
+    return new ChurchJoinDomainPaginationResultDto(data, totalCount);
   }
 
   async findChurchJoinRequestById(

--- a/backend/src/church-join/controller/church-join.controller.ts
+++ b/backend/src/church-join/controller/church-join.controller.ts
@@ -19,10 +19,10 @@ import { TransactionInterceptor } from '../../common/interceptor/transaction.int
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm/query-runner/QueryRunner';
 import { ApiTags } from '@nestjs/swagger';
-import { ApproveJoinRequestDto } from '../dto/approve-join-request.dto';
+import { ApproveJoinRequestDto } from '../dto/request/approve-join-request.dto';
 import { ChurchJoinService } from '../service/church-join.service';
-import { CreateJoinRequestDto } from '../dto/create-join-request.dto';
-import { GetJoinRequestDto } from '../dto/get-join-request.dto';
+import { CreateJoinRequestDto } from '../dto/request/create-join-request.dto';
+import { GetJoinRequestDto } from '../dto/request/get-join-request.dto';
 import { GetRecommendLinkMemberDto } from '../../members/dto/request/get-recommend-link-member.dto';
 import {
   ApiApproveChurchJoinRequest,

--- a/backend/src/church-join/dto/request/approve-join-request.dto.ts
+++ b/backend/src/church-join/dto/request/approve-join-request.dto.ts
@@ -4,7 +4,7 @@ import {
   AssignableChurchUserRole,
   ChurchUserRole,
   UserRole,
-} from '../../user/const/user-role.enum';
+} from '../../../user/const/user-role.enum';
 
 export class ApproveJoinRequestDto {
   @ApiProperty({

--- a/backend/src/church-join/dto/request/create-join-request.dto.ts
+++ b/backend/src/church-join/dto/request/create-join-request.dto.ts
@@ -1,8 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString, Length, Matches } from 'class-validator';
-import { Transform } from 'class-transformer';
 
-import { ChurchJoinException } from '../exception/church-join.exception';
+import { ChurchJoinException } from '../../exception/church-join.exception';
 
 export class CreateJoinRequestDto {
   @ApiProperty({
@@ -13,7 +12,7 @@ export class CreateJoinRequestDto {
   @Matches(/^[A-Za-z0-9]+$/, {
     message: ChurchJoinException.INVALID_CHURCH_CODE,
   })
-  @Transform(({ value }) => value.toUpperCase())
+  //@Transform(({ value }) => value.toUpperCase())
   @Length(6, 20, { message: ChurchJoinException.INVALID_CHURCH_CODE })
   joinCode: string;
 }

--- a/backend/src/church-join/dto/request/get-join-request.dto.ts
+++ b/backend/src/church-join/dto/request/get-join-request.dto.ts
@@ -1,18 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import {
-  IsDate,
-  IsEnum,
-  IsIn,
-  IsNumber,
-  IsOptional,
-  Min,
-} from 'class-validator';
-import { ChurchJoinRequestStatusEnum } from '../const/church-join-request-status.enum';
-import { JoinRequestOrderEnum } from '../const/join-request-order.enum';
-import { TransformStringArray } from '../../common/decorator/transformer/transform-array';
+import { IsDate, IsEnum, IsOptional } from 'class-validator';
+import { ChurchJoinRequestStatusEnum } from '../../const/church-join-request-status.enum';
+import { JoinRequestOrderEnum } from '../../const/join-request-order.enum';
+import { TransformStringArray } from '../../../common/decorator/transformer/transform-array';
+import { BaseOffsetPaginationRequestDto } from '../../../common/dto/request/base-offset-pagination-request.dto';
 
-export class GetJoinRequestDto {
-  @ApiProperty({
+export class GetJoinRequestDto extends BaseOffsetPaginationRequestDto<JoinRequestOrderEnum> {
+  /*@ApiProperty({
     description: '요청 데이터 개수',
     default: 20,
     required: false,
@@ -33,6 +27,16 @@ export class GetJoinRequestDto {
   page: number = 1;
 
   @ApiProperty({
+    description: '정렬 오름차순 / 내림차순',
+    default: 'desc',
+    required: false,
+  })
+  @IsOptional()
+  @IsIn(['asc', 'desc', 'ASC', 'DESC'])
+  orderDirection: 'ASC' | 'DESC' | 'asc' | 'desc' = 'DESC';
+  */
+
+  @ApiProperty({
     description: '정렬 기준',
     enum: JoinRequestOrderEnum,
     default: JoinRequestOrderEnum.createdAt,
@@ -41,15 +45,6 @@ export class GetJoinRequestDto {
   @IsOptional()
   @IsEnum(JoinRequestOrderEnum)
   order: JoinRequestOrderEnum = JoinRequestOrderEnum.createdAt;
-
-  @ApiProperty({
-    description: '정렬 오름차순 / 내림차순',
-    default: 'desc',
-    required: false,
-  })
-  @IsOptional()
-  @IsIn(['asc', 'desc', 'ASC', 'DESC'])
-  orderDirection: 'ASC' | 'DESC' | 'asc' | 'desc' = 'DESC';
 
   @ApiProperty({
     description: '신청 날짜 ~ 부터',

--- a/backend/src/church-join/dto/response/delete-join-request-response.dto.ts
+++ b/backend/src/church-join/dto/response/delete-join-request-response.dto.ts
@@ -1,0 +1,7 @@
+import { BaseDeleteResponseDto } from '../../../common/dto/reponse/base-delete-response.dto';
+
+export class DeleteJoinRequestResponseDto extends BaseDeleteResponseDto {
+  constructor(timestamp: Date, id: number, success: boolean) {
+    super(timestamp, id, success);
+  }
+}

--- a/backend/src/church-join/dto/response/get-join-request-response.dto.ts
+++ b/backend/src/church-join/dto/response/get-join-request-response.dto.ts
@@ -1,0 +1,8 @@
+import { BaseGetResponseDto } from '../../../common/dto/reponse/base-get-response.dto';
+import { ChurchJoinModel } from '../../entity/church-join.entity';
+
+export class GetJoinRequestResponseDto extends BaseGetResponseDto<ChurchJoinModel> {
+  constructor(data: ChurchJoinModel) {
+    super(data);
+  }
+}

--- a/backend/src/church-join/dto/response/join-request-pagination-result.dto.ts
+++ b/backend/src/church-join/dto/response/join-request-pagination-result.dto.ts
@@ -1,10 +1,5 @@
-import { BaseOffsetPaginationResponseDto } from '../../common/dto/reponse/base-offset-pagination-response.dto';
-import { ChurchJoinModel } from '../entity/church-join.entity';
-
-/*export interface JoinRequestPaginationResult
-  extends BaseOffsetPaginationResultDto<ChurchJoinRequestModel> {
-  totalPage: number;
-}*/
+import { BaseOffsetPaginationResponseDto } from '../../../common/dto/reponse/base-offset-pagination-response.dto';
+import { ChurchJoinModel } from '../../entity/church-join.entity';
 
 export class JoinRequestPaginationResult extends BaseOffsetPaginationResponseDto<ChurchJoinModel> {
   constructor(

--- a/backend/src/church-join/dto/response/patch-join-request-response.dto.ts
+++ b/backend/src/church-join/dto/response/patch-join-request-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePatchResponseDto } from '../../../common/dto/reponse/base-patch-response.dto';
+import { ChurchJoinModel } from '../../entity/church-join.entity';
+
+export class PatchJoinRequestResponseDto extends BasePatchResponseDto<ChurchJoinModel> {
+  constructor(data: ChurchJoinModel) {
+    super(data);
+  }
+}

--- a/backend/src/church-join/dto/response/post-join-request-response.dto.ts
+++ b/backend/src/church-join/dto/response/post-join-request-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePostResponseDto } from '../../../common/dto/reponse/base-post-response.dto';
+import { ChurchJoinModel } from '../../entity/church-join.entity';
+
+export class PostJoinRequestResponseDto extends BasePostResponseDto<ChurchJoinModel> {
+  constructor(data: ChurchJoinModel) {
+    super(data);
+  }
+}

--- a/backend/src/church-user/controller/church-user.controller.ts
+++ b/backend/src/church-user/controller/church-user.controller.ts
@@ -69,7 +69,10 @@ export class ChurchUserController {
   })
   @ChurchUserWriteGuard()
   @Patch(':churchUserId/link-member')
-  linkMember() {
+  linkMember(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
+  ) {
     return '개발 전';
   }
 
@@ -78,7 +81,10 @@ export class ChurchUserController {
   })
   @Patch(':churchUserId/unlink-member')
   @ChurchUserWriteGuard()
-  unlinkMember() {
+  unlinkMember(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
+  ) {
     return '개발 전';
   }
 
@@ -87,7 +93,10 @@ export class ChurchUserController {
   })
   @Patch(':churchUserId/leave-church')
   @ChurchUserWriteGuard()
-  leaveChurch() {
+  leaveChurch(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
+  ) {
     return '개발 전';
   }
 }

--- a/backend/src/church-user/exception/church-user.exception.ts
+++ b/backend/src/church-user/exception/church-user.exception.ts
@@ -3,4 +3,5 @@ export const ChurchUserException = {
   NOT_FOUND: '해당 교회 가입 정보를 찾을 수 없습니다.',
   UPDATE_ERROR: '교회 가입 정보 업데이트 도중 에러 발생',
   DELETE_ERROR: '교회 가입 정보 삭제 도중 에러 발생',
+  ALREADY_EXIST: '이미 존재하는 데이터입니다.',
 };


### PR DESCRIPTION
## 주요 내용
교회 가입(ChurchJoin) 관련 API의 응답 형식을 DTO로 정비하고, 이미 링크된 교인을 다시 연결하려는 경우 ConflictException을 발생시키도록 처리함.

## 세부 내용

### 응답 DTO 적용
- ChurchJoinController 전반에 Response DTO 적용
- 일관된 응답 포맷 유지 및 Swagger 문서 명확화

### 중복 연결 예외 처리
- 이미 특정 교회에 연결된 교인을 동일한 방식으로 다시 연결하려는 경우
- ConflictException 발생 (409), 예외 메시지 구체화

## 목적 및 효과
- 응답 구조 개선을 통한 API 명확성 향상
- 중복 요청에 대한 방어 로직 추가로 서비스 안정성 확보