### PR TITLE
fix: 그룹에 소속되지 않은 교인의 예배 출석 수정 불가 문제 해결

### DIFF
--- a/backend/src/worship/controller/worship-attendance.controller.ts
+++ b/backend/src/worship/controller/worship-attendance.controller.ts
@@ -21,7 +21,7 @@ import { WorshipReadGuard } from '../guard/worship-read.guard';
 import { WorshipWriteGuard } from '../guard/worship-write.guard';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
 import { WorshipReadScopeGuard } from '../guard/worship-read-scope.guard';
-import { WorshipTargetGroupGuard } from '../guard/worship-target-group.guard';
+import { WorshipGroupFilterGuard } from '../guard/worship-group-filter.guard';
 import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
 import { DomainType } from '../../permission/const/domain-type.enum';
 import { DomainName } from '../../permission/const/domain-name.enum';
@@ -48,7 +48,7 @@ export class WorshipAttendanceController {
       DomainName.WORSHIP,
       DomainAction.READ,
     ),
-    WorshipTargetGroupGuard,
+    WorshipGroupFilterGuard,
     WorshipReadScopeGuard,
   )
   @WorshipReadGuard()

--- a/backend/src/worship/controller/worship-enrollment.controller.ts
+++ b/backend/src/worship/controller/worship-enrollment.controller.ts
@@ -15,7 +15,7 @@ import { TransactionInterceptor } from '../../common/interceptor/transaction.int
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
 import { WorshipWriteGuard } from '../guard/worship-write.guard';
-import { WorshipTargetGroupGuard } from '../guard/worship-target-group.guard';
+import { WorshipGroupFilterGuard } from '../guard/worship-group-filter.guard';
 import { RequestWorship } from '../decorator/request-worship.decorator';
 import { WorshipModel } from '../entity/worship.entity';
 import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
@@ -44,7 +44,7 @@ export class WorshipEnrollmentController {
       DomainName.WORSHIP,
       DomainAction.READ,
     ),
-    WorshipTargetGroupGuard,
+    WorshipGroupFilterGuard,
     WorshipReadScopeGuard,
   )
   getEnrollments(

--- a/backend/src/worship/guard/worship-group-filter.guard.ts
+++ b/backend/src/worship/guard/worship-group-filter.guard.ts
@@ -18,9 +18,14 @@ import {
   IGroupsDomainService,
 } from '../../management/groups/groups-domain/interface/groups-domain.service.interface';
 import { WorshipException } from '../exception/worship.exception';
+import { CustomRequest } from './worship-read-scope.guard';
+import { ChurchModel } from '../../churches/entity/church.entity';
 
+/**
+ * 필터링 요청한 그룹이 해당 예배의 대상 그룹인지 검사
+ */
 @Injectable()
-export class WorshipTargetGroupGuard implements CanActivate {
+export class WorshipGroupFilterGuard implements CanActivate {
   constructor(
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,
@@ -30,26 +35,49 @@ export class WorshipTargetGroupGuard implements CanActivate {
     private readonly groupsDomainService: IGroupsDomainService,
   ) {}
 
-  async canActivate(context: ExecutionContext): Promise<boolean> {
-    const req = context.switchToHttp().getRequest();
-
+  private async getRequestChurch(req: CustomRequest) {
     const churchId = parseInt(req.params.churchId);
+
+    if (req.church) {
+      return req.church;
+    } else {
+      const church =
+        await this.churchesDomainService.findChurchModelById(churchId);
+
+      req.church = church;
+
+      return church;
+    }
+  }
+
+  private async getRequestWorship(req: CustomRequest, church: ChurchModel) {
     const worshipId = parseInt(req.params.worshipId);
+
+    if (req.worship) {
+      return req.worship;
+    } else {
+      const worship = await this.worshipDomainService.findWorshipModelById(
+        church,
+        worshipId,
+        undefined,
+        { worshipTargetGroups: { group: true } },
+      );
+
+      req.worship = worship;
+
+      return worship;
+    }
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req: CustomRequest = context.switchToHttp().getRequest();
+
+    const church = await this.getRequestChurch(req);
+
+    const worship = await this.getRequestWorship(req, church);
+
     // 조회 요청 그룹 ID
-    const requestGroupId = parseInt(req.query.groupId);
-
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
-    const worship = await this.worshipDomainService.findWorshipModelById(
-      church,
-      worshipId,
-      undefined,
-      { worshipTargetGroups: { group: true } },
-    );
-
-    req.church = church;
-    req.worship = worship;
+    const requestGroupId = parseInt(req.query.groupId as string);
 
     // 필터링할 그룹이 없을 경우 통과
     if (!requestGroupId) return true;


### PR DESCRIPTION
## 주요 내용
예배 출석(WorshipAttendance) 수정 시, 교인이 그룹에 소속되지 않은 경우 로직이 정상적으로 동작하지 않던 문제를 수정

## 세부 내용
- 권한 범위 확인 및 출석 대상 교인에 대한 필터링 과정에서 `groupId`가 null인 교인을 처리하지 못하던 로직을 보완
- 그룹에 소속되지 않은 교인의 출석도 정상적으로 수정할 수 있도록 수정