### PR TITLE
feat: 홈화면 일정 위젯에 심방 일정 조회 기능 추가 및 ScheduleDto 통일 적용

### DIFF
--- a/backend/src/home/const/schedule-type.enum.ts
+++ b/backend/src/home/const/schedule-type.enum.ts
@@ -1,0 +1,5 @@
+export enum ScheduleType {
+  VISITATION = 'visitation',
+  TASK = 'task',
+  EDUCATION = 'education',
+}

--- a/backend/src/home/controller/home.controller.ts
+++ b/backend/src/home/controller/home.controller.ts
@@ -13,13 +13,15 @@ import { HomeService } from '../service/home.service';
 import { GetNewMemberSummaryDto } from '../dto/request/get-new-member-summary.dto';
 import { GetNewMemberDetailDto } from '../dto/request/get-new-member-detail.dto';
 import {
-  ApiGetMyTasks,
+  ApiGetMyInChargedTasks,
+  ApiGetMyInChargedVisitations,
   ApiGetNewMemberDetail,
   ApiGetNewMemberSummary,
 } from '../swagger/home.swagger';
 import { PermissionManager } from '../../permission/decorator/permission-manager.decorator';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { GetMyTasksDto } from '../dto/request/get-my-tasks.dto';
+import { GetMyInChargedVisitationsDto } from '../dto/request/get-my-in-charged-visitations.dto';
 
 @Controller()
 export class HomeController {
@@ -45,10 +47,10 @@ export class HomeController {
     return this.homeService.getNewMemberDetails(church, dto);
   }
 
-  @ApiGetMyTasks()
+  @ApiGetMyInChargedTasks()
   @Get('tasks')
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
-  getMyTasks(
+  getMyInChargedTasks(
     @Query() dto: GetMyTasksDto,
     @PermissionManager() pm: ChurchUserModel,
   ) {
@@ -56,6 +58,20 @@ export class HomeController {
       throw new BadRequestException('from, to 에러');
     }
 
-    return this.homeService.getMyTasks(pm, dto);
+    return this.homeService.getMyInChargedTasks(pm, dto);
+  }
+
+  @ApiGetMyInChargedVisitations()
+  @Get('visitations')
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
+  getMyInChargedVisitations(
+    @Query() dto: GetMyInChargedVisitationsDto,
+    @PermissionManager() pm: ChurchUserModel,
+  ) {
+    if ((dto.from && !dto.to) || (!dto.from && dto.to)) {
+      throw new BadRequestException('from, to 에러');
+    }
+
+    return this.homeService.getMyInChargedVisitations(pm, dto);
   }
 }

--- a/backend/src/home/dto/request/get-my-in-charged-visitations.dto.ts
+++ b/backend/src/home/dto/request/get-my-in-charged-visitations.dto.ts
@@ -1,0 +1,54 @@
+import { BaseOffsetPaginationRequestDto } from '../../../common/dto/request/base-offset-pagination-request.dto';
+import { VisitationOrderEnum } from '../../../visitation/const/visitation-order.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsEnum, IsIn, IsOptional } from 'class-validator';
+import { WidgetRangeEnum } from '../../const/widget-range.enum';
+import { IsYYYYMMDD } from '../../../common/decorator/validator/is-yyyy-mm-dd.validator';
+import { IsAfterDate } from '../../../common/decorator/validator/is-after-date.decorator';
+
+export class GetMyInChargedVisitationsDto extends BaseOffsetPaginationRequestDto<VisitationOrderEnum> {
+  @ApiProperty({
+    description: '정렬 조건',
+    default: VisitationOrderEnum.endDate,
+    enum: VisitationOrderEnum,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(VisitationOrderEnum)
+  order: VisitationOrderEnum = VisitationOrderEnum.endDate;
+
+  @ApiProperty({
+    description: '정렬 오름차순/내림차순',
+    default: 'DESC',
+    required: false,
+  })
+  @IsIn(['asc', 'desc', 'ASC', 'DESC'])
+  @IsOptional()
+  override orderDirection: 'ASC' | 'DESC' | 'asc' | 'desc' = 'DESC';
+
+  @ApiProperty({
+    description: '검색 단위 (주간 / 월간)',
+    enum: WidgetRangeEnum,
+  })
+  @IsEnum(WidgetRangeEnum)
+  range: WidgetRangeEnum;
+
+  @ApiProperty({
+    description: '검색 시작일(YYYY-MM-DD)',
+    required: false,
+  })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('from')
+  from?: string;
+
+  @ApiProperty({
+    description: '검색 종료일(YYYY-MM-DD)',
+    required: false,
+  })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsAfterDate('from')
+  @IsYYYYMMDD('to')
+  to?: string;
+}

--- a/backend/src/home/dto/response/get-my-schedules-response.dto.ts
+++ b/backend/src/home/dto/response/get-my-schedules-response.dto.ts
@@ -1,0 +1,11 @@
+import { WidgetRangeEnum } from '../../const/widget-range.enum';
+
+export class GetMySchedulesResponseDto<T> {
+  constructor(
+    public readonly range: WidgetRangeEnum,
+    public readonly from: Date,
+    public readonly to: Date,
+    public readonly data: T[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/home/dto/response/schedule.dto.ts
+++ b/backend/src/home/dto/response/schedule.dto.ts
@@ -1,0 +1,29 @@
+import { ScheduleType } from '../../const/schedule-type.enum';
+import { EducationSessionStatus } from '../../../management/educations/const/education-status.enum';
+import { TaskStatus } from '../../../task/const/task-status.enum';
+import { VisitationStatus } from '../../../visitation/const/visitation-status.enum';
+
+export class ScheduleDto {
+  id: number;
+  type: ScheduleType;
+  title: string;
+  startDate: Date;
+  endDate: Date;
+  status: EducationSessionStatus | TaskStatus | VisitationStatus;
+
+  constructor(
+    id: number,
+    type: ScheduleType,
+    title: string,
+    startDate: Date,
+    endDate: Date,
+    status: EducationSessionStatus | TaskStatus | VisitationStatus,
+  ) {
+    this.id = id;
+    this.type = type;
+    this.title = title;
+    this.startDate = startDate;
+    this.endDate = endDate;
+    this.status = status;
+  }
+}

--- a/backend/src/home/home.module.ts
+++ b/backend/src/home/home.module.ts
@@ -8,6 +8,7 @@ import { HomePermissionService } from './service/home-permission.service';
 import { MembersDomainModule } from '../members/member-domain/members-domain.module';
 import { HomeService } from './service/home.service';
 import { TaskDomainModule } from '../task/task-domain/task-domain.module';
+import { VisitationDomainModule } from '../visitation/visitation-domain/visitation-domain.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { TaskDomainModule } from '../task/task-domain/task-domain.module';
 
     MembersDomainModule,
     TaskDomainModule,
+    VisitationDomainModule,
   ],
   controllers: [HomeController],
   providers: [

--- a/backend/src/home/swagger/home.swagger.ts
+++ b/backend/src/home/swagger/home.swagger.ts
@@ -27,13 +27,25 @@ export const ApiGetNewMemberDetail = () =>
     }),
   );
 
-export const ApiGetMyTasks = () =>
+export const ApiGetMyInChargedTasks = () =>
   applyDecorators(
     ApiParam({ name: 'churchId' }),
     ApiOperation({
       summary: '내가 담당한 업무 목록 조회',
       description:
         '<h2>이번주/이번달 내가 담당한 업무 목록을 조회합니다.</h2>' +
+        '<p>range: 월간 / 주간 선택</p>' +
+        '<p>from, to: 수동으로 기간을 선택, 값이 없을 경우 이번주 or 이번달 (선택값)</p>',
+    }),
+  );
+
+export const ApiGetMyInChargedVisitations = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({
+      summary: '내가 담당한 심방 목록 조회',
+      description:
+        '<h2>이번주/이번달 내가 담당한 심방 목록을 조회합니다.</h2>' +
         '<p>range: 월간 / 주간 선택</p>' +
         '<p>from, to: 수동으로 기간을 선택, 값이 없을 경우 이번주 or 이번달 (선택값)</p>',
     }),

--- a/backend/src/visitation/const/visitation-order.enum.ts
+++ b/backend/src/visitation/const/visitation-order.enum.ts
@@ -1,5 +1,6 @@
 export enum VisitationOrderEnum {
   startDate = 'startDate',
+  endDate = 'endDate',
   createdAt = 'createdAt',
   updatedAt = 'updatedAt',
 }

--- a/backend/src/visitation/visitation-domain/interface/visitation-meta-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/interface/visitation-meta-domain.service.interface.ts
@@ -5,6 +5,7 @@ import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
 import { GetVisitationDto } from '../../dto/request/get-visitation.dto';
 import { UpdateVisitationMetaDto } from '../../dto/internal/meta/update-visitation-meta.dto';
+import { GetMyInChargedVisitationsDto } from '../../../home/dto/request/get-my-in-charged-visitations.dto';
 
 export const IVISITATION_META_DOMAIN_SERVICE = Symbol(
   'IVISITATION_META_DOMAIN_SERVICE',
@@ -54,4 +55,11 @@ export interface IVisitationMetaDomainService {
   ): Promise<UpdateResult>;
 
   countAllVisitations(church: ChurchModel, qr: QueryRunner): Promise<number>;
+
+  findMyVisitations(
+    me: MemberModel,
+    dto: GetMyInChargedVisitationsDto,
+    from: Date,
+    to: Date,
+  ): Promise<VisitationMetaModel[]>;
 }

--- a/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
@@ -34,6 +34,7 @@ import { ChurchUserRole } from '../../../user/const/user-role.enum';
 import { MemberException } from '../../../members/const/exception/member.exception';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { ManagerException } from '../../../manager/exception/manager.exception';
+import { GetMyInChargedVisitationsDto } from '../../../home/dto/request/get-my-in-charged-visitations.dto';
 
 @Injectable()
 export class VisitationMetaDomainService
@@ -292,5 +293,28 @@ export class VisitationMetaDomainService
     }
 
     return result;
+  }
+
+  async findMyVisitations(
+    inCharge: MemberModel,
+    dto: GetMyInChargedVisitationsDto,
+    from: Date,
+    to: Date,
+  ): Promise<VisitationMetaModel[]> {
+    const repository = this.getVisitationMetaRepository();
+
+    return repository.find({
+      where: {
+        inChargeId: inCharge.id,
+        startDate: LessThanOrEqual(to),
+        endDate: MoreThanOrEqual(from),
+      },
+      order: {
+        [dto.order]: dto.orderDirection,
+      },
+      select: {},
+      take: dto.take,
+      skip: dto.take * (dto.page - 1),
+    });
   }
 }


### PR DESCRIPTION
## 주요 내용
- 홈화면에서 내가 담당한 심방(Visitation) 일정을 조회하는 기능 추가
- 기존 업무(Task) 일정과 동일하게 range 기반 필터링 (`weekly`, `monthly`)
- 일정 기간(startDate ~ endDate)이 지정 범위와 겹치는 모든 항목 포함

## 세부 내용

### API: GET /churches/{churchId}/home/tasks
- 업무 일정(Task) 응답을 ScheduleDto 포맷으로 반환

### API: GET /churches/{churchId}/home/visitations
- 담당자로 지정된 심방 일정 조회
- 일정 기간과 범위(from~to)가 겹치면 포함됨
- 종료일 기준 오름차순 정렬

### ScheduleDto 통합
- 업무(Task), 심방(Visitation), 교육(Education)의 응답 구조를 ScheduleDto로 통일
- 공통 필드: `id`, `type`, `title`, `startDate`, `endDate`, `status`
- `status`는 각 일정 유형에 맞는 enum(TaskStatus, VisitationStatus 등)으로 설정됨

### 응답 공통 구조
```json
{
  "range": "weekly",
  "from": "...",
  "to": "...",
  "data": ScheduleDto[],
  "timestamp": "..."
}