### PR TITLE
fix: 한국 기준 날짜로 예배 세션을 조회할 때 범위 시작 날짜가 누락되는 문제 수정

### DIFF
--- a/backend/src/worship/dto/request/worship-enrollment/get-worship-enrollments.dto.ts
+++ b/backend/src/worship/dto/request/worship-enrollment/get-worship-enrollments.dto.ts
@@ -1,7 +1,7 @@
 import { BaseOffsetPaginationRequestDto } from '../../../../common/dto/request/base-offset-pagination-request.dto';
 import { WorshipEnrollmentOrderEnum } from '../../../const/worship-enrollment-order.enum';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsNumber, Matches } from 'class-validator';
+import { IsDateString, IsEnum, IsNumber, Matches } from 'class-validator';
 import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
 import { fromZonedTime } from 'date-fns-tz';
 import { TIME_ZONE } from '../../../../common/const/time-zone.const';
@@ -29,6 +29,7 @@ export class GetWorshipEnrollmentsDto extends BaseOffsetPaginationRequestDto<Wor
     required: false,
   })
   @IsOptionalNotNull()
+  @IsDateString({ strict: true })
   @Matches(/^\d{4}-\d{2}-\d{2}$/, {
     message: 'fromSessionDate는 YYYY-MM-DD 형식이어야 합니다.',
   })
@@ -39,6 +40,7 @@ export class GetWorshipEnrollmentsDto extends BaseOffsetPaginationRequestDto<Wor
     required: false,
   })
   @IsOptionalNotNull()
+  @IsDateString({ strict: true })
   @Matches(/^\d{4}-\d{2}-\d{2}$/, {
     message: 'toSessionDate는 YYYY-MM-DD 형식이어야 합니다.',
   })

--- a/backend/src/worship/pipe/parse-date.pipe.ts
+++ b/backend/src/worship/pipe/parse-date.pipe.ts
@@ -9,6 +9,8 @@ import { TIME_ZONE } from '../../common/const/time-zone.const';
 export class ParseDatePipe implements PipeTransform {
   private static readonly DATE_REGEX: RegExp = /^\d{4}-\d{2}-\d{2}$/;
 
+  constructor(private readonly timeZone: TIME_ZONE = TIME_ZONE.SEOUL) {}
+
   transform(value: string, metadata: ArgumentMetadata): any {
     if (!ParseDatePipe.DATE_REGEX.test(value.trim())) {
       throw new BadRequestException(
@@ -16,7 +18,7 @@ export class ParseDatePipe implements PipeTransform {
       );
     }
 
-    const parsed = fromZonedTime(value + 'T00:00:00.000', TIME_ZONE.SEOUL);
+    const parsed = fromZonedTime(value + 'T00:00:00.000', this.timeZone);
 
     if (isNaN(parsed.getTime())) {
       throw new BadRequestException('유효하지 않은 날짜 형식입니다.');


### PR DESCRIPTION
## 주요 내용
- WorshipEnrollment 조회 시 fromSessionDate와 toSessionDate 범위 조건에 해당하는 WorshipSession이 누락되는 문제를 해결

## 세부 내용

### WorshipSession 조회 범위 처리
- 기존에는 fromSessionDate/toSessionDate를 DTO에서 Date 타입으로 받으면서 암묵적 형변환이 일어났고, 사용자 입력 '2025-04-13'은 '2025-04-13T00:00:00.000Z'로 해석됨
- 이는 한국 기준으로는 오전 9시여서, 실제로 '2025-04-13' 예배 세션(저장 시 '2025-04-12T15:00:00.000Z')이 조회되지 않는 문제가 있었음
- DTO에서 두 필드를 `string`으로 정의하고, 정규식으로 `YYYY-MM-DD` 형식을 검증한 뒤, 컨트롤러에서 이를 한국 시간 기준으로 UTC 변환하여 쿼리하도록 수정

### 향후 확장 고려
- 현재는 한국 타임존으로 고정하여 처리하며, 이후 Time-Zone 헤더를 통해 유동적으로 타임존 지정 가능하도록 확장 예정