### PR TITLE
fix: 한국 기준 날짜로 예배 세션을 조회할 때 범위 시작 날짜가 누락되는 문제 수정

### DIFF
--- a/backend/src/common/const/time-zone.const.ts
+++ b/backend/src/common/const/time-zone.const.ts
@@ -1,0 +1,3 @@
+export enum TIME_ZONE {
+  SEOUL = 'Asia/Seoul',
+}

--- a/backend/src/worship/controller/worship-session.controller.ts
+++ b/backend/src/worship/controller/worship-session.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   GoneException,
+  Headers,
   Param,
   ParseIntPipe,
   Patch,
@@ -31,6 +32,7 @@ import {
 import { CreateWorshipSessionDto } from '../dto/request/worship-session/create-worship-session.dto';
 import { WorshipReadGuard } from '../guard/worship-read.guard';
 import { WorshipWriteGuard } from '../guard/worship-write.guard';
+import { TIME_ZONE } from '../../common/const/time-zone.const';
 
 @ApiTags('Worships:Sessions')
 @Controller(':worshipId/sessions')
@@ -75,11 +77,13 @@ export class WorshipSessionController {
   @WorshipReadGuard()
   @UseInterceptors(TransactionInterceptor)
   getOrPostRecentSession(
+    @Headers('time-zone') timeZone: TIME_ZONE = TIME_ZONE.SEOUL,
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('worshipId', ParseIntPipe) worshipId: number,
     @QueryRunner() qr: QR,
   ) {
     return this.worshipSessionService.getOrPostRecentSession(
+      timeZone,
       churchId,
       worshipId,
       qr,

--- a/backend/src/worship/dto/request/worship-enrollment/get-worship-enrollments.dto.ts
+++ b/backend/src/worship/dto/request/worship-enrollment/get-worship-enrollments.dto.ts
@@ -4,6 +4,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsNumber, Matches } from 'class-validator';
 import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
 import { fromZonedTime } from 'date-fns-tz';
+import { TIME_ZONE } from '../../../../common/const/time-zone.const';
 
 export class GetWorshipEnrollmentsDto extends BaseOffsetPaginationRequestDto<WorshipEnrollmentOrderEnum> {
   @ApiProperty({
@@ -45,13 +46,13 @@ export class GetWorshipEnrollmentsDto extends BaseOffsetPaginationRequestDto<Wor
 
   get fromSessionDateUtc(): Date | undefined {
     return this.fromSessionDate
-      ? fromZonedTime(`${this.fromSessionDate}T00:00:00`, 'Asia/Seoul')
+      ? fromZonedTime(`${this.fromSessionDate}T00:00:00`, TIME_ZONE.SEOUL)
       : undefined;
   }
 
   get toSessionDateUtc(): Date | undefined {
     return this.toSessionDate
-      ? fromZonedTime(`${this.toSessionDate}T00:00:00`, 'Asia/Seoul')
+      ? fromZonedTime(`${this.toSessionDate}T00:00:00`, TIME_ZONE.SEOUL)
       : undefined;
   }
 }

--- a/backend/src/worship/dto/request/worship-session/create-worship-session.dto.ts
+++ b/backend/src/worship/dto/request/worship-session/create-worship-session.dto.ts
@@ -6,27 +6,33 @@ import {
   MAX_WORSHIP_TITLE,
 } from '../../../constraints/worship.constraints';
 import {
-  IsDate,
   IsNumber,
   IsString,
   IsUrl,
+  Matches,
   MaxLength,
   Min,
 } from 'class-validator';
 import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
 import { PlainTextMaxLength } from '../../../../common/decorator/validator/plain-text-max-length.validator';
 import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
-import { Transform } from 'class-transformer';
 import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import { fromZonedTime } from 'date-fns-tz';
+import { TIME_ZONE } from '../../../../common/const/time-zone.const';
 
 @SanitizeDto()
 export class CreateWorshipSessionDto {
   @ApiProperty({
-    description: '예배 세션 진행 날짜 (필수)',
+    description: '예배 세션 진행 날짜 (필수, YYYY-MM-DD)',
   })
-  @IsDate()
-  @Transform(({ value }) => new Date(value.setHours(0, 0, 0, 0)))
-  sessionDate: Date;
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, {
+    message: 'sessionDate는 YYYY-MM-DD 형식이어야 합니다.',
+  })
+  sessionDate: string;
+
+  get sessionDateUtc(): Date {
+    return fromZonedTime(`${this.sessionDate}T00:00:00`, TIME_ZONE.SEOUL);
+  }
 
   @ApiProperty({
     description: '예배 세션 제목',

--- a/backend/src/worship/pipe/parse-date.pipe.ts
+++ b/backend/src/worship/pipe/parse-date.pipe.ts
@@ -3,10 +3,20 @@ import {
   BadRequestException,
   PipeTransform,
 } from '@nestjs/common';
+import { fromZonedTime } from 'date-fns-tz';
+import { TIME_ZONE } from '../../common/const/time-zone.const';
 
 export class ParseDatePipe implements PipeTransform {
-  transform(value: any, metadata: ArgumentMetadata): any {
-    const parsed = new Date(new Date(value).setHours(0, 0, 0, 0));
+  private static readonly DATE_REGEX: RegExp = /^\d{4}-\d{2}-\d{2}$/;
+
+  transform(value: string, metadata: ArgumentMetadata): any {
+    if (!ParseDatePipe.DATE_REGEX.test(value.trim())) {
+      throw new BadRequestException(
+        '날짜는 YYYY-MM-DD 형식의 문자열이어야 합니다.',
+      );
+    }
+
+    const parsed = fromZonedTime(value + 'T00:00:00.000', TIME_ZONE.SEOUL);
 
     if (isNaN(parsed.getTime())) {
       throw new BadRequestException('유효하지 않은 날짜 형식입니다.');

--- a/backend/src/worship/worship-domain/service/worship-session-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-session-domain.service.ts
@@ -193,14 +193,12 @@ export class WorshipSessionDomainService
   ): Promise<WorshipSessionModel> {
     const repository = this.getRepository(qr);
 
-    await this.assertValidNewSession(worship, dto.sessionDate, repository);
+    await this.assertValidNewSession(worship, dto.sessionDateUtc, repository);
     this.assertValidInChargeMember(inCharge);
 
     return repository.save({
       worshipId: worship.id,
-      //inChargeId: inCharge ? inCharge.id : null,
-      //...dto,
-      sessionDate: dto.sessionDate,
+      sessionDate: dto.sessionDateUtc,
       title: dto.title,
       bibleTitle: dto.title,
       description: dto.description,


### PR DESCRIPTION
## 주요 내용
- WorshipEnrollment 조회 시 fromSessionDate와 toSessionDate 범위 조건에 해당하는 WorshipSession이 누락되는 문제를 해결

## 세부 내용

### WorshipSession 조회 범위 처리
- 기존에는 fromSessionDate/toSessionDate를 DTO에서 Date 타입으로 받으면서 암묵적 형변환이 일어났고, 사용자 입력 '2025-04-13'은 '2025-04-13T00:00:00.000Z'로 해석됨
- 이는 한국 기준으로는 오전 9시여서, 실제로 '2025-04-13' 예배 세션(저장 시 '2025-04-12T15:00:00.000Z')이 조회되지 않는 문제가 있었음
- DTO에서 두 필드를 `string`으로 정의하고, 정규식으로 `YYYY-MM-DD` 형식을 검증한 뒤, 컨트롤러에서 이를 한국 시간 기준으로 UTC 변환하여 쿼리하도록 수정

### 향후 확장 고려
- 현재는 한국 타임존으로 고정하여 처리하며, 이후 Time-Zone 헤더를 통해 유동적으로 타임존 지정 가능하도록 확장 예정