### PR TITLE
feat: 교인 수정/삭제 및 연결된 리소스 작업 시 권한 범위 기반 검증 로직 도입

### DIFF
--- a/backend/src/church-join/service/church-join-permission.service.ts
+++ b/backend/src/church-join/service/church-join-permission.service.ts
@@ -1,6 +1,5 @@
 import { DomainPermissionService } from '../../permission/service/domain-permission.service';
 import { DomainAction } from '../../permission/const/domain-action.enum';
-import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { Inject, Injectable } from '@nestjs/common';
 import {
   ICHURCHES_DOMAIN_SERVICE,
@@ -23,24 +22,24 @@ export class ChurchJoinPermissionService extends DomainPermissionService {
     super();
   }
 
-  async getRequestManagerOrThrow(
-    churchId: number,
-    requestUserId: number,
-  ): Promise<ChurchUserModel> {
+  async getRequestManagerOrThrow(churchId: number, requestUserId: number) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    return this.managerDomainService.findManagerForPermissionCheck(
-      church,
-      requestUserId,
-    );
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    return { requestManager, church };
   }
 
   async hasPermission(
     churchId: number,
     requestUserId: number,
     domainAction: DomainAction,
-  ): Promise<ChurchUserModel | null> {
+  ) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
@@ -57,7 +56,7 @@ export class ChurchJoinPermissionService extends DomainPermissionService {
     );
 
     if (permission) {
-      return requestManager;
+      return { requestManager, church };
     } else {
       return null;
     }

--- a/backend/src/church-user/service/church-user-permission.service.ts
+++ b/backend/src/church-user/service/church-user-permission.service.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { DomainPermissionService } from '../../permission/service/domain-permission.service';
 import { DomainAction } from '../../permission/const/domain-action.enum';
-import { ChurchUserModel } from '../entity/church-user.entity';
 import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
@@ -23,24 +22,24 @@ export class ChurchUserPermissionService extends DomainPermissionService {
     super();
   }
 
-  async getRequestManagerOrThrow(
-    churchId: number,
-    requestUserId: number,
-  ): Promise<ChurchUserModel> {
+  async getRequestManagerOrThrow(churchId: number, requestUserId: number) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    return this.managerDomainService.findManagerForPermissionCheck(
-      church,
-      requestUserId,
-    );
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    return { requestManager, church };
   }
 
   async hasPermission(
     churchId: number,
     requestUserId: number,
     domainAction: DomainAction,
-  ): Promise<ChurchUserModel | null> {
+  ) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
@@ -57,7 +56,7 @@ export class ChurchUserPermissionService extends DomainPermissionService {
     );
 
     if (permission) {
-      return requestManager;
+      return { requestManager, church };
     } else {
       return null;
     }

--- a/backend/src/churches/service/church-permission.service.ts
+++ b/backend/src/churches/service/church-permission.service.ts
@@ -1,6 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { DomainPermissionService } from '../../permission/service/domain-permission.service';
-import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { DomainAction } from '../../permission/const/domain-action.enum';
 import {
   ICHURCHES_DOMAIN_SERVICE,
@@ -23,24 +22,24 @@ export class ChurchPermissionService extends DomainPermissionService {
     super();
   }
 
-  async getRequestManagerOrThrow(
-    churchId: number,
-    requestUserId: number,
-  ): Promise<ChurchUserModel> {
+  async getRequestManagerOrThrow(churchId: number, requestUserId: number) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    return this.managerDomainService.findManagerForPermissionCheck(
-      church,
-      requestUserId,
-    );
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    return { requestManager, church };
   }
 
   async hasPermission(
     churchId: number,
     requestUserId: number,
     domainAction: DomainAction,
-  ): Promise<ChurchUserModel | null> {
+  ) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
@@ -52,13 +51,13 @@ export class ChurchPermissionService extends DomainPermissionService {
 
     if (domainAction === DomainAction.WRITE) {
       if (requestManager.role === ChurchUserRole.OWNER) {
-        return requestManager;
+        return { requestManager, church };
       } else {
         return null;
       }
     } else {
       // 읽기 권한인 경우 교회 관리자 통과
-      return requestManager;
+      return { requestManager, church };
     }
     /*const permission = super.checkPermission(
       DomainType.MANAGEMENT,

--- a/backend/src/common/const/http-method.enum.ts
+++ b/backend/src/common/const/http-method.enum.ts
@@ -1,0 +1,6 @@
+export enum HttpMethod {
+  GET = 'GET',
+  POST = 'POST',
+  PATCH = 'PATCH',
+  DELETE = 'DELETE',
+}

--- a/backend/src/family-relation/service/family-permission.service.ts
+++ b/backend/src/family-relation/service/family-permission.service.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { DomainPermissionService } from '../../permission/service/domain-permission.service';
 import { DomainAction } from '../../permission/const/domain-action.enum';
-import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
@@ -23,24 +22,24 @@ export class FamilyPermissionService extends DomainPermissionService {
     super();
   }
 
-  async getRequestManagerOrThrow(
-    churchId: number,
-    requestUserId: number,
-  ): Promise<ChurchUserModel> {
+  async getRequestManagerOrThrow(churchId: number, requestUserId: number) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    return this.managerDomainService.findManagerForPermissionCheck(
-      church,
-      requestUserId,
-    );
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    return { requestManager, church };
   }
 
   async hasPermission(
     churchId: number,
     requestUserId: number,
     domainAction: DomainAction,
-  ): Promise<ChurchUserModel | null> {
+  ) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
@@ -57,7 +56,7 @@ export class FamilyPermissionService extends DomainPermissionService {
     );
 
     if (permission) {
-      return requestManager;
+      return { requestManager, church };
     } else {
       return null;
     }

--- a/backend/src/management/educations/service/education-permission.service.ts
+++ b/backend/src/management/educations/service/education-permission.service.ts
@@ -10,7 +10,6 @@ import {
   IManagerDomainService,
 } from '../../../manager/manager-domain/service/interface/manager-domain.service.interface';
 import { DomainType } from '../../../permission/const/domain-type.enum';
-import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 
 @Injectable()
 export class EducationPermissionService extends DomainPermissionService {
@@ -23,24 +22,24 @@ export class EducationPermissionService extends DomainPermissionService {
     super();
   }
 
-  async getRequestManagerOrThrow(
-    churchId: number,
-    requestUserId: number,
-  ): Promise<ChurchUserModel> {
+  async getRequestManagerOrThrow(churchId: number, requestUserId: number) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    return this.managerDomainService.findManagerForPermissionCheck(
-      church,
-      requestUserId,
-    );
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    return { requestManager, church };
   }
 
   async hasPermission(
     churchId: number,
     requestUserId: number,
     domainAction: DomainAction,
-  ): Promise<ChurchUserModel | null> {
+  ) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
@@ -57,7 +56,7 @@ export class EducationPermissionService extends DomainPermissionService {
     );
 
     if (permission) {
-      return requestManager;
+      return { requestManager, church };
     } else {
       return null;
     }

--- a/backend/src/management/management-permission.service.ts
+++ b/backend/src/management/management-permission.service.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { DomainPermissionService } from '../permission/service/domain-permission.service';
 import { DomainAction } from '../permission/const/domain-action.enum';
-import { ChurchUserModel } from '../church-user/entity/church-user.entity';
 import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
@@ -23,24 +22,24 @@ export class ManagementPermissionService extends DomainPermissionService {
     super();
   }
 
-  async getRequestManagerOrThrow(
-    churchId: number,
-    requestUserId: number,
-  ): Promise<ChurchUserModel> {
+  async getRequestManagerOrThrow(churchId: number, requestUserId: number) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    return this.managerDomainService.findManagerForPermissionCheck(
-      church,
-      requestUserId,
-    );
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    return { requestManager, church };
   }
 
   async hasPermission(
     churchId: number,
     requestUserId: number,
     domainAction: DomainAction,
-  ): Promise<ChurchUserModel | null> {
+  ) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
@@ -57,7 +56,7 @@ export class ManagementPermissionService extends DomainPermissionService {
     );
 
     if (permission) {
-      return requestManager;
+      return { requestManager, church };
     } else {
       return null;
     }

--- a/backend/src/manager/service/manager-permission.service.ts
+++ b/backend/src/manager/service/manager-permission.service.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { DomainPermissionService } from '../../permission/service/domain-permission.service';
 import { DomainAction } from '../../permission/const/domain-action.enum';
-import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
@@ -23,24 +22,24 @@ export class ManagerPermissionService extends DomainPermissionService {
     super();
   }
 
-  async getRequestManagerOrThrow(
-    churchId: number,
-    requestUserId: number,
-  ): Promise<ChurchUserModel> {
+  async getRequestManagerOrThrow(churchId: number, requestUserId: number) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    return this.managerDomainService.findManagerForPermissionCheck(
-      church,
-      requestUserId,
-    );
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    return { requestManager, church };
   }
 
   async hasPermission(
     churchId: number,
     requestUserId: number,
     domainAction: DomainAction,
-  ): Promise<ChurchUserModel | null> {
+  ) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
     const requestManager =
@@ -56,7 +55,7 @@ export class ManagerPermissionService extends DomainPermissionService {
     );
 
     if (permission) {
-      return requestManager;
+      return { requestManager, church };
     } else {
       return null;
     }

--- a/backend/src/member-history/guard/history-write.guard.ts
+++ b/backend/src/member-history/guard/history-write.guard.ts
@@ -4,6 +4,8 @@ import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
 import { DomainType } from '../../permission/const/domain-type.enum';
 import { DomainName } from '../../permission/const/domain-name.enum';
 import { DomainAction } from '../../permission/const/domain-action.enum';
+import { createScopeGuard } from '../../permission/guard/generic-scope.guard';
+import { HttpMethod } from '../../common/const/http-method.enum';
 
 export const HistoryWriteGuard = () =>
   applyDecorators(
@@ -14,5 +16,7 @@ export const HistoryWriteGuard = () =>
         DomainName.MEMBER,
         DomainAction.WRITE,
       ),
+      createScopeGuard([HttpMethod.GET]),
+      //HistoryScopeGuard,
     ),
   );

--- a/backend/src/member-history/member-history.module.ts
+++ b/backend/src/member-history/member-history.module.ts
@@ -17,6 +17,8 @@ import { MemberHistoryDomainModule } from './member-history-domain/member-histor
 import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
 import { IDOMAIN_PERMISSION_SERVICE } from '../permission/service/domain-permission.service.interface';
 import { HistoryPermissionService } from './service/history-permission.service';
+import { IMEMBER_FILTER_SERVICE } from '../members/service/interface/member-filter.service.interface';
+import { MemberFilterService } from '../members/service/member-filter.service';
 
 @Module({
   imports: [
@@ -44,6 +46,10 @@ import { HistoryPermissionService } from './service/history-permission.service';
     {
       provide: IDOMAIN_PERMISSION_SERVICE,
       useClass: HistoryPermissionService,
+    },
+    {
+      provide: IMEMBER_FILTER_SERVICE,
+      useClass: MemberFilterService,
     },
   ],
   controllers: [

--- a/backend/src/member-history/service/history-permission.service.ts
+++ b/backend/src/member-history/service/history-permission.service.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { DomainPermissionService } from '../../permission/service/domain-permission.service';
 import { DomainAction } from '../../permission/const/domain-action.enum';
-import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
@@ -23,24 +22,24 @@ export class HistoryPermissionService extends DomainPermissionService {
     super();
   }
 
-  async getRequestManagerOrThrow(
-    churchId: number,
-    requestUserId: number,
-  ): Promise<ChurchUserModel> {
+  async getRequestManagerOrThrow(churchId: number, requestUserId: number) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    return this.managerDomainService.findManagerForPermissionCheck(
-      church,
-      requestUserId,
-    );
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    return { requestManager, church };
   }
 
   async hasPermission(
     churchId: number,
     requestUserId: number,
     domainAction: DomainAction,
-  ): Promise<ChurchUserModel | null> {
+  ) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
@@ -57,7 +56,7 @@ export class HistoryPermissionService extends DomainPermissionService {
     );
 
     if (permission) {
-      return requestManager;
+      return { requestManager, church };
     } else {
       return null;
     }

--- a/backend/src/members/controller/members.controller.ts
+++ b/backend/src/members/controller/members.controller.ts
@@ -8,6 +8,7 @@ import {
   Patch,
   Post,
   Query,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { MembersService } from '../service/members.service';
@@ -27,6 +28,8 @@ import { TargetMember } from '../decorator/target-member.decorator';
 import { MemberModel } from '../entity/member.entity';
 import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../churches/entity/church.entity';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { ChurchManagerGuard } from '../../permission/guard/church-manager.guard';
 
 @ApiTags('Churches:Members')
 @Controller('members')
@@ -55,6 +58,7 @@ export class MembersController {
   }
 
   @Get('simple')
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   getMembersSimple(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Query() dto: GetSimpleMembersDto,

--- a/backend/src/members/controller/members.controller.ts
+++ b/backend/src/members/controller/members.controller.ts
@@ -23,6 +23,10 @@ import { MemberReadGuard } from '../guard/member-read.guard';
 import { MemberWriteGuard } from '../guard/member-write.guard';
 import { PermissionManager } from '../../permission/decorator/permission-manager.decorator';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { TargetMember } from '../decorator/target-member.decorator';
+import { MemberModel } from '../entity/member.entity';
+import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
+import { ChurchModel } from '../../churches/entity/church.entity';
 
 @ApiTags('Churches:Members')
 @Controller('members')
@@ -54,7 +58,6 @@ export class MembersController {
   getMembersSimple(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Query() dto: GetSimpleMembersDto,
-    @PermissionManager() pm: ChurchUserModel,
   ) {
     return this.membersService.getSimpleMembers(churchId, dto);
   }
@@ -75,8 +78,11 @@ export class MembersController {
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
     @Body() dto: UpdateMemberDto,
+    @PermissionChurch() church: ChurchModel,
+    @TargetMember() targetMember: MemberModel,
   ) {
-    return this.membersService.updateMember(churchId, memberId, dto);
+    return this.membersService.updateMember(church, targetMember, dto);
+    //return this.membersService.updateMember(churchId, memberId, dto);
   }
 
   @Delete(':memberId')
@@ -85,8 +91,11 @@ export class MembersController {
   deleteMember(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
+    @PermissionChurch() church: ChurchModel,
+    @TargetMember() targetMember: MemberModel,
     @QueryRunner() qr: QR,
   ) {
-    return this.membersService.softDeleteMember(churchId, memberId, qr);
+    return this.membersService.softDeleteMember(church, targetMember, qr);
+    //return this.membersService.softDeleteMember(churchId, memberId, qr);
   }
 }

--- a/backend/src/members/decorator/target-member.decorator.ts
+++ b/backend/src/members/decorator/target-member.decorator.ts
@@ -1,0 +1,7 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const TargetMember = createParamDecorator((_, ctx: ExecutionContext) => {
+  const req = ctx.switchToHttp().getRequest();
+
+  return req.targetMember;
+});

--- a/backend/src/members/guard/member-write.guard.ts
+++ b/backend/src/members/guard/member-write.guard.ts
@@ -4,6 +4,8 @@ import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
 import { DomainType } from '../../permission/const/domain-type.enum';
 import { DomainName } from '../../permission/const/domain-name.enum';
 import { DomainAction } from '../../permission/const/domain-action.enum';
+import { createScopeGuard } from '../../permission/guard/generic-scope.guard';
+import { HttpMethod } from '../../common/const/http-method.enum';
 
 export const MemberWriteGuard = () =>
   applyDecorators(
@@ -14,5 +16,6 @@ export const MemberWriteGuard = () =>
         DomainName.MEMBER,
         DomainAction.WRITE,
       ),
+      createScopeGuard([HttpMethod.GET, HttpMethod.POST]),
     ),
   );

--- a/backend/src/members/service/member-permission.service.ts
+++ b/backend/src/members/service/member-permission.service.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { DomainPermissionService } from '../../permission/service/domain-permission.service';
 import { DomainAction } from '../../permission/const/domain-action.enum';
-import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
@@ -23,24 +22,24 @@ export class MemberPermissionService extends DomainPermissionService {
     super();
   }
 
-  async getRequestManagerOrThrow(
-    churchId: number,
-    requestUserId: number,
-  ): Promise<ChurchUserModel> {
+  async getRequestManagerOrThrow(churchId: number, requestUserId: number) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    return this.managerDomainService.findManagerForPermissionCheck(
-      church,
-      requestUserId,
-    );
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    return { requestManager, church };
   }
 
   async hasPermission(
     churchId: number,
     requestUserId: number,
     domainAction: DomainAction,
-  ): Promise<ChurchUserModel | null> {
+  ) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
@@ -57,7 +56,7 @@ export class MemberPermissionService extends DomainPermissionService {
     );
 
     if (permission) {
-      return requestManager;
+      return { requestManager, church };
     } else {
       return null;
     }

--- a/backend/src/members/service/members.service.ts
+++ b/backend/src/members/service/members.service.ts
@@ -34,6 +34,7 @@ import {
   IMemberFilterService,
 } from './interface/member-filter.service.interface';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { ChurchModel } from '../../churches/entity/church.entity';
 
 @Injectable()
 export class MembersService {
@@ -161,12 +162,14 @@ export class MembersService {
   }
 
   async updateMember(
-    churchId: number,
-    memberId: number,
+    //churchId: number,
+    //memberId: number,
+    church: ChurchModel,
+    targetMember: MemberModel,
     dto: UpdateMemberDto,
     qr?: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
+    /*const church = await this.churchesDomainService.findChurchModelById(
       churchId,
       qr,
     );
@@ -174,7 +177,7 @@ export class MembersService {
       church,
       memberId,
       qr,
-    );
+    );*/
 
     const updatedMember = await this.membersDomainService.updateMember(
       church,
@@ -189,11 +192,13 @@ export class MembersService {
   // 교인 soft delete
   // 교육 등록도 soft delete
   async softDeleteMember(
-    churchId: number,
-    memberId: number,
+    //churchId: number,
+    church: ChurchModel,
+    //memberId: number,
+    targetMember: MemberModel,
     qr: QueryRunner,
   ): Promise<DeleteMemberResponseDto> {
-    const church = await this.churchesDomainService.findChurchModelById(
+    /*const church = await this.churchesDomainService.findChurchModelById(
       churchId,
       qr,
     );
@@ -201,7 +206,7 @@ export class MembersService {
       church,
       memberId,
       qr,
-    );
+    );*/
 
     // 교인 삭제
     await this.membersDomainService.deleteMember(church, targetMember, qr);
@@ -216,7 +221,7 @@ export class MembersService {
     // 트랜잭션이 끝나게 되어 이벤트 요청에서 트랜잭션 처리를 할 수 없음
     this.eventEmitter.emit(
       'member.deleted',
-      new MemberDeletedEvent(churchId, memberId),
+      new MemberDeletedEvent(church.id, targetMember.id),
     );
 
     return new DeleteMemberResponseDto(

--- a/backend/src/permission/decorator/permission-church.decorator.ts
+++ b/backend/src/permission/decorator/permission-church.decorator.ts
@@ -4,14 +4,14 @@ import {
   InternalServerErrorException,
 } from '@nestjs/common';
 
-export const PermissionManager = createParamDecorator(
+export const PermissionChurch = createParamDecorator(
   (_, ctx: ExecutionContext) => {
     const req = ctx.switchToHttp().getRequest();
 
-    if (!req.requestManager) {
-      throw new InternalServerErrorException('Request 내 ChurchUser 누락');
+    if (!req.church) {
+      throw new InternalServerErrorException('Request 내 Church 누락');
     }
 
-    return req.requestManager;
+    return req.church;
   },
 );

--- a/backend/src/permission/exception/permission-scope.exception.ts
+++ b/backend/src/permission/exception/permission-scope.exception.ts
@@ -1,4 +1,5 @@
 export const PermissionScopeException = {
   DELETE_ERROR: '권한 범위 삭제 도중 에러 발생',
   OWNER: '소유자 권한 관리자는 권한 범위를 설정할 수 없습니다.',
+  OUT_OF_SCOPE_MEMBER: '권한 범위 밖의 교인입니다.',
 };

--- a/backend/src/permission/guard/church-manager.guard.ts
+++ b/backend/src/permission/guard/church-manager.guard.ts
@@ -29,13 +29,14 @@ export class ChurchManagerGuard implements CanActivate {
     const churchId = parseInt(req.params.churchId);
     const requestUserId = token.id;
 
-    const requestManager =
+    const { requestManager, church } =
       await this.permissionService.getRequestManagerOrThrow(
         churchId,
         requestUserId,
       );
 
-    req.permissionedChurchUser = requestManager;
+    req.requestManager = requestManager;
+    req.church = church;
 
     return true;
   }

--- a/backend/src/permission/guard/generic-domain.guard.ts
+++ b/backend/src/permission/guard/generic-domain.guard.ts
@@ -53,7 +53,9 @@ export function createDomainGuard(
         );
       }
 
-      req.permissionedChurchUser = hasPermission;
+      //req.permissionedChurchUser = hasPermission;
+      req.requestManager = hasPermission.requestManager;
+      req.church = hasPermission.church;
 
       return true;
     }

--- a/backend/src/permission/guard/generic-scope.guard.ts
+++ b/backend/src/permission/guard/generic-scope.guard.ts
@@ -1,0 +1,70 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  mixin,
+  Type,
+} from '@nestjs/common';
+import {
+  IMEMBERS_DOMAIN_SERVICE,
+  IMembersDomainService,
+} from '../../members/member-domain/interface/members-domain.service.interface';
+import {
+  IMEMBER_FILTER_SERVICE,
+  IMemberFilterService,
+} from '../../members/service/interface/member-filter.service.interface';
+import { HttpMethod } from '../../common/const/http-method.enum';
+import { PermissionScopeException } from '../exception/permission-scope.exception';
+
+export function createScopeGuard(
+  excludeHttpMethods: HttpMethod[],
+): Type<CanActivate> {
+  @Injectable()
+  class GenericScopeGuard implements CanActivate {
+    constructor(
+      @Inject(IMEMBERS_DOMAIN_SERVICE)
+      private readonly membersDomainService: IMembersDomainService,
+      @Inject(IMEMBER_FILTER_SERVICE)
+      private readonly memberFilterService: IMemberFilterService,
+    ) {}
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+      const req = context.switchToHttp().getRequest();
+
+      // 수정, 삭제 시에만 가드 적용
+      if (excludeHttpMethods.includes(req.method)) {
+        return true;
+      }
+
+      const requestManager = req.requestManager;
+      const church = req.church;
+
+      const memberId = parseInt(req.params.memberId);
+
+      const targetMember = await this.membersDomainService.findMemberModelById(
+        church,
+        memberId,
+      );
+
+      const concealedMember = await this.memberFilterService.filterMember(
+        church,
+        requestManager,
+        targetMember,
+      );
+
+      if (concealedMember.isConcealed) {
+        throw new ForbiddenException(
+          PermissionScopeException.OUT_OF_SCOPE_MEMBER,
+        );
+      }
+
+      req.targetMember = targetMember;
+
+      return true;
+    }
+  }
+
+  return mixin(GenericScopeGuard);
+}

--- a/backend/src/permission/service/domain-permission.service.interface.ts
+++ b/backend/src/permission/service/domain-permission.service.interface.ts
@@ -1,5 +1,6 @@
 import { DomainAction } from '../const/domain-action.enum';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { ChurchModel } from '../../churches/entity/church.entity';
 
 export const IDOMAIN_PERMISSION_SERVICE = Symbol('IDOMAIN_PERMISSION_SERVICE');
 
@@ -8,10 +9,10 @@ export interface IDomainPermissionService {
     churchId: number,
     requestUserId: number,
     domainAction: DomainAction,
-  ): Promise<ChurchUserModel | null>;
+  ): Promise<{ requestManager: ChurchUserModel; church: ChurchModel } | null>;
 
   getRequestManagerOrThrow(
     churchId: number,
     requestUserId: number,
-  ): Promise<ChurchUserModel>;
+  ): Promise<{ requestManager: ChurchUserModel; church: ChurchModel }>;
 }

--- a/backend/src/permission/service/domain-permission.service.ts
+++ b/backend/src/permission/service/domain-permission.service.ts
@@ -3,6 +3,7 @@ import { DomainAction } from '../const/domain-action.enum';
 import { DomainType } from '../const/domain-type.enum';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { ChurchUserRole } from '../../user/const/user-role.enum';
+import { ChurchModel } from '../../churches/entity/church.entity';
 
 export abstract class DomainPermissionService
   implements IDomainPermissionService
@@ -11,12 +12,12 @@ export abstract class DomainPermissionService
     churchId: number,
     requestUserId: number,
     domainAction: DomainAction,
-  ): Promise<ChurchUserModel | null>;
+  ): Promise<{ requestManager: ChurchUserModel; church: ChurchModel } | null>;
 
   abstract getRequestManagerOrThrow(
     churchId: number,
     requestUserId: number,
-  ): Promise<ChurchUserModel>;
+  ): Promise<{ requestManager: ChurchUserModel; church: ChurchModel }>;
 
   protected checkPermission(
     domainType: DomainType,

--- a/backend/src/permission/service/permission-permission.service.ts
+++ b/backend/src/permission/service/permission-permission.service.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { DomainPermissionService } from './domain-permission.service';
 import { DomainAction } from '../const/domain-action.enum';
-import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
@@ -27,7 +26,7 @@ export class PermissionPermissionService extends DomainPermissionService {
     churchId: number,
     requestUserId: number,
     domainAction: DomainAction,
-  ): Promise<ChurchUserModel | null> {
+  ) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
@@ -44,22 +43,22 @@ export class PermissionPermissionService extends DomainPermissionService {
     );
 
     if (permission) {
-      return requestManager;
+      return { requestManager, church };
     } else {
       return null;
     }
   }
 
-  async getRequestManagerOrThrow(
-    churchId: number,
-    requestUserId: number,
-  ): Promise<ChurchUserModel> {
+  async getRequestManagerOrThrow(churchId: number, requestUserId: number) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    return this.managerDomainService.findManagerForPermissionCheck(
-      church,
-      requestUserId,
-    );
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    return { requestManager, church };
   }
 }

--- a/backend/src/task/service/task-permission.service.ts
+++ b/backend/src/task/service/task-permission.service.ts
@@ -10,7 +10,6 @@ import {
 import { DomainType } from '../../permission/const/domain-type.enum';
 import { DomainAction } from '../../permission/const/domain-action.enum';
 import { DomainPermissionService } from '../../permission/service/domain-permission.service';
-import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 
 @Injectable()
 export class TaskPermissionService extends DomainPermissionService {
@@ -27,7 +26,7 @@ export class TaskPermissionService extends DomainPermissionService {
     churchId: number,
     requestUserId: number,
     domainAction: DomainAction,
-  ): Promise<ChurchUserModel | null> {
+  ) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
@@ -44,22 +43,22 @@ export class TaskPermissionService extends DomainPermissionService {
     );
 
     if (permission) {
-      return requestManager;
+      return { requestManager, church };
     } else {
       return null;
     }
   }
 
-  async getRequestManagerOrThrow(
-    churchId: number,
-    requestUserId: number,
-  ): Promise<ChurchUserModel> {
+  async getRequestManagerOrThrow(churchId: number, requestUserId: number) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    return this.managerDomainService.findManagerForPermissionCheck(
-      church,
-      requestUserId,
-    );
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    return { requestManager, church };
   }
 }

--- a/backend/src/visitation/service/visitation-permission.service.ts
+++ b/backend/src/visitation/service/visitation-permission.service.ts
@@ -10,7 +10,6 @@ import {
 import { DomainAction } from '../../permission/const/domain-action.enum';
 import { DomainType } from '../../permission/const/domain-type.enum';
 import { DomainPermissionService } from '../../permission/service/domain-permission.service';
-import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 
 @Injectable()
 export class VisitationPermissionService extends DomainPermissionService {
@@ -27,7 +26,7 @@ export class VisitationPermissionService extends DomainPermissionService {
     churchId: number,
     requestUserId: number,
     domainAction: DomainAction,
-  ): Promise<ChurchUserModel | null> {
+  ) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
@@ -44,22 +43,22 @@ export class VisitationPermissionService extends DomainPermissionService {
     );
 
     if (permission) {
-      return requestManager;
+      return { requestManager, church };
     } else {
       return null;
     }
   }
 
-  async getRequestManagerOrThrow(
-    churchId: number,
-    requestUserId: number,
-  ): Promise<ChurchUserModel> {
+  async getRequestManagerOrThrow(churchId: number, requestUserId: number) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    return this.managerDomainService.findManagerForPermissionCheck(
-      church,
-      requestUserId,
-    );
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    return { requestManager, church };
   }
 }


### PR DESCRIPTION
## 주요 내용
- 권한 범위(PermissionScope)에 포함되지 않은 교인에 대해 수정, 삭제, 연결된 리소스 변경(직분, 그룹, 사역 등) 불가능하도록 제한
- 공통화된 GenericScopeGuard 및 createScopeGuard 함수 도입으로 도메인에 관계없이 범위 기반 검증 가능하도록 설계
- 범위 검증 통과 시 해당 교인의 MemberModel 을 Request 객체에 `targetMember` 로 주입하여 후속 로직에서 재사용 가능

## 세부 내용

### GenericScopeGuard
- createScopeGuard(HttpMethod[] 제외할 메서드) 함수로 생성
- GET, POST, PATCH, DELETE 를 HttpMethod enum 으로 지정 가능
- 제외 대상 외의 요청에 대해 요청 대상 교인이 현재 요청자의 PermissionScope 내에 포함되는지 검사
- 포함 시 request 객체에 `targetMember` 주입
- 컨트롤러에서는 `@TargetMember()` 파라미터 데코레이터를 통해 해당 교인 객체 사용

### GenericDomainGuard 개선
- 기존 권한 검증 후 다음 정보들을 Request 객체에 주입:
  - `requestManager`: 요청자 ChurchUser
  - `church`: 요청 대상 Church
- 컨트롤러에서는 다음 데코레이터를 통해 주입된 객체 활용 가능:
  - `@PermissionManager()` — 요청한 관리자 ChurchUser
  - `@PermissionChurch()` — 요청한 교회 Church 모델