### PR TITLE
feat: WorshipSession CRUD 기능 구현 및 WorshipTargetGroup 규칙 변경

### DIFF
--- a/backend/src/worship/const/worship-session-order.enum.ts
+++ b/backend/src/worship/const/worship-session-order.enum.ts
@@ -1,0 +1,5 @@
+export enum WorshipSessionOrderEnum {
+  CREATED_AT = 'createdAt',
+  UPDATED_AT = 'updatedAt',
+  SESSION_DATE = 'sessionDate',
+}

--- a/backend/src/worship/controller/worship-session.controller.ts
+++ b/backend/src/worship/controller/worship-session.controller.ts
@@ -1,6 +1,23 @@
-import { Controller, Get, Param, ParseIntPipe, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseInterceptors,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { WorshipSessionService } from '../service/worship-session.service';
+import { CreateWorshipSessionDto } from '../dto/request/worship-session/create-worship-session.dto';
+import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
+import { QueryRunner } from '../../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm';
+import { GetWorshipSessionsDto } from '../dto/request/worship-session/get-worship-sessions.dto';
+import { UpdateWorshipSessionDto } from '../dto/request/worship-session/update-worship-session.dto';
 
 @ApiTags('Worships:Sessions')
 @Controller(':worshipId/sessions')
@@ -8,14 +25,89 @@ export class WorshipSessionController {
   constructor(private readonly worshipSessionService: WorshipSessionService) {}
 
   @Get()
-  getSessions() {}
+  getSessions(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @Query() dto: GetWorshipSessionsDto,
+  ) {
+    return this.worshipSessionService.getWorshipSessions(
+      churchId,
+      worshipId,
+      dto,
+    );
+  }
 
   @Post()
-  postSession() {}
+  @UseInterceptors(TransactionInterceptor)
+  postSession(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @Body() dto: CreateWorshipSessionDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.worshipSessionService.postWorshipSession(
+      churchId,
+      worshipId,
+      dto,
+      qr,
+    );
+  }
+
+  @Post('recent')
+  @UseInterceptors(TransactionInterceptor)
+  getOrPostRecentSession(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.worshipSessionService.getOrPostRecentSession(
+      churchId,
+      worshipId,
+      qr,
+    );
+  }
 
   @Get(':sessionId')
   getSessionById(
+    @Param('churchId', ParseIntPipe) churchId: number,
     @Param('worshipId', ParseIntPipe) worshipId: number,
     @Param('sessionId', ParseIntPipe) sessionId: number,
-  ) {}
+  ) {
+    return this.worshipSessionService.getSessionById(
+      churchId,
+      worshipId,
+      sessionId,
+    );
+  }
+
+  @Patch(':sessionId')
+  @UseInterceptors(TransactionInterceptor)
+  patchSessionById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @Param('sessionId', ParseIntPipe) sessionId: number,
+    @Body() dto: UpdateWorshipSessionDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.worshipSessionService.patchWorshipSessionById(
+      churchId,
+      worshipId,
+      sessionId,
+      dto,
+      qr,
+    );
+  }
+
+  @Delete(':sessionId')
+  deleteSessionById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @Param('sessionId', ParseIntPipe) sessionId: number,
+  ) {
+    return this.worshipSessionService.deleteWorshipSessionById(
+      churchId,
+      worshipId,
+      sessionId,
+    );
+  }
 }

--- a/backend/src/worship/dto/request/worship-session/create-worship-session.dto.ts
+++ b/backend/src/worship/dto/request/worship-session/create-worship-session.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { WorshipSessionModel } from '../../../entity/worship-session.entity';
+import { MAX_WORSHIP_TITLE } from '../../../constraints/worship.constraints';
+import { IsDate, IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
+import { PlainTextMaxLength } from '../../../../common/decorator/validator/plain-text-max-length.validator';
+import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
+import { Transform } from 'class-transformer';
+
+@SanitizeDto()
+export class CreateWorshipSessionDto extends PickType(WorshipSessionModel, [
+  'title',
+  'description',
+  'sessionDate',
+]) {
+  @ApiProperty({
+    description: '예배 세션 제목',
+    maxLength: MAX_WORSHIP_TITLE,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @IsNoSpecialChar()
+  @MaxLength(MAX_WORSHIP_TITLE)
+  override title: string;
+
+  @ApiProperty({
+    description: '예배 세션 설명 (최대 500자(서식 제외), 빈 문자열 허용)',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @PlainTextMaxLength(500)
+  override description: string;
+
+  @ApiProperty({
+    description: '예배 세션 진행 날짜',
+  })
+  @IsDate()
+  @Transform(({ value }) => new Date(value.setHours(0, 0, 0, 0)))
+  override sessionDate: Date;
+}

--- a/backend/src/worship/dto/request/worship-session/get-worship-sessions.dto.ts
+++ b/backend/src/worship/dto/request/worship-session/get-worship-sessions.dto.ts
@@ -1,0 +1,16 @@
+import { BaseOffsetPaginationRequestDto } from '../../../../common/dto/request/base-offset-pagination-request.dto';
+import { WorshipSessionOrderEnum } from '../../../const/worship-session-order.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+
+export class GetWorshipSessionsDto extends BaseOffsetPaginationRequestDto<WorshipSessionOrderEnum> {
+  @ApiProperty({
+    description: '정렬 기준',
+    enum: WorshipSessionOrderEnum,
+    default: WorshipSessionOrderEnum.SESSION_DATE,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(WorshipSessionOrderEnum)
+  order: WorshipSessionOrderEnum = WorshipSessionOrderEnum.SESSION_DATE;
+}

--- a/backend/src/worship/dto/request/worship-session/update-worship-session.dto.ts
+++ b/backend/src/worship/dto/request/worship-session/update-worship-session.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { MAX_WORSHIP_TITLE } from '../../../constraints/worship.constraints';
+import { IsDate, IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
+import { PlainTextMaxLength } from '../../../../common/decorator/validator/plain-text-max-length.validator';
+import { Transform } from 'class-transformer';
+
+export class UpdateWorshipSessionDto {
+  @ApiProperty({
+    description: '예배 세션 제목',
+    maxLength: MAX_WORSHIP_TITLE,
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @IsNotEmpty()
+  @IsNoSpecialChar()
+  @MaxLength(MAX_WORSHIP_TITLE)
+  title: string;
+
+  @ApiProperty({
+    description: '예배 세션 설명 (최대 500자(서식 제외), 빈 문자열 허용)',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @PlainTextMaxLength(500)
+  description: string;
+
+  @ApiProperty({
+    description: '예배 세션 진행 날짜',
+  })
+  @IsOptionalNotNull()
+  @IsDate()
+  @Transform(({ value }) => new Date(value.setHours(0, 0, 0, 0)))
+  sessionDate: Date;
+}

--- a/backend/src/worship/dto/request/worship/create-worship.dto.ts
+++ b/backend/src/worship/dto/request/worship/create-worship.dto.ts
@@ -2,7 +2,6 @@ import { ApiProperty, PickType } from '@nestjs/swagger';
 import { WorshipModel } from '../../../entity/worship.entity';
 import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
 import {
-  ArrayMinSize,
   IsArray,
   IsNotEmpty,
   IsNumber,
@@ -67,6 +66,6 @@ export class CreateWorshipDto extends PickType(WorshipModel, [
   @Transform(({ value }) => Array.from(new Set(value)))
   @IsNumber({}, { each: true })
   @IsArray()
-  @ArrayMinSize(1)
+  //@ArrayMinSize(1)
   worshipTargetGroupIds: number[];
 }

--- a/backend/src/worship/dto/request/worship/update-worship.dto.ts
+++ b/backend/src/worship/dto/request/worship/update-worship.dto.ts
@@ -1,7 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { MAX_WORSHIP_TITLE } from '../../../constraints/worship.constraints';
 import {
-  ArrayMinSize,
   IsArray,
   IsNotEmpty,
   IsNumber,
@@ -67,6 +66,6 @@ export class UpdateWorshipDto {
   @Transform(({ value }) => Array.from(new Set(value)))
   @IsNumber({}, { each: true })
   @IsArray()
-  @ArrayMinSize(1)
+  //@ArrayMinSize(1)
   worshipTargetGroupIds: number[];
 }

--- a/backend/src/worship/dto/response/worship-session/delete-worship-session.response.dto.ts
+++ b/backend/src/worship/dto/response/worship-session/delete-worship-session.response.dto.ts
@@ -1,0 +1,12 @@
+import { BaseDeleteResponseDto } from '../../../../common/dto/reponse/base-delete-response.dto';
+
+export class DeleteWorshipSessionResponseDto extends BaseDeleteResponseDto {
+  constructor(
+    public readonly timestamp: Date,
+    public readonly id: number,
+    public readonly title: string,
+    public readonly success: boolean,
+  ) {
+    super(timestamp, id, success);
+  }
+}

--- a/backend/src/worship/dto/response/worship-session/get-worship-session-response.dto.ts
+++ b/backend/src/worship/dto/response/worship-session/get-worship-session-response.dto.ts
@@ -1,0 +1,8 @@
+import { BaseGetResponseDto } from '../../../../common/dto/reponse/base-get-response.dto';
+import { WorshipSessionModel } from '../../../entity/worship-session.entity';
+
+export class GetWorshipSessionResponseDto extends BaseGetResponseDto<WorshipSessionModel> {
+  constructor(data: WorshipSessionModel) {
+    super(data);
+  }
+}

--- a/backend/src/worship/dto/response/worship-session/patch-worship-session-response.dto.ts
+++ b/backend/src/worship/dto/response/worship-session/patch-worship-session-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePatchResponseDto } from '../../../../common/dto/reponse/base-patch-response.dto';
+import { WorshipSessionModel } from '../../../entity/worship-session.entity';
+
+export class PatchWorshipSessionResponseDto extends BasePatchResponseDto<WorshipSessionModel> {
+  constructor(data: WorshipSessionModel) {
+    super(data);
+  }
+}

--- a/backend/src/worship/dto/response/worship-session/post-worship-session-response.dto.ts
+++ b/backend/src/worship/dto/response/worship-session/post-worship-session-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePostResponseDto } from '../../../../common/dto/reponse/base-post-response.dto';
+import { WorshipSessionModel } from '../../../entity/worship-session.entity';
+
+export class PostWorshipSessionResponseDto extends BasePostResponseDto<WorshipSessionModel> {
+  constructor(data: WorshipSessionModel) {
+    super(data);
+  }
+}

--- a/backend/src/worship/dto/response/worship-session/worship-session-pagination-response.dto.ts
+++ b/backend/src/worship/dto/response/worship-session/worship-session-pagination-response.dto.ts
@@ -1,0 +1,14 @@
+import { BaseOffsetPaginationResponseDto } from '../../../../common/dto/reponse/base-offset-pagination-response.dto';
+import { WorshipSessionModel } from '../../../entity/worship-session.entity';
+
+export class WorshipSessionPaginationResponseDto extends BaseOffsetPaginationResponseDto<WorshipSessionModel> {
+  constructor(
+    data: WorshipSessionModel[],
+    totalCount: number,
+    count: number,
+    page: number,
+    totalPage: number,
+  ) {
+    super(data, totalCount, count, page, totalPage);
+  }
+}

--- a/backend/src/worship/entity/worship-attendance.entity.ts
+++ b/backend/src/worship/entity/worship-attendance.entity.ts
@@ -21,7 +21,7 @@ export class WorshipAttendanceModel extends BaseModel {
   note: string;
 
   @Index()
-  @Column()
+  @Column({ type: 'timestamptz' })
   sessionDate: Date;
 
   @ManyToOne(

--- a/backend/src/worship/entity/worship-session.entity.ts
+++ b/backend/src/worship/entity/worship-session.entity.ts
@@ -18,6 +18,6 @@ export class WorshipSessionModel extends BaseModel {
   @Column({ default: '' })
   description: string;
 
-  @Column()
+  @Column({ type: 'timestamptz', nullable: true })
   sessionDate: Date;
 }

--- a/backend/src/worship/exception/worship-session.exception.ts
+++ b/backend/src/worship/exception/worship-session.exception.ts
@@ -1,0 +1,7 @@
+export const WorshipSessionException = {
+  ALREADY_EXIST: '해당 날짜에 예배 세션 존재합니다.',
+  NOT_FOUND: '해당 예배 세션을 찾을 수 없습니다.',
+  UPDATE_ERROR: '예배 세션 업데이트 도중 에러 발생',
+  DELETE_ERROR: '예배 세션 삭제 도중 에러 발생',
+  INVALID_SESSION_DAY: '잘못된 예배 세션 요일(날짜)입니다.',
+};

--- a/backend/src/worship/service/worship-session.service.ts
+++ b/backend/src/worship/service/worship-session.service.ts
@@ -1,13 +1,257 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { ConflictException, Inject, Injectable } from '@nestjs/common';
 import {
   IWORSHIP_SESSION_DOMAIN_SERVICE,
   IWorshipSessionDomainService,
 } from '../worship-domain/interface/worship-session-domain.service.interface';
+import { CreateWorshipSessionDto } from '../dto/request/worship-session/create-worship-session.dto';
+import { QueryRunner } from 'typeorm';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IWORSHIP_DOMAIN_SERVICE,
+  IWorshipDomainService,
+} from '../worship-domain/interface/worship-domain.service.interface';
+import { PostWorshipSessionResponseDto } from '../dto/response/worship-session/post-worship-session-response.dto';
+import { GetWorshipSessionResponseDto } from '../dto/response/worship-session/get-worship-session-response.dto';
+import { GetWorshipSessionsDto } from '../dto/request/worship-session/get-worship-sessions.dto';
+import { WorshipSessionPaginationResponseDto } from '../dto/response/worship-session/worship-session-pagination-response.dto';
+import { DeleteWorshipSessionResponseDto } from '../dto/response/worship-session/delete-worship-session.response.dto';
+import { UpdateWorshipSessionDto } from '../dto/request/worship-session/update-worship-session.dto';
+import { WorshipSessionException } from '../exception/worship-session.exception';
+import { PatchWorshipSessionResponseDto } from '../dto/response/worship-session/patch-worship-session-response.dto';
+import { WorshipModel } from '../entity/worship.entity';
 
 @Injectable()
 export class WorshipSessionService {
   constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IWORSHIP_DOMAIN_SERVICE)
+    private readonly worshipDomainService: IWorshipDomainService,
+
     @Inject(IWORSHIP_SESSION_DOMAIN_SERVICE)
     private readonly worshipSessionDomainService: IWorshipSessionDomainService,
   ) {}
+
+  async getWorshipSessions(
+    churchId: number,
+    worshipId: number,
+    dto: GetWorshipSessionsDto,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+    const worship = await this.worshipDomainService.findWorshipModelById(
+      church,
+      worshipId,
+    );
+
+    const { data, totalCount } =
+      await this.worshipSessionDomainService.findWorshipSessions(worship, dto);
+
+    return new WorshipSessionPaginationResponseDto(
+      data,
+      totalCount,
+      data.length,
+      dto.page,
+      Math.ceil(totalCount / dto.take),
+    );
+  }
+
+  async postWorshipSession(
+    churchId: number,
+    worshipId: number,
+    dto: CreateWorshipSessionDto,
+    qr: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const worship = await this.worshipDomainService.findWorshipModelById(
+      church,
+      worshipId,
+      qr,
+    );
+
+    if (dto.sessionDate.getDay() !== worship.worshipDay) {
+      throw new ConflictException(WorshipSessionException.INVALID_SESSION_DAY);
+    }
+
+    const newSession =
+      await this.worshipSessionDomainService.createWorshipSession(
+        worship,
+        dto,
+        qr,
+      );
+
+    const session =
+      await this.worshipSessionDomainService.findWorshipSessionById(
+        worship,
+        newSession.id,
+        qr,
+      );
+
+    return new PostWorshipSessionResponseDto(session);
+  }
+
+  async getSessionById(churchId: number, worshipId: number, sessionId: number) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const worship = await this.worshipDomainService.findWorshipModelById(
+      church,
+      worshipId,
+    );
+
+    const session =
+      await this.worshipSessionDomainService.findWorshipSessionById(
+        worship,
+        sessionId,
+      );
+
+    return new GetWorshipSessionResponseDto(session);
+  }
+
+  async patchWorshipSessionById(
+    churchId: number,
+    worshipId: number,
+    sessionId: number,
+    dto: UpdateWorshipSessionDto,
+    qr: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const worship = await this.worshipDomainService.findWorshipModelById(
+      church,
+      worshipId,
+      qr,
+    );
+
+    const targetSession =
+      await this.worshipSessionDomainService.findWorshipSessionModelById(
+        worship,
+        sessionId,
+        qr,
+      );
+
+    if (dto.sessionDate) {
+      if (dto.sessionDate.getDay() !== worship.worshipDay) {
+        throw new ConflictException(
+          WorshipSessionException.INVALID_SESSION_DAY,
+        );
+      }
+    }
+
+    await this.worshipSessionDomainService.updateWorshipSession(
+      worship,
+      targetSession,
+      dto,
+      qr,
+    );
+
+    const updatedSession =
+      await this.worshipSessionDomainService.findWorshipSessionById(
+        worship,
+        targetSession.id,
+        qr,
+      );
+
+    return new PatchWorshipSessionResponseDto(updatedSession);
+  }
+
+  async deleteWorshipSessionById(
+    churchId: number,
+    worshipId: number,
+    sessionId: number,
+    qr?: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const worship = await this.worshipDomainService.findWorshipModelById(
+      church,
+      worshipId,
+      qr,
+    );
+
+    const targetWorshipSession =
+      await this.worshipSessionDomainService.findWorshipSessionModelById(
+        worship,
+        sessionId,
+        qr,
+      );
+
+    await this.worshipSessionDomainService.deleteWorshipSession(
+      targetWorshipSession,
+      qr,
+    );
+
+    return new DeleteWorshipSessionResponseDto(
+      new Date(),
+      targetWorshipSession.id,
+      targetWorshipSession.title,
+      true,
+    );
+  }
+
+  async getOrPostRecentSession(
+    churchId: number,
+    worshipId: number,
+    qr: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const worship = await this.worshipDomainService.findWorshipModelById(
+      church,
+      worshipId,
+      qr,
+    );
+
+    const recentSessionDate: Date = this.getRecentSessionDate(worship);
+
+    const dto: CreateWorshipSessionDto = {
+      title: `${recentSessionDate.getFullYear()}-${recentSessionDate.getMonth() + 1}-${recentSessionDate.getDate()} ${worship.title}`,
+      description: '',
+      sessionDate: recentSessionDate,
+    };
+
+    const recentSession =
+      await this.worshipSessionDomainService.findOrCreateRecentWorshipSession(
+        worship,
+        dto,
+        qr,
+      );
+
+    return new GetWorshipSessionResponseDto(recentSession);
+  }
+
+  private getRecentSessionDate(worship: WorshipModel) {
+    const today = new Date(new Date().setHours(0, 0, 0, 0));
+    let recentSessionDate: Date;
+
+    if (worship.worshipDay < today.getDay()) {
+      recentSessionDate = new Date(
+        today.getTime() -
+          (today.getDay() - worship.worshipDay) * 24 * 60 * 60 * 1000,
+      );
+    } else {
+      recentSessionDate = new Date(
+        today.getTime() -
+          (7 - (worship.worshipDay - today.getDay())) * 24 * 60 * 60 * 1000,
+      );
+    }
+
+    return recentSessionDate;
+  }
 }

--- a/backend/src/worship/service/worship.service.ts
+++ b/backend/src/worship/service/worship.service.ts
@@ -34,6 +34,10 @@ import {
   IMEMBERS_DOMAIN_SERVICE,
   IMembersDomainService,
 } from '../../members/member-domain/interface/members-domain.service.interface';
+import {
+  IWORSHIP_SESSION_DOMAIN_SERVICE,
+  IWorshipSessionDomainService,
+} from '../worship-domain/interface/worship-session-domain.service.interface';
 
 @Injectable()
 export class WorshipService {
@@ -51,6 +55,8 @@ export class WorshipService {
     private readonly membersDomainService: IMembersDomainService,
     @Inject(IWORSHIP_ENROLLMENT_DOMAIN_SERVICE)
     private readonly worshipEnrollmentDomainService: IWorshipEnrollmentDomainService,
+    @Inject(IWORSHIP_SESSION_DOMAIN_SERVICE)
+    private readonly worshipSessionDomainService: IWorshipSessionDomainService,
   ) {}
 
   async findWorships(churchId: number, dto: GetWorshipsDto) {
@@ -150,7 +156,7 @@ export class WorshipService {
     );
 
     // 예배 대상 그룹 업데이트
-    if (dto.worshipTargetGroupIds && dto.worshipTargetGroupIds.length) {
+    if (dto.worshipTargetGroupIds) {
       await this.handleTargetGroupChange(
         church,
         targetWorship,
@@ -200,6 +206,12 @@ export class WorshipService {
 
     // 예배 대상 교인 정보 삭제
     await this.worshipEnrollmentDomainService.deleteEnrollmentCascade(
+      targetWorship,
+      qr,
+    );
+
+    // 예배 세션 삭제
+    await this.worshipSessionDomainService.deleteWorshipSessionCascade(
       targetWorship,
       qr,
     );

--- a/backend/src/worship/worship-domain/dto/worship-session-domain-pagination-result.dto.ts
+++ b/backend/src/worship/worship-domain/dto/worship-session-domain-pagination-result.dto.ts
@@ -1,0 +1,8 @@
+import { BaseDomainOffsetPaginationResultDto } from '../../../common/dto/base-domain-offset-pagination-result.dto';
+import { WorshipSessionModel } from '../../entity/worship-session.entity';
+
+export class WorshipSessionDomainPaginationResultDto extends BaseDomainOffsetPaginationResultDto<WorshipSessionModel> {
+  constructor(data: WorshipSessionModel[], totalCount: number) {
+    super(data, totalCount);
+  }
+}

--- a/backend/src/worship/worship-domain/interface/worship-session-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-session-domain.service.interface.ts
@@ -1,5 +1,61 @@
+import { WorshipModel } from '../../entity/worship.entity';
+import { CreateWorshipSessionDto } from '../../dto/request/worship-session/create-worship-session.dto';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
+import { WorshipSessionModel } from '../../entity/worship-session.entity';
+import { GetWorshipSessionsDto } from '../../dto/request/worship-session/get-worship-sessions.dto';
+import { WorshipSessionDomainPaginationResultDto } from '../dto/worship-session-domain-pagination-result.dto';
+import { UpdateWorshipSessionDto } from '../../dto/request/worship-session/update-worship-session.dto';
+
 export const IWORSHIP_SESSION_DOMAIN_SERVICE = Symbol(
   'IWORSHIP_SESSION_DOMAIN_SERVICE',
 );
 
-export interface IWorshipSessionDomainService {}
+export interface IWorshipSessionDomainService {
+  findWorshipSessions(
+    worship: WorshipModel,
+    dto: GetWorshipSessionsDto,
+    qr?: QueryRunner,
+  ): Promise<WorshipSessionDomainPaginationResultDto>;
+
+  createWorshipSession(
+    worship: WorshipModel,
+    dto: CreateWorshipSessionDto,
+    qr: QueryRunner,
+  ): Promise<WorshipSessionModel>;
+
+  findOrCreateRecentWorshipSession(
+    worship: WorshipModel,
+    dto: CreateWorshipSessionDto,
+    qr: QueryRunner,
+  ): Promise<WorshipSessionModel>;
+
+  findWorshipSessionById(
+    worship: WorshipModel,
+    sessionId: number,
+    qr?: QueryRunner,
+  ): Promise<WorshipSessionModel>;
+
+  findWorshipSessionModelById(
+    worship: WorshipModel,
+    sessionId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<WorshipSessionModel>,
+  ): Promise<WorshipSessionModel>;
+
+  updateWorshipSession(
+    worship: WorshipModel,
+    worshipSession: WorshipSessionModel,
+    dto: UpdateWorshipSessionDto,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  deleteWorshipSession(
+    worshipSession: WorshipSessionModel,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  deleteWorshipSessionCascade(
+    worship: WorshipModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+}

--- a/backend/src/worship/worship-domain/service/worship-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-domain.service.ts
@@ -177,7 +177,12 @@ export class WorshipDomainService implements IWorshipDomainService {
 
     const result = await repository.update(
       { id: targetWorship.id },
-      { ...dto },
+      {
+        title: dto.title,
+        description: dto.description,
+        worshipDay: dto.worshipDay,
+        repeatPeriod: dto.repeatPeriod,
+      },
     );
 
     if (result.affected === 0) {

--- a/backend/src/worship/worship-domain/service/worship-session-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-session-domain.service.ts
@@ -1,8 +1,27 @@
-import { Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { IWorshipSessionDomainService } from '../interface/worship-session-domain.service.interface';
 import { InjectRepository } from '@nestjs/typeorm';
 import { WorshipSessionModel } from '../../entity/worship-session.entity';
-import { Repository } from 'typeorm';
+import {
+  FindOptionsOrder,
+  FindOptionsRelations,
+  FindOptionsWhere,
+  QueryRunner,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
+import { WorshipModel } from '../../entity/worship.entity';
+import { CreateWorshipSessionDto } from '../../dto/request/worship-session/create-worship-session.dto';
+import { WorshipSessionException } from '../../exception/worship-session.exception';
+import { GetWorshipSessionsDto } from '../../dto/request/worship-session/get-worship-sessions.dto';
+import { WorshipSessionOrderEnum } from '../../const/worship-session-order.enum';
+import { WorshipSessionDomainPaginationResultDto } from '../dto/worship-session-domain-pagination-result.dto';
+import { UpdateWorshipSessionDto } from '../../dto/request/worship-session/update-worship-session.dto';
 
 @Injectable()
 export class WorshipSessionDomainService
@@ -12,4 +31,193 @@ export class WorshipSessionDomainService
     @InjectRepository(WorshipSessionModel)
     private readonly repository: Repository<WorshipSessionModel>,
   ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr ? qr.manager.getRepository(WorshipSessionModel) : this.repository;
+  }
+
+  async findWorshipSessions(
+    worship: WorshipModel,
+    dto: GetWorshipSessionsDto,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    const whereOptions: FindOptionsWhere<WorshipSessionModel> = {
+      worshipId: worship.id,
+    };
+
+    const orderOptions: FindOptionsOrder<WorshipSessionModel> = {
+      [dto.order]: dto.orderDirection,
+    };
+
+    if (dto.order !== WorshipSessionOrderEnum.CREATED_AT) {
+      orderOptions.createdAt = 'asc';
+    }
+
+    const [data, totalCount] = await Promise.all([
+      repository.find({
+        where: whereOptions,
+        order: orderOptions,
+      }),
+
+      repository.count({
+        where: whereOptions,
+      }),
+    ]);
+
+    return new WorshipSessionDomainPaginationResultDto(data, totalCount);
+  }
+
+  private async assertValidNewSession(
+    worship: WorshipModel,
+    sessionDate: Date,
+    repository: Repository<WorshipSessionModel>,
+  ) {
+    const existSession = await repository.findOne({
+      where: {
+        worshipId: worship.id,
+        sessionDate,
+      },
+    });
+
+    if (existSession) {
+      throw new ConflictException(WorshipSessionException.ALREADY_EXIST);
+    }
+
+    return true;
+  }
+
+  async findOrCreateRecentWorshipSession(
+    worship: WorshipModel,
+    dto: CreateWorshipSessionDto,
+    qr: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    const recentWorship = await repository.findOne({
+      where: {
+        worshipId: worship.id,
+        sessionDate: dto.sessionDate,
+      },
+    });
+
+    if (recentWorship) {
+      return recentWorship;
+    }
+
+    return repository.save({ worshipId: worship.id, ...dto });
+  }
+
+  async createWorshipSession(
+    worship: WorshipModel,
+    dto: CreateWorshipSessionDto,
+    qr: QueryRunner,
+  ): Promise<WorshipSessionModel> {
+    const repository = this.getRepository(qr);
+
+    await this.assertValidNewSession(worship, dto.sessionDate, repository);
+
+    return repository.save({
+      worshipId: worship.id,
+      ...dto,
+    });
+  }
+
+  async findWorshipSessionById(
+    worship: WorshipModel,
+    sessionId: number,
+    qr?: QueryRunner,
+  ): Promise<WorshipSessionModel> {
+    const repository = this.getRepository(qr);
+
+    const worshipSession = await repository.findOne({
+      where: {
+        id: sessionId,
+        worshipId: worship.id,
+      },
+    });
+
+    if (!worshipSession) {
+      throw new NotFoundException(WorshipSessionException.NOT_FOUND);
+    }
+
+    return worshipSession;
+  }
+
+  async findWorshipSessionModelById(
+    worship: WorshipModel,
+    sessionId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<WorshipSessionModel>,
+  ) {
+    const repository = this.getRepository(qr);
+
+    const session = await repository.findOne({
+      where: {
+        id: sessionId,
+        worshipId: worship.id,
+      },
+      relations: relationOptions,
+    });
+
+    if (!session) {
+      throw new NotFoundException(WorshipSessionException.NOT_FOUND);
+    }
+
+    return session;
+  }
+
+  async updateWorshipSession(
+    worship: WorshipModel,
+    worshipSession: WorshipSessionModel,
+    dto: UpdateWorshipSessionDto,
+    qr: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    dto.sessionDate &&
+      (await this.assertValidNewSession(worship, dto.sessionDate, repository));
+
+    const result = await repository.update(
+      { id: worshipSession.id },
+      { ...dto },
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        WorshipSessionException.UPDATE_ERROR,
+      );
+    }
+
+    return result;
+  }
+
+  async deleteWorshipSession(
+    worshipSession: WorshipSessionModel,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    const result = await repository.softDelete({ id: worshipSession.id });
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        WorshipSessionException.DELETE_ERROR,
+      );
+    }
+
+    return result;
+  }
+
+  async deleteWorshipSessionCascade(
+    worship: WorshipModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    return repository.softDelete({
+      worshipId: worship.id,
+    });
+  }
 }


### PR DESCRIPTION
## 주요 내용
예배 세션(WorshipSession)에 대한 전체 CRUD 기능 구현
예배 대상 그룹(WorshipTargetGroup) 규칙을 변경하여 빈 배열 허용
예배 삭제 시 하위 세션(WorshipSession) 자동 삭제 처리

## 세부 내용

### GET /churches/{churchId}/worships/{worshipId}/sessions
- 예배 세션 목록 조회
- 페이지네이션 (take, page)
- 정렬 기준: createdAt, updatedAt, sessionDate
- 정렬 방향: asc, desc

### POST /churches/{churchId}/worships/{worshipId}/sessions
- 예배 세션 수동 생성
- 필드: title, description, sessionDate
- 예외 처리:
  - sessionDate의 요일이 worshipDay와 다르면 ConflictException
  - 동일한 sessionDate의 세션이 이미 존재하면 ConflictException

### POST /churches/{churchId}/worships/{worshipId}/sessions/recent
- 가장 최근 세션을 불러오거나 없으면 생성
- 지난 날짜 중 가장 가까운 날짜에 해당하는 세션 생성
- 생성 시 제목은 'YYYY-MM-DD Worship.title' 형식으로 자동 설정

### GET /churches/{churchId}/worships/{worshipId}/sessions/{sessionId}
- 예배 세션 단건 조회

### PATCH /churches/{churchId}/worships/{worshipId}/sessions/{sessionId}
- 세션 수정 (title, description, sessionDate)
- 생성 시와 동일한 유효성 검사 적용

### DELETE /churches/{churchId}/worships/{worshipId}/sessions/{sessionId}
- 예배 세션 삭제

### 예배 삭제 시 후속 처리
- 예배 삭제 시 해당 예배에 속한 모든 세션(WorshipSession) 자동 삭제 처리

### WorshipTargetGroup 규칙 변경
- 변경 전: 예배 생성/수정 시 대상 그룹은 반드시 지정되어야 했음 (빈 배열 허용되지 않음)
- 변경 후: 대상 그룹 빈 배열 허용 → 예배 대상 그룹이 없어도 생성 및 수정 가능