### PR TITLE
feat: WorshipEnrollment 기본 기능 구현 및 예배 연동 처리

### DIFF
--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -37,6 +37,8 @@ export interface IMembersDomainService {
     qr?: QueryRunner,
   ): Promise<MembersDomainPaginationResultDto>;
 
+  findAllMembers(church: ChurchModel, qr?: QueryRunner): Promise<MemberModel[]>;
+
   findRecommendLinkMember(
     church: ChurchModel,
     dto: GetRecommendLinkMemberDto,

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -81,6 +81,19 @@ export class MembersDomainService implements IMembersDomainService {
     };
   }
 
+  async findAllMembers(church: ChurchModel, qr?: QueryRunner) {
+    const repository = this.getMembersRepository(qr);
+
+    return repository.find({
+      where: {
+        churchId: church.id,
+      },
+      order: {
+        id: 'asc',
+      },
+    });
+  }
+
   async findRecommendLinkMember(
     church: ChurchModel,
     dto: GetRecommendLinkMemberDto,

--- a/backend/src/worship/const/worship-enrollment-order.enum.ts
+++ b/backend/src/worship/const/worship-enrollment-order.enum.ts
@@ -1,0 +1,6 @@
+export enum WorshipEnrollmentOrderEnum {
+  CREATED_AT = 'createdAt',
+  UPDATED_AT = 'updatedAt',
+  NAME = 'name',
+  //GROUP_NAME = 'groupName',
+}

--- a/backend/src/worship/controller/worship-enrollment.controller.ts
+++ b/backend/src/worship/controller/worship-enrollment.controller.ts
@@ -1,14 +1,74 @@
-import { Controller, Get } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+  UseInterceptors,
+} from '@nestjs/common';
 import { WorshipEnrollmentService } from '../service/worship-enrollment.service';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { GetWorshipEnrollmentsDto } from '../dto/request/worship-enrollment/get-worship-enrollments.dto';
+import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
+import { QueryRunner } from '../../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm';
 
 @ApiTags('Worships:Enrollments')
-@Controller(':worship/enrollments')
+@Controller(':worshipId/enrollments')
 export class WorshipEnrollmentController {
   constructor(
     private readonly worshipEnrollmentService: WorshipEnrollmentService,
   ) {}
 
   @Get()
-  getEnrollments() {}
+  getEnrollments(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @Query() dto: GetWorshipEnrollmentsDto,
+  ) {
+    return this.worshipEnrollmentService.getEnrollments(
+      churchId,
+      worshipId,
+      dto,
+    );
+  }
+
+  @ApiOperation({
+    summary: '예배 대상 교인 새로고침',
+  })
+  @Post('refresh')
+  @UseInterceptors(TransactionInterceptor)
+  postEnrollment(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.worshipEnrollmentService.refreshEnrollment(
+      churchId,
+      worshipId,
+      qr,
+    );
+  }
+
+  /*@Get(':enrollmentId')
+  getEnrollmentById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @Param('enrollmentId', ParseIntPipe) enrollmentId: number,
+  ) {}*/
+
+  /*@Patch(':enrollmentId')
+  patchEnrollmentById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @Param('enrollmentId', ParseIntPipe) enrollmentId: number,
+  ) {}*/
+
+  /*@Delete(':enrollmentId')
+  deleteEnrollmentById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @Param('enrollmentId', ParseIntPipe) enrollmentId: number,
+  ) {}*/
 }

--- a/backend/src/worship/dto/request/worship-enrollment/get-worship-enrollments.dto.ts
+++ b/backend/src/worship/dto/request/worship-enrollment/get-worship-enrollments.dto.ts
@@ -1,0 +1,24 @@
+import { BaseOffsetPaginationRequestDto } from '../../../../common/dto/request/base-offset-pagination-request.dto';
+import { WorshipEnrollmentOrderEnum } from '../../../const/worship-enrollment-order.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNumber } from 'class-validator';
+import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
+
+export class GetWorshipEnrollmentsDto extends BaseOffsetPaginationRequestDto<WorshipEnrollmentOrderEnum> {
+  @ApiProperty({
+    description: '정렬 조건',
+    enum: WorshipEnrollmentOrderEnum,
+    default: WorshipEnrollmentOrderEnum.CREATED_AT,
+    required: false,
+  })
+  @IsEnum(WorshipEnrollmentOrderEnum)
+  order: WorshipEnrollmentOrderEnum = WorshipEnrollmentOrderEnum.CREATED_AT;
+
+  @ApiProperty({
+    description: '교인 그룹',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsNumber()
+  groupId: number;
+}

--- a/backend/src/worship/dto/response/worship-enrollment/worship-enrollment-pagination-response.dto.ts
+++ b/backend/src/worship/dto/response/worship-enrollment/worship-enrollment-pagination-response.dto.ts
@@ -1,0 +1,14 @@
+import { BaseOffsetPaginationResponseDto } from '../../../../common/dto/reponse/base-offset-pagination-response.dto';
+import { WorshipEnrollmentModel } from '../../../entity/worship-enrollment.entity';
+
+export class WorshipEnrollmentPaginationResponseDto extends BaseOffsetPaginationResponseDto<WorshipEnrollmentModel> {
+  constructor(
+    data: WorshipEnrollmentModel[],
+    totalCount: number,
+    count: number,
+    page: number,
+    totalPage: number,
+  ) {
+    super(data, totalCount, count, page, totalPage);
+  }
+}

--- a/backend/src/worship/service/worship-enrollment.service.ts
+++ b/backend/src/worship/service/worship-enrollment.service.ts
@@ -3,11 +3,112 @@ import {
   IWORSHIP_ENROLLMENT_DOMAIN_SERVICE,
   IWorshipEnrollmentDomainService,
 } from '../worship-domain/interface/worship-enrollment-domain.service.interface';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IWORSHIP_DOMAIN_SERVICE,
+  IWorshipDomainService,
+} from '../worship-domain/interface/worship-domain.service.interface';
+import { QueryRunner } from 'typeorm';
+import { GetWorshipEnrollmentsDto } from '../dto/request/worship-enrollment/get-worship-enrollments.dto';
+import {
+  IMEMBERS_DOMAIN_SERVICE,
+  IMembersDomainService,
+} from '../../members/member-domain/interface/members-domain.service.interface';
+import { MemberModel } from '../../members/entity/member.entity';
+import { WorshipEnrollmentPaginationResponseDto } from '../dto/response/worship-enrollment/worship-enrollment-pagination-response.dto';
 
 @Injectable()
 export class WorshipEnrollmentService {
   constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IWORSHIP_DOMAIN_SERVICE)
+    private readonly worshipDomainService: IWorshipDomainService,
+    @Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,
+
     @Inject(IWORSHIP_ENROLLMENT_DOMAIN_SERVICE)
     private readonly worshipEnrollmentDomainService: IWorshipEnrollmentDomainService,
   ) {}
+
+  async getEnrollments(
+    churchId: number,
+    worshipId: number,
+    dto: GetWorshipEnrollmentsDto,
+    qr?: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const worship = await this.worshipDomainService.findWorshipModelById(
+      church,
+      worshipId,
+      qr,
+    );
+
+    const { data, totalCount } =
+      await this.worshipEnrollmentDomainService.findEnrollments(
+        worship,
+        dto,
+        qr,
+      );
+
+    return new WorshipEnrollmentPaginationResponseDto(
+      data,
+      totalCount,
+      data.length,
+      dto.page,
+      Math.ceil(totalCount / dto.take),
+    );
+  }
+
+  async refreshEnrollment(
+    churchId: number,
+    worshipId: number,
+    qr: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const worship = await this.worshipDomainService.findWorshipModelById(
+      church,
+      worshipId,
+      qr,
+    );
+
+    const allMembers = await this.membersDomainService.findAllMembers(
+      church,
+      qr,
+    );
+
+    const existWorshipEnrollments =
+      await this.worshipEnrollmentDomainService.findAllEnrollments(worship, qr);
+
+    const existEnrollmentMemberIds = new Set(
+      existWorshipEnrollments.map((enrollment) => enrollment.memberId),
+    );
+
+    const notExistEnrollmentMembers: MemberModel[] = [];
+
+    for (const member of allMembers) {
+      if (!existEnrollmentMemberIds.has(member.id)) {
+        notExistEnrollmentMembers.push(member);
+      }
+    }
+
+    const result = await this.worshipEnrollmentDomainService.refreshEnrollments(
+      worship,
+      notExistEnrollmentMembers,
+      qr,
+    );
+
+    return { createdCount: result.length, timestamp: new Date() };
+  }
 }

--- a/backend/src/worship/worship-domain/dto/worship-enrollment-domain-pagination-result.dto.ts
+++ b/backend/src/worship/worship-domain/dto/worship-enrollment-domain-pagination-result.dto.ts
@@ -1,0 +1,8 @@
+import { BaseDomainOffsetPaginationResultDto } from '../../../common/dto/base-domain-offset-pagination-result.dto';
+import { WorshipEnrollmentModel } from '../../entity/worship-enrollment.entity';
+
+export class WorshipEnrollmentDomainPaginationResultDto extends BaseDomainOffsetPaginationResultDto<WorshipEnrollmentModel> {
+  constructor(data: WorshipEnrollmentModel[], totalCount: number) {
+    super(data, totalCount);
+  }
+}

--- a/backend/src/worship/worship-domain/interface/worship-enrollment-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-enrollment-domain.service.interface.ts
@@ -1,5 +1,40 @@
+import { WorshipModel } from '../../entity/worship.entity';
+import { QueryRunner, UpdateResult } from 'typeorm';
+import { MemberModel } from '../../../members/entity/member.entity';
+import { WorshipEnrollmentModel } from '../../entity/worship-enrollment.entity';
+import { GetWorshipEnrollmentsDto } from '../../dto/request/worship-enrollment/get-worship-enrollments.dto';
+import { WorshipEnrollmentDomainPaginationResultDto } from '../dto/worship-enrollment-domain-pagination-result.dto';
+
 export const IWORSHIP_ENROLLMENT_DOMAIN_SERVICE = Symbol(
   'IWORSHIP_ENROLLMENT_DOMAIN',
 );
 
-export interface IWorshipEnrollmentDomainService {}
+export interface IWorshipEnrollmentDomainService {
+  findEnrollments(
+    worship: WorshipModel,
+    dto: GetWorshipEnrollmentsDto,
+    qr?: QueryRunner,
+  ): Promise<WorshipEnrollmentDomainPaginationResultDto>;
+
+  findAllEnrollments(
+    worship: WorshipModel,
+    qr?: QueryRunner,
+  ): Promise<WorshipEnrollmentModel[]>;
+
+  refreshEnrollments(
+    worship: WorshipModel,
+    members: MemberModel[],
+    qr?: QueryRunner,
+  ): Promise<WorshipEnrollmentModel[]>;
+
+  createEnrollmentCascade(
+    newWorship: WorshipModel,
+    members: MemberModel[],
+    qr: QueryRunner,
+  ): Promise<WorshipEnrollmentModel[]>;
+
+  deleteEnrollmentCascade(
+    deletedWorship: WorshipModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+}

--- a/backend/src/worship/worship.module.ts
+++ b/backend/src/worship/worship.module.ts
@@ -11,6 +11,7 @@ import { WorshipAttendanceController } from './controller/worship-attendance.con
 import { WorshipEnrollmentController } from './controller/worship-enrollment.controller';
 import { WorshipDomainModule } from './worship-domain/worship-domain.module';
 import { GroupsDomainModule } from '../management/groups/groups-domain/groups-domain.module';
+import { MembersDomainModule } from '../members/member-domain/members-domain.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { GroupsDomainModule } from '../management/groups/groups-domain/groups-do
       { path: 'churches/:churchId/worships', module: WorshipModule },
     ]),
     ChurchesDomainModule,
+    MembersDomainModule,
     WorshipDomainModule,
     GroupsDomainModule,
   ],


### PR DESCRIPTION
## 주요 내용
WorshipEnrollment에 대한 기본 조회 및 새로고침 기능 구현
예배 생성 시 자동 등록, 삭제 시 연동된 출석 등록 soft delete 처리

## 세부 내용

### GET /churches/{churchId}/worships/{worshipId}/enrollments
- 예배 등록(enrollment) 목록 조회
- 페이지네이션 (take, page)
- 정렬: createdAt, updatedAt, name (교인 이름 기준)
- 정렬 방향: asc, desc
- groupId 필터링 지원 (현재는 지정된 그룹만 필터링, 하위 그룹은 추후 지원 예정)

### POST /churches/{churchId}/worships/{worshipId}/enrollments/refresh
- 누락된 교인의 enrollment 를 찾아 새로 생성
- 특정 교인의 등록 누락 오류 등을 수동으로 복구할 수 있도록 처리

### 예배 생성 시
- 해당 교회 전체 교인 대상 WorshipEnrollment 자동 생성

### 예배 삭제 시
- 해당 예배에 속한 WorshipEnrollment 레코드 soft delete 처리