### PR TITLE
feat: 마이페이지 및 리포트 API /me 경로 전환 기능 추가

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -67,6 +67,7 @@ import { WorshipModule } from './worship/worship.module';
 import { WorshipTargetGroupModel } from './worship/entity/worship-target-group.entity';
 import { CalendarModule } from './calendar/calendar.module';
 import { ChurchEventModel } from './calendar/entity/church-event.entity';
+import { MyPageModule } from './my-page/my-page.module';
 
 @Module({
   imports: [
@@ -198,8 +199,9 @@ import { ChurchEventModel } from './calendar/entity/church-event.entity';
       }),
       inject: [ConfigService],
     }),
-    //CommonModule,
     AuthModule,
+    MyPageModule,
+    ReportModule,
     UserModule,
     ChurchesModule,
     ChurchJoinModule,
@@ -210,7 +212,6 @@ import { ChurchEventModel } from './calendar/entity/church-event.entity';
     MembersModule,
     FamilyRelationModule,
     MemberHistoryModule,
-    ReportModule,
     ManagementModule,
     VisitationModule,
     TaskModule,

--- a/backend/src/church-join/service/church-join.service.ts
+++ b/backend/src/church-join/service/church-join.service.ts
@@ -66,7 +66,7 @@ export class ChurchJoinService {
     qr: QueryRunner,
   ) {
     const userId = accessPayload.id;
-    const user = await this.userDomainService.findUserById(userId);
+    const user = await this.userDomainService.findUserModelById(userId);
 
     /**
      * ChurchUserModel 조회로 소속된 교회가 있는지 확인

--- a/backend/src/churches/service/churches.service.ts
+++ b/backend/src/churches/service/churches.service.ts
@@ -59,7 +59,7 @@ export class ChurchesService {
     dto: CreateChurchDto,
     qr: QueryRunner,
   ) {
-    const ownerUser = await this.userDomainService.findUserById(
+    const ownerUser = await this.userDomainService.findUserModelById(
       accessPayload.id,
       qr,
     );
@@ -141,7 +141,7 @@ export class ChurchesService {
       qr,
     );
 
-    const oldOwnerUser = await this.userDomainService.findUserById(
+    const oldOwnerUser = await this.userDomainService.findUserModelById(
       church.ownerUserId,
       qr,
     );
@@ -160,7 +160,7 @@ export class ChurchesService {
         qr,
       );
 
-    const newOwnerUser = await this.userDomainService.findUserById(
+    const newOwnerUser = await this.userDomainService.findUserModelById(
       newOwnerChurchUser.userId,
       qr,
     );

--- a/backend/src/my-page/dto/controller/my-page.controller.ts
+++ b/backend/src/my-page/dto/controller/my-page.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { MyPageService } from '../service/my-page.service';
+import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
+import { Token } from '../../../auth/decorator/jwt.decorator';
+import { AuthType } from '../../../auth/const/enum/auth-type.enum';
+import { JwtAccessPayload } from '../../../auth/type/jwt';
+
+@Controller()
+export class MyPageController {
+  constructor(private readonly myPageService: MyPageService) {}
+
+  @Get()
+  @UseGuards(AccessTokenGuard)
+  getMe(@Token(AuthType.ACCESS) accessToken: JwtAccessPayload) {
+    return this.myPageService.getMe(accessToken.id);
+  }
+}

--- a/backend/src/my-page/dto/response/get-me-response.dto.ts
+++ b/backend/src/my-page/dto/response/get-me-response.dto.ts
@@ -1,0 +1,8 @@
+import { BaseGetResponseDto } from '../../../common/dto/reponse/base-get-response.dto';
+import { UserModel } from '../../../user/entity/user.entity';
+
+export class GetMeResponseDto extends BaseGetResponseDto<UserModel> {
+  constructor(data: UserModel) {
+    super(data);
+  }
+}

--- a/backend/src/my-page/dto/service/my-page.service.ts
+++ b/backend/src/my-page/dto/service/my-page.service.ts
@@ -1,0 +1,20 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  IUSER_DOMAIN_SERVICE,
+  IUserDomainService,
+} from '../../../user/user-domain/interface/user-domain.service.interface';
+import { GetMeResponseDto } from '../response/get-me-response.dto';
+
+@Injectable()
+export class MyPageService {
+  constructor(
+    @Inject(IUSER_DOMAIN_SERVICE)
+    private readonly userDomainService: IUserDomainService,
+  ) {}
+
+  async getMe(userId: number) {
+    const me = await this.userDomainService.findUserById(userId);
+
+    return new GetMeResponseDto(me);
+  }
+}

--- a/backend/src/my-page/my-page.module.ts
+++ b/backend/src/my-page/my-page.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { RouterModule } from '@nestjs/core';
+import { MyPageController } from './dto/controller/my-page.controller';
+import { MyPageService } from './dto/service/my-page.service';
+import { UserDomainModule } from '../user/user-domain/user-domain.module';
+
+@Module({
+  imports: [
+    RouterModule.register([
+      {
+        path: 'me',
+        module: MyPageModule,
+      },
+    ]),
+    UserDomainModule,
+  ],
+  controllers: [MyPageController],
+  providers: [MyPageService],
+})
+export class MyPageModule {}

--- a/backend/src/report/controller/education-session-report.controller.ts
+++ b/backend/src/report/controller/education-session-report.controller.ts
@@ -24,7 +24,7 @@ import { Token } from '../../auth/decorator/jwt.decorator';
 import { AuthType } from '../../auth/const/enum/auth-type.enum';
 import { JwtAccessPayload } from '../../auth/type/jwt';
 
-@ApiTags('Me:Reports:Education-Sessions')
+@ApiTags('MyPage:Reports:Education-Sessions')
 @Controller('education-session')
 export class EducationSessionReportController {
   constructor(

--- a/backend/src/report/controller/education-session-report.controller.ts
+++ b/backend/src/report/controller/education-session-report.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Patch,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import { EducationSessionReportService } from '../service/education-session-report.service';
 import { GetEducationSessionReportDto } from '../dto/education-report/session/request/get-education-session-report.dto';
@@ -18,8 +19,12 @@ import {
   ApiGetEducationSessionReports,
   ApiPatchEducationSessionReport,
 } from '../const/swagger/education-session-report.swagger';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { Token } from '../../auth/decorator/jwt.decorator';
+import { AuthType } from '../../auth/const/enum/auth-type.enum';
+import { JwtAccessPayload } from '../../auth/type/jwt';
 
-@ApiTags('Churches:Members:Reports:Education-Sessions')
+@ApiTags('Me:Reports:Education-Sessions')
 @Controller('education-session')
 export class EducationSessionReportController {
   constructor(
@@ -27,59 +32,55 @@ export class EducationSessionReportController {
   ) {}
 
   @ApiGetEducationSessionReports()
+  @UseGuards(AccessTokenGuard)
   @Get()
   getEducationSessionReport(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Query() dto: GetEducationSessionReportDto,
   ) {
     return this.educationSessionReportService.getEducationSessionReports(
-      churchId,
-      memberId,
+      accessToken.id,
       dto,
     );
   }
 
   @ApiGetEducationSessionReportById()
+  @UseGuards(AccessTokenGuard)
   @Get(':educationSessionReportId')
   getEducationSessionReportById(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('educationSessionReportId', ParseIntPipe) reportId: number,
   ) {
     return this.educationSessionReportService.getEducationSessionReportById(
-      churchId,
-      memberId,
+      accessToken.id,
       reportId,
     );
   }
 
   @ApiPatchEducationSessionReport()
+  @UseGuards(AccessTokenGuard)
   @Patch(':educationSessionReportId')
   patchEducationSessionReport(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('educationSessionReportId', ParseIntPipe) reportId: number,
     @Body() dto: UpdateEducationSessionReportDto,
   ) {
     return this.educationSessionReportService.patchEducationSessionReport(
-      churchId,
-      memberId,
+      accessToken.id,
       reportId,
       dto,
     );
   }
 
   @ApiDeleteEducationSessionReport()
+  @UseGuards(AccessTokenGuard)
   @Delete(':educationSessionReportId')
   deleteEducationSessionReport(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('educationSessionReportId', ParseIntPipe) reportId: number,
   ) {
     return this.educationSessionReportService.deleteEducationSessionReport(
-      churchId,
-      memberId,
+      accessToken.id,
       reportId,
     );
   }

--- a/backend/src/report/controller/task-report.controller.ts
+++ b/backend/src/report/controller/task-report.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Patch,
   Query,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
@@ -22,6 +23,10 @@ import {
   ApiGetTaskReports,
   ApiPatchTaskReport,
 } from '../const/swagger/task-report.swagger';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { AuthType } from '../../auth/const/enum/auth-type.enum';
+import { Token } from '../../auth/decorator/jwt.decorator';
+import { JwtAccessPayload } from '../../auth/type/jwt';
 
 @ApiTags('Churches:Members:Reports:Tasks')
 @Controller('tasks')
@@ -30,26 +35,25 @@ export class TaskReportController {
 
   @ApiGetTaskReports()
   @Get()
+  @UseGuards(AccessTokenGuard)
   getTaskReports(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
     @Query() dto: GetTaskReportDto,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
   ) {
-    return this.taskReportService.getTaskReports(churchId, memberId, dto);
+    return this.taskReportService.getTaskReports(accessToken.id, dto);
   }
 
   @ApiGetTaskReportById()
   @Get(':taskReportId')
+  @UseGuards(AccessTokenGuard)
   @UseInterceptors(TransactionInterceptor)
   getTaskReportById(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('taskReportId', ParseIntPipe) taskReportId: number,
     @QueryRunner() qr: QR,
   ) {
     return this.taskReportService.getTaskReportById(
-      churchId,
-      memberId,
+      accessToken.id,
       taskReportId,
       qr,
     );

--- a/backend/src/report/controller/task-report.controller.ts
+++ b/backend/src/report/controller/task-report.controller.ts
@@ -28,7 +28,7 @@ import { AuthType } from '../../auth/const/enum/auth-type.enum';
 import { Token } from '../../auth/decorator/jwt.decorator';
 import { JwtAccessPayload } from '../../auth/type/jwt';
 
-@ApiTags('Churches:Members:Reports:Tasks')
+@ApiTags('Me:Reports:Tasks')
 @Controller('tasks')
 export class TaskReportController {
   constructor(private readonly taskReportService: TaskReportService) {}
@@ -60,31 +60,29 @@ export class TaskReportController {
   }
 
   @ApiPatchTaskReport()
+  @UseGuards(AccessTokenGuard)
   @Patch(':taskReportId')
   patchTaskReport(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('taskReportId', ParseIntPipe) taskReportId: number,
     @Body() dto: UpdateTaskReportDto,
   ) {
     return this.taskReportService.patchTaskReport(
-      churchId,
-      memberId,
+      accessToken.id,
       taskReportId,
       dto,
     );
   }
 
   @ApiDeleteTaskReport()
+  @UseGuards(AccessTokenGuard)
   @Delete(':taskReportId')
   deleteTaskReport(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('taskReportId', ParseIntPipe) taskReportId: number,
   ) {
     return this.taskReportService.deleteTaskReport(
-      churchId,
-      memberId,
+      accessToken.id,
       taskReportId,
     );
   }

--- a/backend/src/report/controller/task-report.controller.ts
+++ b/backend/src/report/controller/task-report.controller.ts
@@ -28,7 +28,7 @@ import { AuthType } from '../../auth/const/enum/auth-type.enum';
 import { Token } from '../../auth/decorator/jwt.decorator';
 import { JwtAccessPayload } from '../../auth/type/jwt';
 
-@ApiTags('Me:Reports:Tasks')
+@ApiTags('MyPage:Reports:Tasks')
 @Controller('tasks')
 export class TaskReportController {
   constructor(private readonly taskReportService: TaskReportService) {}

--- a/backend/src/report/controller/visitation-report.controller.ts
+++ b/backend/src/report/controller/visitation-report.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Patch,
   Query,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
@@ -22,65 +23,66 @@ import {
   ApiPatchVisitationReport,
 } from '../const/swagger/visitation-report.swagger';
 import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { AuthType } from '../../auth/const/enum/auth-type.enum';
+import { Token } from '../../auth/decorator/jwt.decorator';
+import { JwtAccessPayload } from '../../auth/type/jwt';
 
-@ApiTags('Churches:Members:Reports:Visitations')
+@ApiTags('Me:Reports:Visitations')
 @Controller('visitations')
 export class VisitationReportController {
   constructor(private readonly reportService: VisitationReportService) {}
 
   @ApiGetVisitationReports()
+  @UseGuards(AccessTokenGuard)
   @Get()
   getVisitationReports(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Query() dto: GetVisitationReportDto,
   ) {
-    return this.reportService.getVisitationReport(churchId, memberId, dto);
+    return this.reportService.getVisitationReport(accessToken.id, dto);
   }
 
   @ApiGetVisitationReportById()
+  @UseGuards(AccessTokenGuard)
   @Get(':visitationReportId')
   @UseInterceptors(TransactionInterceptor)
   getVisitationReportById(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('visitationReportId', ParseIntPipe) visitationReportId: number,
     @QueryRunner() qr: QR,
   ) {
     return this.reportService.getVisitationReportById(
-      churchId,
-      memberId,
+      accessToken.id,
       visitationReportId,
       qr,
     );
   }
 
   @ApiPatchVisitationReport()
+  @UseGuards(AccessTokenGuard)
   @Patch(':visitationReportId')
   patchVisitationReport(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('visitationReportId', ParseIntPipe) visitationReportId: number,
     @Body() dto: UpdateVisitationReportDto,
   ) {
     return this.reportService.updateVisitationReport(
-      churchId,
-      memberId,
+      accessToken.id,
       visitationReportId,
       dto,
     );
   }
 
   @ApiDeleteVisitationReport()
+  @UseGuards(AccessTokenGuard)
   @Delete(':visitationReportId')
   deleteVisitationReport(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
     @Param('visitationReportId', ParseIntPipe) visitationReportId: number,
   ) {
     return this.reportService.deleteVisitationReport(
-      churchId,
-      memberId,
+      accessToken.id,
       visitationReportId,
     );
   }

--- a/backend/src/report/controller/visitation-report.controller.ts
+++ b/backend/src/report/controller/visitation-report.controller.ts
@@ -28,7 +28,7 @@ import { AuthType } from '../../auth/const/enum/auth-type.enum';
 import { Token } from '../../auth/decorator/jwt.decorator';
 import { JwtAccessPayload } from '../../auth/type/jwt';
 
-@ApiTags('Me:Reports:Visitations')
+@ApiTags('MyPage:Reports:Visitations')
 @Controller('visitations')
 export class VisitationReportController {
   constructor(private readonly reportService: VisitationReportService) {}

--- a/backend/src/report/report.module.ts
+++ b/backend/src/report/report.module.ts
@@ -2,8 +2,6 @@ import { Module } from '@nestjs/common';
 import { VisitationReportDomainModule } from './report-domain/visitation-report-domain.module';
 import { RouterModule } from '@nestjs/core';
 import { VisitationReportController } from './controller/visitation-report.controller';
-import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
-import { MembersDomainModule } from '../members/member-domain/members-domain.module';
 import { VisitationReportService } from './service/visitation-report.service';
 import { TaskReportController } from './controller/task-report.controller';
 import { TaskReportService } from './service/task-report.service';
@@ -11,7 +9,6 @@ import { TaskReportDomainModule } from './report-domain/task-report-domain.modul
 import { EducationSessionReportController } from './controller/education-session-report.controller';
 import { EducationSessionReportService } from './service/education-session-report.service';
 import { EducationSessionReportDomainModule } from './report-domain/education-session-report-domain.module';
-import { ChurchUserDomainModule } from '../church-user/church-user-domain/church-user-domain.module';
 import { UserDomainModule } from '../user/user-domain/user-domain.module';
 
 @Module({
@@ -24,9 +21,8 @@ import { UserDomainModule } from '../user/user-domain/user-domain.module';
       },
     ]),
     UserDomainModule,
-    ChurchesDomainModule,
-    ChurchUserDomainModule,
-    MembersDomainModule,
+    //ChurchesDomainModule,
+    //MembersDomainModule,
     VisitationReportDomainModule,
     TaskReportDomainModule,
     EducationSessionReportDomainModule,

--- a/backend/src/report/report.module.ts
+++ b/backend/src/report/report.module.ts
@@ -15,14 +15,11 @@ import { UserDomainModule } from '../user/user-domain/user-domain.module';
   imports: [
     RouterModule.register([
       {
-        //path: 'churches/:churchId/members/:memberId/reports',
         path: 'me/reports',
         module: ReportModule,
       },
     ]),
     UserDomainModule,
-    //ChurchesDomainModule,
-    //MembersDomainModule,
     VisitationReportDomainModule,
     TaskReportDomainModule,
     EducationSessionReportDomainModule,

--- a/backend/src/report/report.module.ts
+++ b/backend/src/report/report.module.ts
@@ -11,16 +11,21 @@ import { TaskReportDomainModule } from './report-domain/task-report-domain.modul
 import { EducationSessionReportController } from './controller/education-session-report.controller';
 import { EducationSessionReportService } from './service/education-session-report.service';
 import { EducationSessionReportDomainModule } from './report-domain/education-session-report-domain.module';
+import { ChurchUserDomainModule } from '../church-user/church-user-domain/church-user-domain.module';
+import { UserDomainModule } from '../user/user-domain/user-domain.module';
 
 @Module({
   imports: [
     RouterModule.register([
       {
-        path: 'churches/:churchId/members/:memberId/reports',
+        //path: 'churches/:churchId/members/:memberId/reports',
+        path: 'me/reports',
         module: ReportModule,
       },
     ]),
+    UserDomainModule,
     ChurchesDomainModule,
+    ChurchUserDomainModule,
     MembersDomainModule,
     VisitationReportDomainModule,
     TaskReportDomainModule,

--- a/backend/src/report/service/education-session-report.service.ts
+++ b/backend/src/report/service/education-session-report.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
 import {
   IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE,
   IEducationSessionReportDomainService,
@@ -34,7 +34,11 @@ export class EducationSessionReportService {
     );
 
     if (!currentChurchUser) {
-      throw new BadRequestException('교회에 가입되지 않은 사용자');
+      throw new ForbiddenException('교회에 가입되지 않은 사용자');
+    }
+
+    if (!currentChurchUser.member) {
+      throw new ForbiddenException('교인 정보 없음');
     }
 
     return currentChurchUser.member;

--- a/backend/src/report/service/education-session-report.service.ts
+++ b/backend/src/report/service/education-session-report.service.ts
@@ -1,12 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
-import {
-  ICHURCHES_DOMAIN_SERVICE,
-  IChurchesDomainService,
-} from '../../churches/churches-domain/interface/churches-domain.service.interface';
-import {
-  IMEMBERS_DOMAIN_SERVICE,
-  IMembersDomainService,
-} from '../../members/member-domain/interface/members-domain.service.interface';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import {
   IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE,
   IEducationSessionReportDomainService,
@@ -18,34 +10,45 @@ import { PatchEducationSessionReportResponseDto } from '../dto/education-report/
 import { GetEducationSessionReportResponseDto } from '../dto/education-report/session/response/get-education-session-report-response.dto';
 import { QueryRunner } from 'typeorm';
 import { DeleteEducationSessionReportResponseDto } from '../dto/education-report/session/response/delete-education-session-report-response.dto';
+import {
+  IUSER_DOMAIN_SERVICE,
+  IUserDomainService,
+} from '../../user/user-domain/interface/user-domain.service.interface';
+import { MemberModel } from '../../members/entity/member.entity';
 
 @Injectable()
 export class EducationSessionReportService {
   constructor(
-    @Inject(ICHURCHES_DOMAIN_SERVICE)
-    private readonly churchesDomainService: IChurchesDomainService,
-    @Inject(IMEMBERS_DOMAIN_SERVICE)
-    private readonly membersDomainService: IMembersDomainService,
+    @Inject(IUSER_DOMAIN_SERVICE)
+    private readonly userDomainService: IUserDomainService,
 
     @Inject(IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE)
     private readonly educationSessionReportDomainService: IEducationSessionReportDomainService,
   ) {}
 
+  private async getCurrentMember(userId: number): Promise<MemberModel> {
+    const user = await this.userDomainService.findUserById(userId);
+
+    const currentChurchUser = user.churchUser.find(
+      (churchUser) => churchUser.leftAt === null,
+    );
+
+    if (!currentChurchUser) {
+      throw new BadRequestException('교회에 가입되지 않은 사용자');
+    }
+
+    return currentChurchUser.member;
+  }
+
   async getEducationSessionReports(
-    churchId: number,
-    memberId: number,
+    userId: number,
     dto: GetEducationSessionReportDto,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-    );
+    const currentMember = await this.getCurrentMember(userId);
 
     const { data, totalCount } =
       await this.educationSessionReportDomainService.findEducationSessionReports(
-        receiver,
+        currentMember,
         dto,
       );
 
@@ -58,17 +61,8 @@ export class EducationSessionReportService {
     );
   }
 
-  async getEducationSessionReportById(
-    churchId: number,
-    receiverId: number,
-    reportId: number,
-  ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      receiverId,
-    );
+  async getEducationSessionReportById(userId: number, reportId: number) {
+    const receiver = await this.getCurrentMember(userId);
 
     const report =
       await this.educationSessionReportDomainService.findEducationSessionReportById(
@@ -81,17 +75,11 @@ export class EducationSessionReportService {
   }
 
   async patchEducationSessionReport(
-    churchId: number,
-    memberId: number,
+    userId: number,
     reportId: number,
     dto: UpdateEducationSessionReportDto,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-    );
+    const receiver = await this.getCurrentMember(userId);
 
     const targetReport =
       await this.educationSessionReportDomainService.findEducationSessionReportModelById(
@@ -115,18 +103,11 @@ export class EducationSessionReportService {
   }
 
   async deleteEducationSessionReport(
-    churchId: number,
-    receiverId: number,
+    userId: number,
     reportId: number,
     qr?: QueryRunner,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      receiverId,
-    );
+    const receiver = await this.getCurrentMember(userId);
 
     const deleteTarget =
       await this.educationSessionReportDomainService.findEducationSessionReportModelById(

--- a/backend/src/report/service/task-report.service.ts
+++ b/backend/src/report/service/task-report.service.ts
@@ -3,14 +3,6 @@ import {
   ITASK_REPORT_DOMAIN_SERVICE,
   ITaskReportDomainService,
 } from '../report-domain/interface/task-report-domain.service.interface';
-import {
-  ICHURCHES_DOMAIN_SERVICE,
-  IChurchesDomainService,
-} from '../../churches/churches-domain/interface/churches-domain.service.interface';
-import {
-  IMEMBERS_DOMAIN_SERVICE,
-  IMembersDomainService,
-} from '../../members/member-domain/interface/members-domain.service.interface';
 import { GetTaskReportDto } from '../dto/task-report/get-task-report.dto';
 import { TaskReportPaginationResultDto } from '../dto/task-report/task-report-pagination-result.dto';
 import { QueryRunner } from 'typeorm';
@@ -19,10 +11,6 @@ import { UpdateTaskReportDto } from '../dto/task-report/request/update-task-repo
 import { PatchTaskReportResponseDto } from '../dto/task-report/response/patch-task-report-response.dto';
 import { DeleteTaskReportResponseDto } from '../dto/task-report/response/delete-task-report-response.dto';
 import {
-  ICHURCH_USER_DOMAIN_SERVICE,
-  IChurchUserDomainService,
-} from '../../church-user/church-user-domain/service/interface/church-user-domain.service.interface';
-import {
   IUSER_DOMAIN_SERVICE,
   IUserDomainService,
 } from '../../user/user-domain/interface/user-domain.service.interface';
@@ -30,20 +18,13 @@ import {
 @Injectable()
 export class TaskReportService {
   constructor(
-    @Inject(ICHURCHES_DOMAIN_SERVICE)
-    private readonly churchesDomainService: IChurchesDomainService,
-    @Inject(IMEMBERS_DOMAIN_SERVICE)
-    private readonly membersDomainService: IMembersDomainService,
-
     @Inject(ITASK_REPORT_DOMAIN_SERVICE)
     private readonly taskReportDomainService: ITaskReportDomainService,
-    @Inject(ICHURCH_USER_DOMAIN_SERVICE)
-    private readonly churchUserDomainService: IChurchUserDomainService,
     @Inject(IUSER_DOMAIN_SERVICE)
     private readonly userDomainService: IUserDomainService,
   ) {}
 
-  async getTaskReports(userId: number, dto: GetTaskReportDto) {
+  private async getCurrentMember(userId: number) {
     const user = await this.userDomainService.findUserById(userId);
 
     const currentChurchUser = user.churchUser.find(
@@ -54,9 +35,15 @@ export class TaskReportService {
       throw new BadRequestException('교회에 가입되지 않은 사용자');
     }
 
+    return currentChurchUser.member;
+  }
+
+  async getTaskReports(userId: number, dto: GetTaskReportDto) {
+    const receiver = await this.getCurrentMember(userId);
+
     const { data, totalCount } =
       await this.taskReportDomainService.findTaskReportsByReceiver(
-        currentChurchUser.member,
+        receiver,
         dto,
       );
 
@@ -74,29 +61,10 @@ export class TaskReportService {
     taskReportId: number,
     qr: QueryRunner,
   ) {
-    /*const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-      qr,
-      //{ user: true },
-    );*/
-    const user = await this.userDomainService.findUserById(userId);
-
-    const currentChurchUser = user.churchUser.find(
-      (churchUser) => churchUser.leftAt === null,
-    );
-
-    if (!currentChurchUser) {
-      throw new BadRequestException('교회에 가입되지 않은 사용자');
-    }
+    const receiver = await this.getCurrentMember(userId);
 
     const report = await this.taskReportDomainService.findTaskReportById(
-      //receiver,
-      currentChurchUser.member,
+      receiver,
       taskReportId,
       true,
       qr,
@@ -106,18 +74,11 @@ export class TaskReportService {
   }
 
   async patchTaskReport(
-    churchId: number,
-    memberId: number,
+    userId: number,
     taskReportId: number,
     dto: UpdateTaskReportDto,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-    );
+    const receiver = await this.getCurrentMember(userId);
 
     const targetTaskReport =
       await this.taskReportDomainService.findTaskReportModelById(
@@ -137,18 +98,8 @@ export class TaskReportService {
     return new PatchTaskReportResponseDto(updatedTaskReport);
   }
 
-  async deleteTaskReport(
-    churchId: number,
-    receiverId: number,
-    taskReportId: number,
-  ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      receiverId,
-    );
+  async deleteTaskReport(userId: number, taskReportId: number) {
+    const receiver = await this.getCurrentMember(userId);
 
     const targetReport =
       await this.taskReportDomainService.findTaskReportModelById(

--- a/backend/src/report/service/task-report.service.ts
+++ b/backend/src/report/service/task-report.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
 import {
   ITASK_REPORT_DOMAIN_SERVICE,
   ITaskReportDomainService,
@@ -32,7 +32,11 @@ export class TaskReportService {
     );
 
     if (!currentChurchUser) {
-      throw new BadRequestException('교회에 가입되지 않은 사용자');
+      throw new ForbiddenException('교회에 가입되지 않은 사용자');
+    }
+
+    if (!currentChurchUser.member) {
+      throw new ForbiddenException('교인 정보 없음');
     }
 
     return currentChurchUser.member;

--- a/backend/src/report/service/visitation-report.service.ts
+++ b/backend/src/report/service/visitation-report.service.ts
@@ -1,46 +1,43 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import {
   IVISITATION_REPORT_DOMAIN_SERVICE,
   IVisitationReportDomainService,
 } from '../report-domain/interface/visitation-report-domain.service.interface';
 import { GetVisitationReportDto } from '../dto/visitation-report/get-visitation-report.dto';
-import {
-  ICHURCHES_DOMAIN_SERVICE,
-  IChurchesDomainService,
-} from '../../churches/churches-domain/interface/churches-domain.service.interface';
-import {
-  IMEMBERS_DOMAIN_SERVICE,
-  IMembersDomainService,
-} from '../../members/member-domain/interface/members-domain.service.interface';
 import { VisitationReportPaginationResultDto } from '../dto/visitation-report/visitation-report-pagination-result.dto';
 import { QueryRunner } from 'typeorm';
 import { UpdateVisitationReportDto } from '../dto/visitation-report/update-visitation-report.dto';
+import {
+  IUSER_DOMAIN_SERVICE,
+  IUserDomainService,
+} from '../../user/user-domain/interface/user-domain.service.interface';
 
 @Injectable()
 export class VisitationReportService {
   constructor(
-    @Inject(ICHURCHES_DOMAIN_SERVICE)
-    private readonly churchesDomainService: IChurchesDomainService,
-    @Inject(IMEMBERS_DOMAIN_SERVICE)
-    private readonly membersDomainService: IMembersDomainService,
+    @Inject(IUSER_DOMAIN_SERVICE)
+    private readonly userDomainService: IUserDomainService,
 
     @Inject(IVISITATION_REPORT_DOMAIN_SERVICE)
     private readonly visitationReportDomainService: IVisitationReportDomainService,
   ) {}
 
-  async getVisitationReport(
-    churchId: number,
-    memberId: number,
-    dto: GetVisitationReportDto,
-  ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-      undefined,
-      //{ user: true },
+  private async getCurrentMember(userId: number) {
+    const user = await this.userDomainService.findUserById(userId);
+
+    const currentChurchUser = user.churchUser.find(
+      (churchUser) => churchUser.leftAt === null,
     );
+
+    if (!currentChurchUser) {
+      throw new BadRequestException('교회에 가입되지 않은 사용자');
+    }
+
+    return currentChurchUser.member;
+  }
+
+  async getVisitationReport(userId: number, dto: GetVisitationReportDto) {
+    const receiver = await this.getCurrentMember(userId);
 
     const { data, totalCount } =
       await this.visitationReportDomainService.findVisitationReportsByReceiver(
@@ -55,35 +52,14 @@ export class VisitationReportService {
       dto.page,
       Math.ceil(totalCount / dto.take),
     );
-
-    /*const paginationResult: VisitationReportPaginationResultDto = {
-      totalCount,
-      data: data,
-      count: dto.take,
-      page: dto.page,
-      totalPage: Math.ceil(totalCount / dto.take),
-    };
-
-    return paginationResult;*/
   }
 
   async getVisitationReportById(
-    churchId: number,
-    memberId: number,
+    userId: number,
     visitationReportId: number,
     qr: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-      qr,
-      //{ user: true },
-    );
+    const receiver = await this.getCurrentMember(userId);
 
     return this.visitationReportDomainService.findVisitationReportById(
       receiver,
@@ -94,18 +70,11 @@ export class VisitationReportService {
   }
 
   async updateVisitationReport(
-    churchId: number,
-    memberId: number,
+    userId: number,
     visitationReportId: number,
     dto: UpdateVisitationReportDto,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-    );
+    const receiver = await this.getCurrentMember(userId);
 
     const targetReport =
       await this.visitationReportDomainService.findVisitationReportModelById(
@@ -125,18 +94,8 @@ export class VisitationReportService {
     );
   }
 
-  async deleteVisitationReport(
-    churchId: number,
-    memberId: number,
-    visitationReportId: number,
-  ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
-    const receiver = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-    );
+  async deleteVisitationReport(userId: number, visitationReportId: number) {
+    const receiver = await this.getCurrentMember(userId);
 
     const targetReport =
       await this.visitationReportDomainService.findVisitationReportModelById(

--- a/backend/src/report/service/visitation-report.service.ts
+++ b/backend/src/report/service/visitation-report.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
 import {
   IVISITATION_REPORT_DOMAIN_SERVICE,
   IVisitationReportDomainService,
@@ -30,7 +30,11 @@ export class VisitationReportService {
     );
 
     if (!currentChurchUser) {
-      throw new BadRequestException('교회에 가입되지 않은 사용자');
+      throw new ForbiddenException('교회에 가입되지 않은 사용자');
+    }
+
+    if (!currentChurchUser.member) {
+      throw new ForbiddenException('교인 정보 없음');
     }
 
     return currentChurchUser.member;

--- a/backend/src/user/entity/user.entity.ts
+++ b/backend/src/user/entity/user.entity.ts
@@ -44,7 +44,4 @@ export class UserModel extends BaseModel {
 
   @OneToMany(() => ChurchJoinModel, (joinRequest) => joinRequest.user)
   joinRequest: ChurchJoinModel;
-
-  /*@OneToOne(() => MemberModel, (member) => member.user)
-  member: MemberModel;*/
 }

--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -21,11 +21,11 @@ export class UserService {
   ) {}
 
   async getUserById(id: number) {
-    return this.userDomainService.findUserById(id);
+    return this.userDomainService.findUserModelById(id);
   }
 
   async getMyJoinRequest(userId: number, qr?: QueryRunner) {
-    const user = await this.userDomainService.findUserById(userId, qr);
+    const user = await this.userDomainService.findUserModelById(userId, qr);
 
     return this.churchJoinRequestsDomainService.findMyChurchJoinRequest(
       user,
@@ -34,7 +34,7 @@ export class UserService {
   }
 
   async cancelMyJoinRequest(userId: number, qr?: QueryRunner) {
-    const user = await this.userDomainService.findUserById(userId, qr);
+    const user = await this.userDomainService.findUserModelById(userId, qr);
 
     const joinRequest =
       await this.churchJoinRequestsDomainService.findMyPendingChurchJoinRequest(
@@ -56,7 +56,7 @@ export class UserService {
   }
 
   async getMyPendingJoinRequest(userId: number) {
-    const user = await this.userDomainService.findUserById(userId);
+    const user = await this.userDomainService.findUserModelById(userId);
 
     return this.churchJoinRequestsDomainService.findMyPendingChurchJoinRequest(
       user,

--- a/backend/src/user/user-domain/interface/user-domain.service.interface.ts
+++ b/backend/src/user/user-domain/interface/user-domain.service.interface.ts
@@ -7,7 +7,9 @@ import { UpdateUserDto } from '../../dto/update-user.dto';
 export const IUSER_DOMAIN_SERVICE = Symbol('IUserDomainService');
 
 export interface IUserDomainService {
-  findUserById(id: number, qr?: QueryRunner): Promise<UserModel>;
+  findUserById(userId: number, qr?: QueryRunner): Promise<UserModel>;
+
+  findUserModelById(id: number, qr?: QueryRunner): Promise<UserModel>;
 
   findUserModelByOAuth(
     provider: string,

--- a/backend/src/user/user-domain/service/user-domain.service.ts
+++ b/backend/src/user/user-domain/service/user-domain.service.ts
@@ -49,13 +49,29 @@ export class UserDomainService implements IUserDomainService {
 
     const user = await repository
       .createQueryBuilder('user')
-      .leftJoinAndSelect(
-        'user.churchUser',
-        'churchUser',
-        'churchUser.leftAt IS NULL',
-      )
-      .leftJoinAndSelect('churchUser.church', 'church') // 교회
-      .leftJoinAndSelect('churchUser.member', 'member') // 교인
+      .leftJoin('user.churchUser', 'churchUser', 'churchUser.leftAt IS NULL')
+      .addSelect([
+        'churchUser.id',
+        'churchUser.createdAt',
+        'churchUser.updatedAt',
+        'churchUser.churchId',
+        'churchUser.memberId',
+        'churchUser.role',
+        'churchUser.joinedAt',
+      ])
+      .leftJoin('churchUser.church', 'church') // 교회
+      .addSelect([
+        'church.id',
+        'church.createdAt',
+        'church.updatedAt',
+        'church.name',
+        'church.phone',
+        'church.denomination',
+        'church.address',
+        'church.detailAddress',
+      ])
+      .leftJoin('churchUser.member', 'member') // 교인
+      .addSelect(['member.id', 'member.name', 'member.profileImageUrl'])
       .leftJoin('member.group', 'group') // 교인 - 그룹
       .addSelect(['group.id', 'group.name'])
       .leftJoin('member.officer', 'officer') // 교인 - 직분

--- a/backend/src/worship/guard/worship-read-scope.guard.ts
+++ b/backend/src/worship/guard/worship-read-scope.guard.ts
@@ -25,13 +25,14 @@ import { ChurchUserRole } from '../../user/const/user-role.enum';
 import { PermissionScopeException } from '../../permission/exception/permission-scope.exception';
 import { WorshipModel } from '../entity/worship.entity';
 import { Request } from 'express';
+import { JwtAccessPayload } from '../../auth/type/jwt';
 
 export interface CustomRequest extends Request {
   church: ChurchModel;
   worship: WorshipModel;
   requestManager: ChurchUserModel;
   permissionScopeGroupIds: number[];
-  tokenPayload: any;
+  tokenPayload: JwtAccessPayload;
 }
 
 /**


### PR DESCRIPTION
## 주요 변경 사항
- **/me 엔드포인트 기반 마이페이지 기능** 및 **JWT 기반 리포트 조회 API 전환 작업**을 포함
- 기존 churchId, memberId 기반 API 구조를 사용자 토큰 기반 구조로 리팩토링하여, **프론트엔드와 사용자 경험 간결화** 목표를 달성

## 상세 변경 내용

### 1. /me API 신설 (마이페이지용 사용자 정보 조회)
- 로그인된 사용자의 기본 정보, 가입한 교회, 연결된 교인 정보, 역할, 권한 등을 조회하는 API 추가
- `/me` 응답 구조에 `churchUser`, `church`, `member`, `permissionTemplate`, `permissionScopes` 등 포함
- `leftAt IS NULL` 조건을 통해 탈퇴하지 않은 교회만 포함

### 2. 리포트 API 경로 변경
- `/churches/{churchId}/reports/*` → `/me/reports/*` 형식으로 변경
- 변경된 API 목록:
  - `GET /me/reports/tasks`
  - `GET /me/reports/visitations`
  - `GET /me/reports/education-session`
- 기존 경로는 제거 처리

### 3. 교인 연결 여부 검증 추가
- 리포트 API 호출 시, `ChurchUser`에 `member`가 연결되지 않은 경우 `ForbiddenException` 발생
- 모든 리포트 서비스에서 일관된 검증 로직 적용 (`churchUser.memberId` 기준)

### 4. 인증 처리
- 모든 /me 하위 API에 `JwtAuthGuard` 적용 완료

### 5. 테스트 및 문서
- 기존 Path Param 기반 테스트 제거
- `/me` 기반 단일 사용자 리포트 조회 테스트 추가

## 향후 작업 예정
- `/me` 기반 리포트 조회 응답 포맷 개선
