### PR TITLE
feat: WorshipSession 날짜 기반 조회/생성 및 수동 생성 기능 분리

### DIFF
--- a/backend/src/worship/dto/request/worship-session/create-worship-session.dto.ts
+++ b/backend/src/worship/dto/request/worship-session/create-worship-session.dto.ts
@@ -1,11 +1,7 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { WorshipSessionModel } from '../../../entity/worship-session.entity';
-import {
-  MAX_DESCRIPTION_LENGTH,
-  MAX_WORSHIP_TITLE,
-} from '../../../constraints/worship.constraints';
-import { IsDate, IsNotEmpty, IsString, MaxLength } from 'class-validator';
-import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import { MAX_DESCRIPTION_LENGTH } from '../../../constraints/worship.constraints';
+import { IsDate, IsString } from 'class-validator';
 import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
 import { PlainTextMaxLength } from '../../../../common/decorator/validator/plain-text-max-length.validator';
 import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
@@ -13,11 +9,11 @@ import { Transform } from 'class-transformer';
 
 @SanitizeDto()
 export class CreateWorshipSessionDto extends PickType(WorshipSessionModel, [
-  'title',
+  //'title',
   'description',
   'sessionDate',
 ]) {
-  @ApiProperty({
+  /*@ApiProperty({
     description: '예배 세션 제목',
     maxLength: MAX_WORSHIP_TITLE,
   })
@@ -25,7 +21,7 @@ export class CreateWorshipSessionDto extends PickType(WorshipSessionModel, [
   @IsNotEmpty()
   @IsNoSpecialChar()
   @MaxLength(MAX_WORSHIP_TITLE)
-  override title: string;
+  override title: string;*/
 
   @ApiProperty({
     description: '예배 세션 설명 (최대 500자(서식 제외), 빈 문자열 허용)',

--- a/backend/src/worship/dto/request/worship-session/update-worship-session.dto.ts
+++ b/backend/src/worship/dto/request/worship-session/update-worship-session.dto.ts
@@ -1,16 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import {
-  MAX_DESCRIPTION_LENGTH,
-  MAX_WORSHIP_TITLE,
-} from '../../../constraints/worship.constraints';
-import { IsDate, IsNotEmpty, IsString, MaxLength } from 'class-validator';
-import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import { MAX_DESCRIPTION_LENGTH } from '../../../constraints/worship.constraints';
+import { IsString } from 'class-validator';
 import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
 import { PlainTextMaxLength } from '../../../../common/decorator/validator/plain-text-max-length.validator';
-import { Transform } from 'class-transformer';
 
 export class UpdateWorshipSessionDto {
-  @ApiProperty({
+  /*@ApiProperty({
     description: '예배 세션 제목',
     maxLength: MAX_WORSHIP_TITLE,
   })
@@ -19,7 +14,7 @@ export class UpdateWorshipSessionDto {
   @IsNotEmpty()
   @IsNoSpecialChar()
   @MaxLength(MAX_WORSHIP_TITLE)
-  title: string;
+  title: string;*/
 
   @ApiProperty({
     description: '예배 세션 설명 (최대 500자(서식 제외), 빈 문자열 허용)',
@@ -30,11 +25,11 @@ export class UpdateWorshipSessionDto {
   @PlainTextMaxLength(MAX_DESCRIPTION_LENGTH)
   description: string;
 
-  @ApiProperty({
+  /*@ApiProperty({
     description: '예배 세션 진행 날짜',
   })
   @IsOptionalNotNull()
   @IsDate()
   @Transform(({ value }) => new Date(value.setHours(0, 0, 0, 0)))
-  sessionDate: Date;
+  sessionDate: Date;*/
 }

--- a/backend/src/worship/dto/response/worship-session/delete-worship-session.response.dto.ts
+++ b/backend/src/worship/dto/response/worship-session/delete-worship-session.response.dto.ts
@@ -4,7 +4,7 @@ export class DeleteWorshipSessionResponseDto extends BaseDeleteResponseDto {
   constructor(
     public readonly timestamp: Date,
     public readonly id: number,
-    public readonly title: string,
+    //public readonly title: string,
     public readonly success: boolean,
   ) {
     super(timestamp, id, success);

--- a/backend/src/worship/entity/worship-session.entity.ts
+++ b/backend/src/worship/entity/worship-session.entity.ts
@@ -12,12 +12,10 @@ export class WorshipSessionModel extends BaseModel {
   @JoinColumn({ name: 'worshipId' })
   worship: WorshipModel;
 
-  @Column()
-  title: string;
-
   @Column({ default: '' })
   description: string;
 
-  @Column({ type: 'timestamptz', nullable: true })
+  @Index()
+  @Column({ type: 'timestamptz' })
   sessionDate: Date;
 }

--- a/backend/src/worship/exception/worship-session.exception.ts
+++ b/backend/src/worship/exception/worship-session.exception.ts
@@ -4,4 +4,6 @@ export const WorshipSessionException = {
   UPDATE_ERROR: '예배 세션 업데이트 도중 에러 발생',
   DELETE_ERROR: '예배 세션 삭제 도중 에러 발생',
   INVALID_SESSION_DAY: '잘못된 예배 세션 요일(날짜)입니다.',
+
+  INVALID_SESSION_DATE: '진행되지 않은 예배의 출석을 기록할 수 없습니다.',
 };

--- a/backend/src/worship/pipe/parse-date.pipe.ts
+++ b/backend/src/worship/pipe/parse-date.pipe.ts
@@ -1,0 +1,17 @@
+import {
+  ArgumentMetadata,
+  BadRequestException,
+  PipeTransform,
+} from '@nestjs/common';
+
+export class ParseDatePipe implements PipeTransform {
+  transform(value: any, metadata: ArgumentMetadata): any {
+    const parsed = new Date(new Date(value).setHours(0, 0, 0, 0));
+
+    if (isNaN(parsed.getTime())) {
+      throw new BadRequestException('유효하지 않은 날짜 형식입니다.');
+    }
+
+    return parsed;
+  }
+}

--- a/backend/src/worship/swagger/worship-session.swagger.ts
+++ b/backend/src/worship/swagger/worship-session.swagger.ts
@@ -1,0 +1,67 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+export const ApiGetSessions = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '예배 세션 목록 조회',
+    }),
+  );
+
+export const ApiGetOrPostRecentSession = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '가장 최근 예배 세션 조회 or 생성',
+      description:
+        '<h2>가장 최근 예배 세션을 조회 또는 생성합니다.</h2>' +
+        '<p>세션을 생성하는 경우 그 하위 Attendance 도 생성됩니다.</p>',
+    }),
+  );
+
+export const ApiGetOrPostSessionByDate = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '특정 날짜의 예배 세션 조회 or 생성',
+      description:
+        '<h2>특정 날짜의 예배 세션을 조회 또는 생성합니다.</h2>' +
+        '<p>요일이 잘못된 경우 또는 미래의 날짜를 지정한 경우 BadRequestException</p>' +
+        '<p>세션을 생성하는 경우 그 하위 Attendance 도 생성됩니다. </p>',
+    }),
+  );
+
+export const ApiPostSessionManual = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '예배 세션 수동 생성',
+      description:
+        '<h2>예배 세션을 수동으로 생성합니다.</h2>' +
+        '<p>예배 진행 전 미리 세션을 생성하는 용도로 Attendance 는 생성되지 않습니다.</p>',
+    }),
+  );
+
+export const ApiGetSessionById = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '예배 세션 단건 조회',
+    }),
+  );
+
+export const ApiPatchSession = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '예배 세션 수정',
+      description:
+        '<h2>예배 세션의 description 을 수정합니다.</h2>' +
+        '<p>html 태그로 서식 지정 가능, script 등 유해 태그 사용 시 필터링 적용</p>' +
+        '<p>서식 제외 500자 제한</p>' +
+        '<p>빈 문자열 허용</p>',
+    }),
+  );
+
+export const ApiDeleteSession = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '예배 세션 개별 삭제',
+      description: '하위 attendance 삭제',
+    }),
+  );

--- a/backend/src/worship/worship-domain/interface/worship-session-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-session-domain.service.interface.ts
@@ -20,12 +20,18 @@ export interface IWorshipSessionDomainService {
   createWorshipSession(
     worship: WorshipModel,
     dto: CreateWorshipSessionDto,
-    qr: QueryRunner,
+    qr?: QueryRunner,
   ): Promise<WorshipSessionModel>;
+
+  findOrCreateWorshipSessionByDate(
+    worship: WorshipModel,
+    sessionDate: Date,
+    qr: QueryRunner,
+  ): Promise<WorshipSessionModel & { isCreated: boolean }>;
 
   findOrCreateRecentWorshipSession(
     worship: WorshipModel,
-    dto: CreateWorshipSessionDto,
+    sessionDate: Date,
     qr: QueryRunner,
   ): Promise<WorshipSessionModel & { isCreated: boolean }>;
 
@@ -43,7 +49,6 @@ export interface IWorshipSessionDomainService {
   ): Promise<WorshipSessionModel>;
 
   updateWorshipSession(
-    worship: WorshipModel,
     worshipSession: WorshipSessionModel,
     dto: UpdateWorshipSessionDto,
     qr: QueryRunner,


### PR DESCRIPTION
## 주요 내용
예배 세션(WorshipSession)을 날짜 기준으로 조회하거나 없을 경우 생성하는 기능 추가 세션 제목(title)을 제거하고 sessionDate는 수정할 수 없도록 제한
수동 세션 생성 엔드포인트를 별도로 분리하고, 이 경우 Attendance는 생성하지 않음

## 세부 내용

### POST /churches/{churchId}/worships/{worshipId}/sessions
- 쿼리 파라미터: sessionDate (Date)
- 해당 날짜의 세션이 존재하면 그대로 반환
- 존재하지 않으면 새로운 세션을 생성하여 반환
- 생성 시 해당 세션에 대한 Attendance도 자동 생성됨
- sessionDate는 현재보다 미래일 수 없음
- sessionDate의 요일이 worshipDay와 다르면 ConflictException

### POST /churches/{churchId}/worships/{worshipId}/sessions/manual
- 요청 본문: sessionDate, description
- 세션을 수동으로 생성
- Attendance는 생성하지 않음
- sessionDate와 요일 유효성 검사는 동일하게 적용됨

### WorshipSession 구조 변경
- title 필드 제거
- sessionDate는 수정 불가
- 수정 가능한 필드는 description만 허용