### PR TITLE
fix: 직분 순서 변경 시 정렬 누락되는 문제 해결

### DIFF
--- a/backend/src/management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface.ts
+++ b/backend/src/management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface.ts
@@ -75,7 +75,7 @@ export interface IMinistryGroupsDomainService {
     dto: UpdateMinistryGroupStructureDto,
     qr: QueryRunner,
     newParentMinistryGroup: MinistryGroupModel | null,
-  ): Promise<MinistryGroupWithParentGroups>;
+  ): Promise<UpdateResult>;
 
   deleteMinistryGroup(
     church: ChurchModel,

--- a/backend/src/management/ministries/ministries-domain/service/ministry-groups-domain.service.ts
+++ b/backend/src/management/ministries/ministries-domain/service/ministry-groups-domain.service.ts
@@ -241,11 +241,6 @@ export class MinistryGroupsDomainService
     );
 
     return subGroupsQuery;
-    /*
-    subGroupsQuery.forEach(console.log);
-    //subGroupsQuery.forEach((row) => console.log(row));
-
-    return subGroupsQuery.map((row: any) => row.id);*/
   }
 
   async createMinistryGroup(
@@ -534,7 +529,7 @@ export class MinistryGroupsDomainService
       );
     }
 
-    return this.findMinistryGroupById(church, targetMinistryGroup.id, qr);
+    return result;
   }
 
   private async validateUpdateHierarchy(

--- a/backend/src/management/ministries/service/ministry-group.service.ts
+++ b/backend/src/management/ministries/service/ministry-group.service.ts
@@ -148,13 +148,19 @@ export class MinistryGroupService {
               qr,
             ); // 새 상위 사역 그룹으로 변경
 
+    await this.ministryGroupsDomainService.updateMinistryGroupStructure(
+      church,
+      targetMinistryGroup,
+      dto,
+      qr,
+      newParentMinistryGroup,
+    );
+
     const updatedMinistryGroup =
-      await this.ministryGroupsDomainService.updateMinistryGroupStructure(
+      await this.ministryGroupsDomainService.findMinistryGroupById(
         church,
-        targetMinistryGroup,
-        dto,
+        ministryGroupId,
         qr,
-        newParentMinistryGroup,
       );
 
     return new MinistryGroupPatchResponseDto(updatedMinistryGroup);


### PR DESCRIPTION
## 주요 내용
- OfficerModel의 `order` 값을 기존보다 큰 값으로 변경할 때 정렬이 깨지던 문제 수정

## 세부 내용
- 직분의 `order`를 증가시키는 경우, 기존 `order`보다 작거나 같은 항목만 정렬 대상이 되던 문제 해결
  - 예: order 2 → 5로 이동 시 order 3, 4인 항목이 갱신되지 않아 정렬이 [1, 3, 4, 5, 5]처럼 잘못되는 문제 발생
- 수정된 로직은 기존 위치와 이동할 위치 사이의 모든 항목을 정확히 1씩 당기거나 밀도록 보정