### PR TITLE
feat: CalendarModule 생성 및 생일 조회 기능 구현

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,6 +24,7 @@
         "coolsms-node-sdk": "^2.1.0",
         "dotenv": "^16.4.5",
         "joi": "^17.13.3",
+        "korean-lunar-calendar": "^0.3.6",
         "ms": "^2.1.3",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
@@ -7159,6 +7160,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/korean-lunar-calendar": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/korean-lunar-calendar/-/korean-lunar-calendar-0.3.6.tgz",
+      "integrity": "sha512-9jpZUH8ph6GsBgIGy8al6z6OfG6TdSIDB99Zj73B35ohtG12EFj3CGE5NzjBsXFiJUUjEr08/XCjfh+flXZVPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.14.0"
       }
     },
     "node_modules/leven": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -35,6 +35,7 @@
     "coolsms-node-sdk": "^2.1.0",
     "dotenv": "^16.4.5",
     "joi": "^17.13.3",
+    "korean-lunar-calendar": "^0.3.6",
     "ms": "^2.1.3",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -65,6 +65,7 @@ import { WorshipSessionModel } from './worship/entity/worship-session.entity';
 import { WorshipAttendanceModel } from './worship/entity/worship-attendance.entity';
 import { WorshipModule } from './worship/worship.module';
 import { WorshipTargetGroupModel } from './worship/entity/worship-target-group.entity';
+import { CalendarModule } from './calendar/calendar.module';
 
 @Module({
   imports: [
@@ -211,6 +212,7 @@ import { WorshipTargetGroupModel } from './worship/entity/worship-target-group.e
     VisitationModule,
     TaskModule,
     WorshipModule,
+    CalendarModule,
 
     ChurchesDomainModule,
     MembersDomainModule,

--- a/backend/src/calendar/calendar.module.ts
+++ b/backend/src/calendar/calendar.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
+import { MembersDomainModule } from '../members/member-domain/members-domain.module';
+import { RouterModule } from '@nestjs/core';
+import { CalendarController } from './controller/calendar.controller';
+import { CalendarService } from './service/calendar.service';
+
+@Module({
+  imports: [
+    RouterModule.register([
+      { path: 'churches/:churchId/calendar', module: CalendarModule },
+    ]),
+    ChurchesDomainModule,
+    MembersDomainModule,
+  ],
+  controllers: [CalendarController],
+  providers: [CalendarService],
+})
+export class CalendarModule {}

--- a/backend/src/calendar/controller/calendar.controller.ts
+++ b/backend/src/calendar/controller/calendar.controller.ts
@@ -1,0 +1,28 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { GetBirthdayMembersDto } from '../dto/get-birthday-members.dto';
+import { CalendarService } from '../service/calendar.service';
+
+@Controller()
+export class CalendarController {
+  constructor(private readonly calendarService: CalendarService) {}
+
+  @Get('birthday')
+  getBirthdayMembers(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetBirthdayMembersDto,
+  ) {
+    return this.calendarService.getBirthdayMembers(churchId, dto);
+  }
+
+  @Post('birthday-migration')
+  migrationBirthdayMMDD(@Param('churchId', ParseIntPipe) churchId: number) {
+    return this.calendarService.migrationBirthdayMMDD(churchId);
+  }
+}

--- a/backend/src/calendar/dto/get-birthday-members.dto.ts
+++ b/backend/src/calendar/dto/get-birthday-members.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDate } from 'class-validator';
+import { IsAfterDate } from '../../common/decorator/validator/is-after-date.decorator';
+
+export class GetBirthdayMembersDto {
+  @ApiProperty({
+    description: '검색 시작 날짜',
+    default: new Date(new Date().setDate(1)).toISOString().slice(0, 10),
+  })
+  @IsDate()
+  fromDate: Date;
+
+  @ApiProperty({
+    description: '검색 종료 날짜',
+    default: new Date(new Date().setDate(31)).toISOString().slice(0, 10),
+  })
+  @IsDate()
+  @IsAfterDate('fromDate')
+  toDate: Date;
+}

--- a/backend/src/calendar/service/calendar.service.ts
+++ b/backend/src/calendar/service/calendar.service.ts
@@ -1,0 +1,37 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IMEMBERS_DOMAIN_SERVICE,
+  IMembersDomainService,
+} from '../../members/member-domain/interface/members-domain.service.interface';
+import { GetBirthdayMembersDto } from '../dto/get-birthday-members.dto';
+
+@Injectable()
+export class CalendarService {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,
+  ) {}
+
+  async migrationBirthdayMMDD(churchId: number) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    await this.membersDomainService.migrationBirthdayMMDD(church);
+  }
+
+  async getBirthdayMembers(churchId: number, dto: GetBirthdayMembersDto) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const from = dto.fromDate.toISOString().slice(5, 10);
+    const to = dto.toDate.toISOString().slice(5, 10);
+
+    return this.membersDomainService.findBirthdayMembers(church, dto);
+  }
+}

--- a/backend/src/members/dto/request/create-member.dto.ts
+++ b/backend/src/members/dto/request/create-member.dto.ts
@@ -106,7 +106,16 @@ export class CreateMemberDto {
   })
   @IsBoolean()
   @IsOptional()
-  isLunar?: boolean = false;
+  isLunar?: boolean;
+
+  @ApiProperty({
+    description: '윤달 여부',
+    default: false,
+    required: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isLeafMonth?: boolean;
 
   @ApiProperty({
     name: 'birth',

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -34,14 +34,6 @@ import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 
 @Entity()
 export class MemberModel extends BaseModel {
-  /*@Index()
-  @Column({ nullable: true })
-  userId: number;
-
-  @OneToOne(() => UserModel, (user) => user.member)
-  @JoinColumn({ name: 'userId' })
-  user: UserModel;*/
-
   @OneToOne(() => ChurchUserModel, (churchUser) => churchUser.member)
   churchUser: ChurchUserModel;
 
@@ -75,9 +67,16 @@ export class MemberModel extends BaseModel {
   @Column({ default: false, comment: '생일 음력 여부' })
   isLunar: boolean;
 
+  @Column({ default: false, comment: '윤달 여부' })
+  isLeafMonth: boolean;
+
   @Index()
   @Column({ nullable: true, comment: '생년 월일' })
   birth: Date;
+
+  @Index()
+  @Column({ type: 'varchar', length: 5, nullable: true })
+  birthdayMMDD: string;
 
   @Index()
   @Column({ enum: GenderEnum, nullable: true, comment: '성별' })

--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -18,6 +18,7 @@ import { GroupRoleModel } from '../../../management/groups/entity/group-role.ent
 import { MembersDomainPaginationResultDto } from '../dto/members-domain-pagination-result.dto';
 import { GetSimpleMembersDto } from '../../dto/request/get-simple-members.dto';
 import { GetRecommendLinkMemberDto } from '../../dto/request/get-recommend-link-member.dto';
+import { GetBirthdayMembersDto } from '../../../calendar/dto/get-birthday-members.dto';
 
 export const IMEMBERS_DOMAIN_SERVICE = Symbol('IMEMBERS_DOMAIN_SERVICE');
 
@@ -30,6 +31,14 @@ export interface IMembersDomainService {
     selectOptions: FindOptionsSelect<MemberModel>,
     qr?: QueryRunner,
   ): Promise<{ data: MemberModel[]; totalCount: number }>;
+
+  migrationBirthdayMMDD(church: ChurchModel): Promise<void>;
+
+  findBirthdayMembers(
+    church: ChurchModel,
+    dto: GetBirthdayMembersDto,
+    qr?: QueryRunner,
+  ): Promise<MemberModel[]>;
 
   findSimpleMembers(
     church: ChurchModel,

--- a/backend/src/members/member-domain/service/dummy-members-domain.service.ts
+++ b/backend/src/members/member-domain/service/dummy-members-domain.service.ts
@@ -21,7 +21,10 @@ export class DummyMembersDomainService implements IDummyMembersDomainService {
   ): MemberModel {
     const membersRepository = this.getMembersRepository();
 
-    return membersRepository.create(dto);
+    return membersRepository.create({
+      ...dto,
+      birthdayMMDD: dto.birth?.toISOString().slice(5, 10),
+    });
   }
 
   createDummyMembers(members: MemberModel[], qr?: QueryRunner) {


### PR DESCRIPTION
## 주요 내용
- 교회 일정표 생성을 위한 CalendarModule 신설
- 특정 기간 내 생일 교인 조회 기능 API 구현
- 생일 조회 성능 향상을 위한 birthdayMMDD 컬럼 추가 및 마이그레이션 엔드포인트 구현

## 세부 내용

### CalendarModule
- `CalendarModule`, `CalendarController`, `CalendarService` 생성
- 라우팅 경로: `/churches/:churchId/calendar`

### 생일 조회 API
- `GET /churches/:churchId/calendar/birthday`
- 필수 쿼리 파라미터: `fromDate`, `toDate`
  - `toDate`는 `fromDate`보다 앞설 수 없음
- 양력 생일 교인은 그대로 월/일 기준으로 조회
- 음력 생일 교인은 요청 날짜 범위를 음력으로 변환하여 조회
- 음력 생일이 윤달인 경우, 윤달이 없는 해에는 평달로 매핑해 디스플레이하므로 쿼리에서 배제
- MemberModel에 `isLeafMonth`(윤달 여부) 컬럼 추가

### 인덱싱 최적화
- `birthdayMMDD` 컬럼(`MM-DD` 형식의 varchar) 추가
  - 생년월일이 `2010-07-02`일 경우 `"07-02"` 저장
  - 해당 컬럼에 인덱스 추가로 범위 조회 성능 개선

### 마이그레이션 엔드포인트
- `POST /churches/:churchId/calendar/birthday-migration`
- `birthdayMMDD` 값이 없는 교인 중 `birth`가 존재하는 경우, `MM-DD`로 변환하여 채워 넣음