### PR TITLE
feat: 예배 도메인 CRUD 기능 구현 완료

### DIFF
--- a/backend/src/worship/constraints/worship.constraints.ts
+++ b/backend/src/worship/constraints/worship.constraints.ts
@@ -1,0 +1,1 @@
+export const MAX_WORSHIP_TITLE = 50;

--- a/backend/src/worship/controller/worship.controller.ts
+++ b/backend/src/worship/controller/worship.controller.ts
@@ -4,11 +4,20 @@ import {
   Delete,
   Get,
   Param,
+  ParseIntPipe,
   Patch,
   Post,
+  Query,
+  UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { WorshipService } from '../service/worship.service';
+import { GetWorshipsDto } from '../dto/request/worship/get-worships.dto';
+import { CreateWorshipDto } from '../dto/request/worship/create-worship.dto';
+import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
+import { QueryRunner } from '../../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm';
+import { UpdateWorshipDto } from '../dto/request/worship/update-worship.dto';
 
 @ApiTags('Worships')
 @Controller()
@@ -16,17 +25,49 @@ export class WorshipController {
   constructor(private readonly worshipService: WorshipService) {}
 
   @Get()
-  getWorships() {}
+  getWorships(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetWorshipsDto,
+  ) {
+    return this.worshipService.findWorships(churchId, dto);
+  }
 
   @Post()
-  postWorship(@Body() body: any) {}
+  @UseInterceptors(TransactionInterceptor)
+  postWorship(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Body() dto: CreateWorshipDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.worshipService.postWorship(churchId, dto, qr);
+  }
 
   @Get(':worshipId')
-  getWorshipById(@Param('worshipId') worshipId: number) {}
+  getWorshipById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+  ) {
+    return this.worshipService.findWorshipById(churchId, worshipId);
+  }
 
   @Patch(':worshipId')
-  patchWorshipById(@Param('worshipId') worshipId: number) {}
+  @UseInterceptors(TransactionInterceptor)
+  patchWorshipById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @Body() dto: UpdateWorshipDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.worshipService.patchWorshipById(churchId, worshipId, dto, qr);
+  }
 
   @Delete(':worshipId')
-  DeleteWorshipById(@Param('worshipId') worshipId: number) {}
+  @UseInterceptors(TransactionInterceptor)
+  DeleteWorshipById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.worshipService.deleteWorshipById(churchId, worshipId, qr);
+  }
 }

--- a/backend/src/worship/dto/request/worship/create-worship.dto.ts
+++ b/backend/src/worship/dto/request/worship/create-worship.dto.ts
@@ -1,1 +1,72 @@
-export class CreateWorshipDto {}
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { WorshipModel } from '../../../entity/worship.entity';
+import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import { MAX_WORSHIP_TITLE } from '../../../constraints/worship.constraints';
+import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
+import { PlainTextMaxLength } from '../../../../common/decorator/validator/plain-text-max-length.validator';
+import { Transform } from 'class-transformer';
+
+@SanitizeDto()
+export class CreateWorshipDto extends PickType(WorshipModel, [
+  'title',
+  'description',
+  'worshipDay',
+  'repeatPeriod',
+]) {
+  @ApiProperty({
+    description: '예배 제목',
+    maxLength: MAX_WORSHIP_TITLE,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @IsNoSpecialChar()
+  @MaxLength(MAX_WORSHIP_TITLE)
+  override title: string;
+
+  @ApiProperty({
+    description: '예배 설명 (최대 500자(서식 제외), 빈 문자열 허용)',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @PlainTextMaxLength(500)
+  override description: string;
+
+  @ApiProperty({
+    description: '예배 진행 요일 (0 ~ 6)',
+    minimum: 0,
+    maximum: 6,
+  })
+  @IsNumber()
+  @Min(0)
+  @Max(6)
+  override worshipDay: number;
+
+  @ApiProperty({
+    description: '반복 주기',
+    minimum: 1,
+  })
+  @IsNumber()
+  @Min(0)
+  override repeatPeriod: number;
+
+  @ApiProperty({
+    description: '예배 대상 그룹 ID 배열',
+  })
+  @Transform(({ value }) => Array.from(new Set(value)))
+  @IsNumber({}, { each: true })
+  @IsArray()
+  @ArrayMinSize(1)
+  worshipTargetGroupIds: number[];
+}

--- a/backend/src/worship/dto/request/worship/update-worship.dto.ts
+++ b/backend/src/worship/dto/request/worship/update-worship.dto.ts
@@ -1,1 +1,72 @@
-export class UpdateWorshipDto {}
+import { ApiProperty } from '@nestjs/swagger';
+import { MAX_WORSHIP_TITLE } from '../../../constraints/worship.constraints';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
+import { PlainTextMaxLength } from '../../../../common/decorator/validator/plain-text-max-length.validator';
+import { Transform } from 'class-transformer';
+
+export class UpdateWorshipDto {
+  @ApiProperty({
+    description: '예배 제목',
+    maxLength: MAX_WORSHIP_TITLE,
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @IsNotEmpty()
+  @IsNoSpecialChar()
+  @MaxLength(MAX_WORSHIP_TITLE)
+  title: string;
+
+  @ApiProperty({
+    description: '예배 설명 (최대 500자(서식 제외), 빈 문자열 허용)',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @PlainTextMaxLength(500)
+  description: string;
+
+  @ApiProperty({
+    description: '예배 진행 요일 (0 ~ 6)',
+    minimum: 0,
+    maximum: 6,
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsNumber()
+  @Min(0)
+  @Max(6)
+  worshipDay: number;
+
+  @ApiProperty({
+    description: '반복 주기',
+    minimum: 1,
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsNumber()
+  @Min(0)
+  repeatPeriod: number;
+
+  @ApiProperty({
+    description: '예배 대상 그룹 ID 배열',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @Transform(({ value }) => Array.from(new Set(value)))
+  @IsNumber({}, { each: true })
+  @IsArray()
+  @ArrayMinSize(1)
+  worshipTargetGroupIds: number[];
+}

--- a/backend/src/worship/exception/worship.exception.ts
+++ b/backend/src/worship/exception/worship.exception.ts
@@ -1,0 +1,6 @@
+export const WorshipException = {
+  NOT_FOUND: '해당 예배를 찾을 수 없습니다.',
+  ALREADY_EXIST: '이미 존재하는 예배 제목입니다.',
+  DELETE_ERROR: '예배 삭제 도중 에러 발생',
+  UPDATE_ERROR: '예배 업데이트 도중 에러 발생',
+};

--- a/backend/src/worship/service/worship.service.ts
+++ b/backend/src/worship/service/worship.service.ts
@@ -7,6 +7,25 @@ import {
   IWORSHIP_DOMAIN_SERVICE,
   IWorshipDomainService,
 } from '../worship-domain/interface/worship-domain.service.interface';
+import { GetWorshipsDto } from '../dto/request/worship/get-worships.dto';
+import { WorshipPaginationResponseDto } from '../dto/response/worship/worship-pagination-response.dto';
+import { QueryRunner } from 'typeorm';
+import { GetWorshipResponseDto } from '../dto/response/worship/get-worship-response.dto';
+import { CreateWorshipDto } from '../dto/request/worship/create-worship.dto';
+import {
+  IWORSHIP_TARGET_GROUP_DOMAIN_SERVICE,
+  IWorshipTargetGroupDomainService,
+} from '../worship-domain/interface/worship-target-group-domain.service.interface';
+import {
+  IGROUPS_DOMAIN_SERVICE,
+  IGroupsDomainService,
+} from '../../management/groups/groups-domain/interface/groups-domain.service.interface';
+import { PostWorshipResponseDto } from '../dto/response/worship/post-worship-response.dto';
+import { DeleteWorshipResponseDto } from '../dto/response/worship/delete-worship-response.dto';
+import { UpdateWorshipDto } from '../dto/request/worship/update-worship.dto';
+import { PatchWorshipResponseDto } from '../dto/response/worship/patch-worship-response.dto';
+import { WorshipModel } from '../entity/worship.entity';
+import { ChurchModel } from '../../churches/entity/church.entity';
 
 @Injectable()
 export class WorshipService {
@@ -15,5 +34,206 @@ export class WorshipService {
     private readonly churchesDomainService: IChurchesDomainService,
     @Inject(IWORSHIP_DOMAIN_SERVICE)
     private readonly worshipDomainService: IWorshipDomainService,
+    @Inject(IWORSHIP_TARGET_GROUP_DOMAIN_SERVICE)
+    private readonly worshipTargetGroupDomainService: IWorshipTargetGroupDomainService,
+    @Inject(IGROUPS_DOMAIN_SERVICE)
+    private readonly groupsDomainService: IGroupsDomainService,
   ) {}
+
+  async findWorships(churchId: number, dto: GetWorshipsDto) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const { data, totalCount } = await this.worshipDomainService.findWorships(
+      church,
+      dto,
+    );
+
+    return new WorshipPaginationResponseDto(
+      data,
+      totalCount,
+      data.length,
+      dto.page,
+      Math.ceil(totalCount / dto.take),
+    );
+  }
+
+  async findWorshipById(churchId: number, worshipId: number, qr?: QueryRunner) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const worship = await this.worshipDomainService.findWorshipById(
+      church,
+      worshipId,
+      qr,
+    );
+
+    return new GetWorshipResponseDto(worship);
+  }
+
+  async postWorship(churchId: number, dto: CreateWorshipDto, qr: QueryRunner) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const newWorship = await this.worshipDomainService.createWorship(
+      church,
+      dto,
+      qr,
+    );
+
+    const groups = await this.groupsDomainService.findGroupModelsByIds(
+      church,
+      dto.worshipTargetGroupIds,
+      qr,
+    );
+
+    // TargetGroup 지정
+    await this.worshipTargetGroupDomainService.createWorshipTargetGroup(
+      newWorship,
+      groups,
+      qr,
+    );
+
+    const worship = await this.worshipDomainService.findWorshipById(
+      church,
+      newWorship.id,
+      qr,
+    );
+
+    return new PostWorshipResponseDto(worship);
+  }
+
+  async patchWorshipById(
+    churchId: number,
+    worshipId: number,
+    dto: UpdateWorshipDto,
+    qr: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const targetWorship = await this.worshipDomainService.findWorshipModelById(
+      church,
+      worshipId,
+      qr,
+      { worshipTargetGroups: true },
+    );
+
+    // 예배 대상 그룹 업데이트
+    if (dto.worshipTargetGroupIds && dto.worshipTargetGroupIds.length) {
+      await this.handleTargetGroupChange(
+        church,
+        targetWorship,
+        dto.worshipTargetGroupIds,
+        qr,
+      );
+    }
+
+    // 예배 정보 업데이트
+    await this.worshipDomainService.updateWorship(
+      church,
+      targetWorship,
+      dto,
+      qr,
+    );
+
+    const updatedWorship = await this.worshipDomainService.findWorshipById(
+      church,
+      targetWorship.id,
+      qr,
+    );
+
+    return new PatchWorshipResponseDto(updatedWorship);
+  }
+
+  async deleteWorshipById(
+    churchId: number,
+    worshipId: number,
+    qr: QueryRunner,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const targetWorship = await this.worshipDomainService.findWorshipModelById(
+      church,
+      worshipId,
+      qr,
+    );
+
+    await this.worshipDomainService.deleteWorship(targetWorship, qr);
+
+    await this.worshipTargetGroupDomainService.deleteWorshipTargetGroupCascade(
+      targetWorship,
+      qr,
+    );
+
+    return new DeleteWorshipResponseDto(
+      new Date(),
+      targetWorship.id,
+      targetWorship.title,
+      true,
+    );
+  }
+
+  private async handleTargetGroupChange(
+    church: ChurchModel,
+    targetWorship: WorshipModel,
+    worshipTargetGroupIds: number[],
+    qr: QueryRunner,
+  ) {
+    // 현재 예배 대상 그룹
+    const currentWorshipTargetGroupIdSet = new Set(
+      targetWorship.worshipTargetGroups.map((group) => group.groupId),
+    );
+
+    const toCreateWorshipTargetGroupIds: number[] = [];
+
+    // 생성할 그룹, 삭제할 그룹 파악
+    worshipTargetGroupIds.forEach((newGroupId) => {
+      // 새 그룹 ID 가 없으면 생성
+      if (!currentWorshipTargetGroupIdSet.has(newGroupId)) {
+        toCreateWorshipTargetGroupIds.push(newGroupId);
+      }
+
+      // 새 그룹 ID 가 있으면 currentWorship 에서 삭제
+      else if (currentWorshipTargetGroupIdSet.has(newGroupId)) {
+        currentWorshipTargetGroupIdSet.delete(newGroupId);
+      }
+    });
+
+    // 현재 예배 대상 그룹 배열에 남은 그룹들을 삭제
+    const toDeleteWorshipTargetGroupIds: number[] = Array.from(
+      currentWorshipTargetGroupIdSet,
+    );
+
+    // 대상 그룹이 삭제해야 하는 경우 --> WorshipTargetGroupModel 물리 삭제
+    toDeleteWorshipTargetGroupIds.length > 0 &&
+      (await this.worshipTargetGroupDomainService.deleteWorshipTargetGroup(
+        targetWorship,
+        toDeleteWorshipTargetGroupIds,
+        qr,
+      ));
+
+    // 새로운 대상 그룹
+    if (toCreateWorshipTargetGroupIds.length > 0) {
+      const newTargetGroups =
+        await this.groupsDomainService.findGroupModelsByIds(
+          church,
+          toCreateWorshipTargetGroupIds,
+          qr,
+        );
+
+      await this.worshipTargetGroupDomainService.createWorshipTargetGroup(
+        targetWorship,
+        newTargetGroups,
+        qr,
+      );
+    }
+  }
 }

--- a/backend/src/worship/worship-domain/dto/worship-domain-pagination-result.dto.ts
+++ b/backend/src/worship/worship-domain/dto/worship-domain-pagination-result.dto.ts
@@ -1,0 +1,8 @@
+import { BaseDomainOffsetPaginationResultDto } from '../../../common/dto/base-domain-offset-pagination-result.dto';
+import { WorshipModel } from '../../entity/worship.entity';
+
+export class WorshipDomainPaginationResultDto extends BaseDomainOffsetPaginationResultDto<WorshipModel> {
+  constructor(data: WorshipModel[], totalCount: number) {
+    super(data, totalCount);
+  }
+}

--- a/backend/src/worship/worship-domain/interface/worship-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-domain.service.interface.ts
@@ -1,3 +1,48 @@
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { GetWorshipsDto } from '../../dto/request/worship/get-worships.dto';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
+import { WorshipDomainPaginationResultDto } from '../dto/worship-domain-pagination-result.dto';
+import { WorshipModel } from '../../entity/worship.entity';
+import { CreateWorshipDto } from '../../dto/request/worship/create-worship.dto';
+import { UpdateWorshipDto } from '../../dto/request/worship/update-worship.dto';
+
 export const IWORSHIP_DOMAIN_SERVICE = Symbol('IWORSHIP_DOMAIN_SERVICE');
 
-export interface IWorshipDomainService {}
+export interface IWorshipDomainService {
+  findWorships(
+    church: ChurchModel,
+    dto: GetWorshipsDto,
+    qr?: QueryRunner,
+  ): Promise<WorshipDomainPaginationResultDto>;
+
+  findWorshipById(
+    church: ChurchModel,
+    worshipId: number,
+    qr?: QueryRunner,
+  ): Promise<WorshipModel>;
+
+  findWorshipModelById(
+    church: ChurchModel,
+    worshipId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<WorshipModel>,
+  ): Promise<WorshipModel>;
+
+  createWorship(
+    church: ChurchModel,
+    dto: CreateWorshipDto,
+    qr: QueryRunner,
+  ): Promise<WorshipModel>;
+
+  updateWorship(
+    church: ChurchModel,
+    targetWorship: WorshipModel,
+    dto: UpdateWorshipDto,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  deleteWorship(
+    targetWorship: WorshipModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+}

--- a/backend/src/worship/worship-domain/interface/worship-target-group-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-target-group-domain.service.interface.ts
@@ -1,0 +1,27 @@
+import { WorshipModel } from '../../entity/worship.entity';
+import { WorshipTargetGroupModel } from '../../entity/worship-target-group.entity';
+import { DeleteResult, QueryRunner } from 'typeorm';
+import { GroupModel } from '../../../management/groups/entity/group.entity';
+
+export const IWORSHIP_TARGET_GROUP_DOMAIN_SERVICE = Symbol(
+  'IWORSHIP_TARGET_GROUP_DOMAIN_SERVICE',
+);
+
+export interface IWorshipTargetGroupDomainService {
+  createWorshipTargetGroup(
+    worship: WorshipModel,
+    targetGroups: GroupModel[],
+    qr: QueryRunner,
+  ): Promise<WorshipTargetGroupModel[]>;
+
+  deleteWorshipTargetGroup(
+    worship: WorshipModel,
+    targetGroupIds: number[],
+    qr?: QueryRunner,
+  ): Promise<DeleteResult>;
+
+  deleteWorshipTargetGroupCascade(
+    targetWorship: WorshipModel,
+    qr: QueryRunner,
+  ): Promise<DeleteResult>;
+}

--- a/backend/src/worship/worship-domain/service/worship-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-domain.service.ts
@@ -1,8 +1,26 @@
-import { Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { IWorshipDomainService } from '../interface/worship-domain.service.interface';
 import { InjectRepository } from '@nestjs/typeorm';
 import { WorshipModel } from '../../entity/worship.entity';
-import { Repository } from 'typeorm';
+import {
+  FindOptionsOrder,
+  FindOptionsRelations,
+  QueryRunner,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { GetWorshipsDto } from '../../dto/request/worship/get-worships.dto';
+import { WorshipOrderEnum } from '../../const/worship-order.enum';
+import { WorshipDomainPaginationResultDto } from '../dto/worship-domain-pagination-result.dto';
+import { WorshipException } from '../../exception/worship.exception';
+import { CreateWorshipDto } from '../../dto/request/worship/create-worship.dto';
+import { UpdateWorshipDto } from '../../dto/request/worship/update-worship.dto';
 
 @Injectable()
 export class WorshipDomainService implements IWorshipDomainService {
@@ -10,4 +28,179 @@ export class WorshipDomainService implements IWorshipDomainService {
     @InjectRepository(WorshipModel)
     private readonly repository: Repository<WorshipModel>,
   ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr ? qr.manager.getRepository(WorshipModel) : this.repository;
+  }
+
+  async findWorships(
+    church: ChurchModel,
+    dto: GetWorshipsDto,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    const orderOptions: FindOptionsOrder<WorshipModel> = {
+      [dto.order]: dto.orderDirection,
+    };
+
+    if (dto.order !== WorshipOrderEnum.CREATED_AT) {
+      orderOptions.createdAt = 'ASC';
+    }
+
+    const [data, totalCount] = await Promise.all([
+      repository.find({
+        where: {
+          churchId: church.id,
+        },
+        order: orderOptions,
+        take: dto.take,
+        skip: dto.take * (dto.page - 1),
+      }),
+
+      repository.count({
+        where: {
+          churchId: church.id,
+        },
+      }),
+    ]);
+
+    return new WorshipDomainPaginationResultDto(data, totalCount);
+  }
+
+  async findWorshipById(
+    church: ChurchModel,
+    worshipId: number,
+    qr?: QueryRunner,
+  ): Promise<WorshipModel> {
+    const repository = this.getRepository(qr);
+
+    const worship = await repository.findOne({
+      where: {
+        churchId: church.id,
+        id: worshipId,
+      },
+      relations: {
+        worshipTargetGroups: {
+          group: true,
+        },
+      },
+      select: {
+        worshipTargetGroups: {
+          id: true,
+          group: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    if (!worship) {
+      throw new NotFoundException(WorshipException.NOT_FOUND);
+    }
+
+    return worship;
+  }
+
+  async findWorshipModelById(
+    church: ChurchModel,
+    worshipId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<WorshipModel>,
+  ): Promise<WorshipModel> {
+    const repository = this.getRepository(qr);
+
+    const worship = await repository.findOne({
+      where: {
+        churchId: church.id,
+        id: worshipId,
+      },
+      relations: relationOptions,
+    });
+
+    if (!worship) {
+      throw new NotFoundException(WorshipException.NOT_FOUND);
+    }
+
+    return worship;
+  }
+
+  private async assertValidWorshipTitle(
+    church: ChurchModel,
+    title: string,
+    repository: Repository<WorshipModel>,
+  ) {
+    const existWorship = await repository.findOne({
+      where: {
+        churchId: church.id,
+        title: title,
+      },
+    });
+
+    if (existWorship) {
+      throw new ConflictException(WorshipException.ALREADY_EXIST);
+    }
+
+    return true;
+  }
+
+  async createWorship(
+    church: ChurchModel,
+    dto: CreateWorshipDto,
+    qr: QueryRunner,
+  ): Promise<WorshipModel> {
+    const repository = this.getRepository(qr);
+
+    await this.assertValidWorshipTitle(church, dto.title, repository);
+
+    return repository.save({
+      churchId: church.id,
+      title: dto.title,
+      description: dto.description,
+      worshipDay: dto.worshipDay,
+      repeatPeriod: dto.repeatPeriod,
+    });
+  }
+
+  async updateWorship(
+    church: ChurchModel,
+    targetWorship: WorshipModel,
+    dto: UpdateWorshipDto,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    if (dto.title) {
+      await this.assertValidWorshipTitle(church, dto.title, repository);
+    }
+
+    const result = await repository.update(
+      { id: targetWorship.id },
+      { ...dto },
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(WorshipException.UPDATE_ERROR);
+    }
+
+    return result;
+  }
+
+  async deleteWorship(
+    targetWorship: WorshipModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    const result = await repository.softDelete({ id: targetWorship.id });
+
+    if (result.affected === 0) {
+      console.log(result);
+
+      throw new InternalServerErrorException(WorshipException.DELETE_ERROR);
+    }
+
+    return result;
+  }
 }

--- a/backend/src/worship/worship-domain/service/worship-target-group-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-target-group-domain.service.ts
@@ -1,0 +1,78 @@
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { IWorshipTargetGroupDomainService } from '../interface/worship-target-group-domain.service.interface';
+import { WorshipModel } from '../../entity/worship.entity';
+import { WorshipTargetGroupModel } from '../../entity/worship-target-group.entity';
+import { DeleteResult, In, QueryRunner, Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import { GroupModel } from '../../../management/groups/entity/group.entity';
+
+@Injectable()
+export class WorshipTargetGroupDomainService
+  implements IWorshipTargetGroupDomainService
+{
+  constructor(
+    @InjectRepository(WorshipTargetGroupModel)
+    private readonly repository: Repository<WorshipTargetGroupModel>,
+  ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(WorshipTargetGroupModel)
+      : this.repository;
+  }
+
+  createWorshipTargetGroup(
+    worship: WorshipModel,
+    targetGroups: GroupModel[],
+    qr?: QueryRunner,
+  ): Promise<WorshipTargetGroupModel[]> {
+    const repository = this.getRepository(qr);
+
+    const worshipTargetGroups = repository.create(
+      targetGroups.map((targetGroup) => ({
+        worshipId: worship.id,
+        groupId: targetGroup.id,
+      })),
+    );
+
+    return repository.save(worshipTargetGroups);
+  }
+
+  async deleteWorshipTargetGroup(
+    worship: WorshipModel,
+    targetGroupIds: number[],
+    qr?: QueryRunner,
+  ): Promise<DeleteResult> {
+    const repository = this.getRepository(qr);
+
+    const result = await repository.delete({
+      worshipId: worship.id,
+      groupId: In(targetGroupIds),
+    });
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException();
+    }
+
+    if (result.affected !== targetGroupIds.length) {
+      throw new BadRequestException();
+    }
+
+    return result;
+  }
+
+  async deleteWorshipTargetGroupCascade(
+    targetWorship: WorshipModel,
+    qr: QueryRunner,
+  ): Promise<DeleteResult> {
+    const repository = this.getRepository(qr);
+
+    return repository.delete({
+      worshipId: targetWorship.id,
+    });
+  }
+}

--- a/backend/src/worship/worship-domain/worship-domain.module.ts
+++ b/backend/src/worship/worship-domain/worship-domain.module.ts
@@ -13,6 +13,8 @@ import { WorshipEnrollmentModel } from '../entity/worship-enrollment.entity';
 import { WorshipSessionModel } from '../entity/worship-session.entity';
 import { WorshipAttendanceModel } from '../entity/worship-attendance.entity';
 import { WorshipTargetGroupModel } from '../entity/worship-target-group.entity';
+import { IWORSHIP_TARGET_GROUP_DOMAIN_SERVICE } from './interface/worship-target-group-domain.service.interface';
+import { WorshipTargetGroupDomainService } from './service/worship-target-group-domain.service';
 
 @Module({
   imports: [
@@ -38,12 +40,17 @@ import { WorshipTargetGroupModel } from '../entity/worship-target-group.entity';
       provide: IWORSHIP_SESSION_DOMAIN_SERVICE,
       useClass: WorshipSessionDomainService,
     },
+    {
+      provide: IWORSHIP_TARGET_GROUP_DOMAIN_SERVICE,
+      useClass: WorshipTargetGroupDomainService,
+    },
   ],
   exports: [
     IWORSHIP_DOMAIN_SERVICE,
     IWORSHIP_ATTENDANCE_DOMAIN_SERVICE,
     IWORSHIP_ENROLLMENT_DOMAIN_SERVICE,
     IWORSHIP_SESSION_DOMAIN_SERVICE,
+    IWORSHIP_TARGET_GROUP_DOMAIN_SERVICE,
   ],
 })
 export class WorshipDomainModule {}

--- a/backend/src/worship/worship.module.ts
+++ b/backend/src/worship/worship.module.ts
@@ -10,6 +10,7 @@ import { WorshipSessionService } from './service/worship-session.service';
 import { WorshipAttendanceController } from './controller/worship-attendance.controller';
 import { WorshipEnrollmentController } from './controller/worship-enrollment.controller';
 import { WorshipDomainModule } from './worship-domain/worship-domain.module';
+import { GroupsDomainModule } from '../management/groups/groups-domain/groups-domain.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { WorshipDomainModule } from './worship-domain/worship-domain.module';
     ]),
     ChurchesDomainModule,
     WorshipDomainModule,
+    GroupsDomainModule,
   ],
   controllers: [
     WorshipController,


### PR DESCRIPTION
## 주요 내용
예배(Worship)에 대한 전체 CRUD API 및 관련 로직 구현
예배 대상 그룹(WorshipTargetGroup)은 예배 수정/삭제 시 동기화 및 삭제되도록 처리

## 세부 내용

### GET /churches/{churchId}/worships
- 교회별 예배 목록 조회
- 페이지네이션 지원 (take, page)
- 정렬 기준: createdAt, updatedAt, title, worshipDay
- 정렬 방향: asc, desc

### POST /churches/{churchId}/worships
- 예배 생성
- title: 예배 제목 (동일 교회 내 중복 불가, 특수문자 금지)
- description: 예배 설명 (script 등 위험 태그 금지)
- worshipDay: 요일 index (0: 일요일 ~ 6: 토요일)
- repeatPeriod: 반복 주기 (주 단위, ex. 2 → 2주에 한 번)
- worshipTargetGroupIds: 예배 대상 그룹 ID 목록

### GET /churches/{churchId}/worships/{worshipId}
- 특정 예배 단건 조회

### PATCH /churches/{churchId}/worships/{worshipId}
- 예배 정보 수정
- POST와 동일한 DTO를 기반으로 optional 필드 처리
- worshipTargetGroupIds는 최종 상태로 반영 (기존과 비교하여 삭제 및 생성 처리)

### DELETE /churches/{churchId}/worships/{worshipId}
- 예배 삭제
- 예배 삭제 시 연결된 WorshipTargetGroup 모두 함께 삭제 처리