### PR TITLE
feat: WorshipAttendance 및 WorshipEnrollment 조회 시 하위 그룹 포함 필터링 기능 추가

### DIFF
--- a/backend/src/worship/dto/request/worship-attendance/get-worship-attendances.dto.ts
+++ b/backend/src/worship/dto/request/worship-attendance/get-worship-attendances.dto.ts
@@ -1,7 +1,7 @@
 import { BaseOffsetPaginationRequestDto } from '../../../../common/dto/request/base-offset-pagination-request.dto';
 import { WorshipAttendanceOrderEnum } from '../../../const/worship-attendance-order.enum';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum } from 'class-validator';
+import { IsEnum, IsNumber, Min } from 'class-validator';
 import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
 
 export class GetWorshipAttendancesDto extends BaseOffsetPaginationRequestDto<WorshipAttendanceOrderEnum> {
@@ -13,4 +13,13 @@ export class GetWorshipAttendancesDto extends BaseOffsetPaginationRequestDto<Wor
   @IsOptionalNotNull()
   @IsEnum(WorshipAttendanceOrderEnum)
   order: WorshipAttendanceOrderEnum = WorshipAttendanceOrderEnum.CREATED_AT;
+
+  @ApiProperty({
+    description: '교인 그룹 ID',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsNumber()
+  @Min(1)
+  groupId?: number;
 }

--- a/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
@@ -14,6 +14,7 @@ export interface IWorshipAttendanceDomainService {
   findAttendances(
     session: WorshipSessionModel,
     dto: GetWorshipAttendancesDto,
+    groupIds?: number[],
     qr?: QueryRunner,
   ): Promise<WorshipAttendanceDomainPaginationResultDto>;
 

--- a/backend/src/worship/worship-domain/interface/worship-enrollment-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-enrollment-domain.service.interface.ts
@@ -13,6 +13,7 @@ export interface IWorshipEnrollmentDomainService {
   findEnrollments(
     worship: WorshipModel,
     dto: GetWorshipEnrollmentsDto,
+    groupIds?: number[],
     qr?: QueryRunner,
   ): Promise<WorshipEnrollmentDomainPaginationResultDto>;
 

--- a/backend/src/worship/worship-domain/service/worship-enrollment-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-enrollment-domain.service.ts
@@ -55,6 +55,7 @@ export class WorshipEnrollmentDomainService
   async findEnrollments(
     worship: WorshipModel,
     dto: GetWorshipEnrollmentsDto,
+    groupIds?: number[],
     qr?: QueryRunner,
   ) {
     const repository = this.getRepository(qr);
@@ -62,7 +63,7 @@ export class WorshipEnrollmentDomainService
     const whereOptions: FindOptionsWhere<WorshipEnrollmentModel> = {
       worshipId: worship.id,
       member: {
-        groupId: dto.groupId && In([dto.groupId]),
+        groupId: groupIds && In(groupIds),
       },
     };
 


### PR DESCRIPTION
## 주요 내용
예배 출석(WorshipAttendance) 및 예배 등록(WorshipEnrollment) 조회 시 그룹 필터링을 확장 지정된 그룹뿐 아니라 해당 그룹의 하위 그룹에 속한 교인의 데이터도 함께 조회되도록 개선

## 세부 내용

### WorshipAttendance 조회
- 쿼리 파라미터로 groupId 지정 시, 해당 그룹에 속한 교인뿐만 아니라 그 하위 그룹에 속한 교인의 Attendance 도 함께 조회됨

### WorshipEnrollment 조회
- 동일하게 groupId 필터링 시 하위 그룹 포함하여 필터링 적용
- 기존에는 지정된 그룹만 대상이었으나, 하위 그룹까지 포함하도록 변경