### PR TITLE
feat: 예배 도메인 가드 적용 및 권한 범위 예외 처리 강화

### DIFF
--- a/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
+++ b/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
@@ -89,6 +89,12 @@ export interface IGroupsDomainService {
 
   findChildGroups(group: GroupModel, qr?: QueryRunner): Promise<ChildGroup[]>;
 
+  findGroupAndDescendantsByIds(
+    church: ChurchModel,
+    rootGroupIds: number[],
+    qr?: QueryRunner,
+  ): Promise<GroupModel[]>;
+
   incrementMembersCount(group: GroupModel, qr: QueryRunner): Promise<boolean>;
 
   decrementMembersCount(group: GroupModel, qr: QueryRunner): Promise<boolean>;

--- a/backend/src/worship/controller/worship-attendance.controller.ts
+++ b/backend/src/worship/controller/worship-attendance.controller.ts
@@ -7,6 +7,7 @@ import {
   Patch,
   Post,
   Query,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { WorshipAttendanceService } from '../service/worship-attendance.service';
@@ -18,6 +19,14 @@ import { QueryRunner as QR } from 'typeorm';
 import { UpdateWorshipAttendanceDto } from '../dto/request/worship-attendance/update-worship-attendance.dto';
 import { WorshipReadGuard } from '../guard/worship-read.guard';
 import { WorshipWriteGuard } from '../guard/worship-write.guard';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { WorshipReadScopeGuard } from '../guard/worship-read-scope.guard';
+import { WorshipTargetGroupGuard } from '../guard/worship-target-group.guard';
+import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
+import { DomainType } from '../../permission/const/domain-type.enum';
+import { DomainName } from '../../permission/const/domain-name.enum';
+import { DomainAction } from '../../permission/const/domain-action.enum';
+import { WorshipAttendanceWriteScopeGuard } from '../guard/worship-attendance-write-scope.guard';
 
 @ApiTags('Worships:Attendance')
 @Controller(':worshipId/sessions/:sessionId/attendances')
@@ -27,6 +36,16 @@ export class WorshipAttendanceController {
   ) {}
 
   @Get()
+  @UseGuards(
+    AccessTokenGuard,
+    createDomainGuard(
+      DomainType.WORSHIP,
+      DomainName.WORSHIP,
+      DomainAction.READ,
+    ),
+    WorshipTargetGroupGuard,
+    WorshipReadScopeGuard,
+  )
   @WorshipReadGuard()
   getAttendances(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -60,6 +79,7 @@ export class WorshipAttendanceController {
   }
 
   @Patch(':attendanceId')
+  @UseGuards(AccessTokenGuard, WorshipAttendanceWriteScopeGuard)
   @WorshipWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   patchAttendance(

--- a/backend/src/worship/controller/worship-enrollment.controller.ts
+++ b/backend/src/worship/controller/worship-enrollment.controller.ts
@@ -5,6 +5,7 @@ import {
   ParseIntPipe,
   Post,
   Query,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { WorshipEnrollmentService } from '../service/worship-enrollment.service';
@@ -15,6 +16,17 @@ import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
 import { WorshipReadGuard } from '../guard/worship-read.guard';
 import { WorshipWriteGuard } from '../guard/worship-write.guard';
+import { WorshipTargetGroupGuard } from '../guard/worship-target-group.guard';
+import { RequestWorship } from '../decorator/request-worship.decorator';
+import { WorshipModel } from '../entity/worship.entity';
+import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { WorshipReadScopeGuard } from '../guard/worship-read-scope.guard';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
+import { DomainType } from '../../permission/const/domain-type.enum';
+import { DomainName } from '../../permission/const/domain-name.enum';
+import { DomainAction } from '../../permission/const/domain-action.enum';
 
 @ApiTags('Worships:Enrollments')
 @Controller(':worshipId/enrollments')
@@ -25,14 +37,28 @@ export class WorshipEnrollmentController {
 
   @Get()
   @WorshipReadGuard()
+  @UseGuards(
+    AccessTokenGuard,
+    createDomainGuard(
+      DomainType.WORSHIP,
+      DomainName.WORSHIP,
+      DomainAction.READ,
+    ),
+    WorshipTargetGroupGuard,
+    WorshipReadScopeGuard,
+  )
   getEnrollments(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('worshipId', ParseIntPipe) worshipId: number,
     @Query() dto: GetWorshipEnrollmentsDto,
+    @PermissionChurch() church: ChurchModel,
+    @RequestWorship() worship: WorshipModel,
   ) {
     return this.worshipEnrollmentService.getEnrollments(
-      churchId,
-      worshipId,
+      //churchId,
+      //worshipId,
+      church,
+      worship,
       dto,
     );
   }

--- a/backend/src/worship/decorator/request-worship.decorator.ts
+++ b/backend/src/worship/decorator/request-worship.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const RequestWorship = createParamDecorator(
+  (a, ctx: ExecutionContext) => {
+    const req = ctx.switchToHttp().getRequest();
+
+    return req.worship;
+  },
+);

--- a/backend/src/worship/exception/worship.exception.ts
+++ b/backend/src/worship/exception/worship.exception.ts
@@ -3,4 +3,6 @@ export const WorshipException = {
   ALREADY_EXIST: '이미 존재하는 예배 제목입니다.',
   DELETE_ERROR: '예배 삭제 도중 에러 발생',
   UPDATE_ERROR: '예배 업데이트 도중 에러 발생',
+
+  INVALID_TARGET_GROUP: '에배 대상 그룹이 아닙니다.',
 };

--- a/backend/src/worship/guard/worship-attendance-write-scope.guard.ts
+++ b/backend/src/worship/guard/worship-attendance-write-scope.guard.ts
@@ -1,0 +1,150 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IMANAGER_DOMAIN_SERVICE,
+  IManagerDomainService,
+} from '../../manager/manager-domain/service/interface/manager-domain.service.interface';
+import {
+  IGROUPS_DOMAIN_SERVICE,
+  IGroupsDomainService,
+} from '../../management/groups/groups-domain/interface/groups-domain.service.interface';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import {
+  IWORSHIP_DOMAIN_SERVICE,
+  IWorshipDomainService,
+} from '../worship-domain/interface/worship-domain.service.interface';
+import {
+  IWORSHIP_SESSION_DOMAIN_SERVICE,
+  IWorshipSessionDomainService,
+} from '../worship-domain/interface/worship-session-domain.service.interface';
+import {
+  IWORSHIP_ATTENDANCE_DOMAIN_SERVICE,
+  IWorshipAttendanceDomainService,
+} from '../worship-domain/interface/worship-attendance-domain.service.interface';
+import { WorshipException } from '../exception/worship.exception';
+import { PermissionScopeException } from '../../permission/exception/permission-scope.exception';
+
+@Injectable()
+export class WorshipAttendanceWriteScopeGuard implements CanActivate {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IMANAGER_DOMAIN_SERVICE)
+    private readonly managerDomainService: IManagerDomainService,
+    @Inject(IGROUPS_DOMAIN_SERVICE)
+    private readonly groupsDomainService: IGroupsDomainService,
+
+    @Inject(IWORSHIP_DOMAIN_SERVICE)
+    private readonly worshipDomainService: IWorshipDomainService,
+    @Inject(IWORSHIP_SESSION_DOMAIN_SERVICE)
+    private readonly worshipSessionDomainService: IWorshipSessionDomainService,
+    @Inject(IWORSHIP_ATTENDANCE_DOMAIN_SERVICE)
+    private readonly worshipAttendanceDomainService: IWorshipAttendanceDomainService,
+  ) {}
+
+  private async getRequestChurch(req: any) {
+    const churchId = parseInt(req.params.churchId);
+
+    return req.church
+      ? req.church
+      : await this.churchesDomainService.findChurchModelById(churchId);
+  }
+
+  private async getRequestManager(
+    req: any,
+    church: ChurchModel,
+  ): Promise<ChurchUserModel> {
+    const token = req.tokenPayload;
+
+    if (!token) {
+      throw new InternalServerErrorException('토큰 처리 과정 누락');
+    }
+
+    const requestUserId = token.id;
+
+    return req.requestManager
+      ? req.requestManager
+      : this.managerDomainService.findManagerForPermissionCheck(
+          church,
+          requestUserId,
+        );
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+
+    const church = await this.getRequestChurch(req);
+    const requestManager = await this.getRequestManager(req, church);
+
+    const worshipId = parseInt(req.params.worshipId);
+    const worship = await this.worshipDomainService.findWorshipModelById(
+      church,
+      worshipId,
+      undefined,
+      { worshipTargetGroups: { group: true } },
+    );
+    const sessionId = parseInt(req.params.sessionId);
+    const session =
+      await this.worshipSessionDomainService.findWorshipSessionModelById(
+        worship,
+        sessionId,
+      );
+    const attendanceId = parseInt(req.params.attendanceId);
+    const targetAttendance =
+      await this.worshipAttendanceDomainService.findWorshipAttendanceById(
+        session,
+        attendanceId,
+      );
+
+    const targetMemberGroupId =
+      targetAttendance.worshipEnrollment.member.group.id;
+
+    // 해당 출석 기록이 예배 대상 그룹에 속하는지 검증
+    const rootTargetWorshipGroupIds = worship.worshipTargetGroups.map(
+      (targetGroup) => targetGroup.group.id,
+    );
+
+    const targetWorshipGroupIds = (
+      await this.groupsDomainService.findGroupAndDescendantsByIds(
+        church,
+        rootTargetWorshipGroupIds,
+      )
+    ).map((group) => group.id);
+
+    if (!targetWorshipGroupIds.includes(targetMemberGroupId)) {
+      throw new ForbiddenException(WorshipException.INVALID_TARGET_GROUP);
+    }
+    // ------------------------------------
+
+    // 관리자의 권한 범위 내에 있는 출석 정보인지 체크
+    const permissionScopeGroupIds = requestManager.permissionScopes.map(
+      (scope) => scope.group.id,
+    );
+
+    const scopeGroupIds = (
+      await this.groupsDomainService.findGroupAndDescendantsByIds(
+        church,
+        permissionScopeGroupIds,
+      )
+    ).map((group) => group.id);
+
+    if (!scopeGroupIds.includes(targetMemberGroupId)) {
+      throw new ForbiddenException(
+        PermissionScopeException.OUT_OF_SCOPE_MEMBER,
+      );
+    }
+
+    return true;
+  }
+}

--- a/backend/src/worship/guard/worship-read-scope.guard.ts
+++ b/backend/src/worship/guard/worship-read-scope.guard.ts
@@ -1,0 +1,112 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IMANAGER_DOMAIN_SERVICE,
+  IManagerDomainService,
+} from '../../manager/manager-domain/service/interface/manager-domain.service.interface';
+import {
+  IGROUPS_DOMAIN_SERVICE,
+  IGroupsDomainService,
+} from '../../management/groups/groups-domain/interface/groups-domain.service.interface';
+import {
+  IWORSHIP_DOMAIN_SERVICE,
+  IWorshipDomainService,
+} from '../worship-domain/interface/worship-domain.service.interface';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { PermissionScopeModel } from '../../permission/entity/permission-scope.entity';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { ChurchUserRole } from '../../user/const/user-role.enum';
+
+@Injectable()
+export class WorshipReadScopeGuard implements CanActivate {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IMANAGER_DOMAIN_SERVICE)
+    private readonly managerDomainService: IManagerDomainService,
+    @Inject(IGROUPS_DOMAIN_SERVICE)
+    private readonly groupsDomainService: IGroupsDomainService,
+    @Inject(IWORSHIP_DOMAIN_SERVICE)
+    private readonly worshipDomainService: IWorshipDomainService,
+  ) {}
+
+  private async getRequestChurch(req) {
+    const churchId = parseInt(req.params.churchId);
+
+    return req.church
+      ? req.church
+      : await this.churchesDomainService.findChurchModelById(churchId);
+  }
+
+  private async getRequestManager(
+    req: any,
+    church: ChurchModel,
+  ): Promise<ChurchUserModel> {
+    const token = req.tokenPayload;
+
+    if (!token) {
+      throw new InternalServerErrorException('토큰 처리 과정 누락');
+    }
+
+    const requestUserId = token.id;
+
+    return req.requestManager
+      ? req.requestManager
+      : this.managerDomainService.findManagerForPermissionCheck(
+          church,
+          requestUserId,
+        );
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+
+    const requestGroupId = parseInt(req.query.groupId);
+
+    if (!requestGroupId) {
+      return true;
+    }
+
+    const church = await this.getRequestChurch(req);
+
+    const requestManager = await this.getRequestManager(req, church);
+
+    if (requestManager.role === ChurchUserRole.OWNER) {
+      return true;
+    }
+
+    const permissionScopeGroupIds = requestManager.permissionScopes.map(
+      (permissionScope: PermissionScopeModel) => permissionScope.group.id,
+    );
+
+    const requestGroup = await this.groupsDomainService.findGroupModelById(
+      church,
+      requestGroupId,
+    );
+
+    const parentGroups = await this.groupsDomainService.findParentGroups(
+      church,
+      requestGroup,
+    );
+
+    const parentGroupIds = parentGroups.map((parentGroup) => parentGroup.id);
+    parentGroupIds.push(requestGroup.id);
+
+    for (const permissionScopeGroupId of permissionScopeGroupIds) {
+      if (parentGroupIds.includes(permissionScopeGroupId)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/backend/src/worship/guard/worship-target-group.guard.ts
+++ b/backend/src/worship/guard/worship-target-group.guard.ts
@@ -1,0 +1,81 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IWORSHIP_DOMAIN_SERVICE,
+  IWorshipDomainService,
+} from '../worship-domain/interface/worship-domain.service.interface';
+import {
+  IGROUPS_DOMAIN_SERVICE,
+  IGroupsDomainService,
+} from '../../management/groups/groups-domain/interface/groups-domain.service.interface';
+import { WorshipException } from '../exception/worship.exception';
+
+@Injectable()
+export class WorshipTargetGroupGuard implements CanActivate {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IWORSHIP_DOMAIN_SERVICE)
+    private readonly worshipDomainService: IWorshipDomainService,
+    @Inject(IGROUPS_DOMAIN_SERVICE)
+    private readonly groupsDomainService: IGroupsDomainService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+
+    const churchId = parseInt(req.params.churchId);
+    const worshipId = parseInt(req.params.worshipId);
+    // 조회 요청 그룹 ID
+    const requestGroupId = parseInt(req.query.groupId);
+
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const worship = await this.worshipDomainService.findWorshipModelById(
+      church,
+      worshipId,
+      undefined,
+      { worshipTargetGroups: { group: true } },
+    );
+
+    req.church = church;
+    req.worship = worship;
+
+    // 필터링할 그룹이 없을 경우 통과
+    if (!requestGroupId) return true;
+
+    const worshipTargetGroups = worship.worshipTargetGroups.map(
+      (targetGroup) => targetGroup.group,
+    );
+
+    // 대상 그룹이 전체인 예배
+    if (worshipTargetGroups.length === 0) {
+      return true;
+    }
+
+    // 대상 그룹과 그 하위 그룹의 ID 들
+    const allowedGroupIds = (
+      await this.groupsDomainService.findGroupAndDescendantsByIds(
+        church,
+        worshipTargetGroups.map((group) => group.id),
+      )
+    ).map((group) => group.id);
+
+    // 요청 그룹이 대상 그룹에 포함되지 않은 경우 ForbiddenException
+    if (!allowedGroupIds.includes(requestGroupId)) {
+      throw new ForbiddenException(WorshipException.INVALID_TARGET_GROUP);
+    }
+
+    return true;
+  }
+}

--- a/backend/src/worship/service/worship-enrollment.service.ts
+++ b/backend/src/worship/service/worship-enrollment.service.ts
@@ -30,6 +30,7 @@ import {
 } from '../../management/groups/groups-domain/interface/groups-domain.service.interface';
 import { WorshipEnrollmentModel } from '../entity/worship-enrollment.entity';
 import { WorshipAttendanceModel } from '../entity/worship-attendance.entity';
+import { WorshipModel } from '../entity/worship.entity';
 
 @Injectable()
 export class WorshipEnrollmentService {
@@ -74,12 +75,14 @@ export class WorshipEnrollmentService {
   }
 
   async getEnrollments(
-    churchId: number,
-    worshipId: number,
+    //churchId: number,
+    //worshipId: number,
+    church: ChurchModel,
+    worship: WorshipModel,
     dto: GetWorshipEnrollmentsDto,
     qr?: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
+    /*const church = await this.churchesDomainService.findChurchModelById(
       churchId,
       qr,
     );
@@ -88,7 +91,7 @@ export class WorshipEnrollmentService {
       church,
       worshipId,
       qr,
-    );
+    );*/
 
     const groupIds = await this.getGroupIds(church, dto, qr);
 


### PR DESCRIPTION
## 주요 내용
예배 출석 관련 데이터에 대한 접근 시, 예배 대상 그룹 및 관리자의 권한 범위를 기준으로 가드와 예외 처리를 강화

## 세부 내용

### WorshipEnrollment
- 조회 시 groupId가 전달된 경우
  - 해당 그룹이 예배의 대상 그룹(WorshipTargetGroup)에 포함되지 않으면 ForbiddenException 발생

### WorshipAttendance
- 조회 시 groupId가 전달된 경우
  - 해당 그룹이 예배 대상 그룹에 포함되지 않으면 ForbiddenException 발생
- 출석 정보 수정 시
  - 수정 대상 교인이 요청자의 권한 범위(PermissionScope)에 포함되지 않을 경우 ForbiddenException 발생