### PR TITLE
feat: 내 계정 정보를 조회하는 /me API 추가 및 리포트 조회 시 교인 연결 여부 검증

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -67,6 +67,7 @@ import { WorshipModule } from './worship/worship.module';
 import { WorshipTargetGroupModel } from './worship/entity/worship-target-group.entity';
 import { CalendarModule } from './calendar/calendar.module';
 import { ChurchEventModel } from './calendar/entity/church-event.entity';
+import { MyPageModule } from './my-page/my-page.module';
 
 @Module({
   imports: [
@@ -198,8 +199,9 @@ import { ChurchEventModel } from './calendar/entity/church-event.entity';
       }),
       inject: [ConfigService],
     }),
-    //CommonModule,
     AuthModule,
+    MyPageModule,
+    ReportModule,
     UserModule,
     ChurchesModule,
     ChurchJoinModule,
@@ -210,7 +212,6 @@ import { ChurchEventModel } from './calendar/entity/church-event.entity';
     MembersModule,
     FamilyRelationModule,
     MemberHistoryModule,
-    ReportModule,
     ManagementModule,
     VisitationModule,
     TaskModule,

--- a/backend/src/my-page/dto/controller/my-page.controller.ts
+++ b/backend/src/my-page/dto/controller/my-page.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { MyPageService } from '../service/my-page.service';
+import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
+import { Token } from '../../../auth/decorator/jwt.decorator';
+import { AuthType } from '../../../auth/const/enum/auth-type.enum';
+import { JwtAccessPayload } from '../../../auth/type/jwt';
+
+@Controller()
+export class MyPageController {
+  constructor(private readonly myPageService: MyPageService) {}
+
+  @Get()
+  @UseGuards(AccessTokenGuard)
+  getMe(@Token(AuthType.ACCESS) accessToken: JwtAccessPayload) {
+    return this.myPageService.getMe(accessToken.id);
+  }
+}

--- a/backend/src/my-page/dto/response/get-me-response.dto.ts
+++ b/backend/src/my-page/dto/response/get-me-response.dto.ts
@@ -1,0 +1,8 @@
+import { BaseGetResponseDto } from '../../../common/dto/reponse/base-get-response.dto';
+import { UserModel } from '../../../user/entity/user.entity';
+
+export class GetMeResponseDto extends BaseGetResponseDto<UserModel> {
+  constructor(data: UserModel) {
+    super(data);
+  }
+}

--- a/backend/src/my-page/dto/service/my-page.service.ts
+++ b/backend/src/my-page/dto/service/my-page.service.ts
@@ -1,0 +1,20 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  IUSER_DOMAIN_SERVICE,
+  IUserDomainService,
+} from '../../../user/user-domain/interface/user-domain.service.interface';
+import { GetMeResponseDto } from '../response/get-me-response.dto';
+
+@Injectable()
+export class MyPageService {
+  constructor(
+    @Inject(IUSER_DOMAIN_SERVICE)
+    private readonly userDomainService: IUserDomainService,
+  ) {}
+
+  async getMe(userId: number) {
+    const me = await this.userDomainService.findUserById(userId);
+
+    return new GetMeResponseDto(me);
+  }
+}

--- a/backend/src/my-page/my-page.module.ts
+++ b/backend/src/my-page/my-page.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { RouterModule } from '@nestjs/core';
+import { MyPageController } from './dto/controller/my-page.controller';
+import { MyPageService } from './dto/service/my-page.service';
+import { UserDomainModule } from '../user/user-domain/user-domain.module';
+
+@Module({
+  imports: [
+    RouterModule.register([
+      {
+        path: 'me',
+        module: MyPageModule,
+      },
+    ]),
+    UserDomainModule,
+  ],
+  controllers: [MyPageController],
+  providers: [MyPageService],
+})
+export class MyPageModule {}

--- a/backend/src/report/controller/education-session-report.controller.ts
+++ b/backend/src/report/controller/education-session-report.controller.ts
@@ -24,7 +24,7 @@ import { Token } from '../../auth/decorator/jwt.decorator';
 import { AuthType } from '../../auth/const/enum/auth-type.enum';
 import { JwtAccessPayload } from '../../auth/type/jwt';
 
-@ApiTags('Me:Reports:Education-Sessions')
+@ApiTags('MyPage:Reports:Education-Sessions')
 @Controller('education-session')
 export class EducationSessionReportController {
   constructor(

--- a/backend/src/report/controller/task-report.controller.ts
+++ b/backend/src/report/controller/task-report.controller.ts
@@ -28,7 +28,7 @@ import { AuthType } from '../../auth/const/enum/auth-type.enum';
 import { Token } from '../../auth/decorator/jwt.decorator';
 import { JwtAccessPayload } from '../../auth/type/jwt';
 
-@ApiTags('Me:Reports:Tasks')
+@ApiTags('MyPage:Reports:Tasks')
 @Controller('tasks')
 export class TaskReportController {
   constructor(private readonly taskReportService: TaskReportService) {}

--- a/backend/src/report/controller/visitation-report.controller.ts
+++ b/backend/src/report/controller/visitation-report.controller.ts
@@ -28,7 +28,7 @@ import { AuthType } from '../../auth/const/enum/auth-type.enum';
 import { Token } from '../../auth/decorator/jwt.decorator';
 import { JwtAccessPayload } from '../../auth/type/jwt';
 
-@ApiTags('Me:Reports:Visitations')
+@ApiTags('MyPage:Reports:Visitations')
 @Controller('visitations')
 export class VisitationReportController {
   constructor(private readonly reportService: VisitationReportService) {}

--- a/backend/src/report/report.module.ts
+++ b/backend/src/report/report.module.ts
@@ -15,14 +15,11 @@ import { UserDomainModule } from '../user/user-domain/user-domain.module';
   imports: [
     RouterModule.register([
       {
-        //path: 'churches/:churchId/members/:memberId/reports',
         path: 'me/reports',
         module: ReportModule,
       },
     ]),
     UserDomainModule,
-    //ChurchesDomainModule,
-    //MembersDomainModule,
     VisitationReportDomainModule,
     TaskReportDomainModule,
     EducationSessionReportDomainModule,

--- a/backend/src/report/service/education-session-report.service.ts
+++ b/backend/src/report/service/education-session-report.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
 import {
   IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE,
   IEducationSessionReportDomainService,
@@ -34,7 +34,11 @@ export class EducationSessionReportService {
     );
 
     if (!currentChurchUser) {
-      throw new BadRequestException('교회에 가입되지 않은 사용자');
+      throw new ForbiddenException('교회에 가입되지 않은 사용자');
+    }
+
+    if (!currentChurchUser.member) {
+      throw new ForbiddenException('교인 정보 없음');
     }
 
     return currentChurchUser.member;

--- a/backend/src/report/service/task-report.service.ts
+++ b/backend/src/report/service/task-report.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
 import {
   ITASK_REPORT_DOMAIN_SERVICE,
   ITaskReportDomainService,
@@ -32,7 +32,11 @@ export class TaskReportService {
     );
 
     if (!currentChurchUser) {
-      throw new BadRequestException('교회에 가입되지 않은 사용자');
+      throw new ForbiddenException('교회에 가입되지 않은 사용자');
+    }
+
+    if (!currentChurchUser.member) {
+      throw new ForbiddenException('교인 정보 없음');
     }
 
     return currentChurchUser.member;

--- a/backend/src/report/service/visitation-report.service.ts
+++ b/backend/src/report/service/visitation-report.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
 import {
   IVISITATION_REPORT_DOMAIN_SERVICE,
   IVisitationReportDomainService,
@@ -30,7 +30,11 @@ export class VisitationReportService {
     );
 
     if (!currentChurchUser) {
-      throw new BadRequestException('교회에 가입되지 않은 사용자');
+      throw new ForbiddenException('교회에 가입되지 않은 사용자');
+    }
+
+    if (!currentChurchUser.member) {
+      throw new ForbiddenException('교인 정보 없음');
     }
 
     return currentChurchUser.member;

--- a/backend/src/user/entity/user.entity.ts
+++ b/backend/src/user/entity/user.entity.ts
@@ -44,7 +44,4 @@ export class UserModel extends BaseModel {
 
   @OneToMany(() => ChurchJoinModel, (joinRequest) => joinRequest.user)
   joinRequest: ChurchJoinModel;
-
-  /*@OneToOne(() => MemberModel, (member) => member.user)
-  member: MemberModel;*/
 }

--- a/backend/src/user/user-domain/service/user-domain.service.ts
+++ b/backend/src/user/user-domain/service/user-domain.service.ts
@@ -49,13 +49,29 @@ export class UserDomainService implements IUserDomainService {
 
     const user = await repository
       .createQueryBuilder('user')
-      .leftJoinAndSelect(
-        'user.churchUser',
-        'churchUser',
-        'churchUser.leftAt IS NULL',
-      )
-      .leftJoinAndSelect('churchUser.church', 'church') // 교회
-      .leftJoinAndSelect('churchUser.member', 'member') // 교인
+      .leftJoin('user.churchUser', 'churchUser', 'churchUser.leftAt IS NULL')
+      .addSelect([
+        'churchUser.id',
+        'churchUser.createdAt',
+        'churchUser.updatedAt',
+        'churchUser.churchId',
+        'churchUser.memberId',
+        'churchUser.role',
+        'churchUser.joinedAt',
+      ])
+      .leftJoin('churchUser.church', 'church') // 교회
+      .addSelect([
+        'church.id',
+        'church.createdAt',
+        'church.updatedAt',
+        'church.name',
+        'church.phone',
+        'church.denomination',
+        'church.address',
+        'church.detailAddress',
+      ])
+      .leftJoin('churchUser.member', 'member') // 교인
+      .addSelect(['member.id', 'member.name', 'member.profileImageUrl'])
       .leftJoin('member.group', 'group') // 교인 - 그룹
       .addSelect(['group.id', 'group.name'])
       .leftJoin('member.officer', 'officer') // 교인 - 직분


### PR DESCRIPTION
## 주요 내용
- 로그인 사용자의 계정 및 교회 가입 정보를 조회하는 **/me API 엔드포인트** 추가
- 사용자 본인의 기본 정보와 함께, 현재 가입된 교회 정보 및 교회 내 역할·권한 정보를 포함한 응답 반환
- **TaskReport, VisitationReport, EducationReport** 조회 시, **ChurchUser에 교인(Member)이 연결되어 있지 않으면 예외 처리**

## 세부 내용
### API
- `GET /me` 경로 추가
- JWT 인증 기반으로 현재 로그인된 사용자의 정보를 조회
- `churchUser.leftAt IS NULL` 조건으로 현재 소속된 교회만 포함

### 응답 구조
- 사용자 기본 정보 (`id`, `name`, `mobilePhone`, `privacyPolicyAgreed`, `role`)
- 소속된 교회 목록 (`churchUser[]`) 및 각 교회 정보
  - 교회 정보 (`church`)
  - 교인 정보 (`member`: 이름, 직분, 그룹, 그룹 역할 등)
  - 역할 정보 (`role`, `joinedAt`)
  - 권한 템플릿 및 단위 권한 (`permissionTemplate.permissionUnits`)
  - 권한 범위 (`permissionScopes`)

### 리포트 조회 시 교인 연결 여부 검증
- `/me/reports/tasks`, `/me/reports/visitations`, `/me/reports/educations` 요청 시, 현재 로그인된 사용자가 소속된 교회의 **교인(Member)로 연결되어 있지 않으면 403 예외 반환**
- 내부적으로 `churchUser.memberId`가 존재하지 않는 경우를 감지하여 차단
- 명시적인 메시지와 함께 `ForbiddenException` 또는 커스텀 예외로 응답 처리

### 서비스 구조
- `MyPageController`, `MyPageService` 구성
- `UserModel` 기준으로 `churchUser`, `church`, `member` 등 관련 관계를 조건 필터와 함께 조회