### PR TITLE
feat: JWT 기반 /me 경로로 TaskReport 조회 API 전환

### DIFF
--- a/backend/src/church-join/service/church-join.service.ts
+++ b/backend/src/church-join/service/church-join.service.ts
@@ -66,7 +66,7 @@ export class ChurchJoinService {
     qr: QueryRunner,
   ) {
     const userId = accessPayload.id;
-    const user = await this.userDomainService.findUserById(userId);
+    const user = await this.userDomainService.findUserModelById(userId);
 
     /**
      * ChurchUserModel 조회로 소속된 교회가 있는지 확인

--- a/backend/src/churches/service/churches.service.ts
+++ b/backend/src/churches/service/churches.service.ts
@@ -59,7 +59,7 @@ export class ChurchesService {
     dto: CreateChurchDto,
     qr: QueryRunner,
   ) {
-    const ownerUser = await this.userDomainService.findUserById(
+    const ownerUser = await this.userDomainService.findUserModelById(
       accessPayload.id,
       qr,
     );
@@ -141,7 +141,7 @@ export class ChurchesService {
       qr,
     );
 
-    const oldOwnerUser = await this.userDomainService.findUserById(
+    const oldOwnerUser = await this.userDomainService.findUserModelById(
       church.ownerUserId,
       qr,
     );
@@ -160,7 +160,7 @@ export class ChurchesService {
         qr,
       );
 
-    const newOwnerUser = await this.userDomainService.findUserById(
+    const newOwnerUser = await this.userDomainService.findUserModelById(
       newOwnerChurchUser.userId,
       qr,
     );

--- a/backend/src/report/controller/task-report.controller.ts
+++ b/backend/src/report/controller/task-report.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Patch,
   Query,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
@@ -22,6 +23,10 @@ import {
   ApiGetTaskReports,
   ApiPatchTaskReport,
 } from '../const/swagger/task-report.swagger';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { AuthType } from '../../auth/const/enum/auth-type.enum';
+import { Token } from '../../auth/decorator/jwt.decorator';
+import { JwtAccessPayload } from '../../auth/type/jwt';
 
 @ApiTags('Churches:Members:Reports:Tasks')
 @Controller('tasks')
@@ -30,26 +35,25 @@ export class TaskReportController {
 
   @ApiGetTaskReports()
   @Get()
+  @UseGuards(AccessTokenGuard)
   getTaskReports(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
     @Query() dto: GetTaskReportDto,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
   ) {
-    return this.taskReportService.getTaskReports(churchId, memberId, dto);
+    return this.taskReportService.getTaskReports(accessToken.id, dto);
   }
 
   @ApiGetTaskReportById()
   @Get(':taskReportId')
+  @UseGuards(AccessTokenGuard)
   @UseInterceptors(TransactionInterceptor)
   getTaskReportById(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('taskReportId', ParseIntPipe) taskReportId: number,
     @QueryRunner() qr: QR,
   ) {
     return this.taskReportService.getTaskReportById(
-      churchId,
-      memberId,
+      accessToken.id,
       taskReportId,
       qr,
     );

--- a/backend/src/report/report.module.ts
+++ b/backend/src/report/report.module.ts
@@ -11,16 +11,21 @@ import { TaskReportDomainModule } from './report-domain/task-report-domain.modul
 import { EducationSessionReportController } from './controller/education-session-report.controller';
 import { EducationSessionReportService } from './service/education-session-report.service';
 import { EducationSessionReportDomainModule } from './report-domain/education-session-report-domain.module';
+import { ChurchUserDomainModule } from '../church-user/church-user-domain/church-user-domain.module';
+import { UserDomainModule } from '../user/user-domain/user-domain.module';
 
 @Module({
   imports: [
     RouterModule.register([
       {
-        path: 'churches/:churchId/members/:memberId/reports',
+        //path: 'churches/:churchId/members/:memberId/reports',
+        path: 'me/reports',
         module: ReportModule,
       },
     ]),
+    UserDomainModule,
     ChurchesDomainModule,
+    ChurchUserDomainModule,
     MembersDomainModule,
     VisitationReportDomainModule,
     TaskReportDomainModule,

--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -21,11 +21,11 @@ export class UserService {
   ) {}
 
   async getUserById(id: number) {
-    return this.userDomainService.findUserById(id);
+    return this.userDomainService.findUserModelById(id);
   }
 
   async getMyJoinRequest(userId: number, qr?: QueryRunner) {
-    const user = await this.userDomainService.findUserById(userId, qr);
+    const user = await this.userDomainService.findUserModelById(userId, qr);
 
     return this.churchJoinRequestsDomainService.findMyChurchJoinRequest(
       user,
@@ -34,7 +34,7 @@ export class UserService {
   }
 
   async cancelMyJoinRequest(userId: number, qr?: QueryRunner) {
-    const user = await this.userDomainService.findUserById(userId, qr);
+    const user = await this.userDomainService.findUserModelById(userId, qr);
 
     const joinRequest =
       await this.churchJoinRequestsDomainService.findMyPendingChurchJoinRequest(
@@ -56,7 +56,7 @@ export class UserService {
   }
 
   async getMyPendingJoinRequest(userId: number) {
-    const user = await this.userDomainService.findUserById(userId);
+    const user = await this.userDomainService.findUserModelById(userId);
 
     return this.churchJoinRequestsDomainService.findMyPendingChurchJoinRequest(
       user,

--- a/backend/src/user/user-domain/interface/user-domain.service.interface.ts
+++ b/backend/src/user/user-domain/interface/user-domain.service.interface.ts
@@ -7,7 +7,9 @@ import { UpdateUserDto } from '../../dto/update-user.dto';
 export const IUSER_DOMAIN_SERVICE = Symbol('IUserDomainService');
 
 export interface IUserDomainService {
-  findUserById(id: number, qr?: QueryRunner): Promise<UserModel>;
+  findUserById(userId: number, qr?: QueryRunner): Promise<UserModel>;
+
+  findUserModelById(id: number, qr?: QueryRunner): Promise<UserModel>;
 
   findUserModelByOAuth(
     provider: string,


### PR DESCRIPTION
## 주요 내용
- **TaskReport 조회 API**를 `/churches/{churchId}/reports/tasks` → `/me/reports/tasks` 형태로 변경
- JWT 토큰을 활용해 **로그인 사용자 스코프**로 리포트 자동 제한

## 세부 내용
### Backend
- `ReportsController` 내 TaskReport 관련 GET 엔드포인트 경로 수정 및 기존 경로 제거
- `JwtAuthGuard` 활성화: 컨트롤러 레벨에서 `@UseGuards(JwtAuthGuard)` 적용
- 단위 테스트 업데이트
  - 기존 Path Param 기반 테스트 삭제
  - `/me/reports/tasks` 성공·권한 오류 케이스 추가