### PR TITLE
fix: 그룹/사역그룹/직분 구조 변경 로직 리팩토링 및 order 유효성 제약 추가

### DIFF
--- a/backend/src/management/groups/const/exception/group.exception.ts
+++ b/backend/src/management/groups/const/exception/group.exception.ts
@@ -6,4 +6,5 @@ export const GroupException = {
     '현재 하위 그룹을 새로운 상위 그룹으로 지정할 수 없습니다.',
   GROUP_HAS_DEPENDENCIES: '해당 그룹에 속한 하위 그룹 또는 교인이 존재합니다.',
   UPDATE_ERROR: '업데이트 도중 에러 발생',
+  INVALID_ORDER: '지정할 수 없는 순서입니다.',
 };

--- a/backend/src/management/groups/service/groups.service.ts
+++ b/backend/src/management/groups/service/groups.service.ts
@@ -122,16 +122,19 @@ export class GroupsService {
       { parentGroup: true },
     );
 
-    const newParentGroup: GroupModel | null =
-      dto.parentGroupId === undefined
-        ? targetGroup.parentGroup // 상위 그룹을 변경하지 않는 경우 (기존 값 유지) nullable
-        : dto.parentGroupId === null
-          ? null // 상위 그룹을 없애는 경우 (최상위 계층으로 이동)
-          : await this.groupsDomainService.findGroupModelById(
-              church,
-              dto.parentGroupId,
-              qr,
-            ); // 새 상위 그룹으로 변경
+    let newParentGroup: GroupModel | null;
+
+    if (dto.parentGroupId === undefined) {
+      newParentGroup = targetGroup.parentGroup;
+    } else if (dto.parentGroupId === null) {
+      newParentGroup = null;
+    } else {
+      newParentGroup = await this.groupsDomainService.findGroupModelById(
+        church,
+        dto.parentGroupId,
+        qr,
+      );
+    }
 
     await this.groupsDomainService.updateGroupStructure(
       church,

--- a/backend/src/management/ministries/const/exception/ministry-group.exception.ts
+++ b/backend/src/management/ministries/const/exception/ministry-group.exception.ts
@@ -6,4 +6,5 @@ export const MinistryGroupException = {
     '현재 하위 그룹을 새로운 상위 그룹으로 지정할 수 없습니다.',
   GROUP_HAS_DEPENDENCIES: '해당 그룹에 속한 사역이 존재합니다.',
   UPDATE_ERROR: '업데이트 도중 에러 발생',
+  INVALID_ORDER: '지정할 수 없는 순서입니다.',
 };

--- a/backend/src/management/ministries/service/ministry-group.service.ts
+++ b/backend/src/management/ministries/service/ministry-group.service.ts
@@ -137,16 +137,20 @@ export class MinistryGroupService {
         { parentMinistryGroup: true },
       );
 
-    const newParentMinistryGroup: MinistryGroupModel | null =
-      dto.parentMinistryGroupId === undefined
-        ? targetMinistryGroup.parentMinistryGroup // 변경하지 않는 경우 (기존 값 유지) nullable
-        : dto.parentMinistryGroupId === null
-          ? null // 상위 사역 그룹을 없애는 경우 (최상위 계층으로 이동)
-          : await this.ministryGroupsDomainService.findMinistryGroupModelById(
-              church,
-              dto.parentMinistryGroupId,
-              qr,
-            ); // 새 상위 사역 그룹으로 변경
+    let newParentMinistryGroup: MinistryGroupModel | null;
+
+    if (dto.parentMinistryGroupId === undefined) {
+      newParentMinistryGroup = targetMinistryGroup.parentMinistryGroup;
+    } else if (dto.parentMinistryGroupId === null) {
+      newParentMinistryGroup = null;
+    } else {
+      newParentMinistryGroup =
+        await this.ministryGroupsDomainService.findMinistryGroupModelById(
+          church,
+          dto.parentMinistryGroupId,
+          qr,
+        );
+    }
 
     await this.ministryGroupsDomainService.updateMinistryGroupStructure(
       church,


### PR DESCRIPTION
## 주요 내용
- 그룹(Group), 사역그룹(MinistryGroup), 직분(Officer)의 구조 변경 로직 리팩토링
- 순서(order) 변경 시 실제 가능한 범위 내 숫자만 허용되도록 유효성 검증 추가

## 세부 내용

### 구조 변경 로직 리팩토링
- 중복 조건 제거 및 order 이동 방향에 따른 정렬 보정 로직 간소화
- 계층 이동 여부와 순서 변경 여부를 명확히 구분하여 불필요한 update 방지
- `parentGroupId` / `parentMinistryGroupId` 계산 로직 단순화

### order 유효성 제약 추가
- 계층 내 존재하는 최대 order 값을 기준으로 유효성 검증
- 예시:
  - (1) 계층 내 order가 1,2,3,4일 경우 → 5 이상의 값은 허용되지 않음
  - (2) 계층 이동 시 대상 계층의 최대 order가 4라면 → 최대 5까지만 허용

### 기타
- 직분/그룹/사역그룹의 구조 변경 시 단일 트랜잭션 내에서 순서 정리 보장