### PR TITLE
feat: WorshipEnrollment 및 WorshipAttendance 정렬 옵션 개선 및 조회 범위 확장

### DIFF
--- a/backend/src/worship/const/worship-attendance-order.enum.ts
+++ b/backend/src/worship/const/worship-attendance-order.enum.ts
@@ -1,4 +1,8 @@
 export enum WorshipAttendanceOrderEnum {
-  CREATED_AT = 'createdAt',
+  //CREATED_AT = 'createdAt',
+  ID = 'id',
   UPDATED_AT = 'updatedAt',
+  ATTENDANCE_STATUS = 'attendanceStatus',
+  NAME = 'name',
+  GROUP_NAME = 'groupName',
 }

--- a/backend/src/worship/const/worship-enrollment-order.enum.ts
+++ b/backend/src/worship/const/worship-enrollment-order.enum.ts
@@ -1,6 +1,7 @@
 export enum WorshipEnrollmentOrderEnum {
-  CREATED_AT = 'createdAt',
+  //CREATED_AT = 'createdAt',
+  ID = 'id',
   UPDATED_AT = 'updatedAt',
   NAME = 'name',
-  //GROUP_NAME = 'groupName',
+  GROUP_NAME = 'groupName',
 }

--- a/backend/src/worship/dto/request/worship-attendance/get-worship-attendances.dto.ts
+++ b/backend/src/worship/dto/request/worship-attendance/get-worship-attendances.dto.ts
@@ -8,11 +8,12 @@ export class GetWorshipAttendancesDto extends BaseOffsetPaginationRequestDto<Wor
   @ApiProperty({
     description: '정렬 조건',
     enum: WorshipAttendanceOrderEnum,
+    default: WorshipAttendanceOrderEnum.ID,
     required: false,
   })
   @IsOptionalNotNull()
   @IsEnum(WorshipAttendanceOrderEnum)
-  order: WorshipAttendanceOrderEnum = WorshipAttendanceOrderEnum.CREATED_AT;
+  order: WorshipAttendanceOrderEnum = WorshipAttendanceOrderEnum.ID;
 
   @ApiProperty({
     description: '교인 그룹 ID',

--- a/backend/src/worship/dto/request/worship-enrollment/get-worship-enrollments.dto.ts
+++ b/backend/src/worship/dto/request/worship-enrollment/get-worship-enrollments.dto.ts
@@ -8,11 +8,11 @@ export class GetWorshipEnrollmentsDto extends BaseOffsetPaginationRequestDto<Wor
   @ApiProperty({
     description: '정렬 조건',
     enum: WorshipEnrollmentOrderEnum,
-    default: WorshipEnrollmentOrderEnum.CREATED_AT,
+    default: WorshipEnrollmentOrderEnum.ID,
     required: false,
   })
   @IsEnum(WorshipEnrollmentOrderEnum)
-  order: WorshipEnrollmentOrderEnum = WorshipEnrollmentOrderEnum.CREATED_AT;
+  order: WorshipEnrollmentOrderEnum = WorshipEnrollmentOrderEnum.ID;
 
   @ApiProperty({
     description: '교인 그룹',

--- a/backend/src/worship/service/worship.service.ts
+++ b/backend/src/worship/service/worship.service.ts
@@ -134,6 +134,7 @@ export class WorshipService {
       qr,
     );
 
+    // Enrollment 생성
     await this.worshipEnrollmentDomainService.refreshEnrollments(
       newWorship,
       allMembers,
@@ -222,8 +223,6 @@ export class WorshipService {
         targetWorship,
         qr,
       );
-
-    console.log(deletedSessionIds);
 
     // 예배 세션들의 출석 정보 삭제
     await this.worshipAttendanceDomainService.deleteAttendanceCascadeWorship(

--- a/backend/src/worship/worship-domain/service/worship-enrollment-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-enrollment-domain.service.ts
@@ -43,6 +43,17 @@ export class WorshipEnrollmentDomainService
       };
 
       return orderOptions;
+    } else if (dto.order === WorshipEnrollmentOrderEnum.GROUP_NAME) {
+      const orderOptions: FindOptionsOrder<WorshipEnrollmentModel> = {
+        member: {
+          group: {
+            name: dto.orderDirection,
+          },
+          name: dto.orderDirection,
+        },
+      };
+
+      return orderOptions;
     } else {
       const orderOptions: FindOptionsOrder<WorshipEnrollmentModel> = {
         [dto.order]: dto.orderDirection,
@@ -70,8 +81,8 @@ export class WorshipEnrollmentDomainService
     const orderOptions: FindOptionsOrder<WorshipEnrollmentModel> =
       this.parseOrderOption(dto);
 
-    if (dto.order !== WorshipEnrollmentOrderEnum.CREATED_AT) {
-      orderOptions.createdAt = 'ASC';
+    if (dto.order !== WorshipEnrollmentOrderEnum.ID) {
+      orderOptions.id = 'ASC';
     }
 
     const [data, totalCount] = await Promise.all([
@@ -80,7 +91,6 @@ export class WorshipEnrollmentDomainService
         order: orderOptions,
         relations: {
           member: MemberSummarizedRelation,
-          worshipAttendances: true,
         },
         select: {
           member: MemberSummarizedSelect,


### PR DESCRIPTION
## 주요 내용
Enrollment 및 Attendance 조회 시 정렬 기준을 개선하고, Attendance 조인 조회 범위를 14개로 확장 bulk insert로 인해 createdAt 기준 정렬이 무의미해진 문제를 id 기반 정렬로 대체

## 세부 내용

### 정렬 기능 개선
- Enrollment, Attendance 조회 시 정렬 조건으로 교인 이름(name) 또는 소속 그룹(group.name) 지정 가능
- 그룹 기준 정렬 시, 동일 그룹 내에서는 교인 이름 기준으로 2차 정렬 처리

### createdAt 정렬 제거 및 대체
- Enrollment, Attendance는 bulk insert로 인해 createdAt이 동일하게 저장됨
- createdAt 정렬은 무의미하므로 id 오름차순 정렬로 기본값 변경

### Attendance 조인 개수 확장
- Enrollment 조회 시 함께 가져오는 Attendance 개수를 기존 12개 → 14개로 확대
- 3개월 분량의 주간 출석 정보를 충분히 확인할 수 있도록 보장