### PR TITLE
feat: 교회별 관리 항목 개수 정적 집계 기능 추가

### DIFF
--- a/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
+++ b/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
@@ -1,4 +1,4 @@
-import { ChurchModel } from '../../entity/church.entity';
+import { ChurchModel, ManagementCountType } from '../../entity/church.entity';
 import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { CreateChurchDto } from '../../dto/create-church.dto';
 import { UpdateChurchDto } from '../../dto/update-church.dto';
@@ -55,6 +55,7 @@ export interface IChurchesDomainService {
     qr: QueryRunner | undefined,
   ): Promise<UpdateResult>;
 
+  // -------교인 수 업데이트---------
   incrementMemberCount(
     church: ChurchModel,
     qr: QueryRunner,
@@ -64,10 +65,30 @@ export interface IChurchesDomainService {
     church: ChurchModel,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
+  // -------교인 수 업데이트---------
 
   transferOwner(
     church: ChurchModel,
     newOwnerChurchUser: ChurchUserModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  incrementManagementCount(
+    church: ChurchModel,
+    countType: ManagementCountType,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  decrementManagementCount(
+    church: ChurchModel,
+    countType: ManagementCountType,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  refreshManagementCount(
+    church: ChurchModel,
+    countType: ManagementCountType,
+    refreshCount: number,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 }

--- a/backend/src/churches/churches-domain/service/churhes-domain.service.ts
+++ b/backend/src/churches/churches-domain/service/churhes-domain.service.ts
@@ -14,7 +14,7 @@ import {
   Repository,
   UpdateResult,
 } from 'typeorm';
-import { ChurchModel } from '../../entity/church.entity';
+import { ChurchModel, ManagementCountType } from '../../entity/church.entity';
 import { UpdateChurchDto } from '../../dto/update-church.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ChurchUserRole } from '../../../user/const/user-role.enum';
@@ -339,6 +339,68 @@ export class ChurchesDomainService implements IChurchesDomainService {
       { id: church.id },
       'memberCount',
       1,
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(ChurchException.UPDATE_ERROR);
+    }
+
+    return result;
+  }
+
+  async decrementManagementCount(
+    church: ChurchModel,
+    countType: ManagementCountType,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getChurchRepository(qr);
+
+    const result = await repository.decrement(
+      {
+        id: church.id,
+      },
+      countType,
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(ChurchException.UPDATE_ERROR);
+    }
+
+    return result;
+  }
+
+  async incrementManagementCount(
+    church: ChurchModel,
+    countType: ManagementCountType,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getChurchRepository(qr);
+
+    const result = await repository.increment({ id: church.id }, countType, 1);
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(ChurchException.UPDATE_ERROR);
+    }
+
+    return result;
+  }
+
+  async refreshManagementCount(
+    church: ChurchModel,
+    countType: ManagementCountType,
+    refreshCount: number,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getChurchRepository(qr);
+
+    const result = await repository.update(
+      {
+        id: church.id,
+      },
+      {
+        [countType]: refreshCount,
+      },
     );
 
     if (result.affected === 0) {

--- a/backend/src/churches/entity/church.entity.ts
+++ b/backend/src/churches/entity/church.entity.ts
@@ -21,6 +21,7 @@ import { ChurchJoinModel } from '../../church-join/entity/church-join.entity';
 import { Exclude } from 'class-transformer';
 import { TaskModel } from '../../task/entity/task.entity';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { WorshipModel } from '../../worship/entity/worship.entity';
 
 @Entity()
 @Unique(['joinCode'])
@@ -62,17 +63,32 @@ export class ChurchModel extends BaseModel {
   @OneToMany(() => ChurchUserModel, (churchUser) => churchUser.church)
   churchUsers: ChurchUserModel[];
 
+  @Column({ default: 0 })
+  groupCount: number;
+
   @OneToMany(() => GroupModel, (group) => group.church)
   groups: GroupModel[];
+
+  @Column({ default: 0 })
+  educationCount: number;
 
   @OneToMany(() => EducationModel, (education) => education.church)
   educations: EducationModel[];
 
+  @Column({ default: 0 })
+  officerCount: number;
+
   @OneToMany(() => OfficerModel, (officer) => officer.church)
   officers: OfficerModel[];
 
+  @Column({ default: 0 })
+  ministryGroupCount: number;
+
   @OneToMany(() => MinistryGroupModel, (ministryGroup) => ministryGroup.church)
   ministryGroups: MinistryGroupModel[];
+
+  @Column({ default: 0 })
+  ministryCount: number;
 
   @OneToMany(() => MinistryModel, (ministry) => ministry.church)
   ministries: MinistryModel[];
@@ -100,7 +116,30 @@ export class ChurchModel extends BaseModel {
   @OneToMany(() => VisitationMetaModel, (visitingMeta) => visitingMeta.church)
   visitations: VisitationMetaModel[];
 
+  @Column({ default: 0 })
+  visitationCount: number;
+
   // 업무
   @OneToMany(() => TaskModel, (task) => task.church)
   tasks: TaskModel[];
+
+  @Column({ default: 0 })
+  taskCount: number;
+
+  @OneToMany(() => WorshipModel, (worship) => worship.church)
+  worships: WorshipModel[];
+
+  @Column({ default: 0 })
+  worshipCount: number;
+}
+
+export enum ManagementCountType {
+  GROUP = 'groupCount',
+  MINISTRY_GROUP = 'ministryGroupCount',
+  MINISTRY = 'ministryCount',
+  OFFICER = 'officerCount',
+  EDUCATION = 'educationCount',
+  VISITATION = 'visitationCount',
+  TASK = 'taskCount',
+  WORSHIP = 'worshipCount',
 }

--- a/backend/src/management/educations/const/swagger/education.swagger.ts
+++ b/backend/src/management/educations/const/swagger/education.swagger.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation } from '@nestjs/swagger';
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
 
 export const ApiGetEducation = () =>
   applyDecorators(
@@ -34,6 +34,21 @@ export const ApiPostEducation = () =>
         '<p><b>제약 조건</b></p>' +
         '<p>교육 이름: 최대 50자, 연속 공백 불가능, 특수문자 사용불가능 (띄어쓰기, - 허용)</p>' +
         '<p>교육 설명: 최대 300자, 내용이 없는 공백 입력 시 입력을 무시함(undefined 처리)</p>',
+    }),
+  );
+
+export const ApiGetInProgressEducations = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '진행중인 교육 조회',
+    }),
+  );
+
+export const ApiRefreshEducationCount = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({
+      summary: '교회 교육 개수 새로고침',
     }),
   );
 

--- a/backend/src/management/educations/service/education-domain/interface/education-domain.service.interface.ts
+++ b/backend/src/management/educations/service/education-domain/interface/education-domain.service.interface.ts
@@ -47,4 +47,6 @@ export interface IEducationDomainService {
     targetEducation: EducationModel,
     qr?: QueryRunner,
   ): Promise<void>;
+
+  countAllEducations(church: ChurchModel, qr: QueryRunner): Promise<number>;
 }

--- a/backend/src/management/educations/service/education-domain/service/education-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/education-domain.service.ts
@@ -57,6 +57,16 @@ export class EducationDomainService implements IEducationDomainService {
     return !!isExist;
   }
 
+  countAllEducations(church: ChurchModel, qr: QueryRunner): Promise<number> {
+    const repository = this.getEducationsRepository(qr);
+
+    return repository.count({
+      where: {
+        churchId: church.id,
+      },
+    });
+  }
+
   async findEducations(
     church: ChurchModel,
     dto: GetEducationDto,

--- a/backend/src/management/groups/const/swagger/group.swagger.ts
+++ b/backend/src/management/groups/const/swagger/group.swagger.ts
@@ -27,6 +27,15 @@ export const ApiPostGroups = () =>
     }),
   );
 
+export const ApiRefreshGroupCount = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({
+      summary: '교회 그룹 개수 새로고침',
+      description: '<h2>교회 내의 그룹 개수를 새로고침합니다.</h2>',
+    }),
+  );
+
 export const ApiGetGroupById = () =>
   applyDecorators(
     ApiOperation({

--- a/backend/src/management/groups/controller/groups.controller.ts
+++ b/backend/src/management/groups/controller/groups.controller.ts
@@ -25,6 +25,7 @@ import {
   ApiPatchGroupName,
   ApiPatchGroupStructure,
   ApiPostGroups,
+  ApiRefreshGroupCount,
 } from '../const/swagger/group.swagger';
 import { GetGroupDto } from '../dto/group/get-group.dto';
 import { GroupReadGuard } from '../guard/group-read.guard';
@@ -32,6 +33,8 @@ import { GroupWriteGuard } from '../guard/group-write.guard';
 import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../../permission/guard/church-manager.guard';
 import { UpdateGroupStructureDto } from '../dto/group/update-group-structure.dto';
+import { PermissionChurch } from '../../../permission/decorator/permission-church.decorator';
+import { ChurchModel } from '../../../churches/entity/church.entity';
 
 @ApiTags('Management:Groups')
 @Controller('groups')
@@ -58,6 +61,17 @@ export class GroupsController {
     @QueryRunner() qr: QR,
   ) {
     return this.groupsService.createGroup(churchId, dto, qr);
+  }
+
+  @ApiRefreshGroupCount()
+  @Patch('refresh-count')
+  @GroupWriteGuard()
+  @UseInterceptors(TransactionInterceptor)
+  refreshGroupCount(
+    @PermissionChurch() church: ChurchModel,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.groupsService.refreshGroupCount(church, qr);
   }
 
   @ApiGetGroupById()

--- a/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
+++ b/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
@@ -83,7 +83,6 @@ export interface IGroupsDomainService {
     targetGroup: GroupModel,
     dto: UpdateGroupNameDto,
     qr: QueryRunner,
-    //newParentGroup: GroupModel | null,
   ): Promise<UpdateResult>;
 
   updateGroupStructure(
@@ -107,4 +106,6 @@ export interface IGroupsDomainService {
   incrementMembersCount(group: GroupModel, qr: QueryRunner): Promise<boolean>;
 
   decrementMembersCount(group: GroupModel, qr: QueryRunner): Promise<boolean>;
+
+  countAllGroups(church: ChurchModel, qr: QueryRunner): Promise<number>;
 }

--- a/backend/src/management/groups/groups-domain/service/groups-domain.service.ts
+++ b/backend/src/management/groups/groups-domain/service/groups-domain.service.ts
@@ -100,6 +100,16 @@ export class GroupsDomainService implements IGroupsDomainService {
     return new GroupDomainPaginationResultDto(data, totalCount);
   }
 
+  async countAllGroups(church: ChurchModel, qr: QueryRunner): Promise<number> {
+    const repository = this.getGroupsRepository(qr);
+
+    return repository.count({
+      where: {
+        churchId: church.id,
+      },
+    });
+  }
+
   async findGroups(
     church: ChurchModel,
     dto: GetGroupDto,

--- a/backend/src/management/ministries/const/swagger/ministry-group.swagger.ts
+++ b/backend/src/management/ministries/const/swagger/ministry-group.swagger.ts
@@ -1,0 +1,19 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
+
+export const ApiRefreshMinistryGroupCount = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({
+      summary: '교회 사역 그룹 개수 새로고침',
+    }),
+  );
+
+export const ApiPatchMinistryGroupName = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '사역 그룹 수정',
+      description:
+        '최상위 그룹으로 설정하려는 경우 parentMinistryGroupId 를 null 로 설정',
+    }),
+  );

--- a/backend/src/management/ministries/const/swagger/ministry.swagger.ts
+++ b/backend/src/management/ministries/const/swagger/ministry.swagger.ts
@@ -33,6 +33,15 @@ export const ApiPostMinistry = () =>
     }),
   );
 
+export const ApiRefreshMinistryCount = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({
+      summary: '교회 사역 개수 새로고침',
+      description: '<h2>교회 내 사역 개수를 새로고침합니다.</h2>',
+    }),
+  );
+
 export const ApiPatchMinistry = () =>
   applyDecorators(
     ApiOperation({

--- a/backend/src/management/ministries/controller/ministries.controller.ts
+++ b/backend/src/management/ministries/controller/ministries.controller.ts
@@ -3,7 +3,6 @@ import {
   Controller,
   Delete,
   Get,
-  GoneException,
   Param,
   ParseIntPipe,
   Patch,
@@ -23,15 +22,16 @@ import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 import {
   ApiDeleteMinistry,
   ApiGetMinistries,
-  ApiGetMinistryById,
   ApiPatchMinistry,
   ApiPostMinistry,
+  ApiRefreshMinistryCount,
   ApiRefreshMinistryMembersCount,
 } from '../const/swagger/ministry.swagger';
-import { MinistryReadGuard } from '../guard/ministry-read.guard';
 import { MinistryWriteGuard } from '../guard/ministry-write.guard';
 import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../../permission/guard/church-manager.guard';
+import { PermissionChurch } from '../../../permission/decorator/permission-church.decorator';
+import { ChurchModel } from '../../../churches/entity/church.entity';
 
 @ApiTags('Management:Ministries')
 @Controller('ministries')
@@ -60,16 +60,15 @@ export class MinistriesController {
     return this.ministryService.createMinistry(churchId, dto, qr);
   }
 
-  @ApiGetMinistryById()
-  @MinistryReadGuard()
-  @Get(':ministryId')
-  getMinistryById(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('ministryId', ParseIntPipe) ministryId: number,
+  @ApiRefreshMinistryCount()
+  @MinistryWriteGuard()
+  @UseInterceptors(TransactionInterceptor)
+  @Patch('refresh-count')
+  refreshMinistryCount(
+    @PermissionChurch() church: ChurchModel,
+    @QueryRunner() qr: QR,
   ) {
-    throw new GoneException('더 이상 사용되지 않는 요청');
-
-    //return this.ministryService.getMinistryById(churchId, ministryId);
+    return this.ministryService.refreshMinistryCount(church, qr);
   }
 
   @ApiPatchMinistry()
@@ -109,4 +108,16 @@ export class MinistriesController {
       ministryId,
     );
   }
+
+  /*@ApiGetMinistryById()
+  @MinistryReadGuard()
+  @Get(':ministryId')
+  getMinistryById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('ministryId', ParseIntPipe) ministryId: number,
+  ) {
+    throw new GoneException('더 이상 사용되지 않는 요청');
+
+    //return this.ministryService.getMinistryById(churchId, ministryId);
+  }*/
 }

--- a/backend/src/management/ministries/controller/ministry-groups.controller.ts
+++ b/backend/src/management/ministries/controller/ministry-groups.controller.ts
@@ -12,7 +12,7 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { MinistryGroupService } from '../service/ministry-group.service';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { CreateMinistryGroupDto } from '../dto/ministry-group/create-ministry-group.dto';
 import { QueryRunner as QR } from 'typeorm';
 import { UpdateMinistryGroupNameDto } from '../dto/ministry-group/update-ministry-group-name.dto';
@@ -23,6 +23,12 @@ import { MinistryWriteGuard } from '../guard/ministry-write.guard';
 import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../../permission/guard/church-manager.guard';
 import { UpdateMinistryGroupStructureDto } from '../dto/ministry-group/update-ministry-group-structure.dto';
+import {
+  ApiPatchMinistryGroupName,
+  ApiRefreshMinistryGroupCount,
+} from '../const/swagger/ministry-group.swagger';
+import { PermissionChurch } from '../../../permission/decorator/permission-church.decorator';
+import { ChurchModel } from '../../../churches/entity/church.entity';
 
 @ApiTags('Management:MinistryGroups')
 @Controller('ministry-groups')
@@ -49,6 +55,17 @@ export class MinistryGroupsController {
     return this.ministryGroupService.createMinistryGroup(churchId, dto, qr);
   }
 
+  @ApiRefreshMinistryGroupCount()
+  @Patch('refresh-count')
+  @MinistryWriteGuard()
+  @UseInterceptors(TransactionInterceptor)
+  refreshMinistryGroupCount(
+    @PermissionChurch() church: ChurchModel,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.ministryGroupService.refreshMinistryGroupCount(church, qr);
+  }
+
   @Delete(':ministryGroupId')
   @MinistryWriteGuard()
   @UseInterceptors(TransactionInterceptor)
@@ -64,11 +81,7 @@ export class MinistryGroupsController {
     );
   }
 
-  @ApiOperation({
-    summary: '사역 그룹 수정',
-    description:
-      '최상위 그룹으로 설정하려는 경우 parentMinistryGroupId 를 null 로 설정',
-  })
+  @ApiPatchMinistryGroupName()
   @Patch(':ministryGroupId/name')
   @MinistryWriteGuard()
   @UseInterceptors(TransactionInterceptor)

--- a/backend/src/management/ministries/ministries-domain/interface/ministries-domain.service.interface.ts
+++ b/backend/src/management/ministries/ministries-domain/interface/ministries-domain.service.interface.ts
@@ -61,4 +61,6 @@ export interface IMinistriesDomainService {
     membersCount: number,
     qr?: QueryRunner,
   ): Promise<MinistryModel>;
+
+  countAllMinistries(church: ChurchModel, qr: QueryRunner): Promise<number>;
 }

--- a/backend/src/management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface.ts
+++ b/backend/src/management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface.ts
@@ -82,4 +82,6 @@ export interface IMinistryGroupsDomainService {
     targetMinistryGroup: MinistryGroupModel,
     qr: QueryRunner,
   ): Promise<void>;
+
+  countAllMinistryGroups(church: ChurchModel, qr: QueryRunner): Promise<number>;
 }

--- a/backend/src/management/ministries/ministries-domain/service/ministries-domain.service.ts
+++ b/backend/src/management/ministries/ministries-domain/service/ministries-domain.service.ts
@@ -68,6 +68,16 @@ export class MinistriesDomainService implements IMinistriesDomainService {
     return !!ministry;
   }
 
+  countAllMinistries(church: ChurchModel, qr: QueryRunner): Promise<number> {
+    const repository = this.getMinistriesRepository(qr);
+
+    return repository.count({
+      where: {
+        churchId: church.id,
+      },
+    });
+  }
+
   async findMinistries(
     church: ChurchModel,
     dto: GetMinistryDto,

--- a/backend/src/management/ministries/ministries-domain/service/ministry-groups-domain.service.ts
+++ b/backend/src/management/ministries/ministries-domain/service/ministry-groups-domain.service.ts
@@ -69,6 +69,19 @@ export class MinistryGroupsDomainService
     return !!group;
   }
 
+  countAllMinistryGroups(
+    church: ChurchModel,
+    qr: QueryRunner,
+  ): Promise<number> {
+    const repository = this.getMinistryGroupsRepository(qr);
+
+    return repository.count({
+      where: {
+        churchId: church.id,
+      },
+    });
+  }
+
   async findMinistryGroups(
     church: ChurchModel,
     parentMinistryGroup: MinistryGroupModel | null,

--- a/backend/src/management/ministries/service/ministry-group.service.ts
+++ b/backend/src/management/ministries/service/ministry-group.service.ts
@@ -17,6 +17,10 @@ import { MinistryGroupPostResponseDto } from '../dto/ministry-group/response/min
 import { MinistryGroupPatchResponseDto } from '../dto/ministry-group/response/ministry-group-patch-response.dto';
 import { MinistryGroupDeleteResponseDto } from '../dto/ministry-group/response/ministry-group-delete-response.dto';
 import { UpdateMinistryGroupStructureDto } from '../dto/ministry-group/update-ministry-group-structure.dto';
+import {
+  ChurchModel,
+  ManagementCountType,
+} from '../../../churches/entity/church.entity';
 
 @Injectable()
 export class MinistryGroupService {
@@ -114,6 +118,12 @@ export class MinistryGroupService {
         dto,
         qr,
       );
+
+    await this.churchesDomainService.incrementManagementCount(
+      church,
+      ManagementCountType.MINISTRY_GROUP,
+      qr,
+    );
 
     return new MinistryGroupPostResponseDto(newMinistryGroup);
   }
@@ -229,7 +239,12 @@ export class MinistryGroupService {
     await this.ministryGroupsDomainService.deleteMinistryGroup(
       church,
       targetMinistryGroup,
-      //ministryGroupId,
+      qr,
+    );
+
+    await this.churchesDomainService.decrementManagementCount(
+      church,
+      ManagementCountType.MINISTRY_GROUP,
       qr,
     );
 
@@ -256,5 +271,19 @@ export class MinistryGroupService {
       ministryGroupId,
       qr,
     );
+  }
+
+  async refreshMinistryGroupCount(church: ChurchModel, qr: QueryRunner) {
+    const ministryGroupCount =
+      await this.ministryGroupsDomainService.countAllMinistryGroups(church, qr);
+
+    await this.churchesDomainService.refreshManagementCount(
+      church,
+      ManagementCountType.MINISTRY_GROUP,
+      ministryGroupCount,
+      qr,
+    );
+
+    return { ministryGroupCount };
   }
 }

--- a/backend/src/management/ministries/service/ministry.service.ts
+++ b/backend/src/management/ministries/service/ministry.service.ts
@@ -21,6 +21,10 @@ import { MinistryOffsetPaginationResponseDto } from '../dto/ministry/response/mi
 import { MinistryDeleteResponseDto } from '../dto/ministry/response/ministry-delete-response.dto';
 import { MinistryPostResponseDto } from '../dto/ministry/response/ministry-post-response.dto';
 import { MinistryPatchResponseDto } from '../dto/ministry/response/ministry-patch-response.dto';
+import {
+  ChurchModel,
+  ManagementCountType,
+} from '../../../churches/entity/church.entity';
 
 @Injectable()
 export class MinistryService {
@@ -117,6 +121,12 @@ export class MinistryService {
       qr,
     );
 
+    await this.churchesDomainService.incrementManagementCount(
+      church,
+      ManagementCountType.MINISTRY,
+      qr,
+    );
+
     return new MinistryPostResponseDto(ministry);
   }
 
@@ -189,6 +199,11 @@ export class MinistryService {
     );
 
     await this.ministriesDomainService.deleteMinistry(ministry, qr);
+    await this.churchesDomainService.decrementManagementCount(
+      church,
+      ManagementCountType.MINISTRY,
+      qr,
+    );
 
     return new MinistryDeleteResponseDto(new Date(), ministry.id, true);
   }
@@ -222,5 +237,21 @@ export class MinistryService {
       );
 
     return new MinistryPatchResponseDto(updatedMinistry);
+  }
+
+  async refreshMinistryCount(church: ChurchModel, qr: QueryRunner) {
+    const ministryCount = await this.ministriesDomainService.countAllMinistries(
+      church,
+      qr,
+    );
+
+    await this.churchesDomainService.refreshManagementCount(
+      church,
+      ManagementCountType.MINISTRY,
+      ministryCount,
+      qr,
+    );
+
+    return { ministryCount };
   }
 }

--- a/backend/src/management/officers/const/swagger/officers.swagger.ts
+++ b/backend/src/management/officers/const/swagger/officers.swagger.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation } from '@nestjs/swagger';
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
 
 export const ApiGetOfficers = () =>
   applyDecorators(
@@ -12,6 +12,15 @@ export const ApiPostOfficer = () =>
   applyDecorators(
     ApiOperation({
       summary: '직분 생성',
+    }),
+  );
+
+export const ApiRefreshOfficerCount = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({
+      summary: '교회 직분 개수 새로고침',
+      description: '<h2>교회 내 직분 개수를 새로고침합니다.</h2>',
     }),
   );
 

--- a/backend/src/management/officers/controller/officers.controller.ts
+++ b/backend/src/management/officers/controller/officers.controller.ts
@@ -24,12 +24,15 @@ import {
   ApiPatchOfficerName,
   ApiPatchOfficerStructure,
   ApiPostOfficer,
+  ApiRefreshOfficerCount,
 } from '../const/swagger/officers.swagger';
 import { GetOfficersDto } from '../dto/request/get-officers.dto';
 import { OfficerWriteGuard } from '../guard/officer-write.guard';
 import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../../permission/guard/church-manager.guard';
 import { UpdateOfficerStructureDto } from '../dto/request/update-officer-structure.dto';
+import { PermissionChurch } from '../../../permission/decorator/permission-church.decorator';
+import { ChurchModel } from '../../../churches/entity/church.entity';
 
 @ApiTags('Management:Officers')
 @Controller('officers')
@@ -56,6 +59,18 @@ export class OfficersController {
     @QueryRunner() qr: QR,
   ) {
     return this.officersService.createOfficer(churchId, dto, qr);
+  }
+
+  @ApiRefreshOfficerCount()
+  @Patch('refresh-count')
+  @OfficerWriteGuard()
+  @UseInterceptors(TransactionInterceptor)
+  refreshOfficerCount(
+    //@Param('churchId', ParseIntPipe) churchId: number,
+    @PermissionChurch() church: ChurchModel,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.officersService.refreshOfficerCount(church, qr);
   }
 
   @ApiDeleteOfficer()

--- a/backend/src/management/officers/officer-domain/interface/officers-domain.service.interface.ts
+++ b/backend/src/management/officers/officer-domain/interface/officers-domain.service.interface.ts
@@ -59,4 +59,6 @@ export interface IOfficersDomainService {
     officer: OfficerModel,
     qr: QueryRunner,
   ): Promise<boolean>;
+
+  countAllOfficers(church: ChurchModel, qr: QueryRunner): Promise<number>;
 }

--- a/backend/src/management/officers/officer-domain/service/officers-domain.service.ts
+++ b/backend/src/management/officers/officer-domain/service/officers-domain.service.ts
@@ -39,6 +39,16 @@ export class OfficersDomainService implements IOfficersDomainService {
       : this.officersRepository;
   }
 
+  countAllOfficers(church: ChurchModel, qr: QueryRunner): Promise<number> {
+    const repository = this.getOfficersRepository(qr);
+
+    return repository.count({
+      where: {
+        churchId: church.id,
+      },
+    });
+  }
+
   async findOfficers(
     church: ChurchModel,
     dto: GetOfficersDto,

--- a/backend/src/permission/guard/generic-domain.guard.ts
+++ b/backend/src/permission/guard/generic-domain.guard.ts
@@ -53,7 +53,6 @@ export function createDomainGuard(
         );
       }
 
-      //req.permissionedChurchUser = hasPermission;
       req.requestManager = hasPermission.requestManager;
       req.church = hasPermission.church;
 

--- a/backend/src/task/const/swagger/task.swagger.ts
+++ b/backend/src/task/const/swagger/task.swagger.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation } from '@nestjs/swagger';
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
 
 export const ApiGetTasks = () =>
   applyDecorators(
@@ -28,6 +28,14 @@ export const ApiPostTask = () =>
         '<p>comment - 업무 내용, 서식 지정 가능 (script, iframe 등 태그 사용 불가능)</p>' +
         '<p>inChargeId - 업무 담당자 ID, manager 이상 권한 필요</p>' +
         '<p>receiverIds - 피보고자 ID, manager 이상 권한 필요</p>',
+    }),
+  );
+
+export const ApiRefreshTaskCount = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({
+      summary: '교회 업무 개수 새로고침',
     }),
   );
 

--- a/backend/src/task/controller/task.controller.ts
+++ b/backend/src/task/controller/task.controller.ts
@@ -27,6 +27,7 @@ import {
   ApiGetTasks,
   ApiPatchTask,
   ApiPostTask,
+  ApiRefreshTaskCount,
 } from '../const/swagger/task.swagger';
 import { AddTaskReportReceiverDto } from '../../report/dto/task-report/request/add-task-report-receiver.dto';
 import { DeleteTaskReportReceiverDto } from '../../report/dto/task-report/request/delete-task-report-receiver.dto';
@@ -34,6 +35,8 @@ import { TaskReadGuard } from '../guard/task-read.guard';
 import { TaskWriteGuard } from '../guard/task-write.guard';
 import { PermissionManager } from '../../permission/decorator/permission-manager.decorator';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
+import { ChurchModel } from '../../churches/entity/church.entity';
 
 @ApiTags('Tasks')
 @Controller()
@@ -53,16 +56,25 @@ export class TaskController {
   @ApiPostTask()
   @TaskWriteGuard()
   @Post()
-  //@UseGuards(AccessTokenGuard, ChurchManagerGuard)
   @UseInterceptors(TransactionInterceptor)
   postTask(
-    //@Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
     @PermissionManager() manager: ChurchUserModel,
     @Param('churchId', ParseIntPipe) churchId: number,
     @Body() dto: CreateTaskDto,
     @QueryRunner() qr: QR,
   ) {
     return this.taskService.postTask(churchId, manager, dto, qr);
+  }
+
+  @ApiRefreshTaskCount()
+  @TaskWriteGuard()
+  @Patch('refresh-count')
+  @UseInterceptors(TransactionInterceptor)
+  refreshTaskCount(
+    @PermissionChurch() church: ChurchModel,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.taskService.refreshTaskCount(church, qr);
   }
 
   @ApiGetTaskById()

--- a/backend/src/task/service/task.service.ts
+++ b/backend/src/task/service/task.service.ts
@@ -22,7 +22,10 @@ import {
   ITaskReportDomainService,
 } from '../../report/report-domain/interface/task-report-domain.service.interface';
 import { DeleteTaskReportReceiverDto } from '../../report/dto/task-report/request/delete-task-report-receiver.dto';
-import { ChurchModel } from '../../churches/entity/church.entity';
+import {
+  ChurchModel,
+  ManagementCountType,
+} from '../../churches/entity/church.entity';
 import {
   IMANAGER_DOMAIN_SERVICE,
   IManagerDomainService,
@@ -301,5 +304,18 @@ export class TaskService {
       deletedReceiverIds: dto.receiverIds,
       deletedCount: result.affected,
     };
+  }
+
+  async refreshTaskCount(church: ChurchModel, qr: QueryRunner) {
+    const taskCount = await this.taskDomainService.countAllTasks(church, qr);
+
+    await this.churchesDomainService.refreshManagementCount(
+      church,
+      ManagementCountType.TASK,
+      taskCount,
+      qr,
+    );
+
+    return { taskCount };
   }
 }

--- a/backend/src/task/task-domain/interface/task-domain.service.interface.ts
+++ b/backend/src/task/task-domain/interface/task-domain.service.interface.ts
@@ -60,4 +60,6 @@ export interface ITaskDomainService {
   ): Promise<UpdateResult>;
 
   deleteTask(targetTask: TaskModel, qr: QueryRunner): Promise<void>;
+
+  countAllTasks(church: ChurchModel, qr: QueryRunner): Promise<number>;
 }

--- a/backend/src/task/task-domain/service/task-domain.service.ts
+++ b/backend/src/task/task-domain/service/task-domain.service.ts
@@ -66,6 +66,16 @@ export class TaskDomainService implements ITaskDomainService {
     }
   }
 
+  countAllTasks(church: ChurchModel, qr: QueryRunner): Promise<number> {
+    const repository = this.getTaskRepository(qr);
+
+    return repository.count({
+      where: {
+        churchId: church.id,
+      },
+    });
+  }
+
   async findTasks(church: ChurchModel, dto: GetTasksDto, qr?: QueryRunner) {
     const taskRepository = this.getTaskRepository(qr);
 

--- a/backend/src/visitation/const/swagger/visitation.swagger.ts
+++ b/backend/src/visitation/const/swagger/visitation.swagger.ts
@@ -4,6 +4,7 @@ import {
   ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiOperation,
+  ApiParam,
 } from '@nestjs/swagger';
 
 export const ApiGetVisitations = () =>
@@ -39,6 +40,14 @@ export const ApiPostVisitation = () =>
         '<p>기록 생성 시 --> VisitationStatus: DONE</p>' +
         '<p>예약 생성이더라도 VisitationDetail 의 내용을 기재할 수 있습니다.</p>' +
         '<p>VisitationDetail 의 개수에 따라 개인 / 그룹 심방이 결정됩니다.</p>',
+    }),
+  );
+
+export const ApiRefreshVisitationCount = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({
+      summary: '교회 심방 개수 새로고침',
     }),
   );
 

--- a/backend/src/visitation/controller/visitation.controller.ts
+++ b/backend/src/visitation/controller/visitation.controller.ts
@@ -23,6 +23,7 @@ import {
   ApiGetVisitations,
   ApiPatchVisitationMeta,
   ApiPostVisitation,
+  ApiRefreshVisitationCount,
 } from '../const/swagger/visitation.swagger';
 import { UpdateVisitationDto } from '../dto/request/update-visitation.dto';
 import { AddReceiverDto } from '../dto/receiever/add-receiver.dto';
@@ -31,6 +32,8 @@ import { VisitationReadGuard } from '../guard/visitation-read.guard';
 import { VisitationWriteGuard } from '../guard/visitation-write.guard';
 import { PermissionManager } from '../../permission/decorator/permission-manager.decorator';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
+import { ChurchModel } from '../../churches/entity/church.entity';
 
 @ApiTags('Visitations')
 @Controller('visitations')
@@ -52,19 +55,24 @@ export class VisitationController {
   @Post()
   @UseInterceptors(TransactionInterceptor)
   postVisitationReservation(
-    //@Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
     @PermissionManager() manager: ChurchUserModel,
     @Param('churchId', ParseIntPipe) churchId: number,
     @Body() dto: CreateVisitationDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.visitationService.createVisitation(
-      //accessPayload.id,
-      manager,
-      churchId,
-      dto,
-      qr,
-    );
+    return this.visitationService.createVisitation(manager, churchId, dto, qr);
+  }
+
+  @ApiRefreshVisitationCount()
+  @Patch('refresh-count')
+  @VisitationWriteGuard()
+  @UseInterceptors(TransactionInterceptor)
+  refreshVisitationCount(
+    //@Param('churchId', ParseIntPipe) churchId: number,
+    @PermissionChurch() church: ChurchModel,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.visitationService.refreshVisitationCount(church, qr);
   }
 
   @ApiGetVisitationById()

--- a/backend/src/visitation/service/visitation.service.ts
+++ b/backend/src/visitation/service/visitation.service.ts
@@ -23,7 +23,10 @@ import { CreateVisitationMetaDto } from '../dto/internal/meta/create-visitation-
 import { GetVisitationDto } from '../dto/request/get-visitation.dto';
 import { VisitationType } from '../const/visitation-type.enum';
 import { UpdateVisitationDto } from '../dto/request/update-visitation.dto';
-import { ChurchModel } from '../../churches/entity/church.entity';
+import {
+  ChurchModel,
+  ManagementCountType,
+} from '../../churches/entity/church.entity';
 import { MemberModel } from '../../members/entity/member.entity';
 import {
   IVISITATION_REPORT_DOMAIN_SERVICE,
@@ -411,5 +414,19 @@ export class VisitationService {
       deleteReceiverIds: deleteReceiverIds,
       deletedCount: result.affected,
     };
+  }
+
+  async refreshVisitationCount(church: ChurchModel, qr: QueryRunner) {
+    const visitationCount =
+      await this.visitationMetaDomainService.countAllVisitations(church, qr);
+
+    await this.churchesDomainService.refreshManagementCount(
+      church,
+      ManagementCountType.VISITATION,
+      visitationCount,
+      qr,
+    );
+
+    return { visitationCount };
   }
 }

--- a/backend/src/visitation/visitation-domain/interface/visitation-meta-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/interface/visitation-meta-domain.service.interface.ts
@@ -52,4 +52,6 @@ export interface IVisitationMetaDomainService {
     metaData: VisitationMetaModel,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
+
+  countAllVisitations(church: ChurchModel, qr: QueryRunner): Promise<number>;
 }

--- a/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
@@ -34,7 +34,6 @@ import { ChurchUserRole } from '../../../user/const/user-role.enum';
 import { MemberException } from '../../../members/const/exception/member.exception';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { ManagerException } from '../../../manager/exception/manager.exception';
-import { UpdateVisitationDto } from '../../dto/request/update-visitation.dto';
 
 @Injectable()
 export class VisitationMetaDomainService
@@ -74,6 +73,16 @@ export class VisitationMetaDomainService
       title: dto.title && ILike(`%${dto.title}%`),
       inChargeId: dto.inChargeId,
     };
+  }
+
+  countAllVisitations(church: ChurchModel, qr: QueryRunner): Promise<number> {
+    const repository = this.getVisitationMetaRepository(qr);
+
+    return repository.count({
+      where: {
+        churchId: church.id,
+      },
+    });
   }
 
   async paginateVisitations(

--- a/backend/src/worship/controller/worship.controller.ts
+++ b/backend/src/worship/controller/worship.controller.ts
@@ -11,7 +11,7 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 import { WorshipService } from '../service/worship.service';
 import { GetWorshipsDto } from '../dto/request/worship/get-worships.dto';
 import { CreateWorshipDto } from '../dto/request/worship/create-worship.dto';
@@ -51,6 +51,17 @@ export class WorshipController {
     @PermissionChurch() church: ChurchModel,
   ) {
     return this.worshipService.postWorship(church, dto, qr);
+  }
+
+  @ApiParam({ name: 'churchId' })
+  @Patch('refresh-count')
+  @WorshipWriteGuard()
+  @UseInterceptors(TransactionInterceptor)
+  refreshWorshipCount(
+    @PermissionChurch() church: ChurchModel,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.worshipService.refreshWorshipCount(church, qr);
   }
 
   @Get(':worshipId')

--- a/backend/src/worship/worship-domain/interface/worship-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-domain.service.interface.ts
@@ -50,4 +50,6 @@ export interface IWorshipDomainService {
     targetWorship: WorshipModel,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
+
+  countAllWorships(church: ChurchModel, qr: QueryRunner): Promise<number>;
 }

--- a/backend/src/worship/worship-domain/service/worship-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-domain.service.ts
@@ -33,6 +33,16 @@ export class WorshipDomainService implements IWorshipDomainService {
     return qr ? qr.manager.getRepository(WorshipModel) : this.repository;
   }
 
+  countAllWorships(church: ChurchModel, qr: QueryRunner): Promise<number> {
+    const repository = this.getRepository(qr);
+
+    return repository.count({
+      where: {
+        churchId: church.id,
+      },
+    });
+  }
+
   async findWorships(
     church: ChurchModel,
     dto: GetWorshipsDto,


### PR DESCRIPTION
## 주요 내용
- ChurchModel에 groupCount, ministryGroupCount, ministryCount, officerCount, educationCount, visitationCount, taskCount, worshipCount 컬럼 추가
- 각 항목 생성/삭제 시 해당 count 값을 자동으로 갱신하도록 로직 구현

## 세부 내용

### Entity
- ChurchModel에 항목별 count 컬럼 추가
  - groupCount
  - ministryGroupCount
  - ministryCount
  - officerCount
  - educationCount
  - visitationCount
  - taskCount
  - worshipCount

### 기능
- 각 도메인별 항목 생성 시 count +1
- 각 도메인별 항목 삭제 시 count -1
- 트랜잭션 내에서 일관성 있게 처리되도록 QueryRunner 기반으로 처리

### 향후 계획
- 교회가 생성할 수 있는 항목 수에 상한선을 두고, count 값 기반으로 제약을 적용할 예정