### PR TITLE
feat: OfficerModel에 order 컬럼 추가 및 정렬/수정 기능 구현

### DIFF
--- a/backend/src/management/groups/entity/group.entity.ts
+++ b/backend/src/management/groups/entity/group.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, Index, ManyToOne, OneToMany, Unique } from 'typeorm';
+import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
 import { GroupRoleModel } from './group-role.entity';
 import { BaseModel } from '../../../common/entity/base.entity';
 import { ChurchModel } from '../../../churches/entity/church.entity';
@@ -6,7 +6,7 @@ import { MemberModel } from '../../../members/entity/member.entity';
 import { GroupHistoryModel } from '../../../member-history/entity/group-history.entity';
 
 @Entity()
-@Unique(['name', 'parentGroupId', 'churchId'])
+//@Unique(['name', 'parentGroupId', 'churchId'])
 export class GroupModel extends BaseModel {
   @Column()
   name: string;

--- a/backend/src/management/officers/const/exception/officers.exception.ts
+++ b/backend/src/management/officers/const/exception/officers.exception.ts
@@ -2,4 +2,6 @@ export const OfficersException = {
   NOT_FOUND: '해당 직분을 찾을 수 없습니다.',
   ALREADY_EXIST: '이미 존재하는 직분입니다.',
   HAS_DEPENDENCIES: '해당 직분에 속한 교인이 존재합니다.',
+  INVALID_ORDER: '지정할 수 없는 순서입니다.',
+  UPDATE_ERROR: '직분 수정 도중 에러 발생',
 };

--- a/backend/src/management/officers/const/officer-order.enum.ts
+++ b/backend/src/management/officers/const/officer-order.enum.ts
@@ -2,4 +2,5 @@ export enum OfficerOrderEnum {
   createdAt = 'createdAt',
   updatedAt = 'updatedAt',
   name = 'name',
+  order = 'order',
 }

--- a/backend/src/management/officers/const/swagger/officers.swagger.ts
+++ b/backend/src/management/officers/const/swagger/officers.swagger.ts
@@ -15,10 +15,18 @@ export const ApiPostOfficer = () =>
     }),
   );
 
-export const ApiPatchOfficer = () =>
+export const ApiPatchOfficerName = () =>
   applyDecorators(
     ApiOperation({
-      summary: '직분 수정',
+      summary: '직분 이름 수정',
+    }),
+  );
+
+export const ApiPatchOfficerStructure = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '직분 구조 수정',
+      description: '<h2>교회 내 직분 구조(순서)를 수정합니다.</h2>',
     }),
   );
 

--- a/backend/src/management/officers/controller/officers.controller.ts
+++ b/backend/src/management/officers/controller/officers.controller.ts
@@ -12,8 +12,8 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { CreateOfficerDto } from '../dto/create-officer.dto';
-import { UpdateOfficerDto } from '../dto/update-officer.dto';
+import { CreateOfficerDto } from '../dto/request/create-officer.dto';
+import { UpdateOfficerNameDto } from '../dto/request/update-officer-name.dto';
 import { OfficersService } from '../service/officers.service';
 import { QueryRunner as QR } from 'typeorm';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
@@ -21,13 +21,15 @@ import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 import {
   ApiDeleteOfficer,
   ApiGetOfficers,
-  ApiPatchOfficer,
+  ApiPatchOfficerName,
+  ApiPatchOfficerStructure,
   ApiPostOfficer,
 } from '../const/swagger/officers.swagger';
 import { GetOfficersDto } from '../dto/request/get-officers.dto';
 import { OfficerWriteGuard } from '../guard/officer-write.guard';
 import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../../permission/guard/church-manager.guard';
+import { UpdateOfficerStructureDto } from '../dto/request/update-officer-structure.dto';
 
 @ApiTags('Management:Officers')
 @Controller('officers')
@@ -56,19 +58,6 @@ export class OfficersController {
     return this.officersService.createOfficer(churchId, dto, qr);
   }
 
-  @ApiPatchOfficer()
-  @OfficerWriteGuard()
-  @Patch(':officerId')
-  @UseInterceptors(TransactionInterceptor)
-  patchOfficer(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('officerId', ParseIntPipe) officerId: number,
-    @Body() dto: UpdateOfficerDto,
-    @QueryRunner() qr: QR,
-  ) {
-    return this.officersService.updateOfficer(churchId, officerId, dto, qr);
-  }
-
   @ApiDeleteOfficer()
   @OfficerWriteGuard()
   @Delete(':officerId')
@@ -79,5 +68,36 @@ export class OfficersController {
     @QueryRunner() qr: QR,
   ) {
     return this.officersService.deleteOfficer(churchId, officerId, qr);
+  }
+
+  @ApiPatchOfficerName()
+  @OfficerWriteGuard()
+  @Patch(':officerId/name')
+  @UseInterceptors(TransactionInterceptor)
+  patchOfficer(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('officerId', ParseIntPipe) officerId: number,
+    @Body() dto: UpdateOfficerNameDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.officersService.updateOfficerName(churchId, officerId, dto, qr);
+  }
+
+  @ApiPatchOfficerStructure()
+  @OfficerWriteGuard()
+  @Patch(':officerId/structure')
+  @UseInterceptors(TransactionInterceptor)
+  patchOfficerStructure(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('officerId', ParseIntPipe) officerId: number,
+    @Body() dto: UpdateOfficerStructureDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.officersService.updateOfficerStructure(
+      churchId,
+      officerId,
+      dto,
+      qr,
+    );
   }
 }

--- a/backend/src/management/officers/dto/request/create-officer.dto.ts
+++ b/backend/src/management/officers/dto/request/create-officer.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString } from 'class-validator';
-import { RemoveSpaces } from '../../../common/decorator/transformer/remove-spaces';
-import { IsNoSpecialChar } from '../../../common/decorator/validator/is-no-special-char.validator';
+import { RemoveSpaces } from '../../../../common/decorator/transformer/remove-spaces';
+import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
 
 export class CreateOfficerDto {
   @ApiProperty({

--- a/backend/src/management/officers/dto/request/get-officers.dto.ts
+++ b/backend/src/management/officers/dto/request/get-officers.dto.ts
@@ -5,12 +5,12 @@ import { IsEnum, IsOptional } from 'class-validator';
 
 export class GetOfficersDto extends BaseOffsetPaginationRequestDto<OfficerOrderEnum> {
   @ApiProperty({
-    description: '정렬 기준 (생성일, 수정일, 이름)',
+    description: '정렬 기준 (지정 순서, 생성일, 수정일, 이름)',
     enum: OfficerOrderEnum,
-    default: OfficerOrderEnum.createdAt,
+    default: OfficerOrderEnum.order,
     required: false,
   })
   @IsEnum(OfficerOrderEnum)
   @IsOptional()
-  order: OfficerOrderEnum = OfficerOrderEnum.createdAt;
+  order: OfficerOrderEnum = OfficerOrderEnum.order;
 }

--- a/backend/src/management/officers/dto/request/update-officer-name.dto.ts
+++ b/backend/src/management/officers/dto/request/update-officer-name.dto.ts
@@ -1,4 +1,6 @@
 import { PickType } from '@nestjs/swagger';
 import { CreateOfficerDto } from './create-officer.dto';
 
-export class UpdateOfficerDto extends PickType(CreateOfficerDto, ['name']) {}
+export class UpdateOfficerNameDto extends PickType(CreateOfficerDto, [
+  'name',
+]) {}

--- a/backend/src/management/officers/dto/request/update-officer-structure.dto.ts
+++ b/backend/src/management/officers/dto/request/update-officer-structure.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, Min } from 'class-validator';
+
+export class UpdateOfficerStructureDto {
+  @ApiProperty({
+    description: '디스플레이 순서',
+    required: true,
+  })
+  @IsNumber()
+  @Min(1)
+  order: number;
+}

--- a/backend/src/management/officers/entity/officer.entity.ts
+++ b/backend/src/management/officers/entity/officer.entity.ts
@@ -1,11 +1,10 @@
-import { Column, Entity, Index, ManyToOne, OneToMany, Unique } from 'typeorm';
+import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
 import { BaseModel } from '../../../common/entity/base.entity';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { OfficerHistoryModel } from '../../../member-history/entity/officer-history.entity';
 
 @Entity()
-@Unique(['name', 'churchId'])
 export class OfficerModel extends BaseModel {
   @Index()
   @Column()
@@ -16,6 +15,9 @@ export class OfficerModel extends BaseModel {
 
   @Column({ length: 30, nullable: true })
   name: string;
+
+  @Column({ default: 1 })
+  order: number;
 
   @Column({ default: 0 })
   membersCount: number;
@@ -28,16 +30,4 @@ export class OfficerModel extends BaseModel {
     (officerHistory) => officerHistory.officer,
   )
   history: OfficerHistoryModel[];
-
-  /*@BeforeRemove()
-  @BeforeSoftRemove()
-  preventIfHasMember() {
-    if (this.members.length > 0) {
-      const memberNames = this.members.map((m) => m.name).join(', ');
-
-      throw new ConflictException(
-        `해당 직분을 갖고 있는 교인이 존재합니다.\n${memberNames}`,
-      );
-    }
-  }*/
 }

--- a/backend/src/management/officers/officer-domain/interface/officers-domain.service.interface.ts
+++ b/backend/src/management/officers/officer-domain/interface/officers-domain.service.interface.ts
@@ -1,8 +1,8 @@
 import { ChurchModel } from '../../../../churches/entity/church.entity';
-import { FindOptionsRelations, QueryRunner } from 'typeorm';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { OfficerModel } from '../../entity/officer.entity';
-import { CreateOfficerDto } from '../../dto/create-officer.dto';
-import { UpdateOfficerDto } from '../../dto/update-officer.dto';
+import { CreateOfficerDto } from '../../dto/request/create-officer.dto';
+import { UpdateOfficerNameDto } from '../../dto/request/update-officer-name.dto';
 import { GetOfficersDto } from '../../dto/request/get-officers.dto';
 import { OfficerDomainPaginationResultDto } from '../../dto/officer-domain-pagination-result.dto';
 
@@ -34,12 +34,19 @@ export interface IOfficersDomainService {
     qr: QueryRunner,
   ): Promise<OfficerModel>;
 
-  updateOfficer(
+  updateOfficerName(
     church: ChurchModel,
     officer: OfficerModel,
-    dto: UpdateOfficerDto,
+    dto: UpdateOfficerNameDto,
     qr?: QueryRunner,
   ): Promise<OfficerModel>;
+
+  updateOfficerStructure(
+    church: ChurchModel,
+    targetOfficer: OfficerModel,
+    order: number,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
 
   deleteOfficer(officer: OfficerModel, qr?: QueryRunner): Promise<void>;
 

--- a/backend/src/management/officers/officer-domain/service/officers-domain.service.ts
+++ b/backend/src/management/officers/officer-domain/service/officers-domain.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   ConflictException,
   Injectable,
+  InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
 import { IOfficersDomainService } from '../interface/officers-domain.service.interface';
@@ -11,13 +12,15 @@ import {
   FindOptionsOrder,
   FindOptionsRelations,
   IsNull,
+  MoreThanOrEqual,
   QueryRunner,
   Repository,
+  UpdateResult,
 } from 'typeorm';
 import { ChurchModel } from '../../../../churches/entity/church.entity';
 import { OfficersException } from '../../const/exception/officers.exception';
-import { CreateOfficerDto } from '../../dto/create-officer.dto';
-import { UpdateOfficerDto } from '../../dto/update-officer.dto';
+import { CreateOfficerDto } from '../../dto/request/create-officer.dto';
+import { UpdateOfficerNameDto } from '../../dto/request/update-officer-name.dto';
 import { GetOfficersDto } from '../../dto/request/get-officers.dto';
 import { OfficerDomainPaginationResultDto } from '../../dto/officer-domain-pagination-result.dto';
 import { OfficerOrderEnum } from '../../const/officer-order.enum';
@@ -151,27 +154,87 @@ export class OfficersDomainService implements IOfficersDomainService {
         churchId: church.id,
         name: dto.name,
       },
-      withDeleted: true,
     });
 
     if (existOfficer) {
-      if (existOfficer.deletedAt) {
-        await officersRepository.remove(existOfficer);
-      } else {
-        throw new ConflictException(OfficersException.ALREADY_EXIST);
-      }
+      throw new ConflictException(OfficersException.ALREADY_EXIST);
     }
+
+    const lastOrderOfficer = await this.officersRepository.find({
+      where: {
+        churchId: church.id,
+      },
+      order: {
+        order: 'DESC',
+      },
+      take: 1,
+    });
+
+    const order = lastOrderOfficer ? lastOrderOfficer[0].order + 1 : 1;
 
     return officersRepository.save({
       churchId: church.id,
       ...dto,
+      order,
     });
   }
 
-  async updateOfficer(
+  async updateOfficerStructure(
+    church: ChurchModel,
+    targetOfficer: OfficerModel,
+    order: number,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const officersRepository = this.getOfficersRepository(qr);
+
+    const lastOrderOfficer = await this.officersRepository.find({
+      where: {
+        churchId: church.id,
+      },
+      order: {
+        order: 'desc',
+      },
+      take: 1,
+    });
+
+    if (lastOrderOfficer[0]) {
+      if (lastOrderOfficer[0].order < order) {
+        throw new ConflictException(OfficersException.INVALID_ORDER);
+      }
+    }
+
+    // 그 외 직분 순서 일괄 변경
+    await officersRepository.update(
+      {
+        churchId: church.id,
+        order: MoreThanOrEqual(order),
+      },
+      {
+        order: () => 'order + 1',
+      },
+    );
+
+    // 수정 대상 직분 순서 변경
+    const result = await officersRepository.update(
+      {
+        id: targetOfficer.id,
+      },
+      {
+        order,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(OfficersException.UPDATE_ERROR);
+    }
+
+    return result;
+  }
+
+  async updateOfficerName(
     church: ChurchModel,
     officer: OfficerModel,
-    dto: UpdateOfficerDto,
+    dto: UpdateOfficerNameDto,
     qr?: QueryRunner,
   ) {
     const officersRepository = this.getOfficersRepository(qr);

--- a/backend/src/management/officers/service/officers.service.ts
+++ b/backend/src/management/officers/service/officers.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { QueryRunner } from 'typeorm';
-import { CreateOfficerDto } from '../dto/create-officer.dto';
-import { UpdateOfficerDto } from '../dto/update-officer.dto';
+import { CreateOfficerDto } from '../dto/request/create-officer.dto';
+import { UpdateOfficerNameDto } from '../dto/request/update-officer-name.dto';
 import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
@@ -15,6 +15,7 @@ import { OfficerPaginationResponseDto } from '../dto/response/officer-pagination
 import { OfficerPostResponse } from '../dto/response/officer-post-response.dto';
 import { OfficerPatchResponse } from '../dto/response/officer-patch.response.dto';
 import { OfficerDeleteResponse } from '../dto/response/officer-delete-response.dto';
+import { UpdateOfficerStructureDto } from '../dto/request/update-officer-structure.dto';
 
 @Injectable()
 export class OfficersService {
@@ -65,10 +66,41 @@ export class OfficersService {
     return new OfficerPostResponse(officer);
   }
 
-  async updateOfficer(
+  async updateOfficerStructure(
     churchId: number,
     officerId: number,
-    dto: UpdateOfficerDto,
+    dto: UpdateOfficerStructureDto,
+    qr: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const targetOfficer = await this.officersDomainService.findOfficerModelById(
+      church,
+      officerId,
+      qr,
+    );
+
+    await this.officersDomainService.updateOfficerStructure(
+      church,
+      targetOfficer,
+      dto.order,
+      qr,
+    );
+
+    return this.officersDomainService.findOfficerById(
+      church,
+      targetOfficer.id,
+      qr,
+    );
+  }
+
+  async updateOfficerName(
+    churchId: number,
+    officerId: number,
+    dto: UpdateOfficerNameDto,
     qr?: QueryRunner,
   ) {
     const church = await this.churchesDomainService.findChurchModelById(
@@ -82,7 +114,7 @@ export class OfficersService {
       qr,
     );
 
-    const updatedOfficer = await this.officersDomainService.updateOfficer(
+    const updatedOfficer = await this.officersDomainService.updateOfficerName(
       church,
       officer,
       dto,


### PR DESCRIPTION
## 주요 내용
- OfficerModel에 직분 순서를 지정할 수 있는 `order` 컬럼 추가
- 직분 생성 시 가장 마지막 순서로 자동 설정
- 직분 수정 시 이름 수정과 순서 수정 기능 분리
- 직분 목록 조회 시 `order` 기준 정렬 적용

## 세부 내용

### Entity
- `OfficerModel`에 `order: number` 컬럼 추가
  - 프론트에서 직분 목록을 사용자 지정 순서대로 정렬하기 위한 용도

### API
- 직분 생성 시 기존 직분 중 가장 높은 `order` 값을 기준으로 마지막 순서로 설정

- 직분 수정 엔드포인트 분리
  - **이름 수정**: `PATCH /churches/{churchId}/management/officers/{officerId}/name`
    - 중복된 이름으로는 수정 불가
  - **순서 수정**: `PATCH /churches/{churchId}/management/officers/{officerId}/structure`
    - `order` 필수
    - `order` 변경 시 다른 직분들의 순서도 연쇄적으로 조정됨

- 직분 목록 조회: `GET /churches/{churchId}/management/officers`
  - `order` 기준 오름차순으로 정렬되어 반환