### PR TITLE
fix: 그룹/직분/사역그룹 순서 정렬 로직 개선 및 사역그룹 order 기능 추가

### DIFF
--- a/backend/src/management/ministries/const/ministry-group-order.enum.ts
+++ b/backend/src/management/ministries/const/ministry-group-order.enum.ts
@@ -1,5 +1,6 @@
 export enum MinistryGroupOrderEnum {
-  createdAt = 'createdAt',
-  updatedAt = 'updatedAt',
-  name = 'name',
+  CREATED_AT = 'createdAt',
+  UPDATED_AT = 'updatedAt',
+  NAME = 'name',
+  ORDER = 'order',
 }

--- a/backend/src/management/ministries/controller/ministry-groups.controller.ts
+++ b/backend/src/management/ministries/controller/ministry-groups.controller.ts
@@ -15,14 +15,14 @@ import { MinistryGroupService } from '../service/ministry-group.service';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CreateMinistryGroupDto } from '../dto/ministry-group/create-ministry-group.dto';
 import { QueryRunner as QR } from 'typeorm';
-import { UpdateMinistryGroupDto } from '../dto/ministry-group/update-ministry-group.dto';
+import { UpdateMinistryGroupNameDto } from '../dto/ministry-group/update-ministry-group-name.dto';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 import { GetMinistryGroupDto } from '../dto/ministry-group/get-ministry-group.dto';
-import { MinistryReadGuard } from '../guard/ministry-read.guard';
 import { MinistryWriteGuard } from '../guard/ministry-write.guard';
 import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../../permission/guard/church-manager.guard';
+import { UpdateMinistryGroupStructureDto } from '../dto/ministry-group/update-ministry-group-structure.dto';
 
 @ApiTags('Management:MinistryGroups')
 @Controller('ministry-groups')
@@ -49,40 +49,6 @@ export class MinistryGroupsController {
     return this.ministryGroupService.createMinistryGroup(churchId, dto, qr);
   }
 
-  @Get(':ministryGroupId')
-  @MinistryReadGuard()
-  getMinistryGroupById(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('ministryGroupId', ParseIntPipe) ministryGroupId: number,
-  ) {
-    return this.ministryGroupService.getMinistryGroupById(
-      churchId,
-      ministryGroupId,
-    );
-  }
-
-  @ApiOperation({
-    summary: '사역 그룹 수정',
-    description:
-      '최상위 그룹으로 설정하려는 경우 parentMinistryGroupId 를 null 로 설정',
-  })
-  @Patch(':ministryGroupId')
-  @MinistryWriteGuard()
-  @UseInterceptors(TransactionInterceptor)
-  patchMinistryGroup(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('ministryGroupId', ParseIntPipe) ministryGroupId: number,
-    @Body() dto: UpdateMinistryGroupDto,
-    @QueryRunner() qr: QR,
-  ) {
-    return this.ministryGroupService.updateMinistryGroup(
-      churchId,
-      ministryGroupId,
-      dto,
-      qr,
-    );
-  }
-
   @Delete(':ministryGroupId')
   @MinistryWriteGuard()
   @UseInterceptors(TransactionInterceptor)
@@ -98,7 +64,46 @@ export class MinistryGroupsController {
     );
   }
 
-  @Get(':ministryGroupId/childGroups')
+  @ApiOperation({
+    summary: '사역 그룹 수정',
+    description:
+      '최상위 그룹으로 설정하려는 경우 parentMinistryGroupId 를 null 로 설정',
+  })
+  @Patch(':ministryGroupId/name')
+  @MinistryWriteGuard()
+  @UseInterceptors(TransactionInterceptor)
+  patchMinistryGroupName(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('ministryGroupId', ParseIntPipe) ministryGroupId: number,
+    @Body() dto: UpdateMinistryGroupNameDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.ministryGroupService.updateMinistryGroupName(
+      churchId,
+      ministryGroupId,
+      dto,
+      qr,
+    );
+  }
+
+  @Patch(':ministryGroupId/structure')
+  @MinistryWriteGuard()
+  @UseInterceptors(TransactionInterceptor)
+  patchMinistryGroupStructure(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('ministryGroupId', ParseIntPipe) ministryGroupId: number,
+    @Body() dto: UpdateMinistryGroupStructureDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.ministryGroupService.updateMinistryGroupStructure(
+      churchId,
+      ministryGroupId,
+      dto,
+      qr,
+    );
+  }
+
+  /*@Get(':ministryGroupId/childGroups')
   @MinistryReadGuard()
   getChildGroups(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -108,5 +113,17 @@ export class MinistryGroupsController {
       churchId,
       ministryGroupId,
     );
-  }
+  }*/
+
+  /*@Get(':ministryGroupId')
+  @MinistryReadGuard()
+  getMinistryGroupById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('ministryGroupId', ParseIntPipe) ministryGroupId: number,
+  ) {
+    return this.ministryGroupService.getMinistryGroupById(
+      churchId,
+      ministryGroupId,
+    );
+  }*/
 }

--- a/backend/src/management/ministries/dto/ministry-group/get-ministry-group.dto.ts
+++ b/backend/src/management/ministries/dto/ministry-group/get-ministry-group.dto.ts
@@ -15,10 +15,10 @@ export class GetMinistryGroupDto extends BaseOffsetPaginationRequestDto<Ministry
   @ApiProperty({
     description: '정렬 기준 (생성일, 수정일, 이름)',
     enum: MinistryGroupOrderEnum,
-    default: MinistryGroupOrderEnum.createdAt,
+    default: MinistryGroupOrderEnum.ORDER,
     required: false,
   })
   @IsEnum(MinistryGroupOrderEnum)
   @IsOptional()
-  order: MinistryGroupOrderEnum = MinistryGroupOrderEnum.createdAt;
+  order: MinistryGroupOrderEnum = MinistryGroupOrderEnum.ORDER;
 }

--- a/backend/src/management/ministries/dto/ministry-group/update-ministry-group-name.dto.ts
+++ b/backend/src/management/ministries/dto/ministry-group/update-ministry-group-name.dto.ts
@@ -1,0 +1,7 @@
+import { PickType } from '@nestjs/swagger';
+import { CreateMinistryGroupDto } from './create-ministry-group.dto';
+
+export class UpdateMinistryGroupNameDto extends PickType(
+  CreateMinistryGroupDto,
+  ['name'],
+) {}

--- a/backend/src/management/ministries/dto/ministry-group/update-ministry-group-structure.dto.ts
+++ b/backend/src/management/ministries/dto/ministry-group/update-ministry-group-structure.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsOptional, Min } from 'class-validator';
+
+export class UpdateMinistryGroupStructureDto {
+  @ApiProperty({
+    description: '지정 순서',
+    required: true,
+  })
+  @IsNumber()
+  @Min(1)
+  order: number;
+
+  @ApiProperty({
+    description: '상위 사역 그룹 ID',
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  parentMinistryGroupId?: number | null;
+}

--- a/backend/src/management/ministries/dto/ministry-group/update-ministry-group.dto.ts
+++ b/backend/src/management/ministries/dto/ministry-group/update-ministry-group.dto.ts
@@ -1,6 +1,0 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateMinistryGroupDto } from './create-ministry-group.dto';
-
-export class UpdateMinistryGroupDto extends PartialType(
-  CreateMinistryGroupDto,
-) {}

--- a/backend/src/management/ministries/entity/ministry-group.entity.ts
+++ b/backend/src/management/ministries/entity/ministry-group.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, Index, ManyToOne, OneToMany, Unique } from 'typeorm';
+import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
 import { MinistryModel } from './ministry.entity';
 import {
   BaseModel,
@@ -7,10 +7,13 @@ import {
 import { ChurchModel } from '../../../churches/entity/church.entity';
 
 @Entity()
-@Unique(['parentMinistryGroupId', 'churchId', 'name'])
+//@Unique(['parentMinistryGroupId', 'churchId', 'name'])
 export class MinistryGroupModel extends BaseModel {
   @Column({ length: 50, comment: '사역 그룹 이름' })
   name: string;
+
+  @Column({ default: 1 })
+  order: number;
 
   @Column({ nullable: true })
   @Index()

--- a/backend/src/management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface.ts
+++ b/backend/src/management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface.ts
@@ -1,10 +1,11 @@
 import { MinistryGroupModel } from '../../entity/ministry-group.entity';
 import { ChurchModel } from '../../../../churches/entity/church.entity';
-import { FindOptionsRelations, QueryRunner } from 'typeorm';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { CreateMinistryGroupDto } from '../../dto/ministry-group/create-ministry-group.dto';
-import { UpdateMinistryGroupDto } from '../../dto/ministry-group/update-ministry-group.dto';
+import { UpdateMinistryGroupNameDto } from '../../dto/ministry-group/update-ministry-group-name.dto';
 import { GetMinistryGroupDto } from '../../dto/ministry-group/get-ministry-group.dto';
 import { MinistryGroupDomainPaginationResponseDto } from '../../dto/ministry-group/response/ministry-group-domain-pagination-response.dto';
+import { UpdateMinistryGroupStructureDto } from '../../dto/ministry-group/update-ministry-group-structure.dto';
 
 export const IMINISTRY_GROUPS_DOMAIN_SERVICE = Symbol(
   'IMINISTRY_GROUPS_DOMAIN_SERVICE',
@@ -61,17 +62,23 @@ export interface IMinistryGroupsDomainService {
     qr: QueryRunner,
   ): Promise<MinistryGroupModel>;
 
-  updateMinistryGroup(
+  updateMinistryGroupName(
     church: ChurchModel,
     targetMinistryGroup: MinistryGroupModel,
-    dto: UpdateMinistryGroupDto,
+    dto: UpdateMinistryGroupNameDto,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  updateMinistryGroupStructure(
+    church: ChurchModel,
+    targetMinistryGroup: MinistryGroupModel,
+    dto: UpdateMinistryGroupStructureDto,
     qr: QueryRunner,
     newParentMinistryGroup: MinistryGroupModel | null,
   ): Promise<MinistryGroupWithParentGroups>;
 
   deleteMinistryGroup(
     church: ChurchModel,
-    //ministryGroupId: number,
     targetMinistryGroup: MinistryGroupModel,
     qr: QueryRunner,
   ): Promise<void>;

--- a/backend/src/management/ministries/ministries-domain/service/ministry-groups-domain.service.ts
+++ b/backend/src/management/ministries/ministries-domain/service/ministry-groups-domain.service.ts
@@ -13,20 +13,25 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { MinistryGroupModel } from '../../entity/ministry-group.entity';
 import {
+  Between,
   FindOptionsOrder,
   FindOptionsRelations,
   IsNull,
+  MoreThan,
+  MoreThanOrEqual,
   QueryRunner,
   Repository,
+  UpdateResult,
 } from 'typeorm';
 import { ChurchModel } from '../../../../churches/entity/church.entity';
 import { MinistryGroupException } from '../../const/exception/ministry-group.exception';
 import { CreateMinistryGroupDto } from '../../dto/ministry-group/create-ministry-group.dto';
-import { UpdateMinistryGroupDto } from '../../dto/ministry-group/update-ministry-group.dto';
+import { UpdateMinistryGroupNameDto } from '../../dto/ministry-group/update-ministry-group-name.dto';
 import { GroupDepthConstraint } from '../../../const/group-depth.constraint';
 import { GetMinistryGroupDto } from '../../dto/ministry-group/get-ministry-group.dto';
 import { MinistryGroupDomainPaginationResponseDto } from '../../dto/ministry-group/response/ministry-group-domain-pagination-response.dto';
 import { MinistryGroupOrderEnum } from '../../const/ministry-group-order.enum';
+import { UpdateMinistryGroupStructureDto } from '../../dto/ministry-group/update-ministry-group-structure.dto';
 
 @Injectable()
 export class MinistryGroupsDomainService
@@ -59,16 +64,7 @@ export class MinistryGroupsDomainService
           : IsNull(),
         name,
       },
-      withDeleted: true,
     });
-
-    if (group) {
-      if (group.deletedAt) {
-        await ministryGroupsRepository.remove(group);
-
-        return false;
-      }
-    }
 
     return !!group;
   }
@@ -85,7 +81,7 @@ export class MinistryGroupsDomainService
       [dto.order]: dto.orderDirection,
     };
 
-    if (dto.order !== MinistryGroupOrderEnum.createdAt) {
+    if (dto.order !== MinistryGroupOrderEnum.CREATED_AT) {
       order.createdAt = 'asc';
     }
 
@@ -258,14 +254,6 @@ export class MinistryGroupsDomainService
     dto: CreateMinistryGroupDto,
     qr: QueryRunner,
   ) {
-    /*const parentMinistryGroup = dto.parentMinistryGroupId
-      ? await this.findMinistryGroupModelById(
-          church,
-          dto.parentMinistryGroupId,
-          qr,
-        )
-      : null;*/
-
     await this.checkIsAvailableName(church, parentMinistryGroup, dto.name, qr);
 
     return parentMinistryGroup
@@ -291,10 +279,24 @@ export class MinistryGroupsDomainService
       throw new BadRequestException(MinistryGroupException.LIMIT_DEPTH_REACHED);
     }
 
+    const [lastOrderMinistryGroup] = await this.ministryGroupsRepository.find({
+      where: {
+        churchId: church.id,
+        parentMinistryGroupId: parentGroup.id,
+      },
+      order: {
+        order: 'desc',
+      },
+      take: 1,
+    });
+
+    const order = lastOrderMinistryGroup ? lastOrderMinistryGroup.order + 1 : 1;
+
     const newGroup = await ministryGroupsRepository.save({
       churchId: church.id,
       name: dto.name,
       parentMinistryGroupId: parentGroup.id,
+      order,
     });
 
     await this.appendChildMinistryGroupId(parentGroup, newGroup, qr);
@@ -309,9 +311,23 @@ export class MinistryGroupsDomainService
   ) {
     const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
 
+    const [lastOrderMinistryGroup] = await this.ministryGroupsRepository.find({
+      where: {
+        churchId: church.id,
+        parentMinistryGroupId: IsNull(),
+      },
+      order: {
+        order: 'desc',
+      },
+      take: 1,
+    });
+
+    const order = lastOrderMinistryGroup ? lastOrderMinistryGroup.order + 1 : 1;
+
     return ministryGroupsRepository.save({
       churchId: church.id,
       ...dto,
+      order,
     });
   }
 
@@ -335,37 +351,79 @@ export class MinistryGroupsDomainService
     return true;
   }
 
-  async updateMinistryGroup(
+  async updateMinistryGroupName(
     church: ChurchModel,
     targetMinistryGroup: MinistryGroupModel,
-    dto: UpdateMinistryGroupDto,
+    dto: UpdateMinistryGroupNameDto,
     qr: QueryRunner,
-    newParentMinistryGroup: MinistryGroupModel | null,
-  ) {
-    const newName = dto.name ?? targetMinistryGroup.name;
+  ): Promise<UpdateResult> {
+    const repository = this.getMinistryGroupsRepository(qr);
 
-    // 사용 가능한 그룹인지 체크 --> 불가능할 경우 ConflictException
-    await this.checkIsAvailableName(
+    if (
+      targetMinistryGroup.parentMinistryGroupId &&
+      targetMinistryGroup.parentMinistryGroup === null
+    ) {
+      throw new InternalServerErrorException('상위 사역 그룹 불러오기 실패');
+    }
+
+    const isExist = await this.isExistMinistryGroup(
       church,
-      newParentMinistryGroup,
-      newName,
+      targetMinistryGroup.parentMinistryGroup,
+      dto.name,
       qr,
     );
 
-    // 새로운 상위 그룹에 넣을 경우
-    if (
-      newParentMinistryGroup &&
-      newParentMinistryGroup.id !== targetMinistryGroup.parentMinistryGroupId
-    ) {
-      await this.validateUpdateHierarchy(
-        church,
-        targetMinistryGroup,
-        newParentMinistryGroup,
-        qr,
+    if (isExist) {
+      throw new ConflictException(MinistryGroupException.ALREADY_EXIST);
+    }
+
+    const result = await repository.update(
+      {
+        id: targetMinistryGroup.id,
+      },
+      {
+        name: dto.name,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        MinistryGroupException.UPDATE_ERROR,
       );
     }
 
+    return result;
+  }
+
+  async updateMinistryGroupStructure(
+    church: ChurchModel,
+    targetMinistryGroup: MinistryGroupModel,
+    dto: UpdateMinistryGroupStructureDto,
+    qr: QueryRunner,
+    newParentMinistryGroup: MinistryGroupModel | null,
+  ) {
+    // 계층 이동 시 사용 가능한 이름, 그룹 depth 확인
     if (dto.parentMinistryGroupId !== undefined) {
+      const isExist = await this.isExistMinistryGroup(
+        church,
+        newParentMinistryGroup,
+        targetMinistryGroup.name,
+        qr,
+      );
+
+      if (isExist) {
+        throw new ConflictException(MinistryGroupException.ALREADY_EXIST);
+      }
+
+      if (dto.parentMinistryGroupId && newParentMinistryGroup) {
+        await this.validateUpdateHierarchy(
+          church,
+          targetMinistryGroup,
+          newParentMinistryGroup,
+          qr,
+        );
+      }
+
       // 기존 상위 그룹에서 타겟 그룹 id 제거
       await this.removeChildMinistryGroupId(
         targetMinistryGroup.parentMinistryGroup,
@@ -382,12 +440,89 @@ export class MinistryGroupsDomainService
 
     const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
 
+    if (dto.order) {
+      let parentMinistryGroupId: any;
+
+      if (dto.parentMinistryGroupId === null) {
+        // 루트 그룹으로 이동
+        parentMinistryGroupId = IsNull();
+      } else if (dto.parentMinistryGroupId === undefined) {
+        // 계층 이동 X
+        parentMinistryGroupId = targetMinistryGroup.parentMinistryGroupId;
+        if (parentMinistryGroupId === null) {
+          // 기존 계층이 루트인 경우
+          parentMinistryGroupId = IsNull();
+        }
+      } else {
+        // 계층 이동
+        parentMinistryGroupId = dto.parentMinistryGroupId;
+      }
+
+      // 계층이 변하는 경우
+      if (dto.parentMinistryGroupId !== undefined) {
+        // 기존 계층 순서 변경
+        await ministryGroupsRepository.update(
+          {
+            churchId: church.id,
+            parentMinistryGroupId:
+              targetMinistryGroup.parentMinistryGroupId === null
+                ? IsNull()
+                : targetMinistryGroup.parentMinistryGroupId,
+            order: MoreThanOrEqual(targetMinistryGroup.order),
+          },
+          {
+            order: () => 'order - 1',
+          },
+        );
+        // 새로운 계층 순서 변경
+        await ministryGroupsRepository.update(
+          {
+            churchId: church.id,
+            parentMinistryGroupId: parentMinistryGroupId,
+            order: MoreThanOrEqual(dto.order),
+          },
+          {
+            order: () => 'order + 1',
+          },
+        );
+      } else {
+        // 계층이 바뀌지 않는 경우
+        // case 1. 뒷 순서로 이동
+        // --> 기존 순서의 뒤부터 새로운 순서까지 order 를 앞으로 이동
+        if (dto.order > targetMinistryGroup.order) {
+          await ministryGroupsRepository.update(
+            {
+              churchId: church.id,
+              parentMinistryGroupId: parentMinistryGroupId,
+              order: Between(targetMinistryGroup.order + 1, dto.order),
+            },
+            {
+              order: () => 'order - 1',
+            },
+          );
+        } else {
+          // case 2. 앞 순서로 이동
+          // --> 새로운 순서부터 기존 순서의 앞까지 order 를 뒤로 이동
+          await ministryGroupsRepository.update(
+            {
+              churchId: church.id,
+              parentMinistryGroupId,
+              order: Between(dto.order, targetMinistryGroup.order - 1),
+            },
+            {
+              order: () => 'order + 1',
+            },
+          );
+        }
+      }
+    }
+
     const result = await ministryGroupsRepository.update(
       {
         id: targetMinistryGroup.id,
       },
       {
-        name: dto.name,
+        order: dto.order,
         parentMinistryGroupId:
           newParentMinistryGroup === null ? null : newParentMinistryGroup.id,
       },
@@ -449,17 +584,9 @@ export class MinistryGroupsDomainService
   async deleteMinistryGroup(
     church: ChurchModel,
     targetMinistryGroup: MinistryGroupModel,
-    //ministryGroupId: number,
     qr: QueryRunner,
   ) {
     const ministryGroupsRepository = this.getMinistryGroupsRepository(qr);
-
-    /*const ministryGroup = await this.findMinistryGroupModelById(
-      church,
-      ministryGroupId,
-      qr,
-      { parentMinistryGroup: true, ministries: true },
-    );*/
 
     // 하위 그룹 or 사역 체크
     if (
@@ -475,6 +602,19 @@ export class MinistryGroupsDomainService
       id: targetMinistryGroup.id,
       deletedAt: IsNull(),
     });
+
+    await ministryGroupsRepository.update(
+      {
+        churchId: church.id,
+        parentMinistryGroupId: targetMinistryGroup.parentMinistryGroupId
+          ? targetMinistryGroup.parentMinistryGroupId
+          : IsNull(),
+        order: MoreThan(targetMinistryGroup.order),
+      },
+      {
+        order: () => 'order - 1',
+      },
+    );
 
     await this.removeChildMinistryGroupId(
       targetMinistryGroup.parentMinistryGroup,

--- a/backend/src/management/ministries/service/ministry-group.service.ts
+++ b/backend/src/management/ministries/service/ministry-group.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { MinistryGroupModel } from '../entity/ministry-group.entity';
 import { FindOptionsRelations, QueryRunner } from 'typeorm';
 import { CreateMinistryGroupDto } from '../dto/ministry-group/create-ministry-group.dto';
-import { UpdateMinistryGroupDto } from '../dto/ministry-group/update-ministry-group.dto';
+import { UpdateMinistryGroupNameDto } from '../dto/ministry-group/update-ministry-group-name.dto';
 import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
@@ -16,6 +16,7 @@ import { MinistryGroupPaginationResultDto } from '../dto/ministry-group/response
 import { MinistryGroupPostResponseDto } from '../dto/ministry-group/response/ministry-group-post-response.dto';
 import { MinistryGroupPatchResponseDto } from '../dto/ministry-group/response/ministry-group-patch-response.dto';
 import { MinistryGroupDeleteResponseDto } from '../dto/ministry-group/response/ministry-group-delete-response.dto';
+import { UpdateMinistryGroupStructureDto } from '../dto/ministry-group/update-ministry-group-structure.dto';
 
 @Injectable()
 export class MinistryGroupService {
@@ -117,10 +118,10 @@ export class MinistryGroupService {
     return new MinistryGroupPostResponseDto(newMinistryGroup);
   }
 
-  async updateMinistryGroup(
+  async updateMinistryGroupStructure(
     churchId: number,
     ministryGroupId: number,
-    dto: UpdateMinistryGroupDto,
+    dto: UpdateMinistryGroupStructureDto,
     qr: QueryRunner,
   ) {
     const church = await this.churchesDomainService.findChurchModelById(
@@ -148,12 +149,50 @@ export class MinistryGroupService {
             ); // 새 상위 사역 그룹으로 변경
 
     const updatedMinistryGroup =
-      await this.ministryGroupsDomainService.updateMinistryGroup(
+      await this.ministryGroupsDomainService.updateMinistryGroupStructure(
         church,
         targetMinistryGroup,
         dto,
         qr,
         newParentMinistryGroup,
+      );
+
+    return new MinistryGroupPatchResponseDto(updatedMinistryGroup);
+  }
+
+  async updateMinistryGroupName(
+    churchId: number,
+    ministryGroupId: number,
+    dto: UpdateMinistryGroupNameDto,
+    qr: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const targetMinistryGroup =
+      await this.ministryGroupsDomainService.findMinistryGroupModelById(
+        church,
+        ministryGroupId,
+        qr,
+        {
+          parentMinistryGroup: true,
+        },
+      );
+
+    await this.ministryGroupsDomainService.updateMinistryGroupName(
+      church,
+      targetMinistryGroup,
+      dto,
+      qr,
+    );
+
+    const updatedMinistryGroup =
+      await this.ministryGroupsDomainService.findMinistryGroupById(
+        church,
+        targetMinistryGroup.id,
+        qr,
       );
 
     return new MinistryGroupPatchResponseDto(updatedMinistryGroup);

--- a/backend/src/management/officers/officer-domain/service/officers-domain.service.ts
+++ b/backend/src/management/officers/officer-domain/service/officers-domain.service.ts
@@ -12,6 +12,7 @@ import {
   FindOptionsOrder,
   FindOptionsRelations,
   IsNull,
+  MoreThan,
   MoreThanOrEqual,
   QueryRunner,
   Repository,
@@ -258,6 +259,16 @@ export class OfficersDomainService implements IOfficersDomainService {
     }
 
     await officersRepository.softDelete({ id: officer.id });
+
+    await officersRepository.update(
+      {
+        churchId: officer.churchId,
+        order: MoreThan(officer.order),
+      },
+      {
+        order: () => 'order + 1',
+      },
+    );
 
     return;
   }


### PR DESCRIPTION
## 주요 내용
- MinistryGroupModel에 `order` 컬럼 추가 및 기존 그룹/직분과 동일한 정렬 로직 적용
- 계층 이동 시 기존 계층의 정렬 누락 문제 해결
- 동일 계층 내 order 변경 시 정렬 누락 문제 해결
- 삭제 시 뒤에 있는 항목들의 order를 앞으로 당기는 로직 추가

## 세부 내용

### Entity
- `MinistryGroupModel`에 `order: number` 컬럼 추가
  - 사용자 지정 정렬을 위한 용도

### 생성
- 그룹, 직분, 사역그룹 생성 시 동일 계층 또는 목록의 마지막 순서로 order 자동 지정

### 수정
- **계층 이동 시 정렬 보정**
  - A → B 계층으로 이동 시 A 계층 내 남은 항목들의 order가 비정상적으로 유지되던 문제 해결
- **동일 계층 내 order 변경 시 정렬 보정**
  - 기존보다 큰 값으로 변경할 때 일부 항목이 누락되어 정렬이 깨지던 문제 해결
  - 예: order 2 → 4로 이동 시 order 3 항목이 건너뛰어지는 문제 해결
- **직분, 사역그룹에도 동일한 수정 엔드포인트와 로직 적용**

### 삭제
- 그룹, 직분, 사역그룹 삭제 시 해당 항목 뒤에 있는 항목들의 order를 1씩 앞으로 당기는 정렬 로직 추가

### 조회
- 모든 목록 조회 시 order 기준 오름차순 정렬 적용