### PR TITLE
feat: 교육 세션 달력 조회 엔드포인트 추가

### DIFF
--- a/backend/src/calendar/calendar.module.ts
+++ b/backend/src/calendar/calendar.module.ts
@@ -7,6 +7,9 @@ import { CalendarService } from './service/calendar.service';
 import { CalendarDomainModule } from './calendar-domain/calendar-domain.module';
 import { ChurchEventService } from './service/church-event.service';
 import { ChurchEventController } from './controller/church-event.controller';
+import { CalendarEducationService } from './service/calendar-education.service';
+import { CalendarEducationController } from './controller/calendar-education.controller';
+import { EducationDomainModule } from '../management/educations/service/education-domain/education-domain.module';
 
 @Module({
   imports: [
@@ -16,8 +19,13 @@ import { ChurchEventController } from './controller/church-event.controller';
     ChurchesDomainModule,
     MembersDomainModule,
     CalendarDomainModule,
+    EducationDomainModule,
   ],
-  controllers: [CalendarController, ChurchEventController],
-  providers: [CalendarService, ChurchEventService],
+  controllers: [
+    CalendarController,
+    ChurchEventController,
+    CalendarEducationController,
+  ],
+  providers: [CalendarService, ChurchEventService, CalendarEducationService],
 })
 export class CalendarModule {}

--- a/backend/src/calendar/controller/calendar-education.controller.ts
+++ b/backend/src/calendar/controller/calendar-education.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import { CalendarEducationService } from '../service/calendar-education.service';
+import { GetEducationSessionForCalendarDto } from '../dto/request/education/get-education-session-for-calendar.dto';
+
+@Controller('educations')
+export class CalendarEducationController {
+  constructor(
+    private readonly calendarEducationService: CalendarEducationService,
+  ) {}
+
+  @Get()
+  getEducationSessionsForCalendar(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetEducationSessionForCalendarDto,
+  ) {
+    return this.calendarEducationService.getEducationSessionsForCalendar(
+      churchId,
+      dto,
+    );
+  }
+
+  @Get(':educationSessionId')
+  getEducationSessionById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('educationSessionId', ParseIntPipe) educationSessionId: number,
+  ) {
+    return this.calendarEducationService.getEducationSessionById(
+      churchId,
+      educationSessionId,
+    );
+  }
+}

--- a/backend/src/calendar/dto/request/education/get-education-session-for-calendar.dto.ts
+++ b/backend/src/calendar/dto/request/education/get-education-session-for-calendar.dto.ts
@@ -1,0 +1,14 @@
+import { IsDate } from 'class-validator';
+import { IsAfterDate } from '../../../../common/decorator/validator/is-after-date.decorator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetEducationSessionForCalendarDto {
+  @ApiProperty({})
+  @IsDate()
+  fromDate: Date;
+
+  @ApiProperty({})
+  @IsDate()
+  @IsAfterDate('fromDate')
+  toDate: Date;
+}

--- a/backend/src/calendar/service/calendar-education.service.ts
+++ b/backend/src/calendar/service/calendar-education.service.ts
@@ -1,0 +1,47 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  IEDUCATION_SESSION_DOMAIN_SERVICE,
+  IEducationSessionDomainService,
+} from '../../management/educations/service/education-domain/interface/education-session-domain.service.interface';
+import { GetEducationSessionForCalendarDto } from '../dto/request/education/get-education-session-for-calendar.dto';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+
+@Injectable()
+export class CalendarEducationService {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+
+    @Inject(IEDUCATION_SESSION_DOMAIN_SERVICE)
+    private readonly educationSessionDomainService: IEducationSessionDomainService,
+  ) {}
+
+  async getEducationSessionsForCalendar(
+    churchId: number,
+    dto: GetEducationSessionForCalendarDto,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    return this.educationSessionDomainService.findEducationSessionsForCalendar(
+      church,
+      dto,
+    );
+  }
+
+  async getEducationSessionById(churchId: number, educationSessionId: number) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const educationSession =
+      await this.educationSessionDomainService.findEducationSessionByIdForCalendar(
+        church,
+        educationSessionId,
+      );
+
+    return educationSession;
+  }
+}

--- a/backend/src/management/educations/service/education-domain/interface/education-session-domain.service.interface.ts
+++ b/backend/src/management/educations/service/education-domain/interface/education-session-domain.service.interface.ts
@@ -6,12 +6,25 @@ import { CreateEducationSessionDto } from '../../../dto/sessions/request/create-
 import { EducationSessionDomainPaginationResultDto } from '../dto/sessions/education-session-domain-pagination-result.dto';
 import { GetEducationSessionDto } from '../../../dto/sessions/request/get-education-session.dto';
 import { ChurchUserModel } from '../../../../../church-user/entity/church-user.entity';
+import { ChurchModel } from '../../../../../churches/entity/church.entity';
+import { GetEducationSessionForCalendarDto } from '../../../../../calendar/dto/request/education/get-education-session-for-calendar.dto';
 
 export const IEDUCATION_SESSION_DOMAIN_SERVICE = Symbol(
   'IEDUCATION_SESSION_DOMAIN_SERVICE',
 );
 
 export interface IEducationSessionDomainService {
+  findEducationSessionsForCalendar(
+    church: ChurchModel,
+    dto: GetEducationSessionForCalendarDto,
+    qr?: QueryRunner,
+  ): Promise<EducationSessionModel[]>;
+
+  findEducationSessionByIdForCalendar(
+    church: ChurchModel,
+    sessionId: number,
+  ): Promise<EducationSessionModel>;
+
   findEducationSessions(
     educationTerm: EducationTermModel,
     dto: GetEducationSessionDto,


### PR DESCRIPTION
## 주요 내용
- 일정표에 교육 세션을 표시하기 위한 REST API 구현
- Calendar 영역 확장: 교육 세션(EducationSession) 목록을 기간별로 조회

## 세부 내용

### API
- **GET `/churches/:churchId/calendar/educations`**
  - 필수 쿼리 파라미터: `fromDate`, `toDate`
    - `toDate`는 `fromDate`보다 앞설 수 없음
  - 교회-교육-교육Term-교육Session 다단계 조인으로 교회 단위 필터링
  - 기간 겹침 공식 `session.startDate ≤ toDate` **AND** `session.endDate ≥ fromDate`

### 응답 예시
```json
[
  {
    "id": 3,
    "session": 1,
    "title": "교육1-기수1-회차2",
    "startDate": "2025-06-01T13:29:04.221Z",
    "endDate": "2025-06-01T13:29:04.221Z",
    "status": "reserve",
    "inCharge": { "id": 4, "name": "장주현", ... },
    "educationTerm": {
      "id": 1,
      "term": 1,
      "status": "reserve",
      "education": { "id": 1, "name": "교육" }
    }
  }
]