### PR TITLE
feat: 교회 일정표 이벤트 CRUD 기능 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -66,6 +66,7 @@ import { WorshipAttendanceModel } from './worship/entity/worship-attendance.enti
 import { WorshipModule } from './worship/worship.module';
 import { WorshipTargetGroupModel } from './worship/entity/worship-target-group.entity';
 import { CalendarModule } from './calendar/calendar.module';
+import { ChurchEventModel } from './calendar/entity/church-event.entity';
 
 @Module({
   imports: [
@@ -183,6 +184,8 @@ import { CalendarModule } from './calendar/calendar.module';
           WorshipSessionModel,
           WorshipAttendanceModel,
           WorshipTargetGroupModel,
+          // 교회 일정표/이벤트
+          ChurchEventModel,
         ],
         synchronize: true,
       }),

--- a/backend/src/calendar/calendar-domain/calendar-domain.module.ts
+++ b/backend/src/calendar/calendar-domain/calendar-domain.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ChurchEventModel } from '../entity/church-event.entity';
+import { ICHURCH_EVENT_DOMAIN_SERVICE } from './interface/church-event-domain.service.interface';
+import { ChurchEventDomainService } from './service/church-event-domain.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ChurchEventModel])],
+  providers: [
+    {
+      provide: ICHURCH_EVENT_DOMAIN_SERVICE,
+      useClass: ChurchEventDomainService,
+    },
+  ],
+  exports: [ICHURCH_EVENT_DOMAIN_SERVICE],
+})
+export class CalendarDomainModule {}

--- a/backend/src/calendar/calendar-domain/interface/church-event-domain.service.interface.ts
+++ b/backend/src/calendar/calendar-domain/interface/church-event-domain.service.interface.ts
@@ -1,0 +1,48 @@
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { CreateChurchEventDto } from '../../dto/request/event/create-church-event.dto';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
+import { ChurchEventModel } from '../../entity/church-event.entity';
+import { GetChurchEventsDto } from '../../dto/request/event/get-church-events.dto';
+import { UpdateChurchEventDto } from '../../dto/request/event/update-church-event.dto';
+
+export const ICHURCH_EVENT_DOMAIN_SERVICE = Symbol(
+  'ICHURCH_EVENT_DOMAIN_SERVICE',
+);
+
+export interface IChurchEventDomainService {
+  createChurchEvent(
+    church: ChurchModel,
+    dto: CreateChurchEventDto,
+    qr?: QueryRunner,
+  ): Promise<ChurchEventModel>;
+
+  findChurchEvents(
+    church: ChurchModel,
+    dto: GetChurchEventsDto,
+    qr?: QueryRunner,
+  ): Promise<ChurchEventModel[]>;
+
+  findChurchEventById(
+    church: ChurchModel,
+    eventId: number,
+    qr?: QueryRunner,
+  ): Promise<ChurchEventModel>;
+
+  findChurchEventModelById(
+    church: ChurchModel,
+    eventId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<ChurchEventModel>,
+  ): Promise<ChurchEventModel>;
+
+  updateChurchEvent(
+    event: ChurchEventModel,
+    dto: UpdateChurchEventDto,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  deleteChurchEvent(
+    event: ChurchEventModel,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+}

--- a/backend/src/calendar/calendar-domain/service/church-event-domain.service.ts
+++ b/backend/src/calendar/calendar-domain/service/church-event-domain.service.ts
@@ -1,0 +1,142 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { IChurchEventDomainService } from '../interface/church-event-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ChurchEventModel } from '../../entity/church-event.entity';
+import {
+  Between,
+  FindOptionsRelations,
+  QueryRunner,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { CreateChurchEventDto } from '../../dto/request/event/create-church-event.dto';
+import { GetChurchEventsDto } from '../../dto/request/event/get-church-events.dto';
+import { ChurchEventException } from '../../exception/church-event.exception';
+import { UpdateChurchEventDto } from '../../dto/request/event/update-church-event.dto';
+
+@Injectable()
+export class ChurchEventDomainService implements IChurchEventDomainService {
+  constructor(
+    @InjectRepository(ChurchEventModel)
+    private readonly churchEventRepository: Repository<ChurchEventModel>,
+  ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(ChurchEventModel)
+      : this.churchEventRepository;
+  }
+
+  async createChurchEvent(
+    church: ChurchModel,
+    dto: CreateChurchEventDto,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    return repository.save({ ...dto, churchId: church.id });
+  }
+
+  async findChurchEventById(
+    church: ChurchModel,
+    eventId: number,
+    qr?: QueryRunner,
+  ): Promise<ChurchEventModel> {
+    const repository = this.getRepository(qr);
+
+    const event = await repository.findOne({
+      where: {
+        churchId: church.id,
+        id: eventId,
+      },
+    });
+
+    if (!event) {
+      throw new NotFoundException(ChurchEventException.NOT_FOUND);
+    }
+
+    return event;
+  }
+
+  async findChurchEventModelById(
+    church: ChurchModel,
+    eventId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<ChurchEventModel>,
+  ): Promise<ChurchEventModel> {
+    const repository = this.getRepository(qr);
+
+    const eventModel = await repository.findOne({
+      where: {
+        churchId: church.id,
+        id: eventId,
+      },
+      relations: relationOptions,
+    });
+
+    if (!eventModel) {
+      throw new NotFoundException(ChurchEventException.NOT_FOUND);
+    }
+
+    return eventModel;
+  }
+
+  findChurchEvents(
+    church: ChurchModel,
+    dto: GetChurchEventsDto,
+    qr?: QueryRunner,
+  ): Promise<ChurchEventModel[]> {
+    const repository = this.getRepository(qr);
+
+    return repository.find({
+      where: {
+        churchId: church.id,
+        date: Between(dto.fromDate, dto.toDate),
+      },
+      order: { date: 'ASC' },
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        title: true,
+        date: true,
+      },
+    });
+  }
+
+  async updateChurchEvent(
+    event: ChurchEventModel,
+    dto: UpdateChurchEventDto,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    const result = await repository.update({ id: event.id }, { ...dto });
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(ChurchEventException.UPDATE_ERROR);
+    }
+
+    return result;
+  }
+
+  async deleteChurchEvent(
+    event: ChurchEventModel,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    const result = await repository.softDelete({ id: event.id });
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(ChurchEventException.DELETE_ERROR);
+    }
+
+    return result;
+  }
+}

--- a/backend/src/calendar/calendar.module.ts
+++ b/backend/src/calendar/calendar.module.ts
@@ -4,6 +4,9 @@ import { MembersDomainModule } from '../members/member-domain/members-domain.mod
 import { RouterModule } from '@nestjs/core';
 import { CalendarController } from './controller/calendar.controller';
 import { CalendarService } from './service/calendar.service';
+import { CalendarDomainModule } from './calendar-domain/calendar-domain.module';
+import { ChurchEventService } from './service/church-event.service';
+import { ChurchEventController } from './controller/church-event.controller';
 
 @Module({
   imports: [
@@ -12,8 +15,9 @@ import { CalendarService } from './service/calendar.service';
     ]),
     ChurchesDomainModule,
     MembersDomainModule,
+    CalendarDomainModule,
   ],
-  controllers: [CalendarController],
-  providers: [CalendarService],
+  controllers: [CalendarController, ChurchEventController],
+  providers: [CalendarService, ChurchEventService],
 })
 export class CalendarModule {}

--- a/backend/src/calendar/const/church-event.constraints.ts
+++ b/backend/src/calendar/const/church-event.constraints.ts
@@ -1,0 +1,2 @@
+export const MAX_CHURCH_EVENT_TITLE = 50;
+export const MAX_CHURCH_EVENT_DESCRIPTION = 1000;

--- a/backend/src/calendar/controller/calendar.controller.ts
+++ b/backend/src/calendar/controller/calendar.controller.ts
@@ -6,7 +6,7 @@ import {
   Post,
   Query,
 } from '@nestjs/common';
-import { GetBirthdayMembersDto } from '../dto/get-birthday-members.dto';
+import { GetBirthdayMembersDto } from '../dto/request/birthday/get-birthday-members.dto';
 import { CalendarService } from '../service/calendar.service';
 
 @Controller()

--- a/backend/src/calendar/controller/church-event.controller.ts
+++ b/backend/src/calendar/controller/church-event.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { ChurchEventService } from '../service/church-event.service';
+import { CreateChurchEventDto } from '../dto/request/event/create-church-event.dto';
+import { GetChurchEventsDto } from '../dto/request/event/get-church-events.dto';
+import { UpdateChurchEventDto } from '../dto/request/event/update-church-event.dto';
+
+@Controller('events')
+export class ChurchEventController {
+  constructor(private readonly churchEventService: ChurchEventService) {}
+
+  @Get()
+  getChurchEvents(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetChurchEventsDto,
+  ) {
+    return this.churchEventService.getChurchEvents(churchId, dto);
+  }
+
+  @Post()
+  postChurchEvents(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Body() dto: CreateChurchEventDto,
+  ) {
+    return this.churchEventService.postChurchEvent(churchId, dto);
+  }
+
+  @Get(':eventId')
+  getChurchEventById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('eventId', ParseIntPipe) eventId: number,
+  ) {
+    return this.churchEventService.getChurchEventById(churchId, eventId);
+  }
+
+  @Patch(':eventId')
+  patchChurchEvent(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('eventId', ParseIntPipe) eventId: number,
+    @Body() dto: UpdateChurchEventDto,
+  ) {
+    return this.churchEventService.patchChurchEvent(churchId, eventId, dto);
+  }
+
+  @Delete(':eventId')
+  deleteChurchEvent(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('eventId', ParseIntPipe) eventId: number,
+  ) {
+    return this.churchEventService.deleteChurchEvent(churchId, eventId);
+  }
+}

--- a/backend/src/calendar/dto/request/birthday/get-birthday-members.dto.ts
+++ b/backend/src/calendar/dto/request/birthday/get-birthday-members.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsDate } from 'class-validator';
-import { IsAfterDate } from '../../common/decorator/validator/is-after-date.decorator';
+import { IsAfterDate } from '../../../../common/decorator/validator/is-after-date.decorator';
 
 export class GetBirthdayMembersDto {
   @ApiProperty({

--- a/backend/src/calendar/dto/request/event/create-church-event.dto.ts
+++ b/backend/src/calendar/dto/request/event/create-church-event.dto.ts
@@ -1,0 +1,36 @@
+import { IsDate, IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
+import { PlainTextMaxLength } from '../../../../common/decorator/validator/plain-text-max-length.validator';
+import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  MAX_CHURCH_EVENT_DESCRIPTION,
+  MAX_CHURCH_EVENT_TITLE,
+} from '../../../const/church-event.constraints';
+
+@SanitizeDto()
+export class CreateChurchEventDto {
+  @ApiProperty({
+    description: '이벤트 제목',
+  })
+  @IsString()
+  @IsNoSpecialChar()
+  @IsNotEmpty()
+  @MaxLength(MAX_CHURCH_EVENT_TITLE)
+  title: string;
+
+  @ApiProperty({
+    description: '교회 이벤트 날짜',
+  })
+  @IsDate()
+  date: Date;
+
+  @ApiProperty({
+    description: '교회 이벤트 상세내용',
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @PlainTextMaxLength(MAX_CHURCH_EVENT_DESCRIPTION)
+  description?: string;
+}

--- a/backend/src/calendar/dto/request/event/get-church-events.dto.ts
+++ b/backend/src/calendar/dto/request/event/get-church-events.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDate } from 'class-validator';
+import { IsAfterDate } from '../../../../common/decorator/validator/is-after-date.decorator';
+
+export class GetChurchEventsDto {
+  @ApiProperty()
+  @IsDate()
+  fromDate: Date;
+
+  @ApiProperty()
+  @IsDate()
+  @IsAfterDate('fromDate')
+  toDate: Date;
+}

--- a/backend/src/calendar/dto/request/event/update-church-event.dto.ts
+++ b/backend/src/calendar/dto/request/event/update-church-event.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDate, IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import {
+  MAX_CHURCH_EVENT_DESCRIPTION,
+  MAX_CHURCH_EVENT_TITLE,
+} from '../../../const/church-event.constraints';
+import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
+import { PlainTextMaxLength } from '../../../../common/decorator/validator/plain-text-max-length.validator';
+import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
+
+@SanitizeDto()
+export class UpdateChurchEventDto {
+  @ApiProperty({
+    description: '이벤트 제목',
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @IsNoSpecialChar()
+  @IsNotEmpty()
+  @MaxLength(MAX_CHURCH_EVENT_TITLE)
+  title: string;
+
+  @ApiProperty({
+    description: '교회 이벤트 날짜',
+  })
+  @IsOptionalNotNull()
+  @IsDate()
+  date: Date;
+
+  @ApiProperty({
+    description: '교회 이벤트 상세내용',
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @PlainTextMaxLength(MAX_CHURCH_EVENT_DESCRIPTION)
+  description?: string;
+}

--- a/backend/src/calendar/dto/response/event/delete-church-event-response.dto.ts
+++ b/backend/src/calendar/dto/response/event/delete-church-event-response.dto.ts
@@ -1,0 +1,12 @@
+import { BaseDeleteResponseDto } from '../../../../common/dto/reponse/base-delete-response.dto';
+
+export class DeleteChurchEventResponseDto extends BaseDeleteResponseDto {
+  constructor(
+    public readonly timestamp: Date,
+    public readonly id: number,
+    public readonly title: string,
+    public readonly success: boolean,
+  ) {
+    super(timestamp, id, success);
+  }
+}

--- a/backend/src/calendar/dto/response/event/get-church-event-response.dto.ts
+++ b/backend/src/calendar/dto/response/event/get-church-event-response.dto.ts
@@ -1,0 +1,10 @@
+import { BaseGetResponseDto } from '../../../../common/dto/reponse/base-get-response.dto';
+import { ChurchEventModel } from '../../../entity/church-event.entity';
+
+export class GetChurchEventResponseDto extends BaseGetResponseDto<
+  ChurchEventModel | ChurchEventModel[]
+> {
+  constructor(data: ChurchEventModel | ChurchEventModel[]) {
+    super(data);
+  }
+}

--- a/backend/src/calendar/dto/response/event/patch-church-event-response.dto.ts
+++ b/backend/src/calendar/dto/response/event/patch-church-event-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePatchResponseDto } from '../../../../common/dto/reponse/base-patch-response.dto';
+import { ChurchEventModel } from '../../../entity/church-event.entity';
+
+export class PatchChurchEventResponseDto extends BasePatchResponseDto<ChurchEventModel> {
+  constructor(data: ChurchEventModel) {
+    super(data);
+  }
+}

--- a/backend/src/calendar/dto/response/event/post-church-event-response.dto.ts
+++ b/backend/src/calendar/dto/response/event/post-church-event-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePostResponseDto } from '../../../../common/dto/reponse/base-post-response.dto';
+import { ChurchEventModel } from '../../../entity/church-event.entity';
+
+export class PostChurchEventResponseDto extends BasePostResponseDto<ChurchEventModel> {
+  constructor(data: ChurchEventModel) {
+    super(data);
+  }
+}

--- a/backend/src/calendar/entity/church-event.entity.ts
+++ b/backend/src/calendar/entity/church-event.entity.ts
@@ -1,0 +1,24 @@
+import { BaseModel } from '../../common/entity/base.entity';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { ChurchModel } from '../../churches/entity/church.entity';
+
+@Entity()
+export class ChurchEventModel extends BaseModel {
+  @Index()
+  @Column()
+  churchId: number;
+
+  @ManyToOne(() => ChurchModel)
+  @JoinColumn({ name: 'churchId' })
+  church: ChurchModel;
+
+  @Column()
+  title: string;
+
+  @Index()
+  @Column({ type: 'timestamptz' })
+  date: Date;
+
+  @Column({ default: '' })
+  description: string;
+}

--- a/backend/src/calendar/exception/church-event.exception.ts
+++ b/backend/src/calendar/exception/church-event.exception.ts
@@ -1,0 +1,5 @@
+export const ChurchEventException = {
+  NOT_FOUND: '해당 교회 이벤트를 찾을 수 없습니다.',
+  UPDATE_ERROR: '교회 이벤트 업데이트 도중 에러 발생',
+  DELETE_ERROR: '교회 이벤트 삭제 도중 에러 발생',
+};

--- a/backend/src/calendar/service/calendar.service.ts
+++ b/backend/src/calendar/service/calendar.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
@@ -7,7 +7,7 @@ import {
   IMEMBERS_DOMAIN_SERVICE,
   IMembersDomainService,
 } from '../../members/member-domain/interface/members-domain.service.interface';
-import { GetBirthdayMembersDto } from '../dto/get-birthday-members.dto';
+import { GetBirthdayMembersDto } from '../dto/request/birthday/get-birthday-members.dto';
 
 @Injectable()
 export class CalendarService {
@@ -29,8 +29,8 @@ export class CalendarService {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    const from = dto.fromDate.toISOString().slice(5, 10);
-    const to = dto.toDate.toISOString().slice(5, 10);
+    //const from = dto.fromDate.toISOString().slice(5, 10);
+    //const to = dto.toDate.toISOString().slice(5, 10);
 
     return this.membersDomainService.findBirthdayMembers(church, dto);
   }

--- a/backend/src/calendar/service/church-event.service.ts
+++ b/backend/src/calendar/service/church-event.service.ts
@@ -1,0 +1,100 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { CreateChurchEventDto } from '../dto/request/event/create-church-event.dto';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  ICHURCH_EVENT_DOMAIN_SERVICE,
+  IChurchEventDomainService,
+} from '../calendar-domain/interface/church-event-domain.service.interface';
+import { PostChurchEventResponseDto } from '../dto/response/event/post-church-event-response.dto';
+import { GetChurchEventsDto } from '../dto/request/event/get-church-events.dto';
+import { GetChurchEventResponseDto } from '../dto/response/event/get-church-event-response.dto';
+import { UpdateChurchEventDto } from '../dto/request/event/update-church-event.dto';
+import { PatchChurchEventResponseDto } from '../dto/response/event/patch-church-event-response.dto';
+import { DeleteChurchEventResponseDto } from '../dto/response/event/delete-church-event-response.dto';
+
+@Injectable()
+export class ChurchEventService {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(ICHURCH_EVENT_DOMAIN_SERVICE)
+    private readonly churchEventDomainService: IChurchEventDomainService,
+  ) {}
+
+  async getChurchEvents(churchId: number, dto: GetChurchEventsDto) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const events = await this.churchEventDomainService.findChurchEvents(
+      church,
+      dto,
+    );
+
+    return new GetChurchEventResponseDto(events);
+  }
+
+  async postChurchEvent(churchId: number, dto: CreateChurchEventDto) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const newChurchEvent =
+      await this.churchEventDomainService.createChurchEvent(church, dto);
+
+    return new PostChurchEventResponseDto(newChurchEvent);
+  }
+
+  async getChurchEventById(churchId: number, eventId: number) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const event = await this.churchEventDomainService.findChurchEventById(
+      church,
+      eventId,
+    );
+
+    return new GetChurchEventResponseDto(event);
+  }
+
+  async patchChurchEvent(
+    churchId: number,
+    eventId: number,
+    dto: UpdateChurchEventDto,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const event = await this.churchEventDomainService.findChurchEventModelById(
+      church,
+      eventId,
+    );
+
+    await this.churchEventDomainService.updateChurchEvent(event, dto);
+
+    const updatedEvent =
+      await this.churchEventDomainService.findChurchEventById(church, event.id);
+
+    return new PatchChurchEventResponseDto(updatedEvent);
+  }
+
+  async deleteChurchEvent(churchId: number, eventId: number) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const event = await this.churchEventDomainService.findChurchEventModelById(
+      church,
+      eventId,
+    );
+
+    await this.churchEventDomainService.deleteChurchEvent(event);
+
+    return new DeleteChurchEventResponseDto(
+      new Date(),
+      event.id,
+      event.title,
+      true,
+    );
+  }
+}

--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -18,7 +18,7 @@ import { GroupRoleModel } from '../../../management/groups/entity/group-role.ent
 import { MembersDomainPaginationResultDto } from '../dto/members-domain-pagination-result.dto';
 import { GetSimpleMembersDto } from '../../dto/request/get-simple-members.dto';
 import { GetRecommendLinkMemberDto } from '../../dto/request/get-recommend-link-member.dto';
-import { GetBirthdayMembersDto } from '../../../calendar/dto/get-birthday-members.dto';
+import { GetBirthdayMembersDto } from '../../../calendar/dto/request/birthday/get-birthday-members.dto';
 
 export const IMEMBERS_DOMAIN_SERVICE = Symbol('IMEMBERS_DOMAIN_SERVICE');
 

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -39,7 +39,7 @@ import {
   MemberSummarizedSelect,
 } from '../../const/member-find-options.const';
 import { GetRecommendLinkMemberDto } from '../../dto/request/get-recommend-link-member.dto';
-import { GetBirthdayMembersDto } from '../../../calendar/dto/get-birthday-members.dto';
+import { GetBirthdayMembersDto } from '../../../calendar/dto/request/birthday/get-birthday-members.dto';
 import KoreanLunarCalendar from 'korean-lunar-calendar';
 
 @Injectable()
@@ -133,12 +133,12 @@ export class MembersDomainService implements IMembersDomainService {
     const fromLunarObject = fromLunarCalendar.getLunarCalendar();
     const toLunarObject = toLunarCalendar.getLunarCalendar();
 
-    const fromLunarDate = new Date(
+    /*const fromLunarDate = new Date(
       `${fromLunarObject.year}-${fromLunarObject.month}-${fromLunarObject.day}`,
     );
     const toLunarDate = new Date(
       `${toLunarObject.year}-${toLunarObject.month}-${toLunarObject.day}`,
-    );
+    );*/
 
     const from = dto.fromDate.toISOString().slice(5, 10);
     const to = dto.toDate.toISOString().slice(5, 10);
@@ -189,7 +189,9 @@ export class MembersDomainService implements IMembersDomainService {
         'groupRole.id',
         'groupRole.role',
       ])
-      .orderBy('"birthdayMMDD"', 'ASC');
+      .orderBy('"birthdayMMDD"', 'ASC')
+      .addOrderBy('birth', 'ASC')
+      .addOrderBy('member.id', 'ASC');
 
     return query.getMany();
   }


### PR DESCRIPTION
## 주요 내용
- 교회 일정표에 표시될 이벤트(ChurchEvent) CRUD API 구현
- ChurchModel과 연동되는 ChurchEventModel 생성 및 유효성 검증 적용

## 세부 내용

### ChurchEventModel
- 컬럼: `title`(제목), `date`(날짜), `description`(상세내용)
- ChurchModel과 N:1 관계
- 유효성 제약
  - `title`: 특수문자 불가, 최대 50자
  - `description`: 서식 제외 1000자, 빈 문자열 가능

### API 엔드포인트

#### 이벤트 목록 조회
- `GET /churches/:churchId/calendar/events`
- 쿼리 파라미터: `fromDate`, `toDate` (기간 필터링)
  - `toDate`는 `fromDate`보다 앞일 수 없음

#### 이벤트 생성
- `POST /churches/:churchId/calendar/events`
- 필수 필드: `title`, `date`
- 선택 필드: `description`

#### 이벤트 단건 조회
- `GET /churches/:churchId/calendar/events/:eventId`

#### 이벤트 수정
- `PATCH /churches/:churchId/calendar/events/:eventId`

#### 이벤트 삭제
- `DELETE /churches/:churchId/calendar/events/:eventId`