### PR TITLE
feat: 교인 등록 시 WorshipEnrollment 자동 생성 및 Attendance 분리 생성 처리

### DIFF
--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -386,7 +386,7 @@ export class MembersDomainService implements IMembersDomainService {
       }
     }
 
-    return membersRepository.save({ ...dto, church });
+    return membersRepository.save({ ...dto, churchId: church.id });
   }
 
   async updateMember(

--- a/backend/src/members/members.module.ts
+++ b/backend/src/members/members.module.ts
@@ -13,10 +13,10 @@ import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.mo
 import { GroupsDomainModule } from '../management/groups/groups-domain/groups-domain.module';
 import { IMEMBER_FILTER_SERVICE } from './service/interface/member-filter.service.interface';
 import { MemberFilterService } from './service/member-filter.service';
+import { WorshipDomainModule } from '../worship/worship-domain/worship-domain.module';
 
 @Module({
   imports: [
-    //TypeOrmModule.forFeature([MemberModel, ChurchModel]),
     RouterModule.register([
       { path: 'churches/:churchId', module: MembersModule },
     ]),
@@ -25,6 +25,7 @@ import { MemberFilterService } from './service/member-filter.service';
     MembersDomainModule,
     FamilyRelationDomainModule,
     GroupsDomainModule,
+    WorshipDomainModule,
   ],
   controllers: [MembersController],
   providers: [

--- a/backend/src/members/service/members.service.ts
+++ b/backend/src/members/service/members.service.ts
@@ -35,6 +35,14 @@ import {
 } from './interface/member-filter.service.interface';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { ChurchModel } from '../../churches/entity/church.entity';
+import {
+  IWORSHIP_DOMAIN_SERVICE,
+  IWorshipDomainService,
+} from '../../worship/worship-domain/interface/worship-domain.service.interface';
+import {
+  IWORSHIP_ENROLLMENT_DOMAIN_SERVICE,
+  IWorshipEnrollmentDomainService,
+} from '../../worship/worship-domain/interface/worship-enrollment-domain.service.interface';
 
 @Injectable()
 export class MembersService {
@@ -49,6 +57,10 @@ export class MembersService {
     private readonly searchMembersService: ISearchMembersService,
     @Inject(IFAMILY_RELATION_DOMAIN_SERVICE)
     private readonly familyDomainService: IFamilyRelationDomainService,
+    @Inject(IWORSHIP_DOMAIN_SERVICE)
+    private readonly worshipDomainService: IWorshipDomainService,
+    @Inject(IWORSHIP_ENROLLMENT_DOMAIN_SERVICE)
+    private readonly worshipEnrollmentDomainService: IWorshipEnrollmentDomainService,
 
     @Inject(IMEMBER_FILTER_SERVICE)
     private readonly memberFilterService: IMemberFilterService,
@@ -139,6 +151,17 @@ export class MembersService {
     const newMember = await this.membersDomainService.createMember(
       church,
       dto,
+      qr,
+    );
+
+    const worships = await this.worshipDomainService.findAllWorships(
+      church,
+      qr,
+    );
+
+    await this.worshipEnrollmentDomainService.createNewMemberEnrollments(
+      newMember,
+      worships,
       qr,
     );
 

--- a/backend/src/worship/worship-domain/interface/worship-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-domain.service.interface.ts
@@ -15,6 +15,11 @@ export interface IWorshipDomainService {
     qr?: QueryRunner,
   ): Promise<WorshipDomainPaginationResultDto>;
 
+  findAllWorships(
+    church: ChurchModel,
+    qr: QueryRunner,
+  ): Promise<WorshipModel[]>;
+
   findWorshipById(
     church: ChurchModel,
     worshipId: number,

--- a/backend/src/worship/worship-domain/interface/worship-enrollment-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-enrollment-domain.service.interface.ts
@@ -24,6 +24,12 @@ export interface IWorshipEnrollmentDomainService {
     qr?: QueryRunner,
   ): Promise<any>;
 
+  createNewMemberEnrollments(
+    newMember: MemberModel,
+    worships: WorshipModel[],
+    qr: QueryRunner,
+  ): Promise<WorshipEnrollmentModel[]>;
+
   findAllEnrollments(
     worship: WorshipModel,
     qr?: QueryRunner,

--- a/backend/src/worship/worship-domain/service/worship-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-domain.service.ts
@@ -68,6 +68,19 @@ export class WorshipDomainService implements IWorshipDomainService {
     return new WorshipDomainPaginationResultDto(data, totalCount);
   }
 
+  async findAllWorships(
+    church: ChurchModel,
+    qr: QueryRunner,
+  ): Promise<WorshipModel[]> {
+    const repository = this.getRepository(qr);
+
+    const qb = repository
+      .createQueryBuilder('worship')
+      .where('worship.churchId = :churchId', { churchId: church.id });
+
+    return qb.getMany();
+  }
+
   async findWorshipById(
     church: ChurchModel,
     worshipId: number,

--- a/backend/src/worship/worship-domain/service/worship-enrollment-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-enrollment-domain.service.ts
@@ -242,6 +242,23 @@ export class WorshipEnrollmentDomainService
     return repository.save(enrollments, { chunk: 100 });
   }
 
+  createNewMemberEnrollments(
+    newMember: MemberModel,
+    worships: WorshipModel[],
+    qr: QueryRunner,
+  ): Promise<WorshipEnrollmentModel[]> {
+    const repository = this.getRepository(qr);
+
+    const newEnrollments = repository.create(
+      worships.map((worship) => ({
+        worshipId: worship.id,
+        memberId: newMember.id,
+      })),
+    );
+
+    return repository.save(newEnrollments, { chunk: 100 });
+  }
+
   async createEnrollmentCascade(
     newWorship: WorshipModel,
     members: MemberModel[],


### PR DESCRIPTION
## 주요 내용
교인을 새로 등록할 때 해당 교회에 존재하는 모든 예배(Worship)에 대한 WorshipEnrollment를 자동 생성하도록 구현 출석(Attendance)은 명시적으로 지정된 세션에 대해서만 생성하도록 분리하여 처리

## 세부 내용

### WorshipEnrollment 자동 생성
- 새로운 교인이 등록될 경우, 해당 교회에 존재하는 모든 Worship에 대한 WorshipEnrollment를 생성
- Enrollment는 예배 대상자의 기본 구성을 위한 것으로, 교회 참여 이전의 데이터는 포함하지 않음

### WorshipAttendance 생성 방식
- 교인이 등록되더라도 과거 세션에 대한 Attendance는 자동 생성되지 않음
- 대신 명시적으로 세션 단위로 출석 생성을 요청하도록 엔드포인트 분리
- `POST /churches/{churchId}/worships/{worshipId}/sessions/{sessionId}/attendances/refresh`
  - 지정된 세션에 대해 해당 예배의 모든 Enrollment를 기준으로 Attendance를 생성
  - 과거 또는 특정 세션에 대한 출석 생성이 필요한 경우에만 수동 호출