### PR TITLE
feat: JWT 기반 /me 경로로 EducationReport, VisitationReport 조회 API 전환

### DIFF
--- a/backend/src/report/controller/education-session-report.controller.ts
+++ b/backend/src/report/controller/education-session-report.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Patch,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import { EducationSessionReportService } from '../service/education-session-report.service';
 import { GetEducationSessionReportDto } from '../dto/education-report/session/request/get-education-session-report.dto';
@@ -18,8 +19,12 @@ import {
   ApiGetEducationSessionReports,
   ApiPatchEducationSessionReport,
 } from '../const/swagger/education-session-report.swagger';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { Token } from '../../auth/decorator/jwt.decorator';
+import { AuthType } from '../../auth/const/enum/auth-type.enum';
+import { JwtAccessPayload } from '../../auth/type/jwt';
 
-@ApiTags('Churches:Members:Reports:Education-Sessions')
+@ApiTags('Me:Reports:Education-Sessions')
 @Controller('education-session')
 export class EducationSessionReportController {
   constructor(
@@ -27,59 +32,55 @@ export class EducationSessionReportController {
   ) {}
 
   @ApiGetEducationSessionReports()
+  @UseGuards(AccessTokenGuard)
   @Get()
   getEducationSessionReport(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Query() dto: GetEducationSessionReportDto,
   ) {
     return this.educationSessionReportService.getEducationSessionReports(
-      churchId,
-      memberId,
+      accessToken.id,
       dto,
     );
   }
 
   @ApiGetEducationSessionReportById()
+  @UseGuards(AccessTokenGuard)
   @Get(':educationSessionReportId')
   getEducationSessionReportById(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('educationSessionReportId', ParseIntPipe) reportId: number,
   ) {
     return this.educationSessionReportService.getEducationSessionReportById(
-      churchId,
-      memberId,
+      accessToken.id,
       reportId,
     );
   }
 
   @ApiPatchEducationSessionReport()
+  @UseGuards(AccessTokenGuard)
   @Patch(':educationSessionReportId')
   patchEducationSessionReport(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('educationSessionReportId', ParseIntPipe) reportId: number,
     @Body() dto: UpdateEducationSessionReportDto,
   ) {
     return this.educationSessionReportService.patchEducationSessionReport(
-      churchId,
-      memberId,
+      accessToken.id,
       reportId,
       dto,
     );
   }
 
   @ApiDeleteEducationSessionReport()
+  @UseGuards(AccessTokenGuard)
   @Delete(':educationSessionReportId')
   deleteEducationSessionReport(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('educationSessionReportId', ParseIntPipe) reportId: number,
   ) {
     return this.educationSessionReportService.deleteEducationSessionReport(
-      churchId,
-      memberId,
+      accessToken.id,
       reportId,
     );
   }

--- a/backend/src/report/controller/task-report.controller.ts
+++ b/backend/src/report/controller/task-report.controller.ts
@@ -28,7 +28,7 @@ import { AuthType } from '../../auth/const/enum/auth-type.enum';
 import { Token } from '../../auth/decorator/jwt.decorator';
 import { JwtAccessPayload } from '../../auth/type/jwt';
 
-@ApiTags('Churches:Members:Reports:Tasks')
+@ApiTags('Me:Reports:Tasks')
 @Controller('tasks')
 export class TaskReportController {
   constructor(private readonly taskReportService: TaskReportService) {}
@@ -60,31 +60,29 @@ export class TaskReportController {
   }
 
   @ApiPatchTaskReport()
+  @UseGuards(AccessTokenGuard)
   @Patch(':taskReportId')
   patchTaskReport(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('taskReportId', ParseIntPipe) taskReportId: number,
     @Body() dto: UpdateTaskReportDto,
   ) {
     return this.taskReportService.patchTaskReport(
-      churchId,
-      memberId,
+      accessToken.id,
       taskReportId,
       dto,
     );
   }
 
   @ApiDeleteTaskReport()
+  @UseGuards(AccessTokenGuard)
   @Delete(':taskReportId')
   deleteTaskReport(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('taskReportId', ParseIntPipe) taskReportId: number,
   ) {
     return this.taskReportService.deleteTaskReport(
-      churchId,
-      memberId,
+      accessToken.id,
       taskReportId,
     );
   }

--- a/backend/src/report/controller/visitation-report.controller.ts
+++ b/backend/src/report/controller/visitation-report.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Patch,
   Query,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
@@ -22,65 +23,66 @@ import {
   ApiPatchVisitationReport,
 } from '../const/swagger/visitation-report.swagger';
 import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { AuthType } from '../../auth/const/enum/auth-type.enum';
+import { Token } from '../../auth/decorator/jwt.decorator';
+import { JwtAccessPayload } from '../../auth/type/jwt';
 
-@ApiTags('Churches:Members:Reports:Visitations')
+@ApiTags('Me:Reports:Visitations')
 @Controller('visitations')
 export class VisitationReportController {
   constructor(private readonly reportService: VisitationReportService) {}
 
   @ApiGetVisitationReports()
+  @UseGuards(AccessTokenGuard)
   @Get()
   getVisitationReports(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Query() dto: GetVisitationReportDto,
   ) {
-    return this.reportService.getVisitationReport(churchId, memberId, dto);
+    return this.reportService.getVisitationReport(accessToken.id, dto);
   }
 
   @ApiGetVisitationReportById()
+  @UseGuards(AccessTokenGuard)
   @Get(':visitationReportId')
   @UseInterceptors(TransactionInterceptor)
   getVisitationReportById(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('visitationReportId', ParseIntPipe) visitationReportId: number,
     @QueryRunner() qr: QR,
   ) {
     return this.reportService.getVisitationReportById(
-      churchId,
-      memberId,
+      accessToken.id,
       visitationReportId,
       qr,
     );
   }
 
   @ApiPatchVisitationReport()
+  @UseGuards(AccessTokenGuard)
   @Patch(':visitationReportId')
   patchVisitationReport(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('visitationReportId', ParseIntPipe) visitationReportId: number,
     @Body() dto: UpdateVisitationReportDto,
   ) {
     return this.reportService.updateVisitationReport(
-      churchId,
-      memberId,
+      accessToken.id,
       visitationReportId,
       dto,
     );
   }
 
   @ApiDeleteVisitationReport()
+  @UseGuards(AccessTokenGuard)
   @Delete(':visitationReportId')
   deleteVisitationReport(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('visitationReportId', ParseIntPipe) visitationReportId: number,
   ) {
     return this.reportService.deleteVisitationReport(
-      churchId,
-      memberId,
+      accessToken.id,
       visitationReportId,
     );
   }

--- a/backend/src/report/report.module.ts
+++ b/backend/src/report/report.module.ts
@@ -2,8 +2,6 @@ import { Module } from '@nestjs/common';
 import { VisitationReportDomainModule } from './report-domain/visitation-report-domain.module';
 import { RouterModule } from '@nestjs/core';
 import { VisitationReportController } from './controller/visitation-report.controller';
-import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
-import { MembersDomainModule } from '../members/member-domain/members-domain.module';
 import { VisitationReportService } from './service/visitation-report.service';
 import { TaskReportController } from './controller/task-report.controller';
 import { TaskReportService } from './service/task-report.service';
@@ -11,7 +9,6 @@ import { TaskReportDomainModule } from './report-domain/task-report-domain.modul
 import { EducationSessionReportController } from './controller/education-session-report.controller';
 import { EducationSessionReportService } from './service/education-session-report.service';
 import { EducationSessionReportDomainModule } from './report-domain/education-session-report-domain.module';
-import { ChurchUserDomainModule } from '../church-user/church-user-domain/church-user-domain.module';
 import { UserDomainModule } from '../user/user-domain/user-domain.module';
 
 @Module({
@@ -24,9 +21,8 @@ import { UserDomainModule } from '../user/user-domain/user-domain.module';
       },
     ]),
     UserDomainModule,
-    ChurchesDomainModule,
-    ChurchUserDomainModule,
-    MembersDomainModule,
+    //ChurchesDomainModule,
+    //MembersDomainModule,
     VisitationReportDomainModule,
     TaskReportDomainModule,
     EducationSessionReportDomainModule,

--- a/backend/src/report/service/education-session-report.service.ts
+++ b/backend/src/report/service/education-session-report.service.ts
@@ -1,12 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
-import {
-  ICHURCHES_DOMAIN_SERVICE,
-  IChurchesDomainService,
-} from '../../churches/churches-domain/interface/churches-domain.service.interface';
-import {
-  IMEMBERS_DOMAIN_SERVICE,
-  IMembersDomainService,
-} from '../../members/member-domain/interface/members-domain.service.interface';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import {
   IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE,
   IEducationSessionReportDomainService,
@@ -18,34 +10,45 @@ import { PatchEducationSessionReportResponseDto } from '../dto/education-report/
 import { GetEducationSessionReportResponseDto } from '../dto/education-report/session/response/get-education-session-report-response.dto';
 import { QueryRunner } from 'typeorm';
 import { DeleteEducationSessionReportResponseDto } from '../dto/education-report/session/response/delete-education-session-report-response.dto';
+import {
+  IUSER_DOMAIN_SERVICE,
+  IUserDomainService,
+} from '../../user/user-domain/interface/user-domain.service.interface';
+import { MemberModel } from '../../members/entity/member.entity';
 
 @Injectable()
 export class EducationSessionReportService {
   constructor(
-    @Inject(ICHURCHES_DOMAIN_SERVICE)
-    private readonly churchesDomainService: IChurchesDomainService,
-    @Inject(IMEMBERS_DOMAIN_SERVICE)
-    private readonly membersDomainService: IMembersDomainService,
+    @Inject(IUSER_DOMAIN_SERVICE)
+    private readonly userDomainService: IUserDomainService,
 
     @Inject(IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE)
     private readonly educationSessionReportDomainService: IEducationSessionReportDomainService,
   ) {}
 
+  private async getCurrentMember(userId: number): Promise<MemberModel> {
+    const user = await this.userDomainService.findUserById(userId);
+
+    const currentChurchUser = user.churchUser.find(
+      (churchUser) => churchUser.leftAt === null,
+    );
+
+    if (!currentChurchUser) {
+      throw new BadRequestException('교회에 가입되지 않은 사용자');
+    }
+
+    return currentChurchUser.member;
+  }
+
   async getEducationSessionReports(
-    churchId: number,
-    memberId: number,
+    userId: number,
     dto: GetEducationSessionReportDto,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-    );
+    const currentMember = await this.getCurrentMember(userId);
 
     const { data, totalCount } =
       await this.educationSessionReportDomainService.findEducationSessionReports(
-        receiver,
+        currentMember,
         dto,
       );
 
@@ -58,17 +61,8 @@ export class EducationSessionReportService {
     );
   }
 
-  async getEducationSessionReportById(
-    churchId: number,
-    receiverId: number,
-    reportId: number,
-  ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      receiverId,
-    );
+  async getEducationSessionReportById(userId: number, reportId: number) {
+    const receiver = await this.getCurrentMember(userId);
 
     const report =
       await this.educationSessionReportDomainService.findEducationSessionReportById(
@@ -81,17 +75,11 @@ export class EducationSessionReportService {
   }
 
   async patchEducationSessionReport(
-    churchId: number,
-    memberId: number,
+    userId: number,
     reportId: number,
     dto: UpdateEducationSessionReportDto,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-    );
+    const receiver = await this.getCurrentMember(userId);
 
     const targetReport =
       await this.educationSessionReportDomainService.findEducationSessionReportModelById(
@@ -115,18 +103,11 @@ export class EducationSessionReportService {
   }
 
   async deleteEducationSessionReport(
-    churchId: number,
-    receiverId: number,
+    userId: number,
     reportId: number,
     qr?: QueryRunner,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      receiverId,
-    );
+    const receiver = await this.getCurrentMember(userId);
 
     const deleteTarget =
       await this.educationSessionReportDomainService.findEducationSessionReportModelById(

--- a/backend/src/report/service/task-report.service.ts
+++ b/backend/src/report/service/task-report.service.ts
@@ -3,14 +3,6 @@ import {
   ITASK_REPORT_DOMAIN_SERVICE,
   ITaskReportDomainService,
 } from '../report-domain/interface/task-report-domain.service.interface';
-import {
-  ICHURCHES_DOMAIN_SERVICE,
-  IChurchesDomainService,
-} from '../../churches/churches-domain/interface/churches-domain.service.interface';
-import {
-  IMEMBERS_DOMAIN_SERVICE,
-  IMembersDomainService,
-} from '../../members/member-domain/interface/members-domain.service.interface';
 import { GetTaskReportDto } from '../dto/task-report/get-task-report.dto';
 import { TaskReportPaginationResultDto } from '../dto/task-report/task-report-pagination-result.dto';
 import { QueryRunner } from 'typeorm';
@@ -19,10 +11,6 @@ import { UpdateTaskReportDto } from '../dto/task-report/request/update-task-repo
 import { PatchTaskReportResponseDto } from '../dto/task-report/response/patch-task-report-response.dto';
 import { DeleteTaskReportResponseDto } from '../dto/task-report/response/delete-task-report-response.dto';
 import {
-  ICHURCH_USER_DOMAIN_SERVICE,
-  IChurchUserDomainService,
-} from '../../church-user/church-user-domain/service/interface/church-user-domain.service.interface';
-import {
   IUSER_DOMAIN_SERVICE,
   IUserDomainService,
 } from '../../user/user-domain/interface/user-domain.service.interface';
@@ -30,20 +18,13 @@ import {
 @Injectable()
 export class TaskReportService {
   constructor(
-    @Inject(ICHURCHES_DOMAIN_SERVICE)
-    private readonly churchesDomainService: IChurchesDomainService,
-    @Inject(IMEMBERS_DOMAIN_SERVICE)
-    private readonly membersDomainService: IMembersDomainService,
-
     @Inject(ITASK_REPORT_DOMAIN_SERVICE)
     private readonly taskReportDomainService: ITaskReportDomainService,
-    @Inject(ICHURCH_USER_DOMAIN_SERVICE)
-    private readonly churchUserDomainService: IChurchUserDomainService,
     @Inject(IUSER_DOMAIN_SERVICE)
     private readonly userDomainService: IUserDomainService,
   ) {}
 
-  async getTaskReports(userId: number, dto: GetTaskReportDto) {
+  private async getCurrentMember(userId: number) {
     const user = await this.userDomainService.findUserById(userId);
 
     const currentChurchUser = user.churchUser.find(
@@ -54,9 +35,15 @@ export class TaskReportService {
       throw new BadRequestException('교회에 가입되지 않은 사용자');
     }
 
+    return currentChurchUser.member;
+  }
+
+  async getTaskReports(userId: number, dto: GetTaskReportDto) {
+    const receiver = await this.getCurrentMember(userId);
+
     const { data, totalCount } =
       await this.taskReportDomainService.findTaskReportsByReceiver(
-        currentChurchUser.member,
+        receiver,
         dto,
       );
 
@@ -74,29 +61,10 @@ export class TaskReportService {
     taskReportId: number,
     qr: QueryRunner,
   ) {
-    /*const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-      qr,
-      //{ user: true },
-    );*/
-    const user = await this.userDomainService.findUserById(userId);
-
-    const currentChurchUser = user.churchUser.find(
-      (churchUser) => churchUser.leftAt === null,
-    );
-
-    if (!currentChurchUser) {
-      throw new BadRequestException('교회에 가입되지 않은 사용자');
-    }
+    const receiver = await this.getCurrentMember(userId);
 
     const report = await this.taskReportDomainService.findTaskReportById(
-      //receiver,
-      currentChurchUser.member,
+      receiver,
       taskReportId,
       true,
       qr,
@@ -106,18 +74,11 @@ export class TaskReportService {
   }
 
   async patchTaskReport(
-    churchId: number,
-    memberId: number,
+    userId: number,
     taskReportId: number,
     dto: UpdateTaskReportDto,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-    );
+    const receiver = await this.getCurrentMember(userId);
 
     const targetTaskReport =
       await this.taskReportDomainService.findTaskReportModelById(
@@ -137,18 +98,8 @@ export class TaskReportService {
     return new PatchTaskReportResponseDto(updatedTaskReport);
   }
 
-  async deleteTaskReport(
-    churchId: number,
-    receiverId: number,
-    taskReportId: number,
-  ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      receiverId,
-    );
+  async deleteTaskReport(userId: number, taskReportId: number) {
+    const receiver = await this.getCurrentMember(userId);
 
     const targetReport =
       await this.taskReportDomainService.findTaskReportModelById(

--- a/backend/src/report/service/visitation-report.service.ts
+++ b/backend/src/report/service/visitation-report.service.ts
@@ -1,46 +1,43 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import {
   IVISITATION_REPORT_DOMAIN_SERVICE,
   IVisitationReportDomainService,
 } from '../report-domain/interface/visitation-report-domain.service.interface';
 import { GetVisitationReportDto } from '../dto/visitation-report/get-visitation-report.dto';
-import {
-  ICHURCHES_DOMAIN_SERVICE,
-  IChurchesDomainService,
-} from '../../churches/churches-domain/interface/churches-domain.service.interface';
-import {
-  IMEMBERS_DOMAIN_SERVICE,
-  IMembersDomainService,
-} from '../../members/member-domain/interface/members-domain.service.interface';
 import { VisitationReportPaginationResultDto } from '../dto/visitation-report/visitation-report-pagination-result.dto';
 import { QueryRunner } from 'typeorm';
 import { UpdateVisitationReportDto } from '../dto/visitation-report/update-visitation-report.dto';
+import {
+  IUSER_DOMAIN_SERVICE,
+  IUserDomainService,
+} from '../../user/user-domain/interface/user-domain.service.interface';
 
 @Injectable()
 export class VisitationReportService {
   constructor(
-    @Inject(ICHURCHES_DOMAIN_SERVICE)
-    private readonly churchesDomainService: IChurchesDomainService,
-    @Inject(IMEMBERS_DOMAIN_SERVICE)
-    private readonly membersDomainService: IMembersDomainService,
+    @Inject(IUSER_DOMAIN_SERVICE)
+    private readonly userDomainService: IUserDomainService,
 
     @Inject(IVISITATION_REPORT_DOMAIN_SERVICE)
     private readonly visitationReportDomainService: IVisitationReportDomainService,
   ) {}
 
-  async getVisitationReport(
-    churchId: number,
-    memberId: number,
-    dto: GetVisitationReportDto,
-  ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-      undefined,
-      //{ user: true },
+  private async getCurrentMember(userId: number) {
+    const user = await this.userDomainService.findUserById(userId);
+
+    const currentChurchUser = user.churchUser.find(
+      (churchUser) => churchUser.leftAt === null,
     );
+
+    if (!currentChurchUser) {
+      throw new BadRequestException('교회에 가입되지 않은 사용자');
+    }
+
+    return currentChurchUser.member;
+  }
+
+  async getVisitationReport(userId: number, dto: GetVisitationReportDto) {
+    const receiver = await this.getCurrentMember(userId);
 
     const { data, totalCount } =
       await this.visitationReportDomainService.findVisitationReportsByReceiver(
@@ -55,35 +52,14 @@ export class VisitationReportService {
       dto.page,
       Math.ceil(totalCount / dto.take),
     );
-
-    /*const paginationResult: VisitationReportPaginationResultDto = {
-      totalCount,
-      data: data,
-      count: dto.take,
-      page: dto.page,
-      totalPage: Math.ceil(totalCount / dto.take),
-    };
-
-    return paginationResult;*/
   }
 
   async getVisitationReportById(
-    churchId: number,
-    memberId: number,
+    userId: number,
     visitationReportId: number,
     qr: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-      qr,
-      //{ user: true },
-    );
+    const receiver = await this.getCurrentMember(userId);
 
     return this.visitationReportDomainService.findVisitationReportById(
       receiver,
@@ -94,18 +70,11 @@ export class VisitationReportService {
   }
 
   async updateVisitationReport(
-    churchId: number,
-    memberId: number,
+    userId: number,
     visitationReportId: number,
     dto: UpdateVisitationReportDto,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-    );
+    const receiver = await this.getCurrentMember(userId);
 
     const targetReport =
       await this.visitationReportDomainService.findVisitationReportModelById(
@@ -125,18 +94,8 @@ export class VisitationReportService {
     );
   }
 
-  async deleteVisitationReport(
-    churchId: number,
-    memberId: number,
-    visitationReportId: number,
-  ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-    );
+  async deleteVisitationReport(userId: number, visitationReportId: number) {
+    const receiver = await this.getCurrentMember(userId);
 
     const targetReport =
       await this.visitationReportDomainService.findVisitationReportModelById(

--- a/backend/src/worship/guard/worship-read-scope.guard.ts
+++ b/backend/src/worship/guard/worship-read-scope.guard.ts
@@ -25,13 +25,14 @@ import { ChurchUserRole } from '../../user/const/user-role.enum';
 import { PermissionScopeException } from '../../permission/exception/permission-scope.exception';
 import { WorshipModel } from '../entity/worship.entity';
 import { Request } from 'express';
+import { JwtAccessPayload } from '../../auth/type/jwt';
 
 export interface CustomRequest extends Request {
   church: ChurchModel;
   worship: WorshipModel;
   requestManager: ChurchUserModel;
   permissionScopeGroupIds: number[];
-  tokenPayload: any;
+  tokenPayload: JwtAccessPayload;
 }
 
 /**


### PR DESCRIPTION
## 주요 내용
- **EducationReport, VisitationReport 조회 API**를 `/churches/{churchId}/reports/education-session` → `/me/reports/education-session` 형태로 변경
- JWT 토큰을 활용해 **로그인 사용자 스코프**로 리포트 자동 제한

## 세부 내용
### Backend
- `ReportsController` 내 EducationReport, VisitationReport 관련 엔드포인트 경로 수정 및 기존 경로 제거
- `JwtAuthGuard` 활성화: 컨트롤러 레벨에서 `@UseGuards(JwtAuthGuard)` 적용