### PR TITLE
feat: WorshipSession에 세션 관련 정보 필드 추가 및 수동 생성 시 입력 기능 구현

### DIFF
--- a/backend/src/worship/constraints/worship.constraints.ts
+++ b/backend/src/worship/constraints/worship.constraints.ts
@@ -3,9 +3,12 @@ export const MAX_WORSHIP_TITLE = 50;
 // -------------------------------------------------------------
 
 // ------------------Worship Session Constraints -------------------
-export const MAX_DESCRIPTION_LENGTH = 500;
+export const MAX_WORSHIP_SESSION_TITLE_LENGTH = 50;
+export const MAX_WORSHIP_SESSION_BIBLE_TITLE_LENGTH = 200;
+export const MAX_WORSHIP_SESSION_DESCRIPTION_LENGTH = 1000;
+export const MAX_WORSHIP_SESSION_NOTE_LENGTH = 500;
 // -----------------------------------------------------------------
 
 // -------------------Worship Attendance Constraints-------------------
-export const MAX_NOTE_LENGTH = 120;
+export const MAX_WORSHIP_ATTENDANCE_NOTE_LENGTH = 120;
 // --------------------------------------------------------------------

--- a/backend/src/worship/dto/request/worship-attendance/update-worship-attendance.dto.ts
+++ b/backend/src/worship/dto/request/worship-attendance/update-worship-attendance.dto.ts
@@ -3,7 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
 import { IsEnum, IsString, MaxLength } from 'class-validator';
 import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
-import { MAX_NOTE_LENGTH } from '../../../constraints/worship.constraints';
+import { MAX_WORSHIP_ATTENDANCE_NOTE_LENGTH } from '../../../constraints/worship.constraints';
 
 @SanitizeDto()
 export class UpdateWorshipAttendanceDto {
@@ -22,6 +22,6 @@ export class UpdateWorshipAttendanceDto {
   })
   @IsOptionalNotNull()
   @IsString()
-  @MaxLength(MAX_NOTE_LENGTH)
+  @MaxLength(MAX_WORSHIP_ATTENDANCE_NOTE_LENGTH)
   note: string;
 }

--- a/backend/src/worship/dto/request/worship-session/create-worship-session.dto.ts
+++ b/backend/src/worship/dto/request/worship-session/create-worship-session.dto.ts
@@ -1,41 +1,76 @@
-import { ApiProperty, PickType } from '@nestjs/swagger';
-import { WorshipSessionModel } from '../../../entity/worship-session.entity';
-import { MAX_DESCRIPTION_LENGTH } from '../../../constraints/worship.constraints';
-import { IsDate, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  MAX_WORSHIP_SESSION_BIBLE_TITLE_LENGTH,
+  MAX_WORSHIP_SESSION_DESCRIPTION_LENGTH,
+  MAX_WORSHIP_SESSION_TITLE_LENGTH,
+  MAX_WORSHIP_TITLE,
+} from '../../../constraints/worship.constraints';
+import {
+  IsDate,
+  IsNumber,
+  IsString,
+  IsUrl,
+  MaxLength,
+  Min,
+} from 'class-validator';
 import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
 import { PlainTextMaxLength } from '../../../../common/decorator/validator/plain-text-max-length.validator';
 import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
 import { Transform } from 'class-transformer';
+import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
 
 @SanitizeDto()
-export class CreateWorshipSessionDto extends PickType(WorshipSessionModel, [
-  //'title',
-  'description',
-  'sessionDate',
-]) {
-  /*@ApiProperty({
-    description: '예배 세션 제목',
-    maxLength: MAX_WORSHIP_TITLE,
+export class CreateWorshipSessionDto {
+  @ApiProperty({
+    description: '예배 세션 진행 날짜 (필수)',
   })
-  @IsString()
-  @IsNotEmpty()
-  @IsNoSpecialChar()
-  @MaxLength(MAX_WORSHIP_TITLE)
-  override title: string;*/
+  @IsDate()
+  @Transform(({ value }) => new Date(value.setHours(0, 0, 0, 0)))
+  sessionDate: Date;
 
   @ApiProperty({
-    description: '예배 세션 설명 (최대 500자(서식 제외), 빈 문자열 허용)',
+    description: '예배 세션 제목',
+    maxLength: MAX_WORSHIP_TITLE,
     required: false,
   })
   @IsOptionalNotNull()
   @IsString()
-  @PlainTextMaxLength(MAX_DESCRIPTION_LENGTH)
-  override description: string;
+  @IsNoSpecialChar()
+  @MaxLength(MAX_WORSHIP_SESSION_TITLE_LENGTH)
+  title: string;
 
   @ApiProperty({
-    description: '예배 세션 진행 날짜',
+    description: '성경 본문',
+    required: false,
   })
-  @IsDate()
-  @Transform(({ value }) => new Date(value.setHours(0, 0, 0, 0)))
-  override sessionDate: Date;
+  @IsOptionalNotNull()
+  @IsString()
+  @PlainTextMaxLength(MAX_WORSHIP_SESSION_BIBLE_TITLE_LENGTH)
+  bibleTitle: string;
+
+  @ApiProperty({
+    description: '예배 세션 설명 (최대 1000자(서식 제외), 빈 문자열 허용)',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @PlainTextMaxLength(MAX_WORSHIP_SESSION_DESCRIPTION_LENGTH)
+  description: string;
+
+  @ApiProperty({
+    description: '예배 세션 영상 URL',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsUrl()
+  videoUrl: string;
+
+  @ApiProperty({
+    description: '설교자 교인 ID',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsNumber()
+  @Min(1)
+  inChargeId: number;
 }

--- a/backend/src/worship/dto/request/worship-session/update-worship-session.dto.ts
+++ b/backend/src/worship/dto/request/worship-session/update-worship-session.dto.ts
@@ -1,35 +1,59 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { MAX_DESCRIPTION_LENGTH } from '../../../constraints/worship.constraints';
-import { IsString } from 'class-validator';
+import {
+  MAX_WORSHIP_SESSION_BIBLE_TITLE_LENGTH,
+  MAX_WORSHIP_SESSION_DESCRIPTION_LENGTH,
+  MAX_WORSHIP_SESSION_TITLE_LENGTH,
+  MAX_WORSHIP_TITLE,
+} from '../../../constraints/worship.constraints';
+import { IsNumber, IsString, IsUrl, MaxLength, Min } from 'class-validator';
 import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
 import { PlainTextMaxLength } from '../../../../common/decorator/validator/plain-text-max-length.validator';
+import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
 
 export class UpdateWorshipSessionDto {
-  /*@ApiProperty({
+  @ApiProperty({
     description: '예배 세션 제목',
     maxLength: MAX_WORSHIP_TITLE,
-  })
-  @IsOptionalNotNull()
-  @IsString()
-  @IsNotEmpty()
-  @IsNoSpecialChar()
-  @MaxLength(MAX_WORSHIP_TITLE)
-  title: string;*/
-
-  @ApiProperty({
-    description: '예배 세션 설명 (최대 500자(서식 제외), 빈 문자열 허용)',
     required: false,
   })
   @IsOptionalNotNull()
   @IsString()
-  @PlainTextMaxLength(MAX_DESCRIPTION_LENGTH)
-  description: string;
+  @IsNoSpecialChar()
+  @MaxLength(MAX_WORSHIP_SESSION_TITLE_LENGTH)
+  title: string;
 
-  /*@ApiProperty({
-    description: '예배 세션 진행 날짜',
+  @ApiProperty({
+    description: '성경 본문',
+    required: false,
   })
   @IsOptionalNotNull()
-  @IsDate()
-  @Transform(({ value }) => new Date(value.setHours(0, 0, 0, 0)))
-  sessionDate: Date;*/
+  @IsString()
+  @PlainTextMaxLength(MAX_WORSHIP_SESSION_BIBLE_TITLE_LENGTH)
+  bibleTitle: string;
+
+  @ApiProperty({
+    description: '예배 세션 설명 (최대 1000자(서식 제외), 빈 문자열 허용)',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @PlainTextMaxLength(MAX_WORSHIP_SESSION_DESCRIPTION_LENGTH)
+  description: string;
+
+  @ApiProperty({
+    description: '예배 세션 영상 URL',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsUrl()
+  videoUrl: string;
+
+  @ApiProperty({
+    description: '설교자 교인 ID',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsNumber()
+  @Min(1)
+  inChargeId: number;
 }

--- a/backend/src/worship/entity/worship-session.entity.ts
+++ b/backend/src/worship/entity/worship-session.entity.ts
@@ -1,6 +1,7 @@
 import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { BaseModel } from '../../common/entity/base.entity';
 import { WorshipModel } from './worship.entity';
+import { MemberModel } from '../../members/entity/member.entity';
 
 @Entity()
 export class WorshipSessionModel extends BaseModel {
@@ -12,10 +13,26 @@ export class WorshipSessionModel extends BaseModel {
   @JoinColumn({ name: 'worshipId' })
   worship: WorshipModel;
 
-  @Column({ default: '' })
-  description: string;
-
   @Index()
   @Column({ type: 'timestamptz' })
   sessionDate: Date;
+
+  @Column({ default: '' })
+  title: string;
+
+  @Column({ default: '' })
+  bibleTitle: string;
+
+  @Column({ default: '' })
+  videoUrl: string;
+
+  @Column({ default: '' })
+  description: string;
+
+  @Column({ nullable: true })
+  inChargeId: number;
+
+  @ManyToOne(() => MemberModel)
+  @JoinColumn({ name: 'inChargeId' })
+  inCharge: MemberModel;
 }

--- a/backend/src/worship/worship-domain/interface/worship-session-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-session-domain.service.interface.ts
@@ -5,6 +5,7 @@ import { WorshipSessionModel } from '../../entity/worship-session.entity';
 import { GetWorshipSessionsDto } from '../../dto/request/worship-session/get-worship-sessions.dto';
 import { WorshipSessionDomainPaginationResultDto } from '../dto/worship-session-domain-pagination-result.dto';
 import { UpdateWorshipSessionDto } from '../../dto/request/worship-session/update-worship-session.dto';
+import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 
 export const IWORSHIP_SESSION_DOMAIN_SERVICE = Symbol(
   'IWORSHIP_SESSION_DOMAIN_SERVICE',
@@ -19,6 +20,7 @@ export interface IWorshipSessionDomainService {
 
   createWorshipSession(
     worship: WorshipModel,
+    inCharge: ChurchUserModel | null,
     dto: CreateWorshipSessionDto,
     qr?: QueryRunner,
   ): Promise<WorshipSessionModel>;
@@ -50,6 +52,7 @@ export interface IWorshipSessionDomainService {
 
   updateWorshipSession(
     worshipSession: WorshipSessionModel,
+    inCharge: ChurchUserModel | null,
     dto: UpdateWorshipSessionDto,
     qr: QueryRunner,
   ): Promise<UpdateResult>;

--- a/backend/src/worship/worship.module.ts
+++ b/backend/src/worship/worship.module.ts
@@ -12,6 +12,7 @@ import { WorshipEnrollmentController } from './controller/worship-enrollment.con
 import { WorshipDomainModule } from './worship-domain/worship-domain.module';
 import { GroupsDomainModule } from '../management/groups/groups-domain/groups-domain.module';
 import { MembersDomainModule } from '../members/member-domain/members-domain.module';
+import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { MembersDomainModule } from '../members/member-domain/members-domain.mod
     MembersDomainModule,
     WorshipDomainModule,
     GroupsDomainModule,
+    ManagerDomainModule,
   ],
   controllers: [
     WorshipController,


### PR DESCRIPTION
## 주요 내용
WorshipSession에 예배 세션 관련 정보를 작성 및 수정할 수 있는 필드 추가
해당 필드들은 수동 생성 시에만 입력 가능하며, 날짜 기반 자동 생성 시에는 비어 있는 상태로 생성됨

## 세부 내용

### 추가된 필드
- title: 세션 제목
- bibleTitle: 사용된 성경 구절 또는 본문
- videoUrl: 세션 영상 URL
- description: 세션 설명 및 특이사항
- inChargeId / inCharge: 해당 세션의 설교자

### 기능 제한 및 동작 방식
- 위 필드들은 모두 선택 입력 사항이며, 세션 생성 시 필수 아님
- 날짜 기반 조회 또는 생성, 가장 최근 세션 조회 또는 생성에서는 해당 필드 없이 빈 상태로 세션 생성
- 수동 생성 요청에서만 위 필드들을 입력 및 저장 가능
- 이후 세션 수정(PATCH) 요청을 통해 해당 필드 수정 가능