### PR TITLE
feat: 예배 출석 및 등록 정보 조회 시 권한 범위 기반 필터링 로직 적용

### DIFF
--- a/backend/src/permission/exception/permission-scope.exception.ts
+++ b/backend/src/permission/exception/permission-scope.exception.ts
@@ -2,4 +2,5 @@ export const PermissionScopeException = {
   DELETE_ERROR: '권한 범위 삭제 도중 에러 발생',
   OWNER: '소유자 권한 관리자는 권한 범위를 설정할 수 없습니다.',
   OUT_OF_SCOPE_MEMBER: '권한 범위 밖의 교인입니다.',
+  OUT_OF_SCOPE_GROUP: '권한 범위 밖의 그룹입니다.',
 };

--- a/backend/src/worship/controller/worship-attendance.controller.ts
+++ b/backend/src/worship/controller/worship-attendance.controller.ts
@@ -27,6 +27,11 @@ import { DomainType } from '../../permission/const/domain-type.enum';
 import { DomainName } from '../../permission/const/domain-name.enum';
 import { DomainAction } from '../../permission/const/domain-action.enum';
 import { WorshipAttendanceWriteScopeGuard } from '../guard/worship-attendance-write-scope.guard';
+import { PermissionScopeGroups } from '../decorator/permission-scope-groups.decorator';
+import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { RequestWorship } from '../decorator/request-worship.decorator';
+import { WorshipModel } from '../entity/worship.entity';
 
 @ApiTags('Worships:Attendance')
 @Controller(':worshipId/sessions/:sessionId/attendances')
@@ -52,12 +57,16 @@ export class WorshipAttendanceController {
     @Param('worshipId', ParseIntPipe) worshipId: number,
     @Param('sessionId', ParseIntPipe) sessionId: number,
     @Query() dto: GetWorshipAttendancesDto,
+    @PermissionChurch() church: ChurchModel,
+    @RequestWorship() worship: WorshipModel,
+    @PermissionScopeGroups() permissionScopeGroupIds?: number[],
   ) {
     return this.worshipAttendanceService.getAttendances(
-      churchId,
-      worshipId,
+      church,
+      worship,
       sessionId,
       dto,
+      permissionScopeGroupIds,
     );
   }
 

--- a/backend/src/worship/controller/worship-enrollment.controller.ts
+++ b/backend/src/worship/controller/worship-enrollment.controller.ts
@@ -27,6 +27,7 @@ import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
 import { DomainType } from '../../permission/const/domain-type.enum';
 import { DomainName } from '../../permission/const/domain-name.enum';
 import { DomainAction } from '../../permission/const/domain-action.enum';
+import { PermissionScopeGroups } from '../decorator/permission-scope-groups.decorator';
 
 @ApiTags('Worships:Enrollments')
 @Controller(':worshipId/enrollments')
@@ -53,13 +54,13 @@ export class WorshipEnrollmentController {
     @Query() dto: GetWorshipEnrollmentsDto,
     @PermissionChurch() church: ChurchModel,
     @RequestWorship() worship: WorshipModel,
+    @PermissionScopeGroups() permissionScopeGroupIds?: number[],
   ) {
     return this.worshipEnrollmentService.getEnrollments(
-      //churchId,
-      //worshipId,
       church,
       worship,
       dto,
+      permissionScopeGroupIds,
     );
   }
 

--- a/backend/src/worship/decorator/permission-scope-groups.decorator.ts
+++ b/backend/src/worship/decorator/permission-scope-groups.decorator.ts
@@ -1,0 +1,18 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { CustomRequest } from '../guard/worship-read-scope.guard';
+
+export const PermissionScopeGroups = createParamDecorator(
+  (_, ctx: ExecutionContext) => {
+    const req: CustomRequest = ctx.switchToHttp().getRequest();
+
+    if (!req.permissionScopeGroupIds) {
+      throw new InternalServerErrorException('권한 범위 처리 과정 누락');
+    }
+
+    return req.permissionScopeGroupIds;
+  },
+);

--- a/backend/src/worship/decorator/request-worship.decorator.ts
+++ b/backend/src/worship/decorator/request-worship.decorator.ts
@@ -1,8 +1,16 @@
-import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import {
+  createParamDecorator,
+  ExecutionContext,
+  InternalServerErrorException,
+} from '@nestjs/common';
 
 export const RequestWorship = createParamDecorator(
   (a, ctx: ExecutionContext) => {
     const req = ctx.switchToHttp().getRequest();
+
+    if (!req.worship) {
+      throw new InternalServerErrorException('예배 처리 과정 누락');
+    }
 
     return req.worship;
   },

--- a/backend/src/worship/service/worship-enrollment.service.ts
+++ b/backend/src/worship/service/worship-enrollment.service.ts
@@ -50,13 +50,13 @@ export class WorshipEnrollmentService {
     private readonly worshipAttendanceDomainService: IWorshipAttendanceDomainService,
   ) {}
 
-  private async getGroupIds(
+  private async getRequestGroupIds(
     church: ChurchModel,
     dto: GetWorshipEnrollmentsDto,
     qr?: QueryRunner,
-  ) {
+  ): Promise<number[] | undefined> {
     if (!dto.groupId) {
-      return;
+      return undefined;
     }
 
     const group = await this.groupsDomainService.findGroupModelById(
@@ -74,26 +74,89 @@ export class WorshipEnrollmentService {
     return groupIds;
   }
 
+  private async getDefaultGroupIds(
+    church: ChurchModel,
+    worship: WorshipModel,
+    qr?: QueryRunner,
+  ) {
+    const rootTargetGroupIds = worship.worshipTargetGroups.map(
+      (group) => group.group.id,
+    );
+
+    const defaultGroupIds = (
+      await this.groupsDomainService.findGroupAndDescendantsByIds(
+        church,
+        rootTargetGroupIds,
+        qr,
+      )
+    ).map((group) => group.id);
+
+    if (defaultGroupIds.length) {
+      return defaultGroupIds;
+    } else {
+      return undefined;
+    }
+  }
+
+  private intersection(
+    defaultWorshipTargetGroupIds?: number[],
+    permissionScopeGroupIds?: number[],
+  ) {
+    /*
+    2. 예배 범위가 전체인 경우
+    --> defaultWorshipTargetGroup 이 빈 배열 []
+      case 1. 권한 범위가 정해져있는 경우
+      --> permissionScopeGroupIds 로 조회
+      case 2. 권한 범위가 전체인 경우
+      --> 그룹 조건 없이 모두 조회
+    */
+    if (!defaultWorshipTargetGroupIds) {
+      return permissionScopeGroupIds;
+    }
+
+    /*
+    3. 예배 범위가 정해진 경우
+      case 1. 권한 범위가 정해져 있는 경우
+      --> defaultWorshipTargetGroup 과 permissionScopeGroupIds 의 교집합으로 조회
+      case 2. 권한 범위가 전체인 경우
+      --> permissionScopeGroupIds 가 undefined
+      --> defaultWorshipTargetGroup 으로 조회
+     */
+    if (!permissionScopeGroupIds) {
+      return defaultWorshipTargetGroupIds;
+    }
+
+    const targetGroupIdSet = new Set(defaultWorshipTargetGroupIds);
+
+    return permissionScopeGroupIds.filter((scopeGroupId) =>
+      targetGroupIdSet.has(scopeGroupId),
+    );
+  }
+
   async getEnrollments(
-    //churchId: number,
-    //worshipId: number,
     church: ChurchModel,
     worship: WorshipModel,
     dto: GetWorshipEnrollmentsDto,
+    permissionScopeGroupIds?: number[],
     qr?: QueryRunner,
   ) {
-    /*const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
+    // 조회 요청 groupId, 가드에서 검증 완료
+    /*
+    1. 요청에서 groupId 를 특정하는 경우
+       -> 가드에서 예배 범위, 사용자의 권한 체크
+       -> 그대로 보여줌
+     */
+    const requestGroupIds = await this.getRequestGroupIds(church, dto, qr);
+
+    const defaultWorshipTargetGroup = await this.getDefaultGroupIds(
+      church,
+      worship,
       qr,
     );
 
-    const worship = await this.worshipDomainService.findWorshipModelById(
-      church,
-      worshipId,
-      qr,
-    );*/
-
-    const groupIds = await this.getGroupIds(church, dto, qr);
+    const groupIds = requestGroupIds
+      ? requestGroupIds
+      : this.intersection(defaultWorshipTargetGroup, permissionScopeGroupIds);
 
     const { data, totalCount } =
       await this.worshipEnrollmentDomainService.findEnrollmentsByQueryBuilder(

--- a/backend/src/worship/worship-domain/service/worship-enrollment-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-enrollment-domain.service.ts
@@ -88,10 +88,10 @@ export class WorshipEnrollmentDomainService
       .addSelect(
         `
         CASE
-          WHEN enrollment."presentCount" + enrollment."absentCount" = 0 THEN NULL
+          WHEN enrollment."presentCount" + enrollment."absentCount" = 0 THEN 0
           ELSE enrollment."presentCount"::float / (enrollment."presentCount" + enrollment."absentCount")
         END`,
-        'attendanceRate',
+        'attendance_rate',
       )
       .where('enrollment.worshipId = :worshipId', { worshipId });
   }
@@ -102,7 +102,7 @@ export class WorshipEnrollmentDomainService
   ) {
     if (dto.order === WorshipEnrollmentOrderEnum.ATTENDANCE_RATE) {
       qb.orderBy(
-        'attendanceRate',
+        'attendance_rate',
         dto.orderDirection.toUpperCase() as 'ASC' | 'DESC',
       );
       qb.addOrderBy('enrollment.id', 'ASC');
@@ -157,8 +157,7 @@ export class WorshipEnrollmentDomainService
     ]);
 
     const data = entities.map((entity, i) => {
-      const rate =
-        raw[i].attendanceRate !== null ? Number(raw[i].attendanceRate) : null;
+      const rate = Number(raw[i].attendance_rate);
       return {
         ...entity,
         attendanceRate: rate,
@@ -166,7 +165,6 @@ export class WorshipEnrollmentDomainService
     });
 
     return new WorshipEnrollmentDomainPaginationResultDto(data, totalCount);
-    //return { data, totalCount };
   }
 
   async findEnrollments(


### PR DESCRIPTION
## 주요 내용
WorshipEnrollment 및 WorshipAttendance 조회 시, 사용자의 권한 범위와 예배 대상 그룹(WorshipTargetGroup)을 기반으로 한 필터링 로직을 적용

## 세부 내용

### 공통
- 사용자 요청에 따라 groupId 명시 여부 및 예배 대상 범위에 따라 조회 범위를 동적으로 결정

### 요청에 groupId 명시된 경우
- Guard를 통해 예배 대상 그룹 포함 여부 및 사용자의 권한 범위 체크
- 통과한 경우 해당 groupId 기준으로 조회 수행

### 예배 대상 그룹이 전체인 경우 (WorshipTargetGroup이 비어 있음)
- 권한 범위가 제한된 경우 → permissionScopeGroupIds 기준으로 조회
- 권한 범위가 전체인 경우 → 그룹 조건 없이 전체 조회

### 예배 대상 그룹이 특정되어 있는 경우
- 권한 범위가 제한된 경우 → 예배 대상 그룹과 권한 범위의 교집합을 기준으로 조회
- 권한 범위가 전체인 경우 → 예배 대상 그룹 기준으로 조회