### PR TITLE
feat: 홈화면 신규 등록자 요약 및 상세 조회 API 추가

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -68,6 +68,7 @@ import { WorshipTargetGroupModel } from './worship/entity/worship-target-group.e
 import { CalendarModule } from './calendar/calendar.module';
 import { ChurchEventModel } from './calendar/entity/church-event.entity';
 import { MyPageModule } from './my-page/my-page.module';
+import { HomeModule } from './home/home.module';
 
 @Module({
   imports: [
@@ -217,6 +218,7 @@ import { MyPageModule } from './my-page/my-page.module';
     TaskModule,
     WorshipModule,
     CalendarModule,
+    HomeModule,
 
     ChurchesDomainModule,
     MembersDomainModule,

--- a/backend/src/common/decorator/validator/is-yyyy-mm-dd.validator.ts
+++ b/backend/src/common/decorator/validator/is-yyyy-mm-dd.validator.ts
@@ -1,0 +1,28 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+} from 'class-validator';
+
+export function IsYYYYMMDD(
+  fieldLabel: string,
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isYYYYMMDD',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: {
+        message: `${fieldLabel} 은 YYYY-MM-DD 형식이어야 합니다.`,
+        ...validationOptions,
+      },
+      validator: {
+        validate(value: any, _args: ValidationArguments) {
+          if (typeof value !== 'string') return false;
+          return /^\d{4}-\d{2}-\d{2}$/.test(value);
+        },
+      },
+    });
+  };
+}

--- a/backend/src/home/const/get-new-member-detail-order.enum.ts
+++ b/backend/src/home/const/get-new-member-detail-order.enum.ts
@@ -1,0 +1,3 @@
+export enum GetNewMemberDetailOrderEnum {
+  REGISTERED_AT = 'registeredAt',
+}

--- a/backend/src/home/const/get-new-member-summary-range.enum.ts
+++ b/backend/src/home/const/get-new-member-summary-range.enum.ts
@@ -1,0 +1,4 @@
+export enum GetNewMemberSummaryRangeEnum {
+  WEEKLY = 'weekly',
+  MONTHLY = 'monthly',
+}

--- a/backend/src/home/controller/home.controller.ts
+++ b/backend/src/home/controller/home.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { ChurchManagerGuard } from '../../permission/guard/church-manager.guard';
+import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { HomeService } from '../service/home.service';
+import { GetNewMemberSummaryDto } from '../dto/request/get-new-member-summary.dto';
+import { GetNewMemberDetailDto } from '../dto/request/get-new-member-detail.dto';
+import {
+  ApiGetNewMemberDetail,
+  ApiGetNewMemberSummary,
+} from '../swagger/home.swagger';
+
+@Controller()
+export class HomeController {
+  constructor(private readonly homeService: HomeService) {}
+
+  @ApiGetNewMemberSummary()
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
+  @Get('members/new/summary')
+  getNewMemberSummary(
+    @PermissionChurch() church: ChurchModel,
+    @Query() dto: GetNewMemberSummaryDto,
+  ) {
+    return this.homeService.getNewMemberSummary(church, dto);
+  }
+
+  @ApiGetNewMemberDetail()
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
+  @Get('members/new/details')
+  getNewMemberDetails(
+    @PermissionChurch() church: ChurchModel,
+    @Query() dto: GetNewMemberDetailDto,
+  ) {
+    return this.homeService.getNewMemberDetails(church, dto);
+  }
+}

--- a/backend/src/home/dto/request/get-new-member-detail.dto.ts
+++ b/backend/src/home/dto/request/get-new-member-detail.dto.ts
@@ -1,0 +1,32 @@
+import { BaseOffsetPaginationRequestDto } from '../../../common/dto/request/base-offset-pagination-request.dto';
+import { GetNewMemberDetailOrderEnum } from '../../const/get-new-member-detail-order.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsEnum, IsOptional } from 'class-validator';
+import { GetNewMemberSummaryRangeEnum } from '../../const/get-new-member-summary-range.enum';
+import { IsYYYYMMDD } from '../../../common/decorator/validator/is-yyyy-mm-dd.validator';
+
+export class GetNewMemberDetailDto extends BaseOffsetPaginationRequestDto<GetNewMemberDetailOrderEnum> {
+  @ApiProperty({
+    description: '정렬 조건',
+    default: GetNewMemberDetailOrderEnum.REGISTERED_AT,
+    enum: GetNewMemberDetailOrderEnum,
+    required: false,
+  })
+  @IsEnum(GetNewMemberDetailOrderEnum)
+  order: GetNewMemberDetailOrderEnum =
+    GetNewMemberDetailOrderEnum.REGISTERED_AT;
+
+  @ApiProperty({
+    description: '신규 교인 검색 단위 범위',
+    enum: GetNewMemberSummaryRangeEnum,
+    default: GetNewMemberSummaryRangeEnum.WEEKLY,
+  })
+  @IsEnum(GetNewMemberSummaryRangeEnum)
+  range: GetNewMemberSummaryRangeEnum = GetNewMemberSummaryRangeEnum.WEEKLY;
+
+  @ApiProperty({})
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('periodStart')
+  periodStart: string;
+}

--- a/backend/src/home/dto/request/get-new-member-summary.dto.ts
+++ b/backend/src/home/dto/request/get-new-member-summary.dto.ts
@@ -1,0 +1,34 @@
+import { GetNewMemberSummaryRangeEnum } from '../../const/get-new-member-summary-range.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsEnum, IsOptional } from 'class-validator';
+import { IsAfterDate } from '../../../common/decorator/validator/is-after-date.decorator';
+import { IsYYYYMMDD } from '../../../common/decorator/validator/is-yyyy-mm-dd.validator';
+
+export class GetNewMemberSummaryDto {
+  @ApiProperty({
+    description: '신규 교인 검색 단위 범위',
+    enum: GetNewMemberSummaryRangeEnum,
+    default: GetNewMemberSummaryRangeEnum.WEEKLY,
+  })
+  @IsEnum(GetNewMemberSummaryRangeEnum)
+  range: GetNewMemberSummaryRangeEnum = GetNewMemberSummaryRangeEnum.WEEKLY;
+
+  @ApiProperty({
+    description: '등록기간 시작 날짜 (YYYY-MM-DD)',
+    required: false,
+  })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('from')
+  from?: string;
+
+  @ApiProperty({
+    description: '등록기간 종료 날짜 (YYYY-MM-DD)',
+    required: false,
+  })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('to')
+  @IsAfterDate('from')
+  to?: string;
+}

--- a/backend/src/home/dto/response/get-new-member-detail-response.dto.ts
+++ b/backend/src/home/dto/response/get-new-member-detail-response.dto.ts
@@ -1,0 +1,8 @@
+import { MemberModel } from '../../../members/entity/member.entity';
+
+export class GetNewMemberDetailResponseDto {
+  constructor(
+    public readonly data: MemberModel[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/home/dto/response/get-new-member-summary-response.dto.ts
+++ b/backend/src/home/dto/response/get-new-member-summary-response.dto.ts
@@ -1,0 +1,8 @@
+export class GetNewMemberSummaryResponseDto {
+  constructor(
+    public readonly range: 'weekly' | 'monthly',
+    public readonly unit: 'week' | 'month',
+    public readonly data: { periodStart: Date; count: number }[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/home/dto/response/new-member-summary.dto.ts
+++ b/backend/src/home/dto/response/new-member-summary.dto.ts
@@ -1,0 +1,9 @@
+export class NewMemberSummaryDto {
+  period_start: string;
+  count: number;
+
+  constructor(period_start: string, count: number) {
+    this.period_start = period_start;
+    this.count = count;
+  }
+}

--- a/backend/src/home/home.module.ts
+++ b/backend/src/home/home.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common';
+import { RouterModule } from '@nestjs/core';
+import { HomeController } from './controller/home.controller';
+import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
+import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
+import { IDOMAIN_PERMISSION_SERVICE } from '../permission/service/domain-permission.service.interface';
+import { HomePermissionService } from './service/home-permission.service';
+import { MembersDomainModule } from '../members/member-domain/members-domain.module';
+import { HomeService } from './service/home.service';
+
+@Module({
+  imports: [
+    RouterModule.register([
+      { path: 'churches/:churchId/home', module: HomeModule },
+    ]),
+    ChurchesDomainModule,
+    ManagerDomainModule,
+
+    MembersDomainModule,
+  ],
+  controllers: [HomeController],
+  providers: [
+    HomeService,
+    {
+      provide: IDOMAIN_PERMISSION_SERVICE,
+      useClass: HomePermissionService,
+    },
+  ],
+})
+export class HomeModule {}

--- a/backend/src/home/service/home-permission.service.ts
+++ b/backend/src/home/service/home-permission.service.ts
@@ -1,0 +1,69 @@
+import { DomainPermissionService } from '../../permission/service/domain-permission.service';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { DomainAction } from '../../permission/const/domain-action.enum';
+import {
+  IChurchesDomainService,
+  ICHURCHES_DOMAIN_SERVICE,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import { Inject } from '@nestjs/common';
+import {
+  IMANAGER_DOMAIN_SERVICE,
+  IManagerDomainService,
+} from '../../manager/manager-domain/service/interface/manager-domain.service.interface';
+
+export class HomePermissionService extends DomainPermissionService {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IMANAGER_DOMAIN_SERVICE)
+    private readonly managerDomainService: IManagerDomainService,
+  ) {
+    super();
+  }
+
+  async getRequestManagerOrThrow(
+    churchId: number,
+    requestUserId: number,
+  ): Promise<{
+    requestManager: ChurchUserModel;
+    church: ChurchModel;
+  }> {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    return { requestManager, church };
+  }
+
+  async hasPermission(
+    churchId: number,
+    requestUserId: number,
+    domainAction: DomainAction,
+  ): Promise<{
+    requestManager: ChurchUserModel;
+    church: ChurchModel;
+  } | null> {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    const permission = true;
+
+    if (permission) {
+      return { requestManager, church };
+    } else {
+      return null;
+    }
+  }
+}

--- a/backend/src/home/service/home.service.ts
+++ b/backend/src/home/service/home.service.ts
@@ -1,0 +1,100 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  IMEMBERS_DOMAIN_SERVICE,
+  IMembersDomainService,
+} from '../../members/member-domain/interface/members-domain.service.interface';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { fromZonedTime, toZonedTime } from 'date-fns-tz';
+import { TIME_ZONE } from '../../common/const/time-zone.const';
+import { GetNewMemberSummaryRangeEnum } from '../const/get-new-member-summary-range.enum';
+import {
+  add,
+  endOfDay,
+  getWeekOfMonth,
+  startOfDay,
+  subMonths,
+  subWeeks,
+} from 'date-fns';
+import { GetNewMemberSummaryDto } from '../dto/request/get-new-member-summary.dto';
+import { GetNewMemberSummaryResponseDto } from '../dto/response/get-new-member-summary-response.dto';
+import { GetNewMemberDetailDto } from '../dto/request/get-new-member-detail.dto';
+import { GetNewMemberDetailResponseDto } from '../dto/response/get-new-member-detail-response.dto';
+
+@Injectable()
+export class HomeService {
+  constructor(
+    @Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,
+  ) {}
+
+  private getDateRange(range: 'weekly' | 'monthly') {
+    const timeZone = TIME_ZONE.SEOUL;
+    const now = new Date();
+
+    if (range === 'weekly') {
+      const start = subWeeks(startOfDay(now), 4);
+      const end = endOfDay(now);
+
+      return {
+        from: fromZonedTime(start, timeZone),
+        to: fromZonedTime(end, timeZone),
+      };
+    }
+
+    // MONTHLY
+    const start = subMonths(startOfDay(now), 12);
+    const end = endOfDay(now);
+
+    return {
+      from: fromZonedTime(start, timeZone),
+      to: toZonedTime(end, timeZone),
+    };
+  }
+
+  async getNewMemberSummary(church: ChurchModel, dto: GetNewMemberSummaryDto) {
+    const defaultRange = this.getDateRange(dto.range);
+
+    const from = dto.from
+      ? fromZonedTime(dto.from, TIME_ZONE.SEOUL)
+      : defaultRange.from;
+    const to = dto.to
+      ? fromZonedTime(endOfDay(new Date(dto.to)), TIME_ZONE.SEOUL)
+      : defaultRange.to;
+
+    const data = await this.membersDomainService.getNewMemberSummary(
+      church,
+      dto.range,
+      from,
+      to,
+    );
+
+    const result = data.map((summary) => ({
+      weekOfMonth: getWeekOfMonth(summary.period_start, { weekStartsOn: 0 }),
+      periodStart: fromZonedTime(summary.period_start, TIME_ZONE.SEOUL),
+      count: summary.count,
+    }));
+
+    return new GetNewMemberSummaryResponseDto(
+      dto.range,
+      dto.range === GetNewMemberSummaryRangeEnum.WEEKLY ? 'week' : 'month',
+      result,
+    );
+  }
+
+  async getNewMemberDetails(church: ChurchModel, dto: GetNewMemberDetailDto) {
+    const from = fromZonedTime(dto.periodStart, TIME_ZONE.SEOUL);
+    const to =
+      dto.range === 'weekly'
+        ? fromZonedTime(endOfDay(add(from, { weeks: 1 })), TIME_ZONE.SEOUL)
+        : fromZonedTime(endOfDay(add(from, { months: 1 })), TIME_ZONE.SEOUL);
+
+    const newMembers = await this.membersDomainService.findNewMemberDetails(
+      church,
+      dto,
+      from,
+      to,
+    );
+
+    return new GetNewMemberDetailResponseDto(newMembers);
+  }
+}

--- a/backend/src/home/swagger/home.swagger.ts
+++ b/backend/src/home/swagger/home.swagger.ts
@@ -1,0 +1,28 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
+
+export const ApiGetNewMemberSummary = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({
+      summary: '신규 등록자 요약 조회',
+      description:
+        '<h2>신규 등록자 요약(수)를 조회합니다.</h2>' +
+        '<p>from, to 값이 없을 경우 검색범위는 이번달 or 올해로 자동 지정됩니다.</p>' +
+        '<p><b>쿼리 파라미터</b></p>' +
+        '<p>range: 신규 등록자 조회의 월간/주간을 선택</p>' +
+        '<p>월간: 올해 신규 등록자 수를 월간 조회</p>' +
+        '<p>주간: 이번달 신규 등록자 수를 주간 조회</p>' +
+        '<p>from: 신규 등록자 조회 시작 날짜 (선택값)</p>' +
+        '<p>to: 신규 등록자 조회 종료 날짜 (선택값)</p>',
+    }),
+  );
+
+export const ApiGetNewMemberDetail = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({
+      summary: '신규 등록자 상세 조회',
+      description: '<h2>신규 등록자를 상세 조회합니다.</h2>',
+    }),
+  );

--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -19,6 +19,8 @@ import { MembersDomainPaginationResultDto } from '../dto/members-domain-paginati
 import { GetSimpleMembersDto } from '../../dto/request/get-simple-members.dto';
 import { GetRecommendLinkMemberDto } from '../../dto/request/get-recommend-link-member.dto';
 import { GetBirthdayMembersDto } from '../../../calendar/dto/request/birthday/get-birthday-members.dto';
+import { GetNewMemberSummaryRangeEnum } from '../../../home/const/get-new-member-summary-range.enum';
+import { GetNewMemberDetailDto } from '../../../home/dto/request/get-new-member-detail.dto';
 
 export const IMEMBERS_DOMAIN_SERVICE = Symbol('IMEMBERS_DOMAIN_SERVICE');
 
@@ -172,4 +174,18 @@ export interface IMembersDomainService {
   ): Promise<UpdateResult>;
 
   endMemberGroup(member: MemberModel, qr: QueryRunner): Promise<UpdateResult>;
+
+  getNewMemberSummary(
+    church: ChurchModel,
+    range: GetNewMemberSummaryRangeEnum,
+    from: Date,
+    to: Date,
+  ): Promise<any[]>;
+
+  findNewMemberDetails(
+    church: ChurchModel,
+    dto: GetNewMemberDetailDto,
+    from: Date,
+    to: Date,
+  ): Promise<MemberModel[]>;
 }

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -8,6 +8,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { MemberModel } from '../../entity/member.entity';
 import {
+  Between,
   FindOptionsOrder,
   FindOptionsRelations,
   FindOptionsSelect,
@@ -41,6 +42,9 @@ import {
 import { GetRecommendLinkMemberDto } from '../../dto/request/get-recommend-link-member.dto';
 import { GetBirthdayMembersDto } from '../../../calendar/dto/request/birthday/get-birthday-members.dto';
 import KoreanLunarCalendar from 'korean-lunar-calendar';
+import { GetNewMemberSummaryRangeEnum } from '../../../home/const/get-new-member-summary-range.enum';
+import { GetNewMemberDetailDto } from '../../../home/dto/request/get-new-member-detail.dto';
+import { NewMemberSummaryDto } from '../../../home/dto/response/new-member-summary.dto';
 
 @Injectable()
 export class MembersDomainService implements IMembersDomainService {
@@ -677,5 +681,75 @@ export class MembersDomainService implements IMembersDomainService {
         groupRoleId: null,
       },
     );
+  }
+
+  async getNewMemberSummary(
+    church: ChurchModel,
+    range: GetNewMemberSummaryRangeEnum,
+    from: Date,
+    to: Date,
+  ): Promise<NewMemberSummaryDto[]> {
+    const repository = this.getMembersRepository();
+
+    const qb = repository.createQueryBuilder('member');
+
+    if (range === GetNewMemberSummaryRangeEnum.WEEKLY) {
+      qb.select([
+        `
+        (
+          DATE_TRUNC('day', member.registeredAt AT TIME ZONE 'UTC' AT TIME ZONE :tz)  -- 타임존 적용
+          - (EXTRACT(DOW FROM (member.registeredAt AT TIME ZONE 'UTC') AT TIME ZONE :tz)::int) * INTERVAL '1 day'
+        ) AS period_start
+        `,
+        `COUNT(*)::int AS count`,
+      ]);
+    } else {
+      qb.select([
+        `
+          DATE_TRUNC('month',(member.registeredAt AT TIME ZONE 'UTC') AT TIME ZONE :tz) AS period_start
+          `,
+        `COUNT(*)::int AS count`,
+      ]);
+    }
+
+    qb.where('member.churchId = :churchId', { churchId: church.id })
+      .andWhere(`member.registeredAt BETWEEN :from AND :to`, {
+        from,
+        to,
+      })
+      .groupBy('period_start')
+      .orderBy('period_start', 'ASC')
+      .setParameters({
+        tz: 'Asia/Seoul', // 원하는 타임존
+      });
+
+    const data: { period_start: string; count: number }[] =
+      await qb.getRawMany();
+
+    return data.map((d) => new NewMemberSummaryDto(d.period_start, d.count));
+  }
+
+  async findNewMemberDetails(
+    church: ChurchModel,
+    dto: GetNewMemberDetailDto,
+    from: Date,
+    to: Date,
+  ): Promise<MemberModel[]> {
+    const repository = this.getMembersRepository();
+
+    return repository.find({
+      where: {
+        churchId: church.id,
+        registeredAt: Between(from, to),
+      },
+      relations: MemberSummarizedRelation,
+      select: { ...MemberSummarizedSelect, registeredAt: true },
+      order: {
+        [dto.order]: dto.orderDirection,
+        id: 'ASC',
+      },
+      take: dto.take,
+      skip: dto.take * (dto.page - 1),
+    });
   }
 }

--- a/backend/src/worship/dto/request/worship-enrollment/get-worship-enrollments.dto.ts
+++ b/backend/src/worship/dto/request/worship-enrollment/get-worship-enrollments.dto.ts
@@ -1,10 +1,11 @@
 import { BaseOffsetPaginationRequestDto } from '../../../../common/dto/request/base-offset-pagination-request.dto';
 import { WorshipEnrollmentOrderEnum } from '../../../const/worship-enrollment-order.enum';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDateString, IsEnum, IsNumber, Matches } from 'class-validator';
+import { IsDateString, IsEnum, IsNumber } from 'class-validator';
 import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
 import { fromZonedTime } from 'date-fns-tz';
 import { TIME_ZONE } from '../../../../common/const/time-zone.const';
+import { IsYYYYMMDD } from '../../../../common/decorator/validator/is-yyyy-mm-dd.validator';
 
 export class GetWorshipEnrollmentsDto extends BaseOffsetPaginationRequestDto<WorshipEnrollmentOrderEnum> {
   @ApiProperty({
@@ -30,9 +31,7 @@ export class GetWorshipEnrollmentsDto extends BaseOffsetPaginationRequestDto<Wor
   })
   @IsOptionalNotNull()
   @IsDateString({ strict: true })
-  @Matches(/^\d{4}-\d{2}-\d{2}$/, {
-    message: 'fromSessionDate는 YYYY-MM-DD 형식이어야 합니다.',
-  })
+  @IsYYYYMMDD('fromSessionDate')
   fromSessionDate: string;
 
   @ApiProperty({
@@ -41,9 +40,7 @@ export class GetWorshipEnrollmentsDto extends BaseOffsetPaginationRequestDto<Wor
   })
   @IsOptionalNotNull()
   @IsDateString({ strict: true })
-  @Matches(/^\d{4}-\d{2}-\d{2}$/, {
-    message: 'toSessionDate는 YYYY-MM-DD 형식이어야 합니다.',
-  })
+  @IsYYYYMMDD('toSessionDate')
   toSessionDate: string;
 
   get fromSessionDateUtc(): Date | undefined {

--- a/backend/src/worship/dto/request/worship-session/create-worship-session.dto.ts
+++ b/backend/src/worship/dto/request/worship-session/create-worship-session.dto.ts
@@ -6,10 +6,10 @@ import {
   MAX_WORSHIP_TITLE,
 } from '../../../constraints/worship.constraints';
 import {
+  IsDateString,
   IsNumber,
   IsString,
   IsUrl,
-  Matches,
   MaxLength,
   Min,
 } from 'class-validator';
@@ -19,15 +19,15 @@ import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decora
 import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
 import { fromZonedTime } from 'date-fns-tz';
 import { TIME_ZONE } from '../../../../common/const/time-zone.const';
+import { IsYYYYMMDD } from '../../../../common/decorator/validator/is-yyyy-mm-dd.validator';
 
 @SanitizeDto()
 export class CreateWorshipSessionDto {
   @ApiProperty({
     description: '예배 세션 진행 날짜 (필수, YYYY-MM-DD)',
   })
-  @Matches(/^\d{4}-\d{2}-\d{2}$/, {
-    message: 'sessionDate는 YYYY-MM-DD 형식이어야 합니다.',
-  })
+  @IsYYYYMMDD('sessionDate')
+  @IsDateString({ strict: true })
   sessionDate: string;
 
   get sessionDateUtc(): Date {


### PR DESCRIPTION
## 주요 내용
- 홈화면 대시보드에서 활용할 수 있는 신규 등록자 통계 및 상세 조회 기능 구현
- 등록자 수 통계는 주간 또는 월간 단위로 조회 가능
- 상세 조회는 주차 또는 월 단위 기준으로 등록자 목록을 페이징 처리하여 반환

## 세부 내용

### API: GET /churches/{churchId}/home/members/new/summary
- range: 'weekly' 또는 'monthly' (필수)
- from, to: 선택 (없을 경우 기본값 적용)
  - weekly: 최근 4주
  - monthly: 최근 12개월
- 응답 데이터에는 periodStart, count, weekOfMonth 포함
- periodStart는 타임존(Asia/Seoul) 기준으로 집계 후 UTC로 변환하여 반환
- weekOfMonth는 주간 기준에서만 포함됨

### API: GET /churches/{churchId}/home/members/new/details
- range: 'weekly' 또는 'monthly' (필수)
- periodStart: 기준 시작일 (YYYY-MM-DD)
- take, page: 페이징 파라미터
- order, orderDirection: 정렬 옵션 (기본 registeredAt)
- 등록자별 프로필, 소속 그룹 및 직분 정보 포함하여 반환

### 기타
- from/to 날짜 계산 시 Asia/Seoul 타임존 기준으로 변환 후 UTC로 쿼리
- 정규식 기반의 YYYY-MM-DD 유효성 검사 데코레이터는 커스텀 validator로 분리