### PR TITLE
feat: 그룹 순서를 위한 order 컬럼 추가 및 구조 수정/조회 정렬 기능 반영

### DIFF
--- a/backend/src/management/groups/const/group-order.enum.ts
+++ b/backend/src/management/groups/const/group-order.enum.ts
@@ -2,4 +2,5 @@ export enum GroupOrderEnum {
   createdAt = 'createdAt',
   updatedAt = 'updatedAt',
   name = 'name',
+  order = 'order',
 }

--- a/backend/src/management/groups/const/swagger/group.swagger.ts
+++ b/backend/src/management/groups/const/swagger/group.swagger.ts
@@ -40,16 +40,28 @@ export const ApiGetGroupById = () =>
     }),
   );
 
-export const ApiPatchGroup = () =>
+export const ApiPatchGroupName = () =>
   applyDecorators(
     ApiOperation({
-      summary: '그룹 수정',
+      summary: '그룹 이름 수정',
       description:
-        '<h2>교회 내의 그룹을 수정합니다.</h2>' +
+        '<h2>교회 내의 그룹의 이름을 수정합니다.</h2>' +
         '<p>수정 가능 요소</p>' +
-        '<p>1. 그룹 이름 (중복 불가)</p>' +
+        '<p>1. 그룹 이름 (중복 불가)</p>' /* +
         '<p>2. 상위 그룹</p>' +
-        '<p>상위 그룹을 없애려는 경우 ministryGroupId 를 null 로 설정</p>',
+        '<p>상위 그룹을 없애려는 경우 ministryGroupId 를 null 로 설정</p>',*/,
+    }),
+  );
+
+export const ApiPatchGroupStructure = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '그룹 구조 수정',
+      description:
+        '<h2>교회 내의 그룹의 구조를 수정합니다.</h2>' +
+        '<p>수정 가능 요소</p>' +
+        '<p>1. 순서 (order): 필수값</p>' +
+        '<p>2. 상위 그룹 (최상위 그룹으로 바꿀 경우 parentGroupId 를 null 로 설정</p>',
     }),
   );
 

--- a/backend/src/management/groups/controller/groups.controller.ts
+++ b/backend/src/management/groups/controller/groups.controller.ts
@@ -14,25 +14,24 @@ import {
 import { ApiTags } from '@nestjs/swagger';
 import { GroupsService } from '../service/groups.service';
 import { CreateGroupDto } from '../dto/group/create-group.dto';
-import { UpdateGroupDto } from '../dto/group/update-group.dto';
+import { UpdateGroupNameDto } from '../dto/group/update-group-name.dto';
 import { QueryRunner as QR } from 'typeorm';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 import {
   ApiDeleteGroup,
-  ApiGetChildGroupIds,
   ApiGetGroupById,
   ApiGetGroups,
-  ApiGetGroupsByName,
-  ApiPatchGroup,
+  ApiPatchGroupName,
+  ApiPatchGroupStructure,
   ApiPostGroups,
 } from '../const/swagger/group.swagger';
 import { GetGroupDto } from '../dto/group/get-group.dto';
-import { GetGroupByNameDto } from '../dto/group/get-group-by-name.dto';
 import { GroupReadGuard } from '../guard/group-read.guard';
 import { GroupWriteGuard } from '../guard/group-write.guard';
 import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../../permission/guard/church-manager.guard';
+import { UpdateGroupStructureDto } from '../dto/group/update-group-structure.dto';
 
 @ApiTags('Management:Groups')
 @Controller('groups')
@@ -40,7 +39,6 @@ export class GroupsController {
   constructor(private readonly groupsService: GroupsService) {}
 
   @ApiGetGroups()
-  //@GroupReadGuard()
   @Get()
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   getGroups(
@@ -48,15 +46,6 @@ export class GroupsController {
     @Query() dto: GetGroupDto,
   ) {
     return this.groupsService.getGroups(churchId, dto);
-  }
-
-  @ApiGetGroupsByName()
-  @Get('search')
-  getGroupsByName(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Query() dto: GetGroupByNameDto,
-  ) {
-    return this.groupsService.getGroupsByName(churchId, dto);
   }
 
   @ApiPostGroups()
@@ -81,19 +70,6 @@ export class GroupsController {
     return this.groupsService.getGroupByIdWithParents(churchId, groupId);
   }
 
-  @ApiPatchGroup()
-  @GroupWriteGuard()
-  @Patch(':groupId')
-  @UseInterceptors(TransactionInterceptor)
-  patchGroup(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('groupId', ParseIntPipe) groupId: number,
-    @Body() dto: UpdateGroupDto,
-    @QueryRunner() qr: QR,
-  ) {
-    return this.groupsService.updateGroup(churchId, groupId, dto, qr);
-  }
-
   @ApiDeleteGroup()
   @GroupWriteGuard()
   @Delete(':groupId')
@@ -102,12 +78,46 @@ export class GroupsController {
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('groupId', ParseIntPipe) groupId: number,
     @QueryRunner() qr: QR,
-    //@Query('cascade', ParseBoolPipe) cascade: boolean = false,
   ) {
-    return this.groupsService.deleteGroup(churchId, groupId, qr /*cascade*/);
+    return this.groupsService.deleteGroup(churchId, groupId, qr);
   }
 
-  @ApiGetChildGroupIds()
+  @ApiPatchGroupName()
+  @GroupWriteGuard()
+  @Patch(':groupId/name')
+  @UseInterceptors(TransactionInterceptor)
+  patchGroup(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('groupId', ParseIntPipe) groupId: number,
+    @Body() dto: UpdateGroupNameDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.groupsService.updateGroupName(churchId, groupId, dto, qr);
+  }
+
+  @ApiPatchGroupStructure()
+  @Patch(':groupId/structure')
+  @GroupWriteGuard()
+  @UseInterceptors(TransactionInterceptor)
+  patchGroupStructure(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('groupId', ParseIntPipe) groupId: number,
+    @Body() dto: UpdateGroupStructureDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.groupsService.updateGroupStructure(churchId, groupId, dto, qr);
+  }
+
+  /*@ApiGetGroupsByName()
+  @Get('search')
+  getGroupsByName(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetGroupByNameDto,
+  ) {
+    return this.groupsService.getGroupsByName(churchId, dto);
+  }*/
+
+  /*@ApiGetChildGroupIds()
   @GroupReadGuard()
   @Get(':groupId/childGroups')
   getChildGroupIds(
@@ -115,5 +125,5 @@ export class GroupsController {
     @Param('groupId', ParseIntPipe) groupId: number,
   ) {
     return this.groupsService.getChildGroupIds(churchId, groupId);
-  }
+  }*/
 }

--- a/backend/src/management/groups/dto/group/get-group.dto.ts
+++ b/backend/src/management/groups/dto/group/get-group.dto.ts
@@ -13,12 +13,12 @@ export class GetGroupDto extends BaseOffsetPaginationRequestDto<GroupOrderEnum> 
   parentGroupId: number = 0;
 
   @ApiProperty({
-    description: '정렬 기준 (생성일, 수정일, 이름)',
+    description: '정렬 기준 (지정 순서, 생성일, 수정일, 이름)',
     enum: GroupOrderEnum,
-    default: GroupOrderEnum.createdAt,
+    default: GroupOrderEnum.order,
     required: false,
   })
   @IsEnum(GroupOrderEnum)
   @IsOptional()
-  order: GroupOrderEnum = GroupOrderEnum.createdAt;
+  order: GroupOrderEnum = GroupOrderEnum.order;
 }

--- a/backend/src/management/groups/dto/group/update-group-name.dto.ts
+++ b/backend/src/management/groups/dto/group/update-group-name.dto.ts
@@ -1,0 +1,4 @@
+import { PickType } from '@nestjs/swagger';
+import { CreateGroupDto } from './create-group.dto';
+
+export class UpdateGroupNameDto extends PickType(CreateGroupDto, ['name']) {}

--- a/backend/src/management/groups/dto/group/update-group-structure.dto.ts
+++ b/backend/src/management/groups/dto/group/update-group-structure.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsOptional, Min } from 'class-validator';
+
+export class UpdateGroupStructureDto {
+  @ApiProperty({
+    description: '상위 그룹 ID',
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  parentGroupId?: number | null;
+
+  @ApiProperty({
+    description: '그룹의 디스플레이 순서',
+    required: true,
+  })
+  @IsNumber()
+  @Min(1)
+  order: number;
+}

--- a/backend/src/management/groups/dto/group/update-group.dto.ts
+++ b/backend/src/management/groups/dto/group/update-group.dto.ts
@@ -1,4 +1,0 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateGroupDto } from './create-group.dto';
-
-export class UpdateGroupDto extends PartialType(CreateGroupDto) {}

--- a/backend/src/management/groups/entity/group.entity.ts
+++ b/backend/src/management/groups/entity/group.entity.ts
@@ -11,6 +11,9 @@ export class GroupModel extends BaseModel {
   @Column()
   name: string;
 
+  @Column({ default: 1 })
+  order: number;
+
   @Index()
   @Column({ type: 'int', nullable: true })
   parentGroupId: number | null;

--- a/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
+++ b/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
@@ -1,11 +1,12 @@
 import { GroupModel } from '../../entity/group.entity';
 import { ChurchModel } from '../../../../churches/entity/church.entity';
-import { FindOptionsRelations, QueryRunner } from 'typeorm';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { CreateGroupDto } from '../../dto/group/create-group.dto';
-import { UpdateGroupDto } from '../../dto/group/update-group.dto';
+import { UpdateGroupNameDto } from '../../dto/group/update-group-name.dto';
 import { GetGroupDto } from '../../dto/group/get-group.dto';
 import { GetGroupByNameDto } from '../../dto/group/get-group-by-name.dto';
 import { GroupDomainPaginationResultDto } from '../dto/group-domain-pagination-result.dto';
+import { UpdateGroupStructureDto } from '../../dto/group/update-group-structure.dto';
 
 export interface ParentGroup {
   id: number;
@@ -77,13 +78,21 @@ export interface IGroupsDomainService {
     qr: QueryRunner,
   ): Promise<GroupModel>;
 
-  updateGroup(
+  updateGroupName(
     church: ChurchModel,
     targetGroup: GroupModel,
-    dto: UpdateGroupDto,
+    dto: UpdateGroupNameDto,
+    qr: QueryRunner,
+    //newParentGroup: GroupModel | null,
+  ): Promise<UpdateResult>;
+
+  updateGroupStructure(
+    church: ChurchModel,
+    targetGroup: GroupModel,
+    dto: UpdateGroupStructureDto,
     qr: QueryRunner,
     newParentGroup: GroupModel | null,
-  ): Promise<GroupModel>;
+  ): Promise<UpdateResult>;
 
   deleteGroup(deleteTarget: GroupModel, qr: QueryRunner): Promise<void>;
 

--- a/backend/src/management/groups/service/groups.service.ts
+++ b/backend/src/management/groups/service/groups.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { GroupModel } from '../entity/group.entity';
 import { FindOptionsRelations, QueryRunner } from 'typeorm';
 import { CreateGroupDto } from '../dto/group/create-group.dto';
-import { UpdateGroupDto } from '../dto/group/update-group.dto';
+import { UpdateGroupNameDto } from '../dto/group/update-group-name.dto';
 import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
@@ -15,6 +15,7 @@ import { GetGroupDto } from '../dto/group/get-group.dto';
 import { GroupPaginationResultDto } from '../dto/response/group-pagination-result.dto';
 import { GroupDeleteResponseDto } from '../dto/response/group-delete-response.dto';
 import { GetGroupByNameDto } from '../dto/group/get-group-by-name.dto';
+import { UpdateGroupStructureDto } from '../dto/group/update-group-structure.dto';
 
 @Injectable()
 export class GroupsService {
@@ -103,10 +104,10 @@ export class GroupsService {
     return this.groupsDomainService.createGroup(church, dto, qr);
   }
 
-  async updateGroup(
+  async updateGroupStructure(
     churchId: number,
     groupId: number,
-    dto: UpdateGroupDto,
+    dto: UpdateGroupStructureDto,
     qr: QueryRunner,
   ) {
     const church = await this.churchesDomainService.findChurchModelById(
@@ -132,13 +133,43 @@ export class GroupsService {
               qr,
             ); // 새 상위 그룹으로 변경
 
-    return this.groupsDomainService.updateGroup(
+    await this.groupsDomainService.updateGroupStructure(
       church,
       targetGroup,
       dto,
       qr,
       newParentGroup,
     );
+
+    return this.groupsDomainService.findGroupById(church, targetGroup.id, qr);
+  }
+
+  async updateGroupName(
+    churchId: number,
+    groupId: number,
+    dto: UpdateGroupNameDto,
+    qr: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const targetGroup = await this.groupsDomainService.findGroupModelById(
+      church,
+      groupId,
+      qr,
+      { parentGroup: true },
+    );
+
+    await this.groupsDomainService.updateGroupName(
+      church,
+      targetGroup,
+      dto,
+      qr,
+    );
+
+    return this.groupsDomainService.findGroupById(church, targetGroup.id, qr);
   }
 
   async deleteGroup(churchId: number, groupId: number, qr: QueryRunner) {


### PR DESCRIPTION
## 주요 내용
- GroupModel에 그룹 표시 순서를 위한 `order` 컬럼 추가
- 그룹 생성 시 동일 계층 내 마지막 순서로 `order` 자동 설정
- 그룹 수정 기능을 이름 수정과 구조 수정으로 분리
- 그룹 목록 조회 시 `order` 기준 정렬 적용

## 세부 내용

### Entity
- `GroupModel`에 `order: number` 컬럼 추가
  - 프론트에서 사용자 지정 순서대로 그룹을 정렬하기 위한 용도

### API
- 그룹 생성 시 해당 계층의 가장 마지막 `order` 값을 기준으로 자동 설정

- 그룹 수정 엔드포인트 분리
  - **이름 수정**: `PATCH /churches/{churchId}/management/groups/{groupId}/name`
    - 기존 그룹 수정 시 제약과 동일하게 중복된 이름으로는 수정 불가
  - **구조 수정**: `PATCH /churches/{churchId}/management/groups/{groupId}/structure`
    - `parentGroupId`(nullable), `order` 필수
    - `parentGroupId`가 `null`이면 최상위 그룹으로 이동
    - `order` 변경 시 동일 계층 내 다른 그룹들의 `order`도 연쇄적으로 조정됨

- 그룹 목록 조회: `GET /churches/{churchId}/management/groups`
  - 동일 계층 내 그룹들을 `order` 기준 오름차순으로 정렬하여 반환