### PR TITLE
feat: CalendarModule 및 교회 일정/교육 세션 기능 추가

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,6 +24,7 @@
         "coolsms-node-sdk": "^2.1.0",
         "dotenv": "^16.4.5",
         "joi": "^17.13.3",
+        "korean-lunar-calendar": "^0.3.6",
         "ms": "^2.1.3",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
@@ -7159,6 +7160,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/korean-lunar-calendar": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/korean-lunar-calendar/-/korean-lunar-calendar-0.3.6.tgz",
+      "integrity": "sha512-9jpZUH8ph6GsBgIGy8al6z6OfG6TdSIDB99Zj73B35ohtG12EFj3CGE5NzjBsXFiJUUjEr08/XCjfh+flXZVPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.14.0"
       }
     },
     "node_modules/leven": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -35,6 +35,7 @@
     "coolsms-node-sdk": "^2.1.0",
     "dotenv": "^16.4.5",
     "joi": "^17.13.3",
+    "korean-lunar-calendar": "^0.3.6",
     "ms": "^2.1.3",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -66,6 +66,7 @@ import { WorshipAttendanceModel } from './worship/entity/worship-attendance.enti
 import { WorshipModule } from './worship/worship.module';
 import { WorshipTargetGroupModel } from './worship/entity/worship-target-group.entity';
 import { CalendarModule } from './calendar/calendar.module';
+import { ChurchEventModel } from './calendar/entity/church-event.entity';
 
 @Module({
   imports: [
@@ -183,6 +184,8 @@ import { CalendarModule } from './calendar/calendar.module';
           WorshipSessionModel,
           WorshipAttendanceModel,
           WorshipTargetGroupModel,
+          // 교회 일정표/이벤트
+          ChurchEventModel,
         ],
         synchronize: true,
       }),

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -65,6 +65,7 @@ import { WorshipSessionModel } from './worship/entity/worship-session.entity';
 import { WorshipAttendanceModel } from './worship/entity/worship-attendance.entity';
 import { WorshipModule } from './worship/worship.module';
 import { WorshipTargetGroupModel } from './worship/entity/worship-target-group.entity';
+import { CalendarModule } from './calendar/calendar.module';
 
 @Module({
   imports: [
@@ -211,6 +212,7 @@ import { WorshipTargetGroupModel } from './worship/entity/worship-target-group.e
     VisitationModule,
     TaskModule,
     WorshipModule,
+    CalendarModule,
 
     ChurchesDomainModule,
     MembersDomainModule,

--- a/backend/src/calendar/calendar-domain/calendar-domain.module.ts
+++ b/backend/src/calendar/calendar-domain/calendar-domain.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ChurchEventModel } from '../entity/church-event.entity';
+import { ICHURCH_EVENT_DOMAIN_SERVICE } from './interface/church-event-domain.service.interface';
+import { ChurchEventDomainService } from './service/church-event-domain.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ChurchEventModel])],
+  providers: [
+    {
+      provide: ICHURCH_EVENT_DOMAIN_SERVICE,
+      useClass: ChurchEventDomainService,
+    },
+  ],
+  exports: [ICHURCH_EVENT_DOMAIN_SERVICE],
+})
+export class CalendarDomainModule {}

--- a/backend/src/calendar/calendar-domain/interface/church-event-domain.service.interface.ts
+++ b/backend/src/calendar/calendar-domain/interface/church-event-domain.service.interface.ts
@@ -1,0 +1,48 @@
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { CreateChurchEventDto } from '../../dto/request/event/create-church-event.dto';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
+import { ChurchEventModel } from '../../entity/church-event.entity';
+import { GetChurchEventsDto } from '../../dto/request/event/get-church-events.dto';
+import { UpdateChurchEventDto } from '../../dto/request/event/update-church-event.dto';
+
+export const ICHURCH_EVENT_DOMAIN_SERVICE = Symbol(
+  'ICHURCH_EVENT_DOMAIN_SERVICE',
+);
+
+export interface IChurchEventDomainService {
+  createChurchEvent(
+    church: ChurchModel,
+    dto: CreateChurchEventDto,
+    qr?: QueryRunner,
+  ): Promise<ChurchEventModel>;
+
+  findChurchEvents(
+    church: ChurchModel,
+    dto: GetChurchEventsDto,
+    qr?: QueryRunner,
+  ): Promise<ChurchEventModel[]>;
+
+  findChurchEventById(
+    church: ChurchModel,
+    eventId: number,
+    qr?: QueryRunner,
+  ): Promise<ChurchEventModel>;
+
+  findChurchEventModelById(
+    church: ChurchModel,
+    eventId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<ChurchEventModel>,
+  ): Promise<ChurchEventModel>;
+
+  updateChurchEvent(
+    event: ChurchEventModel,
+    dto: UpdateChurchEventDto,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  deleteChurchEvent(
+    event: ChurchEventModel,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+}

--- a/backend/src/calendar/calendar-domain/service/church-event-domain.service.ts
+++ b/backend/src/calendar/calendar-domain/service/church-event-domain.service.ts
@@ -1,0 +1,142 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { IChurchEventDomainService } from '../interface/church-event-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ChurchEventModel } from '../../entity/church-event.entity';
+import {
+  Between,
+  FindOptionsRelations,
+  QueryRunner,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { CreateChurchEventDto } from '../../dto/request/event/create-church-event.dto';
+import { GetChurchEventsDto } from '../../dto/request/event/get-church-events.dto';
+import { ChurchEventException } from '../../exception/church-event.exception';
+import { UpdateChurchEventDto } from '../../dto/request/event/update-church-event.dto';
+
+@Injectable()
+export class ChurchEventDomainService implements IChurchEventDomainService {
+  constructor(
+    @InjectRepository(ChurchEventModel)
+    private readonly churchEventRepository: Repository<ChurchEventModel>,
+  ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(ChurchEventModel)
+      : this.churchEventRepository;
+  }
+
+  async createChurchEvent(
+    church: ChurchModel,
+    dto: CreateChurchEventDto,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    return repository.save({ ...dto, churchId: church.id });
+  }
+
+  async findChurchEventById(
+    church: ChurchModel,
+    eventId: number,
+    qr?: QueryRunner,
+  ): Promise<ChurchEventModel> {
+    const repository = this.getRepository(qr);
+
+    const event = await repository.findOne({
+      where: {
+        churchId: church.id,
+        id: eventId,
+      },
+    });
+
+    if (!event) {
+      throw new NotFoundException(ChurchEventException.NOT_FOUND);
+    }
+
+    return event;
+  }
+
+  async findChurchEventModelById(
+    church: ChurchModel,
+    eventId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<ChurchEventModel>,
+  ): Promise<ChurchEventModel> {
+    const repository = this.getRepository(qr);
+
+    const eventModel = await repository.findOne({
+      where: {
+        churchId: church.id,
+        id: eventId,
+      },
+      relations: relationOptions,
+    });
+
+    if (!eventModel) {
+      throw new NotFoundException(ChurchEventException.NOT_FOUND);
+    }
+
+    return eventModel;
+  }
+
+  findChurchEvents(
+    church: ChurchModel,
+    dto: GetChurchEventsDto,
+    qr?: QueryRunner,
+  ): Promise<ChurchEventModel[]> {
+    const repository = this.getRepository(qr);
+
+    return repository.find({
+      where: {
+        churchId: church.id,
+        date: Between(dto.fromDate, dto.toDate),
+      },
+      order: { date: 'ASC' },
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        title: true,
+        date: true,
+      },
+    });
+  }
+
+  async updateChurchEvent(
+    event: ChurchEventModel,
+    dto: UpdateChurchEventDto,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    const result = await repository.update({ id: event.id }, { ...dto });
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(ChurchEventException.UPDATE_ERROR);
+    }
+
+    return result;
+  }
+
+  async deleteChurchEvent(
+    event: ChurchEventModel,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    const result = await repository.softDelete({ id: event.id });
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(ChurchEventException.DELETE_ERROR);
+    }
+
+    return result;
+  }
+}

--- a/backend/src/calendar/calendar.module.ts
+++ b/backend/src/calendar/calendar.module.ts
@@ -7,6 +7,9 @@ import { CalendarService } from './service/calendar.service';
 import { CalendarDomainModule } from './calendar-domain/calendar-domain.module';
 import { ChurchEventService } from './service/church-event.service';
 import { ChurchEventController } from './controller/church-event.controller';
+import { CalendarEducationService } from './service/calendar-education.service';
+import { CalendarEducationController } from './controller/calendar-education.controller';
+import { EducationDomainModule } from '../management/educations/service/education-domain/education-domain.module';
 
 @Module({
   imports: [
@@ -16,8 +19,13 @@ import { ChurchEventController } from './controller/church-event.controller';
     ChurchesDomainModule,
     MembersDomainModule,
     CalendarDomainModule,
+    EducationDomainModule,
   ],
-  controllers: [CalendarController, ChurchEventController],
-  providers: [CalendarService, ChurchEventService],
+  controllers: [
+    CalendarController,
+    ChurchEventController,
+    CalendarEducationController,
+  ],
+  providers: [CalendarService, ChurchEventService, CalendarEducationService],
 })
 export class CalendarModule {}

--- a/backend/src/calendar/calendar.module.ts
+++ b/backend/src/calendar/calendar.module.ts
@@ -4,6 +4,9 @@ import { MembersDomainModule } from '../members/member-domain/members-domain.mod
 import { RouterModule } from '@nestjs/core';
 import { CalendarController } from './controller/calendar.controller';
 import { CalendarService } from './service/calendar.service';
+import { CalendarDomainModule } from './calendar-domain/calendar-domain.module';
+import { ChurchEventService } from './service/church-event.service';
+import { ChurchEventController } from './controller/church-event.controller';
 
 @Module({
   imports: [
@@ -12,8 +15,9 @@ import { CalendarService } from './service/calendar.service';
     ]),
     ChurchesDomainModule,
     MembersDomainModule,
+    CalendarDomainModule,
   ],
-  controllers: [CalendarController],
-  providers: [CalendarService],
+  controllers: [CalendarController, ChurchEventController],
+  providers: [CalendarService, ChurchEventService],
 })
 export class CalendarModule {}

--- a/backend/src/calendar/calendar.module.ts
+++ b/backend/src/calendar/calendar.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
+import { MembersDomainModule } from '../members/member-domain/members-domain.module';
+import { RouterModule } from '@nestjs/core';
+import { CalendarController } from './controller/calendar.controller';
+import { CalendarService } from './service/calendar.service';
+
+@Module({
+  imports: [
+    RouterModule.register([
+      { path: 'churches/:churchId/calendar', module: CalendarModule },
+    ]),
+    ChurchesDomainModule,
+    MembersDomainModule,
+  ],
+  controllers: [CalendarController],
+  providers: [CalendarService],
+})
+export class CalendarModule {}

--- a/backend/src/calendar/calendar.module.ts
+++ b/backend/src/calendar/calendar.module.ts
@@ -2,8 +2,8 @@ import { Module } from '@nestjs/common';
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
 import { MembersDomainModule } from '../members/member-domain/members-domain.module';
 import { RouterModule } from '@nestjs/core';
-import { CalendarController } from './controller/calendar.controller';
-import { CalendarService } from './service/calendar.service';
+import { CalendarBirthdayController } from './controller/calendar-birthday.controller';
+import { CalendarBirthdayService } from './service/calendar-birthday.service';
 import { CalendarDomainModule } from './calendar-domain/calendar-domain.module';
 import { ChurchEventService } from './service/church-event.service';
 import { ChurchEventController } from './controller/church-event.controller';
@@ -22,10 +22,14 @@ import { EducationDomainModule } from '../management/educations/service/educatio
     EducationDomainModule,
   ],
   controllers: [
-    CalendarController,
+    CalendarBirthdayController,
     ChurchEventController,
     CalendarEducationController,
   ],
-  providers: [CalendarService, ChurchEventService, CalendarEducationService],
+  providers: [
+    CalendarBirthdayService,
+    ChurchEventService,
+    CalendarEducationService,
+  ],
 })
 export class CalendarModule {}

--- a/backend/src/calendar/const/church-event.constraints.ts
+++ b/backend/src/calendar/const/church-event.constraints.ts
@@ -1,0 +1,2 @@
+export const MAX_CHURCH_EVENT_TITLE = 50;
+export const MAX_CHURCH_EVENT_DESCRIPTION = 1000;

--- a/backend/src/calendar/controller/calendar-birthday.controller.ts
+++ b/backend/src/calendar/controller/calendar-birthday.controller.ts
@@ -7,11 +7,13 @@ import {
   Query,
 } from '@nestjs/common';
 import { GetBirthdayMembersDto } from '../dto/request/birthday/get-birthday-members.dto';
-import { CalendarService } from '../service/calendar.service';
+import { CalendarBirthdayService } from '../service/calendar-birthday.service';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('Calendar:Birthday')
 @Controller()
-export class CalendarController {
-  constructor(private readonly calendarService: CalendarService) {}
+export class CalendarBirthdayController {
+  constructor(private readonly calendarService: CalendarBirthdayService) {}
 
   @Get('birthday')
   getBirthdayMembers(

--- a/backend/src/calendar/controller/calendar-education.controller.ts
+++ b/backend/src/calendar/controller/calendar-education.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { CalendarEducationService } from '../service/calendar-education.service';
 import { GetEducationSessionForCalendarDto } from '../dto/request/education/get-education-session-for-calendar.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('Calendar:Educations')
 @Controller('educations')
 export class CalendarEducationController {
   constructor(

--- a/backend/src/calendar/controller/calendar-education.controller.ts
+++ b/backend/src/calendar/controller/calendar-education.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import { CalendarEducationService } from '../service/calendar-education.service';
+import { GetEducationSessionForCalendarDto } from '../dto/request/education/get-education-session-for-calendar.dto';
+
+@Controller('educations')
+export class CalendarEducationController {
+  constructor(
+    private readonly calendarEducationService: CalendarEducationService,
+  ) {}
+
+  @Get()
+  getEducationSessionsForCalendar(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetEducationSessionForCalendarDto,
+  ) {
+    return this.calendarEducationService.getEducationSessionsForCalendar(
+      churchId,
+      dto,
+    );
+  }
+
+  @Get(':educationSessionId')
+  getEducationSessionById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('educationSessionId', ParseIntPipe) educationSessionId: number,
+  ) {
+    return this.calendarEducationService.getEducationSessionById(
+      churchId,
+      educationSessionId,
+    );
+  }
+}

--- a/backend/src/calendar/controller/calendar.controller.ts
+++ b/backend/src/calendar/controller/calendar.controller.ts
@@ -1,0 +1,28 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { GetBirthdayMembersDto } from '../dto/get-birthday-members.dto';
+import { CalendarService } from '../service/calendar.service';
+
+@Controller()
+export class CalendarController {
+  constructor(private readonly calendarService: CalendarService) {}
+
+  @Get('birthday')
+  getBirthdayMembers(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetBirthdayMembersDto,
+  ) {
+    return this.calendarService.getBirthdayMembers(churchId, dto);
+  }
+
+  @Post('birthday-migration')
+  migrationBirthdayMMDD(@Param('churchId', ParseIntPipe) churchId: number) {
+    return this.calendarService.migrationBirthdayMMDD(churchId);
+  }
+}

--- a/backend/src/calendar/controller/calendar.controller.ts
+++ b/backend/src/calendar/controller/calendar.controller.ts
@@ -6,7 +6,7 @@ import {
   Post,
   Query,
 } from '@nestjs/common';
-import { GetBirthdayMembersDto } from '../dto/get-birthday-members.dto';
+import { GetBirthdayMembersDto } from '../dto/request/birthday/get-birthday-members.dto';
 import { CalendarService } from '../service/calendar.service';
 
 @Controller()

--- a/backend/src/calendar/controller/church-event.controller.ts
+++ b/backend/src/calendar/controller/church-event.controller.ts
@@ -13,7 +13,9 @@ import { ChurchEventService } from '../service/church-event.service';
 import { CreateChurchEventDto } from '../dto/request/event/create-church-event.dto';
 import { GetChurchEventsDto } from '../dto/request/event/get-church-events.dto';
 import { UpdateChurchEventDto } from '../dto/request/event/update-church-event.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('Calendar:Events')
 @Controller('events')
 export class ChurchEventController {
   constructor(private readonly churchEventService: ChurchEventService) {}

--- a/backend/src/calendar/controller/church-event.controller.ts
+++ b/backend/src/calendar/controller/church-event.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { ChurchEventService } from '../service/church-event.service';
+import { CreateChurchEventDto } from '../dto/request/event/create-church-event.dto';
+import { GetChurchEventsDto } from '../dto/request/event/get-church-events.dto';
+import { UpdateChurchEventDto } from '../dto/request/event/update-church-event.dto';
+
+@Controller('events')
+export class ChurchEventController {
+  constructor(private readonly churchEventService: ChurchEventService) {}
+
+  @Get()
+  getChurchEvents(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetChurchEventsDto,
+  ) {
+    return this.churchEventService.getChurchEvents(churchId, dto);
+  }
+
+  @Post()
+  postChurchEvents(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Body() dto: CreateChurchEventDto,
+  ) {
+    return this.churchEventService.postChurchEvent(churchId, dto);
+  }
+
+  @Get(':eventId')
+  getChurchEventById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('eventId', ParseIntPipe) eventId: number,
+  ) {
+    return this.churchEventService.getChurchEventById(churchId, eventId);
+  }
+
+  @Patch(':eventId')
+  patchChurchEvent(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('eventId', ParseIntPipe) eventId: number,
+    @Body() dto: UpdateChurchEventDto,
+  ) {
+    return this.churchEventService.patchChurchEvent(churchId, eventId, dto);
+  }
+
+  @Delete(':eventId')
+  deleteChurchEvent(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('eventId', ParseIntPipe) eventId: number,
+  ) {
+    return this.churchEventService.deleteChurchEvent(churchId, eventId);
+  }
+}

--- a/backend/src/calendar/dto/get-birthday-members.dto.ts
+++ b/backend/src/calendar/dto/get-birthday-members.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDate } from 'class-validator';
+import { IsAfterDate } from '../../common/decorator/validator/is-after-date.decorator';
+
+export class GetBirthdayMembersDto {
+  @ApiProperty({
+    description: '검색 시작 날짜',
+    default: new Date(new Date().setDate(1)).toISOString().slice(0, 10),
+  })
+  @IsDate()
+  fromDate: Date;
+
+  @ApiProperty({
+    description: '검색 종료 날짜',
+    default: new Date(new Date().setDate(31)).toISOString().slice(0, 10),
+  })
+  @IsDate()
+  @IsAfterDate('fromDate')
+  toDate: Date;
+}

--- a/backend/src/calendar/dto/request/birthday/get-birthday-members.dto.ts
+++ b/backend/src/calendar/dto/request/birthday/get-birthday-members.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsDate } from 'class-validator';
-import { IsAfterDate } from '../../common/decorator/validator/is-after-date.decorator';
+import { IsAfterDate } from '../../../../common/decorator/validator/is-after-date.decorator';
 
 export class GetBirthdayMembersDto {
   @ApiProperty({

--- a/backend/src/calendar/dto/request/education/get-education-session-for-calendar.dto.ts
+++ b/backend/src/calendar/dto/request/education/get-education-session-for-calendar.dto.ts
@@ -1,0 +1,14 @@
+import { IsDate } from 'class-validator';
+import { IsAfterDate } from '../../../../common/decorator/validator/is-after-date.decorator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetEducationSessionForCalendarDto {
+  @ApiProperty({})
+  @IsDate()
+  fromDate: Date;
+
+  @ApiProperty({})
+  @IsDate()
+  @IsAfterDate('fromDate')
+  toDate: Date;
+}

--- a/backend/src/calendar/dto/request/event/create-church-event.dto.ts
+++ b/backend/src/calendar/dto/request/event/create-church-event.dto.ts
@@ -1,0 +1,36 @@
+import { IsDate, IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
+import { PlainTextMaxLength } from '../../../../common/decorator/validator/plain-text-max-length.validator';
+import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  MAX_CHURCH_EVENT_DESCRIPTION,
+  MAX_CHURCH_EVENT_TITLE,
+} from '../../../const/church-event.constraints';
+
+@SanitizeDto()
+export class CreateChurchEventDto {
+  @ApiProperty({
+    description: '이벤트 제목',
+  })
+  @IsString()
+  @IsNoSpecialChar()
+  @IsNotEmpty()
+  @MaxLength(MAX_CHURCH_EVENT_TITLE)
+  title: string;
+
+  @ApiProperty({
+    description: '교회 이벤트 날짜',
+  })
+  @IsDate()
+  date: Date;
+
+  @ApiProperty({
+    description: '교회 이벤트 상세내용',
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @PlainTextMaxLength(MAX_CHURCH_EVENT_DESCRIPTION)
+  description?: string;
+}

--- a/backend/src/calendar/dto/request/event/get-church-events.dto.ts
+++ b/backend/src/calendar/dto/request/event/get-church-events.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDate } from 'class-validator';
+import { IsAfterDate } from '../../../../common/decorator/validator/is-after-date.decorator';
+
+export class GetChurchEventsDto {
+  @ApiProperty()
+  @IsDate()
+  fromDate: Date;
+
+  @ApiProperty()
+  @IsDate()
+  @IsAfterDate('fromDate')
+  toDate: Date;
+}

--- a/backend/src/calendar/dto/request/event/update-church-event.dto.ts
+++ b/backend/src/calendar/dto/request/event/update-church-event.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDate, IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import {
+  MAX_CHURCH_EVENT_DESCRIPTION,
+  MAX_CHURCH_EVENT_TITLE,
+} from '../../../const/church-event.constraints';
+import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
+import { PlainTextMaxLength } from '../../../../common/decorator/validator/plain-text-max-length.validator';
+import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
+
+@SanitizeDto()
+export class UpdateChurchEventDto {
+  @ApiProperty({
+    description: '이벤트 제목',
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @IsNoSpecialChar()
+  @IsNotEmpty()
+  @MaxLength(MAX_CHURCH_EVENT_TITLE)
+  title: string;
+
+  @ApiProperty({
+    description: '교회 이벤트 날짜',
+  })
+  @IsOptionalNotNull()
+  @IsDate()
+  date: Date;
+
+  @ApiProperty({
+    description: '교회 이벤트 상세내용',
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @PlainTextMaxLength(MAX_CHURCH_EVENT_DESCRIPTION)
+  description?: string;
+}

--- a/backend/src/calendar/dto/response/event/delete-church-event-response.dto.ts
+++ b/backend/src/calendar/dto/response/event/delete-church-event-response.dto.ts
@@ -1,0 +1,12 @@
+import { BaseDeleteResponseDto } from '../../../../common/dto/reponse/base-delete-response.dto';
+
+export class DeleteChurchEventResponseDto extends BaseDeleteResponseDto {
+  constructor(
+    public readonly timestamp: Date,
+    public readonly id: number,
+    public readonly title: string,
+    public readonly success: boolean,
+  ) {
+    super(timestamp, id, success);
+  }
+}

--- a/backend/src/calendar/dto/response/event/get-church-event-response.dto.ts
+++ b/backend/src/calendar/dto/response/event/get-church-event-response.dto.ts
@@ -1,0 +1,10 @@
+import { BaseGetResponseDto } from '../../../../common/dto/reponse/base-get-response.dto';
+import { ChurchEventModel } from '../../../entity/church-event.entity';
+
+export class GetChurchEventResponseDto extends BaseGetResponseDto<
+  ChurchEventModel | ChurchEventModel[]
+> {
+  constructor(data: ChurchEventModel | ChurchEventModel[]) {
+    super(data);
+  }
+}

--- a/backend/src/calendar/dto/response/event/patch-church-event-response.dto.ts
+++ b/backend/src/calendar/dto/response/event/patch-church-event-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePatchResponseDto } from '../../../../common/dto/reponse/base-patch-response.dto';
+import { ChurchEventModel } from '../../../entity/church-event.entity';
+
+export class PatchChurchEventResponseDto extends BasePatchResponseDto<ChurchEventModel> {
+  constructor(data: ChurchEventModel) {
+    super(data);
+  }
+}

--- a/backend/src/calendar/dto/response/event/post-church-event-response.dto.ts
+++ b/backend/src/calendar/dto/response/event/post-church-event-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePostResponseDto } from '../../../../common/dto/reponse/base-post-response.dto';
+import { ChurchEventModel } from '../../../entity/church-event.entity';
+
+export class PostChurchEventResponseDto extends BasePostResponseDto<ChurchEventModel> {
+  constructor(data: ChurchEventModel) {
+    super(data);
+  }
+}

--- a/backend/src/calendar/entity/church-event.entity.ts
+++ b/backend/src/calendar/entity/church-event.entity.ts
@@ -1,0 +1,24 @@
+import { BaseModel } from '../../common/entity/base.entity';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { ChurchModel } from '../../churches/entity/church.entity';
+
+@Entity()
+export class ChurchEventModel extends BaseModel {
+  @Index()
+  @Column()
+  churchId: number;
+
+  @ManyToOne(() => ChurchModel)
+  @JoinColumn({ name: 'churchId' })
+  church: ChurchModel;
+
+  @Column()
+  title: string;
+
+  @Index()
+  @Column({ type: 'timestamptz' })
+  date: Date;
+
+  @Column({ default: '' })
+  description: string;
+}

--- a/backend/src/calendar/exception/church-event.exception.ts
+++ b/backend/src/calendar/exception/church-event.exception.ts
@@ -1,0 +1,5 @@
+export const ChurchEventException = {
+  NOT_FOUND: '해당 교회 이벤트를 찾을 수 없습니다.',
+  UPDATE_ERROR: '교회 이벤트 업데이트 도중 에러 발생',
+  DELETE_ERROR: '교회 이벤트 삭제 도중 에러 발생',
+};

--- a/backend/src/calendar/service/calendar-birthday.service.ts
+++ b/backend/src/calendar/service/calendar-birthday.service.ts
@@ -10,7 +10,7 @@ import {
 import { GetBirthdayMembersDto } from '../dto/request/birthday/get-birthday-members.dto';
 
 @Injectable()
-export class CalendarService {
+export class CalendarBirthdayService {
   constructor(
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,

--- a/backend/src/calendar/service/calendar-education.service.ts
+++ b/backend/src/calendar/service/calendar-education.service.ts
@@ -1,0 +1,47 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  IEDUCATION_SESSION_DOMAIN_SERVICE,
+  IEducationSessionDomainService,
+} from '../../management/educations/service/education-domain/interface/education-session-domain.service.interface';
+import { GetEducationSessionForCalendarDto } from '../dto/request/education/get-education-session-for-calendar.dto';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+
+@Injectable()
+export class CalendarEducationService {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+
+    @Inject(IEDUCATION_SESSION_DOMAIN_SERVICE)
+    private readonly educationSessionDomainService: IEducationSessionDomainService,
+  ) {}
+
+  async getEducationSessionsForCalendar(
+    churchId: number,
+    dto: GetEducationSessionForCalendarDto,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    return this.educationSessionDomainService.findEducationSessionsForCalendar(
+      church,
+      dto,
+    );
+  }
+
+  async getEducationSessionById(churchId: number, educationSessionId: number) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const educationSession =
+      await this.educationSessionDomainService.findEducationSessionByIdForCalendar(
+        church,
+        educationSessionId,
+      );
+
+    return educationSession;
+  }
+}

--- a/backend/src/calendar/service/calendar.service.ts
+++ b/backend/src/calendar/service/calendar.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
@@ -7,7 +7,7 @@ import {
   IMEMBERS_DOMAIN_SERVICE,
   IMembersDomainService,
 } from '../../members/member-domain/interface/members-domain.service.interface';
-import { GetBirthdayMembersDto } from '../dto/get-birthday-members.dto';
+import { GetBirthdayMembersDto } from '../dto/request/birthday/get-birthday-members.dto';
 
 @Injectable()
 export class CalendarService {
@@ -29,8 +29,8 @@ export class CalendarService {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    const from = dto.fromDate.toISOString().slice(5, 10);
-    const to = dto.toDate.toISOString().slice(5, 10);
+    //const from = dto.fromDate.toISOString().slice(5, 10);
+    //const to = dto.toDate.toISOString().slice(5, 10);
 
     return this.membersDomainService.findBirthdayMembers(church, dto);
   }

--- a/backend/src/calendar/service/calendar.service.ts
+++ b/backend/src/calendar/service/calendar.service.ts
@@ -1,0 +1,37 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IMEMBERS_DOMAIN_SERVICE,
+  IMembersDomainService,
+} from '../../members/member-domain/interface/members-domain.service.interface';
+import { GetBirthdayMembersDto } from '../dto/get-birthday-members.dto';
+
+@Injectable()
+export class CalendarService {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,
+  ) {}
+
+  async migrationBirthdayMMDD(churchId: number) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    await this.membersDomainService.migrationBirthdayMMDD(church);
+  }
+
+  async getBirthdayMembers(churchId: number, dto: GetBirthdayMembersDto) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const from = dto.fromDate.toISOString().slice(5, 10);
+    const to = dto.toDate.toISOString().slice(5, 10);
+
+    return this.membersDomainService.findBirthdayMembers(church, dto);
+  }
+}

--- a/backend/src/calendar/service/church-event.service.ts
+++ b/backend/src/calendar/service/church-event.service.ts
@@ -1,0 +1,100 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { CreateChurchEventDto } from '../dto/request/event/create-church-event.dto';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  ICHURCH_EVENT_DOMAIN_SERVICE,
+  IChurchEventDomainService,
+} from '../calendar-domain/interface/church-event-domain.service.interface';
+import { PostChurchEventResponseDto } from '../dto/response/event/post-church-event-response.dto';
+import { GetChurchEventsDto } from '../dto/request/event/get-church-events.dto';
+import { GetChurchEventResponseDto } from '../dto/response/event/get-church-event-response.dto';
+import { UpdateChurchEventDto } from '../dto/request/event/update-church-event.dto';
+import { PatchChurchEventResponseDto } from '../dto/response/event/patch-church-event-response.dto';
+import { DeleteChurchEventResponseDto } from '../dto/response/event/delete-church-event-response.dto';
+
+@Injectable()
+export class ChurchEventService {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(ICHURCH_EVENT_DOMAIN_SERVICE)
+    private readonly churchEventDomainService: IChurchEventDomainService,
+  ) {}
+
+  async getChurchEvents(churchId: number, dto: GetChurchEventsDto) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const events = await this.churchEventDomainService.findChurchEvents(
+      church,
+      dto,
+    );
+
+    return new GetChurchEventResponseDto(events);
+  }
+
+  async postChurchEvent(churchId: number, dto: CreateChurchEventDto) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const newChurchEvent =
+      await this.churchEventDomainService.createChurchEvent(church, dto);
+
+    return new PostChurchEventResponseDto(newChurchEvent);
+  }
+
+  async getChurchEventById(churchId: number, eventId: number) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const event = await this.churchEventDomainService.findChurchEventById(
+      church,
+      eventId,
+    );
+
+    return new GetChurchEventResponseDto(event);
+  }
+
+  async patchChurchEvent(
+    churchId: number,
+    eventId: number,
+    dto: UpdateChurchEventDto,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const event = await this.churchEventDomainService.findChurchEventModelById(
+      church,
+      eventId,
+    );
+
+    await this.churchEventDomainService.updateChurchEvent(event, dto);
+
+    const updatedEvent =
+      await this.churchEventDomainService.findChurchEventById(church, event.id);
+
+    return new PatchChurchEventResponseDto(updatedEvent);
+  }
+
+  async deleteChurchEvent(churchId: number, eventId: number) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const event = await this.churchEventDomainService.findChurchEventModelById(
+      church,
+      eventId,
+    );
+
+    await this.churchEventDomainService.deleteChurchEvent(event);
+
+    return new DeleteChurchEventResponseDto(
+      new Date(),
+      event.id,
+      event.title,
+      true,
+    );
+  }
+}

--- a/backend/src/management/educations/service/education-domain/interface/education-session-domain.service.interface.ts
+++ b/backend/src/management/educations/service/education-domain/interface/education-session-domain.service.interface.ts
@@ -6,12 +6,25 @@ import { CreateEducationSessionDto } from '../../../dto/sessions/request/create-
 import { EducationSessionDomainPaginationResultDto } from '../dto/sessions/education-session-domain-pagination-result.dto';
 import { GetEducationSessionDto } from '../../../dto/sessions/request/get-education-session.dto';
 import { ChurchUserModel } from '../../../../../church-user/entity/church-user.entity';
+import { ChurchModel } from '../../../../../churches/entity/church.entity';
+import { GetEducationSessionForCalendarDto } from '../../../../../calendar/dto/request/education/get-education-session-for-calendar.dto';
 
 export const IEDUCATION_SESSION_DOMAIN_SERVICE = Symbol(
   'IEDUCATION_SESSION_DOMAIN_SERVICE',
 );
 
 export interface IEducationSessionDomainService {
+  findEducationSessionsForCalendar(
+    church: ChurchModel,
+    dto: GetEducationSessionForCalendarDto,
+    qr?: QueryRunner,
+  ): Promise<EducationSessionModel[]>;
+
+  findEducationSessionByIdForCalendar(
+    church: ChurchModel,
+    sessionId: number,
+  ): Promise<EducationSessionModel>;
+
   findEducationSessions(
     educationTerm: EducationTermModel,
     dto: GetEducationSessionDto,

--- a/backend/src/members/dto/request/create-member.dto.ts
+++ b/backend/src/members/dto/request/create-member.dto.ts
@@ -106,7 +106,16 @@ export class CreateMemberDto {
   })
   @IsBoolean()
   @IsOptional()
-  isLunar?: boolean = false;
+  isLunar?: boolean;
+
+  @ApiProperty({
+    description: '윤달 여부',
+    default: false,
+    required: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isLeafMonth?: boolean;
 
   @ApiProperty({
     name: 'birth',

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -34,14 +34,6 @@ import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 
 @Entity()
 export class MemberModel extends BaseModel {
-  /*@Index()
-  @Column({ nullable: true })
-  userId: number;
-
-  @OneToOne(() => UserModel, (user) => user.member)
-  @JoinColumn({ name: 'userId' })
-  user: UserModel;*/
-
   @OneToOne(() => ChurchUserModel, (churchUser) => churchUser.member)
   churchUser: ChurchUserModel;
 
@@ -75,9 +67,16 @@ export class MemberModel extends BaseModel {
   @Column({ default: false, comment: '생일 음력 여부' })
   isLunar: boolean;
 
+  @Column({ default: false, comment: '윤달 여부' })
+  isLeafMonth: boolean;
+
   @Index()
   @Column({ nullable: true, comment: '생년 월일' })
   birth: Date;
+
+  @Index()
+  @Column({ type: 'varchar', length: 5, nullable: true })
+  birthdayMMDD: string;
 
   @Index()
   @Column({ enum: GenderEnum, nullable: true, comment: '성별' })

--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -18,7 +18,7 @@ import { GroupRoleModel } from '../../../management/groups/entity/group-role.ent
 import { MembersDomainPaginationResultDto } from '../dto/members-domain-pagination-result.dto';
 import { GetSimpleMembersDto } from '../../dto/request/get-simple-members.dto';
 import { GetRecommendLinkMemberDto } from '../../dto/request/get-recommend-link-member.dto';
-import { GetBirthdayMembersDto } from '../../../calendar/dto/get-birthday-members.dto';
+import { GetBirthdayMembersDto } from '../../../calendar/dto/request/birthday/get-birthday-members.dto';
 
 export const IMEMBERS_DOMAIN_SERVICE = Symbol('IMEMBERS_DOMAIN_SERVICE');
 

--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -18,6 +18,7 @@ import { GroupRoleModel } from '../../../management/groups/entity/group-role.ent
 import { MembersDomainPaginationResultDto } from '../dto/members-domain-pagination-result.dto';
 import { GetSimpleMembersDto } from '../../dto/request/get-simple-members.dto';
 import { GetRecommendLinkMemberDto } from '../../dto/request/get-recommend-link-member.dto';
+import { GetBirthdayMembersDto } from '../../../calendar/dto/get-birthday-members.dto';
 
 export const IMEMBERS_DOMAIN_SERVICE = Symbol('IMEMBERS_DOMAIN_SERVICE');
 
@@ -30,6 +31,14 @@ export interface IMembersDomainService {
     selectOptions: FindOptionsSelect<MemberModel>,
     qr?: QueryRunner,
   ): Promise<{ data: MemberModel[]; totalCount: number }>;
+
+  migrationBirthdayMMDD(church: ChurchModel): Promise<void>;
+
+  findBirthdayMembers(
+    church: ChurchModel,
+    dto: GetBirthdayMembersDto,
+    qr?: QueryRunner,
+  ): Promise<MemberModel[]>;
 
   findSimpleMembers(
     church: ChurchModel,

--- a/backend/src/members/member-domain/service/dummy-members-domain.service.ts
+++ b/backend/src/members/member-domain/service/dummy-members-domain.service.ts
@@ -21,7 +21,10 @@ export class DummyMembersDomainService implements IDummyMembersDomainService {
   ): MemberModel {
     const membersRepository = this.getMembersRepository();
 
-    return membersRepository.create(dto);
+    return membersRepository.create({
+      ...dto,
+      birthdayMMDD: dto.birth?.toISOString().slice(5, 10),
+    });
   }
 
   createDummyMembers(members: MemberModel[], qr?: QueryRunner) {

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -39,7 +39,7 @@ import {
   MemberSummarizedSelect,
 } from '../../const/member-find-options.const';
 import { GetRecommendLinkMemberDto } from '../../dto/request/get-recommend-link-member.dto';
-import { GetBirthdayMembersDto } from '../../../calendar/dto/get-birthday-members.dto';
+import { GetBirthdayMembersDto } from '../../../calendar/dto/request/birthday/get-birthday-members.dto';
 import KoreanLunarCalendar from 'korean-lunar-calendar';
 
 @Injectable()
@@ -133,12 +133,12 @@ export class MembersDomainService implements IMembersDomainService {
     const fromLunarObject = fromLunarCalendar.getLunarCalendar();
     const toLunarObject = toLunarCalendar.getLunarCalendar();
 
-    const fromLunarDate = new Date(
+    /*const fromLunarDate = new Date(
       `${fromLunarObject.year}-${fromLunarObject.month}-${fromLunarObject.day}`,
     );
     const toLunarDate = new Date(
       `${toLunarObject.year}-${toLunarObject.month}-${toLunarObject.day}`,
-    );
+    );*/
 
     const from = dto.fromDate.toISOString().slice(5, 10);
     const to = dto.toDate.toISOString().slice(5, 10);
@@ -189,7 +189,9 @@ export class MembersDomainService implements IMembersDomainService {
         'groupRole.id',
         'groupRole.role',
       ])
-      .orderBy('"birthdayMMDD"', 'ASC');
+      .orderBy('"birthdayMMDD"', 'ASC')
+      .addOrderBy('birth', 'ASC')
+      .addOrderBy('member.id', 'ASC');
 
     return query.getMany();
   }


### PR DESCRIPTION
## 주요 내용
- **CalendarModule** 신설로 교회 일정표 도메인 분리
- 기간별 **생일 교인 조회 API** 구현 및 `birthdayMMDD` 인덱싱 도입  
- **ChurchEvent**(교회 일정) CRUD API 전 범위 구현  
- **교육 세션(EducationSession)** 기간 조회 엔드포인트 추가  
- `birthdayMMDD` 마이그레이션 전용 엔드포인트 제공

## 세부 내용

### CalendarModule
- `CalendarModule`, `CalendarController`, `CalendarService` 생성  
- 베이스 라우팅: `/churches/:churchId/calendar`

### 생일 조회 API
- `GET /churches/:churchId/calendar/birthday?fromDate&toDate`
  - `toDate`는 `fromDate`보다 앞설 수 없음
- 음력→양력 변환·윤달(`isLeafMonth`) 매핑 로직 포함
- `MemberModel`에 `isLeafMonth` 컬럼 추가

### 인덱싱 및 마이그레이션
- `birthdayMMDD`(`MM-DD` 형식) 파생 컬럼 및 인덱스 추가
- `POST /churches/:churchId/calendar/birthday-migration`  
  - `birth` 존재 && `birthdayMMDD` 없는 교인 대상 일괄 변환

### ChurchEvent CRUD
- `ChurchEventModel` 컬럼: `title(≤50)`, `date`, `description(≤1000)`
- ChurchModel N:1 연관 및 유효성 검증
- 엔드포인트  
  - 목록: `GET /churches/:churchId/calendar/events?fromDate&toDate`  
  - 생성: `POST /churches/:churchId/calendar/events`  
  - 단건: `GET /churches/:churchId/calendar/events/:eventId`  
  - 수정: `PATCH /churches/:churchId/calendar/events/:eventId`  
  - 삭제: `DELETE /churches/:churchId/calendar/events/:eventId`

### 교육 세션 달력 조회
- `GET /churches/:churchId/calendar/educations?fromDate&toDate`
  - `session.startDate ≤ toDate` **AND** `session.endDate ≥ fromDate`
  - 교회→교육→Term→Session 다단계 조인 최적화
- 응답에 `inCharge`, `educationTerm`, `education` 요약 포함
