### PR TITLE
feat: 홈화면에서 내가 담당한 업무 일정을 조회하는 API 추가

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -22,6 +22,8 @@
         "class-validator": "^0.14.1",
         "cookie-parser": "^1.4.7",
         "coolsms-node-sdk": "^2.1.0",
+        "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "dotenv": "^16.4.5",
         "joi": "^17.13.3",
         "korean-lunar-calendar": "^0.3.6",
@@ -690,13 +692,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -4212,6 +4211,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/coolsms-node-sdk/node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -4323,19 +4338,22 @@
       "license": "MIT"
     },
     "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/dayjs": {
@@ -8641,12 +8659,6 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "license": "Apache-2.0"
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,8 @@
     "class-validator": "^0.14.1",
     "cookie-parser": "^1.4.7",
     "coolsms-node-sdk": "^2.1.0",
+    "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "dotenv": "^16.4.5",
     "joi": "^17.13.3",
     "korean-lunar-calendar": "^0.3.6",

--- a/backend/src/home/const/widget-range.enum.ts
+++ b/backend/src/home/const/widget-range.enum.ts
@@ -1,4 +1,4 @@
-export enum GetNewMemberSummaryRangeEnum {
+export enum WidgetRangeEnum {
   WEEKLY = 'weekly',
   MONTHLY = 'monthly',
 }

--- a/backend/src/home/controller/home.controller.ts
+++ b/backend/src/home/controller/home.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../permission/guard/church-manager.guard';
 import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
@@ -7,9 +13,13 @@ import { HomeService } from '../service/home.service';
 import { GetNewMemberSummaryDto } from '../dto/request/get-new-member-summary.dto';
 import { GetNewMemberDetailDto } from '../dto/request/get-new-member-detail.dto';
 import {
+  ApiGetMyTasks,
   ApiGetNewMemberDetail,
   ApiGetNewMemberSummary,
 } from '../swagger/home.swagger';
+import { PermissionManager } from '../../permission/decorator/permission-manager.decorator';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { GetMyTasksDto } from '../dto/request/get-my-tasks.dto';
 
 @Controller()
 export class HomeController {
@@ -33,5 +43,19 @@ export class HomeController {
     @Query() dto: GetNewMemberDetailDto,
   ) {
     return this.homeService.getNewMemberDetails(church, dto);
+  }
+
+  @ApiGetMyTasks()
+  @Get('tasks')
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
+  getMyTasks(
+    @Query() dto: GetMyTasksDto,
+    @PermissionManager() pm: ChurchUserModel,
+  ) {
+    if ((dto.from && !dto.to) || (!dto.from && dto.to)) {
+      throw new BadRequestException('from, to 에러');
+    }
+
+    return this.homeService.getMyTasks(pm, dto);
   }
 }

--- a/backend/src/home/dto/request/get-my-tasks.dto.ts
+++ b/backend/src/home/dto/request/get-my-tasks.dto.ts
@@ -1,0 +1,54 @@
+import { BaseOffsetPaginationRequestDto } from '../../../common/dto/request/base-offset-pagination-request.dto';
+import { TaskOrder } from '../../../task/const/task-order.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsEnum, IsIn, IsOptional } from 'class-validator';
+import { IsYYYYMMDD } from '../../../common/decorator/validator/is-yyyy-mm-dd.validator';
+import { IsAfterDate } from '../../../common/decorator/validator/is-after-date.decorator';
+import { WidgetRangeEnum } from '../../const/widget-range.enum';
+
+export class GetMyTasksDto extends BaseOffsetPaginationRequestDto<TaskOrder> {
+  @ApiProperty({
+    description: '정렬 조건',
+    default: TaskOrder.endDate,
+    enum: TaskOrder,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(TaskOrder)
+  order: TaskOrder = TaskOrder.endDate;
+
+  @ApiProperty({
+    description: '정렬 오름차순/내림차순',
+    default: 'DESC',
+    required: false,
+  })
+  @IsIn(['asc', 'desc', 'ASC', 'DESC'])
+  @IsOptional()
+  override orderDirection: 'ASC' | 'DESC' | 'asc' | 'desc' = 'DESC';
+
+  @ApiProperty({
+    description: '검색 단위 (주간 / 월간)',
+    enum: WidgetRangeEnum,
+  })
+  @IsEnum(WidgetRangeEnum)
+  range: WidgetRangeEnum;
+
+  @ApiProperty({
+    description: '검색 시작일(YYYY-MM-DD)',
+    required: false,
+  })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('from')
+  from?: string;
+
+  @ApiProperty({
+    description: '검색 종료일(YYYY-MM-DD)',
+    required: false,
+  })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsAfterDate('from')
+  @IsYYYYMMDD('to')
+  to?: string;
+}

--- a/backend/src/home/dto/request/get-new-member-detail.dto.ts
+++ b/backend/src/home/dto/request/get-new-member-detail.dto.ts
@@ -2,7 +2,7 @@ import { BaseOffsetPaginationRequestDto } from '../../../common/dto/request/base
 import { GetNewMemberDetailOrderEnum } from '../../const/get-new-member-detail-order.enum';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsDateString, IsEnum, IsOptional } from 'class-validator';
-import { GetNewMemberSummaryRangeEnum } from '../../const/get-new-member-summary-range.enum';
+import { WidgetRangeEnum } from '../../const/widget-range.enum';
 import { IsYYYYMMDD } from '../../../common/decorator/validator/is-yyyy-mm-dd.validator';
 
 export class GetNewMemberDetailDto extends BaseOffsetPaginationRequestDto<GetNewMemberDetailOrderEnum> {
@@ -18,11 +18,11 @@ export class GetNewMemberDetailDto extends BaseOffsetPaginationRequestDto<GetNew
 
   @ApiProperty({
     description: '신규 교인 검색 단위 범위',
-    enum: GetNewMemberSummaryRangeEnum,
-    default: GetNewMemberSummaryRangeEnum.WEEKLY,
+    enum: WidgetRangeEnum,
+    default: WidgetRangeEnum.WEEKLY,
   })
-  @IsEnum(GetNewMemberSummaryRangeEnum)
-  range: GetNewMemberSummaryRangeEnum = GetNewMemberSummaryRangeEnum.WEEKLY;
+  @IsEnum(WidgetRangeEnum)
+  range: WidgetRangeEnum = WidgetRangeEnum.WEEKLY;
 
   @ApiProperty({})
   @IsOptional()

--- a/backend/src/home/dto/request/get-new-member-summary.dto.ts
+++ b/backend/src/home/dto/request/get-new-member-summary.dto.ts
@@ -1,4 +1,4 @@
-import { GetNewMemberSummaryRangeEnum } from '../../const/get-new-member-summary-range.enum';
+import { WidgetRangeEnum } from '../../const/widget-range.enum';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsDateString, IsEnum, IsOptional } from 'class-validator';
 import { IsAfterDate } from '../../../common/decorator/validator/is-after-date.decorator';
@@ -7,11 +7,11 @@ import { IsYYYYMMDD } from '../../../common/decorator/validator/is-yyyy-mm-dd.va
 export class GetNewMemberSummaryDto {
   @ApiProperty({
     description: '신규 교인 검색 단위 범위',
-    enum: GetNewMemberSummaryRangeEnum,
-    default: GetNewMemberSummaryRangeEnum.WEEKLY,
+    enum: WidgetRangeEnum,
+    default: WidgetRangeEnum.WEEKLY,
   })
-  @IsEnum(GetNewMemberSummaryRangeEnum)
-  range: GetNewMemberSummaryRangeEnum = GetNewMemberSummaryRangeEnum.WEEKLY;
+  @IsEnum(WidgetRangeEnum)
+  range: WidgetRangeEnum = WidgetRangeEnum.WEEKLY;
 
   @ApiProperty({
     description: '등록기간 시작 날짜 (YYYY-MM-DD)',

--- a/backend/src/home/dto/response/get-my-tasks-response.dto.ts
+++ b/backend/src/home/dto/response/get-my-tasks-response.dto.ts
@@ -1,0 +1,12 @@
+import { TaskModel } from '../../../task/entity/task.entity';
+import { WidgetRangeEnum } from '../../const/widget-range.enum';
+
+export class GetMyTasksResponseDto {
+  constructor(
+    public readonly range: WidgetRangeEnum,
+    public readonly from: Date,
+    public readonly to: Date,
+    public readonly data: TaskModel[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/home/home.module.ts
+++ b/backend/src/home/home.module.ts
@@ -7,6 +7,7 @@ import { IDOMAIN_PERMISSION_SERVICE } from '../permission/service/domain-permiss
 import { HomePermissionService } from './service/home-permission.service';
 import { MembersDomainModule } from '../members/member-domain/members-domain.module';
 import { HomeService } from './service/home.service';
+import { TaskDomainModule } from '../task/task-domain/task-domain.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { HomeService } from './service/home.service';
     ManagerDomainModule,
 
     MembersDomainModule,
+    TaskDomainModule,
   ],
   controllers: [HomeController],
   providers: [

--- a/backend/src/home/swagger/home.swagger.ts
+++ b/backend/src/home/swagger/home.swagger.ts
@@ -26,3 +26,15 @@ export const ApiGetNewMemberDetail = () =>
       description: '<h2>신규 등록자를 상세 조회합니다.</h2>',
     }),
   );
+
+export const ApiGetMyTasks = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({
+      summary: '내가 담당한 업무 목록 조회',
+      description:
+        '<h2>이번주/이번달 내가 담당한 업무 목록을 조회합니다.</h2>' +
+        '<p>range: 월간 / 주간 선택</p>' +
+        '<p>from, to: 수동으로 기간을 선택, 값이 없을 경우 이번주 or 이번달 (선택값)</p>',
+    }),
+  );

--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -19,7 +19,7 @@ import { MembersDomainPaginationResultDto } from '../dto/members-domain-paginati
 import { GetSimpleMembersDto } from '../../dto/request/get-simple-members.dto';
 import { GetRecommendLinkMemberDto } from '../../dto/request/get-recommend-link-member.dto';
 import { GetBirthdayMembersDto } from '../../../calendar/dto/request/birthday/get-birthday-members.dto';
-import { GetNewMemberSummaryRangeEnum } from '../../../home/const/get-new-member-summary-range.enum';
+import { WidgetRangeEnum } from '../../../home/const/widget-range.enum';
 import { GetNewMemberDetailDto } from '../../../home/dto/request/get-new-member-detail.dto';
 
 export const IMEMBERS_DOMAIN_SERVICE = Symbol('IMEMBERS_DOMAIN_SERVICE');
@@ -177,7 +177,7 @@ export interface IMembersDomainService {
 
   getNewMemberSummary(
     church: ChurchModel,
-    range: GetNewMemberSummaryRangeEnum,
+    range: WidgetRangeEnum,
     from: Date,
     to: Date,
   ): Promise<any[]>;

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -42,7 +42,7 @@ import {
 import { GetRecommendLinkMemberDto } from '../../dto/request/get-recommend-link-member.dto';
 import { GetBirthdayMembersDto } from '../../../calendar/dto/request/birthday/get-birthday-members.dto';
 import KoreanLunarCalendar from 'korean-lunar-calendar';
-import { GetNewMemberSummaryRangeEnum } from '../../../home/const/get-new-member-summary-range.enum';
+import { WidgetRangeEnum } from '../../../home/const/widget-range.enum';
 import { GetNewMemberDetailDto } from '../../../home/dto/request/get-new-member-detail.dto';
 import { NewMemberSummaryDto } from '../../../home/dto/response/new-member-summary.dto';
 
@@ -685,7 +685,7 @@ export class MembersDomainService implements IMembersDomainService {
 
   async getNewMemberSummary(
     church: ChurchModel,
-    range: GetNewMemberSummaryRangeEnum,
+    range: WidgetRangeEnum,
     from: Date,
     to: Date,
   ): Promise<NewMemberSummaryDto[]> {
@@ -693,7 +693,7 @@ export class MembersDomainService implements IMembersDomainService {
 
     const qb = repository.createQueryBuilder('member');
 
-    if (range === GetNewMemberSummaryRangeEnum.WEEKLY) {
+    if (range === WidgetRangeEnum.WEEKLY) {
       qb.select([
         `
         (

--- a/backend/src/task/const/task-find-options.const.ts
+++ b/backend/src/task/const/task-find-options.const.ts
@@ -6,9 +6,6 @@ import {
 } from '../../members/const/member-find-options.const';
 
 export const TasksFindOptionsRelation: FindOptionsRelations<TaskModel> = {
-  /*subTasks: {
-    inCharge: MemberSummarizedRelation,
-  },*/
   inCharge: MemberSummarizedRelation,
 };
 
@@ -35,7 +32,6 @@ export const TasksFindOptionsSelect: FindOptionsSelect<TaskModel> = {
   status: true,
   startDate: true,
   endDate: true,
-  //subTasks: SubTaskFindOptionsSelect,
   inCharge: MemberSummarizedSelect,
 };
 

--- a/backend/src/task/const/task-order.enum.ts
+++ b/backend/src/task/const/task-order.enum.ts
@@ -3,4 +3,5 @@ export enum TaskOrder {
   updatedAt = 'updatedAt',
   title = 'title',
   startDate = 'startDate',
+  endDate = 'endDate',
 }

--- a/backend/src/task/task-domain/interface/task-domain.service.interface.ts
+++ b/backend/src/task/task-domain/interface/task-domain.service.interface.ts
@@ -6,6 +6,8 @@ import { GetTasksDto } from '../../dto/request/get-tasks.dto';
 import { TaskDomainPaginationResultDto } from '../../dto/task-domain-pagination-result.dto';
 import { UpdateTaskDto } from '../../dto/request/update-task.dto';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
+import { GetMyTasksDto } from '../../../home/dto/request/get-my-tasks.dto';
+import { MemberModel } from '../../../members/entity/member.entity';
 
 export const ITASK_DOMAIN_SERVICE = Symbol('ITASK_DOMAIN_SERVICE');
 
@@ -44,16 +46,16 @@ export interface ITaskDomainService {
 
   createTask(
     church: ChurchModel,
-    creatorManager: ChurchUserModel, //MemberModel,
+    creatorManager: ChurchUserModel,
     parentTask: TaskModel | null,
-    inChargeMember: ChurchUserModel | null, //MemberModel | null,
+    inChargeMember: ChurchUserModel | null,
     dto: CreateTaskDto,
     qr: QueryRunner,
   ): Promise<TaskModel>;
 
   updateTask(
     targetTask: TaskModel,
-    newInChargeMember: ChurchUserModel | null, //MemberModel | null,
+    newInChargeMember: ChurchUserModel | null,
     newParentTask: TaskModel | null,
     dto: UpdateTaskDto,
     qr: QueryRunner,
@@ -62,4 +64,11 @@ export interface ITaskDomainService {
   deleteTask(targetTask: TaskModel, qr: QueryRunner): Promise<void>;
 
   countAllTasks(church: ChurchModel, qr: QueryRunner): Promise<number>;
+
+  findMyTasks(
+    inCharge: MemberModel,
+    dto: GetMyTasksDto,
+    from: Date,
+    to: Date,
+  ): Promise<TaskModel[]>;
 }

--- a/backend/src/task/task-domain/service/task-domain.service.ts
+++ b/backend/src/task/task-domain/service/task-domain.service.ts
@@ -42,6 +42,8 @@ import {
   MemberSummarizedRelation,
   MemberSummarizedSelect,
 } from '../../../members/const/member-find-options.const';
+import { GetMyTasksDto } from '../../../home/dto/request/get-my-tasks.dto';
+import { MemberModel } from '../../../members/entity/member.entity';
 
 @Injectable()
 export class TaskDomainService implements ITaskDomainService {
@@ -421,5 +423,28 @@ export class TaskDomainService implements ITaskDomainService {
     }
 
     return;
+  }
+
+  async findMyTasks(
+    inCharge: MemberModel,
+    dto: GetMyTasksDto,
+    from: Date,
+    to: Date,
+  ): Promise<TaskModel[]> {
+    const repository = this.getTaskRepository();
+
+    return repository.find({
+      where: {
+        inChargeId: inCharge.id,
+        startDate: LessThanOrEqual(to),
+        endDate: MoreThanOrEqual(from),
+      },
+      order: {
+        [dto.order]: dto.orderDirection,
+      },
+      select: { ...TasksFindOptionsSelect },
+      take: dto.take,
+      skip: dto.take * (dto.page - 1),
+    });
   }
 }


### PR DESCRIPTION
## 주요 내용
- 로그인한 사용자가 담당자로 지정된 업무(Task) 중, 이번 주 또는 이번 달에 해당하는 일정 조회 기능 추가
- 홈화면 위젯에서 사용할 수 있도록 설계된 간단한 일정 요약 API

## 세부 내용

### API: GET /churches/{churchId}/home/tasks
- `range`: 'weekly' 또는 'monthly' (필수)
  - weekly: 이번 주 (일요일~토요일 기준)
  - monthly: 이번 달 (1일~말일 기준)
- 현재 시각 기준으로 자동 기간 계산 (Asia/Seoul 기준 → UTC 변환 후 쿼리)
- 로그인 사용자의 inChargeId를 기준으로 필터링
- 일정의 `startDate ~ endDate`가 선택된 기간과 겹치는 경우만 조회됨
- 종료일(`endDate`)이 임박한 순서로 정렬됨

### 응답 포맷 예시
```json
{
  "range": "monthly",
  "from": "2025-05-31T15:00:00.000Z",
  "to": "2025-06-30T14:59:59.999Z",
  "data": [
    {
      "id": 4,
      "title": "권한 테스트",
      "status": "reserve",
      "startDate": "...",
      "endDate": "..."
    },
    ...
  ],
  "timestamp": "2025-07-15T01:19:21.117Z"
}