### PR TITLE
fix: 한국 기준 날짜로 예배 세션을 조회할 때 범위 시작 날짜가 누락되는 문제 수정

### DIFF
--- a/backend/src/management/officers/officer-domain/service/officers-domain.service.ts
+++ b/backend/src/management/officers/officer-domain/service/officers-domain.service.ts
@@ -131,8 +131,6 @@ export class OfficersDomainService implements IOfficersDomainService {
     });
 
     if (officer && officer.deletedAt) {
-      console.log(officer);
-
       await officersRepository.remove(officer);
 
       return false;

--- a/backend/src/worship/dto/request/worship-enrollment/get-worship-enrollments.dto.ts
+++ b/backend/src/worship/dto/request/worship-enrollment/get-worship-enrollments.dto.ts
@@ -1,8 +1,9 @@
 import { BaseOffsetPaginationRequestDto } from '../../../../common/dto/request/base-offset-pagination-request.dto';
 import { WorshipEnrollmentOrderEnum } from '../../../const/worship-enrollment-order.enum';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDate, IsEnum, IsNumber } from 'class-validator';
+import { IsEnum, IsNumber, Matches } from 'class-validator';
 import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
+import { fromZonedTime } from 'date-fns-tz';
 
 export class GetWorshipEnrollmentsDto extends BaseOffsetPaginationRequestDto<WorshipEnrollmentOrderEnum> {
   @ApiProperty({
@@ -23,18 +24,34 @@ export class GetWorshipEnrollmentsDto extends BaseOffsetPaginationRequestDto<Wor
   groupId: number;
 
   @ApiProperty({
-    description: '불러올 예배 세션 시작 날짜',
+    description: '불러올 예배 세션 시작 날짜 (YYYY-MM-DD)',
     required: false,
   })
   @IsOptionalNotNull()
-  @IsDate()
-  fromSessionDate: Date;
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, {
+    message: 'fromSessionDate는 YYYY-MM-DD 형식이어야 합니다.',
+  })
+  fromSessionDate: string;
 
   @ApiProperty({
-    description: '불러올 예배 세션 마지막 날짜',
+    description: '불러올 예배 세션 마지막 날짜 (YYYY-MM-DD)',
     required: false,
   })
   @IsOptionalNotNull()
-  @IsDate()
-  toSessionDate: Date;
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, {
+    message: 'toSessionDate는 YYYY-MM-DD 형식이어야 합니다.',
+  })
+  toSessionDate: string;
+
+  get fromSessionDateUtc(): Date | undefined {
+    return this.fromSessionDate
+      ? fromZonedTime(`${this.fromSessionDate}T00:00:00`, 'Asia/Seoul')
+      : undefined;
+  }
+
+  get toSessionDateUtc(): Date | undefined {
+    return this.toSessionDate
+      ? fromZonedTime(`${this.toSessionDate}T00:00:00`, 'Asia/Seoul')
+      : undefined;
+  }
 }

--- a/backend/src/worship/service/worship-enrollment.service.ts
+++ b/backend/src/worship/service/worship-enrollment.service.ts
@@ -169,11 +169,23 @@ export class WorshipEnrollmentService {
       (enrollment: WorshipEnrollmentModel) => enrollment.id,
     );
 
+    /*if (dto.fromSessionDate && !dto.toSessionDate) {
+      dto.toSessionDate = new Date(
+        dto.fromSessionDate.getTime() + 100 * 24 * 60 * 60 * 1000,
+      );
+    }
+
+    if (!dto.fromSessionDate && dto.toSessionDate) {
+      dto.fromSessionDate = new Date(
+        dto.toSessionDate.getTime() - 100 * 24 * 60 * 60 * 1000,
+      );
+    }*/
+
     const attendances =
       await this.worshipAttendanceDomainService.joinAttendance(
         enrollmentIds,
-        dto.fromSessionDate,
-        dto.toSessionDate,
+        dto.fromSessionDateUtc,
+        dto.toSessionDateUtc,
         qr,
       );
 


### PR DESCRIPTION
## 주요 내용
- WorshipEnrollment 조회 시 fromSessionDate와 toSessionDate 범위 조건에 해당하는 WorshipSession이 누락되는 문제를 해결

## 세부 내용

### WorshipSession 조회 범위 처리
- 기존에는 fromSessionDate/toSessionDate를 DTO에서 Date 타입으로 받으면서 암묵적 형변환이 일어났고, 사용자 입력 '2025-04-13'은 '2025-04-13T00:00:00.000Z'로 해석됨
- 이는 한국 기준으로는 오전 9시여서, 실제로 '2025-04-13' 예배 세션(저장 시 '2025-04-12T15:00:00.000Z')이 조회되지 않는 문제가 있었음
- DTO에서 두 필드를 `string`으로 정의하고, 정규식으로 `YYYY-MM-DD` 형식을 검증한 뒤, 컨트롤러에서 이를 한국 시간 기준으로 UTC 변환하여 쿼리하도록 수정

### 향후 확장 고려
- 현재는 한국 타임존으로 고정하여 처리하며, 이후 Time-Zone 헤더를 통해 유동적으로 타임존 지정 가능하도록 확장 예정