### PR TITLE
feat: WorshipEnrollment 출석률 정렬 조건 추가 및 Attendance N+1 문제 최적화

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -39,10 +39,10 @@ lerna-debug.log*
 # dotenv environment variable files
 backend/.env
 .env.development.local
-.env.test.local
+../.env.test
 .env.production.local
 .env.local
-.env
+../.env
 
 # temp directory
 .temp

--- a/backend/src/member-history/decorator/is-valid-history-date.decorator.ts
+++ b/backend/src/member-history/decorator/is-valid-history-date.decorator.ts
@@ -5,11 +5,7 @@ import {
   ValidatorConstraintInterface,
   ValidatorOptions,
 } from 'class-validator';
-import {
-  BadRequestException,
-  Injectable,
-  InternalServerErrorException,
-} from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 
 @ValidatorConstraint({ name: 'IsValidHistoryDate', async: false })
 @Injectable()
@@ -30,7 +26,9 @@ export class IsValidHistoryDateConstraint
       );
     }
 
-    const input = value.setHours(0, 0, 0, 0);
+    return true;
+
+    /*const input = value.setHours(0, 0, 0, 0);
 
     const now = new Date().setHours(0, 0, 0, 0);
 
@@ -38,9 +36,9 @@ export class IsValidHistoryDateConstraint
       throw new BadRequestException(
         '이력의 날짜는 현재 날짜를 넘어설 수 없습니다.',
       );
-    }
+    }*/
 
-    return true;
+    //return true;
   }
 }
 

--- a/backend/src/worship/const/worship-enrollment-order.enum.ts
+++ b/backend/src/worship/const/worship-enrollment-order.enum.ts
@@ -4,4 +4,5 @@ export enum WorshipEnrollmentOrderEnum {
   UPDATED_AT = 'updatedAt',
   NAME = 'name',
   GROUP_NAME = 'groupName',
+  ATTENDANCE_RATE = 'attendanceRate',
 }

--- a/backend/src/worship/service/worship-attendance.service.ts
+++ b/backend/src/worship/service/worship-attendance.service.ts
@@ -212,7 +212,7 @@ export class WorshipAttendanceService {
     );
   }
 
-  async joinAttendance(
+  /*async joinAttendance(
     enrollment: WorshipEnrollmentModel,
     fromSessionDate?: Date,
     toSessionDate?: Date,
@@ -224,7 +224,7 @@ export class WorshipAttendanceService {
       toSessionDate,
       qr,
     );
-  }
+  }*/
 
   private async updatePresentAbsentCount(
     targetAttendance: WorshipAttendanceModel,

--- a/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
@@ -19,7 +19,7 @@ export interface IWorshipAttendanceDomainService {
   ): Promise<WorshipAttendanceDomainPaginationResultDto>;
 
   joinAttendance(
-    enrollment: WorshipEnrollmentModel,
+    enrollmentIds: number[],
     fromSessionDate?: Date,
     toSessionDate?: Date,
     qr?: QueryRunner,

--- a/backend/src/worship/worship-domain/interface/worship-enrollment-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-enrollment-domain.service.interface.ts
@@ -17,6 +17,13 @@ export interface IWorshipEnrollmentDomainService {
     qr?: QueryRunner,
   ): Promise<WorshipEnrollmentDomainPaginationResultDto>;
 
+  findEnrollmentsByQueryBuilder(
+    worship: WorshipModel,
+    dto: GetWorshipEnrollmentsDto,
+    groupIds?: number[],
+    qr?: QueryRunner,
+  ): Promise<any>;
+
   findAllEnrollments(
     worship: WorshipModel,
     qr?: QueryRunner,

--- a/backend/src/worship/worship-domain/service/worship-attendance-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-attendance-domain.service.ts
@@ -132,7 +132,7 @@ export class WorshipAttendanceDomainService
   }
 
   async joinAttendance(
-    enrollment: WorshipEnrollmentModel,
+    enrollmentIds: number[],
     fromSessionDate?: Date,
     toSessionDate?: Date,
     qr?: QueryRunner,
@@ -143,40 +143,37 @@ export class WorshipAttendanceDomainService
       fromSessionDate && toSessionDate
         ? await repository.find({
             where: {
-              worshipEnrollmentId: enrollment.id,
+              worshipEnrollmentId: In(enrollmentIds),
               sessionDate: Between(fromSessionDate, toSessionDate),
             },
             order: {
-              sessionDate: 'ASC',
+              sessionDate: 'DESC',
             },
             select: {
               id: true,
+              worshipEnrollmentId: true,
               attendanceStatus: true,
               sessionDate: true,
             },
-            take: 14,
+            take: 14 * enrollmentIds.length,
           })
         : await repository.find({
             where: {
-              worshipEnrollmentId: enrollment.id,
+              worshipEnrollmentId: In(enrollmentIds),
             },
             order: {
-              sessionDate: 'ASC',
+              sessionDate: 'DESC',
             },
             select: {
               id: true,
+              worshipEnrollmentId: true,
               attendanceStatus: true,
               sessionDate: true,
             },
-            take: 14,
+            take: 14 * enrollmentIds.length,
           });
 
-    for (let i = 0; i < attendances.length / 2; i++) {
-      const temp = attendances[i];
-
-      attendances[i] = attendances[attendances.length - 1 - i];
-      attendances[attendances.length - 1 - i] = temp;
-    }
+    attendances.reverse();
 
     return attendances;
   }


### PR DESCRIPTION
## 주요 내용
WorshipEnrollment 조회 시 출석률(attendanceRate)을 기준으로 정렬할 수 있는 옵션을 추가하고, Attendance N+1 조회 문제를 2번의 쿼리로 분리하여 애플리케이션 레벨에서 효율적으로 매핑하도록 개선

## 세부 내용

### 1. 출석률 정렬 조건 추가
- WorshipEnrollmentOrderEnum에 `attendanceRate` 추가
- 출석률 기준 오름차순 / 내림차순 정렬 가능
- 계산 기준: 선택된 Attendance 기간 내 출석률 (출석 수 / 총 출석 대상 수)

### 2. Attendance N+1 조회 최적화
- 기존에는 각 Enrollment에 대해 Attendance를 개별 쿼리로 조회해 N+1 문제가 발생
- Enrollment ID 목록을 기준으로 Attendance를 한 번에 조회한 후, 메모리에서 매핑
- 최대 Enrollment 50개, 각 Attendance 14개로 제한되어 있어 애플리케이션 레벨에서 충분히 처리 가능

### 3. 날짜 검증 정책 변경
- 교인에게 그룹, 직분, 사역 부여 시 클라이언트가 당일 날짜를 보냈음에도 서버에서 미래 날짜로 인식되는 문제 발생
- 원인: 클라이언트-서버 간 timezone 차이
- 해결: 서버에서 미래 날짜로 판단하지 않도록 검증 제거 → 클라이언트 단에서 유효성 검증 수행하도록 변경