### PR TITLE
feat: WorshipAttendance 새로고침 및 업데이트 기능 추가

### DIFF
--- a/backend/src/worship/controller/worship-attendance.controller.ts
+++ b/backend/src/worship/controller/worship-attendance.controller.ts
@@ -1,7 +1,21 @@
-import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseInterceptors,
+} from '@nestjs/common';
 import { WorshipAttendanceService } from '../service/worship-attendance.service';
 import { ApiTags } from '@nestjs/swagger';
 import { GetWorshipAttendancesDto } from '../dto/request/worship-attendance/get-worship-attendances.dto';
+import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
+import { QueryRunner } from '../../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm';
+import { UpdateWorshipAttendanceDto } from '../dto/request/worship-attendance/update-worship-attendance.dto';
 
 @ApiTags('Worships:Attendance')
 @Controller(':worshipId/sessions/:sessionId/attendances')
@@ -22,6 +36,42 @@ export class WorshipAttendanceController {
       worshipId,
       sessionId,
       dto,
+    );
+  }
+
+  @Post()
+  @UseInterceptors(TransactionInterceptor)
+  refreshAttendance(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @Param('sessionId', ParseIntPipe) sessionId: number,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.worshipAttendanceService.refreshAttendance(
+      churchId,
+      worshipId,
+      sessionId,
+      qr,
+    );
+  }
+
+  @Patch(':attendanceId')
+  @UseInterceptors(TransactionInterceptor)
+  patchAttendance(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @Param('sessionId', ParseIntPipe) sessionId: number,
+    @Param('attendanceId', ParseIntPipe) attendanceId: number,
+    @Body() dto: UpdateWorshipAttendanceDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.worshipAttendanceService.patchAttendance(
+      churchId,
+      worshipId,
+      sessionId,
+      attendanceId,
+      dto,
+      qr,
     );
   }
 }

--- a/backend/src/worship/entity/worship-attendance.entity.ts
+++ b/backend/src/worship/entity/worship-attendance.entity.ts
@@ -24,9 +24,14 @@ export class WorshipAttendanceModel extends BaseModel {
   @Column({ type: 'timestamptz' })
   sessionDate: Date;
 
+  @Index()
+  @Column()
+  worshipEnrollmentId: number;
+
   @ManyToOne(
     () => WorshipEnrollmentModel,
     (enrollment) => enrollment.worshipAttendances,
   )
+  @JoinColumn({ name: 'worshipEnrollmentId' })
   worshipEnrollment: WorshipEnrollmentModel;
 }

--- a/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
@@ -1,7 +1,10 @@
 import { GetWorshipAttendancesDto } from 'src/worship/dto/request/worship-attendance/get-worship-attendances.dto';
 import { WorshipSessionModel } from '../../entity/worship-session.entity';
 import { WorshipAttendanceDomainPaginationResultDto } from '../dto/worship-attendance-domain-pagination-result.dto';
-import { QueryRunner } from 'typeorm';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
+import { WorshipAttendanceModel } from '../../entity/worship-attendance.entity';
+import { WorshipEnrollmentModel } from '../../entity/worship-enrollment.entity';
+import { UpdateWorshipAttendanceDto } from '../../dto/request/worship-attendance/update-worship-attendance.dto';
 
 export const IWORSHIP_ATTENDANCE_DOMAIN_SERVICE = Symbol(
   'IWORSHIP_ATTENDANCE_DOMAIN_SERVICE',
@@ -13,4 +16,34 @@ export interface IWorshipAttendanceDomainService {
     dto: GetWorshipAttendancesDto,
     qr?: QueryRunner,
   ): Promise<WorshipAttendanceDomainPaginationResultDto>;
+
+  findAllAttendances(
+    session: WorshipSessionModel,
+    qr: QueryRunner,
+  ): Promise<WorshipAttendanceModel[]>;
+
+  refreshAttendances(
+    session: WorshipSessionModel,
+    notExistAttendanceEnrollments: WorshipEnrollmentModel[],
+    qr: QueryRunner,
+  ): Promise<WorshipAttendanceModel[]>;
+
+  findWorshipAttendanceModelById(
+    session: WorshipSessionModel,
+    attendanceId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<WorshipAttendanceModel>,
+  ): Promise<WorshipAttendanceModel>;
+
+  findWorshipAttendanceById(
+    session: WorshipSessionModel,
+    attendanceId: number,
+    qr?: QueryRunner,
+  ): Promise<WorshipAttendanceModel>;
+
+  updateAttendance(
+    targetAttendance: WorshipAttendanceModel,
+    dto: UpdateWorshipAttendanceDto,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
 }

--- a/backend/src/worship/worship-domain/service/worship-attendance-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-attendance-domain.service.ts
@@ -1,11 +1,27 @@
-import { Injectable } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { IWorshipAttendanceDomainService } from '../interface/worship-attendance-domain.service.interface';
 import { InjectRepository } from '@nestjs/typeorm';
 import { WorshipAttendanceModel } from '../../entity/worship-attendance.entity';
-import { QueryRunner, Repository } from 'typeorm';
+import {
+  FindOptionsRelations,
+  QueryRunner,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
 import { WorshipSessionModel } from '../../entity/worship-session.entity';
 import { GetWorshipAttendancesDto } from '../../dto/request/worship-attendance/get-worship-attendances.dto';
 import { WorshipAttendanceDomainPaginationResultDto } from '../dto/worship-attendance-domain-pagination-result.dto';
+import { WorshipEnrollmentModel } from '../../entity/worship-enrollment.entity';
+import { WorshipAttendanceException } from '../../exception/worship-attendance.exception';
+import {
+  MemberSummarizedRelation,
+  MemberSummarizedSelect,
+} from '../../../members/const/member-find-options.const';
+import { UpdateWorshipAttendanceDto } from '../../dto/request/worship-attendance/update-worship-attendance.dto';
 
 @Injectable()
 export class WorshipAttendanceDomainService
@@ -51,5 +67,116 @@ export class WorshipAttendanceDomainService
     ]);
 
     return new WorshipAttendanceDomainPaginationResultDto(data, totalCount);
+  }
+
+  async findAllAttendances(session: WorshipSessionModel, qr: QueryRunner) {
+    const repository = this.getRepository(qr);
+
+    return repository.find({
+      where: {
+        worshipSessionId: session.id,
+      },
+      relations: {
+        worshipEnrollment: true,
+      },
+    });
+  }
+
+  refreshAttendances(
+    session: WorshipSessionModel,
+    notExistAttendanceEnrollments: WorshipEnrollmentModel[],
+    qr: QueryRunner,
+  ): Promise<WorshipAttendanceModel[]> {
+    const repository = this.getRepository(qr);
+
+    const attendances = repository.create(
+      notExistAttendanceEnrollments.map((enrollment) => ({
+        sessionDate: session.sessionDate,
+        worshipSessionId: session.id,
+        worshipEnrollmentId: enrollment.id,
+      })),
+    );
+
+    return repository.save(attendances, { chunk: 100 });
+  }
+
+  async findWorshipAttendanceModelById(
+    session: WorshipSessionModel,
+    attendanceId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<WorshipAttendanceModel>,
+  ): Promise<WorshipAttendanceModel> {
+    const repository = this.getRepository(qr);
+
+    const attendance = await repository.findOne({
+      where: {
+        worshipSessionId: session.id,
+        id: attendanceId,
+      },
+      relations: relationOptions,
+    });
+
+    if (!attendance) {
+      throw new NotFoundException(WorshipAttendanceException.NOT_FOUND);
+    }
+
+    return attendance;
+  }
+
+  async findWorshipAttendanceById(
+    session: WorshipSessionModel,
+    attendanceId: number,
+    qr?: QueryRunner,
+  ): Promise<WorshipAttendanceModel> {
+    const repository = this.getRepository(qr);
+
+    const attendance = await repository.findOne({
+      where: {
+        worshipSessionId: session.id,
+        id: attendanceId,
+      },
+      relations: {
+        worshipEnrollment: {
+          member: MemberSummarizedRelation,
+        },
+      },
+      select: {
+        worshipEnrollment: {
+          id: true,
+          member: MemberSummarizedSelect,
+        },
+      },
+    });
+
+    if (!attendance) {
+      throw new NotFoundException(WorshipAttendanceException.NOT_FOUND);
+    }
+
+    return attendance;
+  }
+
+  async updateAttendance(
+    targetAttendance: WorshipAttendanceModel,
+    dto: UpdateWorshipAttendanceDto,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    const result = await repository.update(
+      {
+        id: targetAttendance.id,
+      },
+      {
+        ...dto,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        WorshipAttendanceException.UPDATE_ERROR,
+      );
+    }
+
+    return result;
   }
 }


### PR DESCRIPTION
## 주요 내용
예배 출석(WorshipAttendance)에 대한 새로고침(refresh) 및 개별 출석 정보 수정 기능 구현

## 세부 내용

### POST /churches/{churchId}/worships/{worshipId}/sessions/{sessionId}/attendances/refresh
- 해당 세션에 대한 출석 정보 일괄 생성 또는 보정
- 등록(enrollment)은 되어 있으나 출석(attendance)이 누락된 교인을 찾아 출석 생성
- 중복 생성 없이 필요한 데이터만 보완

### PATCH /churches/{churchId}/worships/{worshipId}/sessions/{sessionId}/attendances/{attendanceId}
- 출석 정보 수정
- 수정 가능 항목: 출석 여부(isAttended), 비고(note)