### PR TITLE
feat: MemberFilterService 도입 및 권한 기반 교인 정보 필터링 적용

### DIFF
--- a/backend/src/members/controller/members.controller.ts
+++ b/backend/src/members/controller/members.controller.ts
@@ -21,6 +21,8 @@ import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { GetSimpleMembersDto } from '../dto/request/get-simple-members.dto';
 import { MemberReadGuard } from '../guard/member-read.guard';
 import { MemberWriteGuard } from '../guard/member-write.guard';
+import { PermissionManager } from '../../permission/decorator/permission-manager.decorator';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 
 @ApiTags('Churches:Members')
 @Controller('members')
@@ -32,8 +34,9 @@ export class MembersController {
   getMembers(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Query() dto: GetMemberDto,
+    @PermissionManager() pm: ChurchUserModel,
   ) {
-    return this.membersService.getMembers(churchId, dto);
+    return this.membersService.getMembers(churchId, pm, dto);
   }
 
   @Post()
@@ -51,6 +54,7 @@ export class MembersController {
   getMembersSimple(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Query() dto: GetSimpleMembersDto,
+    @PermissionManager() pm: ChurchUserModel,
   ) {
     return this.membersService.getSimpleMembers(churchId, dto);
   }
@@ -60,8 +64,9 @@ export class MembersController {
   getMemberById(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
+    @PermissionManager() pm: ChurchUserModel,
   ) {
-    return this.membersService.getMemberById(churchId, memberId);
+    return this.membersService.getMemberById(churchId, memberId, pm);
   }
 
   @Patch(':memberId')

--- a/backend/src/members/members.module.ts
+++ b/backend/src/members/members.module.ts
@@ -10,6 +10,9 @@ import { FamilyRelationDomainModule } from '../family-relation/family-relation-d
 import { IDOMAIN_PERMISSION_SERVICE } from '../permission/service/domain-permission.service.interface';
 import { MemberPermissionService } from './service/member-permission.service';
 import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
+import { GroupsDomainModule } from '../management/groups/groups-domain/groups-domain.module';
+import { IMEMBER_FILTER_SERVICE } from './service/interface/member-filter.service.interface';
+import { MemberFilterService } from './service/member-filter.service';
 
 @Module({
   imports: [
@@ -21,6 +24,7 @@ import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.mo
     ManagerDomainModule,
     MembersDomainModule,
     FamilyRelationDomainModule,
+    GroupsDomainModule,
   ],
   controllers: [MembersController],
   providers: [
@@ -32,6 +36,10 @@ import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.mo
     {
       provide: IDOMAIN_PERMISSION_SERVICE,
       useClass: MemberPermissionService,
+    },
+    {
+      provide: IMEMBER_FILTER_SERVICE,
+      useClass: MemberFilterService,
     },
   ],
   exports: [],

--- a/backend/src/members/service/interface/member-filter.service.interface.ts
+++ b/backend/src/members/service/interface/member-filter.service.interface.ts
@@ -1,0 +1,19 @@
+import { MemberModel } from '../../entity/member.entity';
+import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+
+export const IMEMBER_FILTER_SERVICE = Symbol('MEMBER_FILTER_SERVICE');
+
+export interface IMemberFilterService {
+  filterMembers(
+    church: ChurchModel,
+    requestManager: ChurchUserModel,
+    members: MemberModel[],
+  ): Promise<MemberModel[]>;
+
+  filterMember(
+    church: ChurchModel,
+    requestManager: ChurchUserModel,
+    member: MemberModel,
+  ): Promise<MemberModel>;
+}

--- a/backend/src/members/service/member-filter.service.ts
+++ b/backend/src/members/service/member-filter.service.ts
@@ -1,0 +1,101 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IMemberFilterService } from './interface/member-filter.service.interface';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { MemberModel } from '../entity/member.entity';
+import {
+  IGROUPS_DOMAIN_SERVICE,
+  IGroupsDomainService,
+} from '../../management/groups/groups-domain/interface/groups-domain.service.interface';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { ChurchUserRole } from '../../user/const/user-role.enum';
+
+@Injectable()
+export class MemberFilterService implements IMemberFilterService {
+  constructor(
+    @Inject(IGROUPS_DOMAIN_SERVICE)
+    private readonly groupsDomainService: IGroupsDomainService,
+  ) {}
+
+  async filterMember(
+    church: ChurchModel,
+    requestManager: ChurchUserModel,
+    member: MemberModel,
+  ): Promise<MemberModel> {
+    if (!member.groupId) {
+      return member;
+    }
+
+    if (requestManager.role === ChurchUserRole.OWNER) {
+      return member;
+    }
+
+    const memberGroup = await this.groupsDomainService.findGroupModelById(
+      church,
+      member.groupId,
+    );
+
+    const memberParentGroups = await this.groupsDomainService.findParentGroups(
+      church,
+      memberGroup,
+    );
+
+    const possibleScopes = memberParentGroups.map(
+      (parentGroup) => parentGroup.id,
+    );
+    possibleScopes.push(member.groupId);
+
+    const possibleScopesSet = new Set(possibleScopes);
+
+    const managerScopes = requestManager.permissionScopes.map(
+      (scope) => scope.group.id,
+    );
+
+    for (const managerScope of managerScopes) {
+      if (possibleScopesSet.has(managerScope)) {
+        return member;
+      }
+    }
+
+    return this.concealInfo(member);
+  }
+
+  private concealInfo(member: MemberModel) {
+    const openInfo = new Set([
+      'id',
+      'createdAt',
+      'updatedAt',
+      'registeredAt',
+      'profileImageUrl',
+      'name',
+      'birth',
+      'isLunar',
+      'gender',
+      'group',
+      'groupRole',
+      'officer',
+      'ministries',
+      'educations',
+    ]);
+
+    for (const key of Object.keys(member)) {
+      if (openInfo.has(key)) {
+        continue;
+      }
+      member[key] = 'CONCEALED';
+    }
+
+    return member;
+  }
+
+  async filterMembers(
+    church: ChurchModel,
+    requestManager: ChurchUserModel,
+    members: MemberModel[],
+  ) {
+    return Promise.all(
+      members.map((member) =>
+        this.filterMember(church, requestManager, member),
+      ),
+    );
+  }
+}

--- a/backend/src/members/service/search-members.service.ts
+++ b/backend/src/members/service/search-members.service.ts
@@ -233,6 +233,7 @@ export class SearchMembersService implements ISearchMembersService {
       [dto.order]: this.isChurchManagementColumn(dto.order)
         ? { id: true, name: true }
         : true,
+      groupId: true,
     };
   }
 


### PR DESCRIPTION
## 주요 내용
- IMemberFilterService 인터페이스 및 구현체 MemberFilterService 생성
- 요청자의 PermissionScope 기준으로 교인(MemberModel)의 응답 정보 필터링 처리
- Scope에 포함되지 않은 교인의 경우, 민감 정보는 "CONCEALED"로 대체하여 응답

## 세부 내용
### 필터링 제외 대상 필드
- id
- createdAt
- updatedAt
- registeredAt
- profileImageUrl
- name
- birth
- isLunar
- gender
- group
- groupRole
- officer
- ministries
- educations

### 적용 대상 엔드포인트
- GET /churches/{churchId}/members
- GET /churches/{churchId}/members/{memberId}