### PR TITLE
feat: 홈화면에서 보고받은 일정 조회 기능 추가

### DIFF
--- a/backend/src/home/controller/home.controller.ts
+++ b/backend/src/home/controller/home.controller.ts
@@ -2,6 +2,8 @@ import {
   BadRequestException,
   Controller,
   Get,
+  Param,
+  ParseIntPipe,
   Query,
   UseGuards,
 } from '@nestjs/common';
@@ -14,12 +16,14 @@ import { GetNewMemberSummaryDto } from '../dto/request/get-new-member-summary.dt
 import { GetNewMemberDetailDto } from '../dto/request/get-new-member-detail.dto';
 import {
   ApiGetMyInChargedSchedules,
+  ApiGetMyScheduleReports,
   ApiGetNewMemberDetail,
   ApiGetNewMemberSummary,
 } from '../swagger/home.swagger';
 import { PermissionManager } from '../../permission/decorator/permission-manager.decorator';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { GetMyInChargedSchedulesDto } from '../dto/request/get-my-in-charged-schedules.dto';
+import { GetMyReportsDto } from '../dto/request/get-my-reports.dto';
 
 @Controller()
 export class HomeController {
@@ -59,45 +63,18 @@ export class HomeController {
     return this.homeService.getMyInChargedSchedules(pm, dto);
   }
 
-  /*@ApiGetMyInChargedTasks()
-  @Get('schedules/tasks')
+  @ApiGetMyScheduleReports()
+  @Get('reports')
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
-  getMyInChargedTasks(
-    @Query() dto: GetMyInChargedSchedulesDto,
+  getMyScheduleReports(
+    @Param('churchId', ParseIntPipe) churchId: number,
     @PermissionManager() pm: ChurchUserModel,
+    @Query() dto: GetMyReportsDto,
   ) {
     if ((dto.from && !dto.to) || (!dto.from && dto.to)) {
       throw new BadRequestException('from, to 에러');
     }
 
-    return this.homeService.getMyInChargedTasks(pm, dto);
-  }*/
-
-  /*@ApiGetMyInChargedVisitations()
-  @Get('schedules/visitations')
-  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
-  getMyInChargedVisitations(
-    @Query() dto: GetMyInChargedSchedulesDto,
-    @PermissionManager() pm: ChurchUserModel,
-  ) {
-    if ((dto.from && !dto.to) || (!dto.from && dto.to)) {
-      throw new BadRequestException('from, to 에러');
-    }
-
-    return this.homeService.getMyInChargedVisitations(pm, dto);
-  }*/
-
-  /*@ApiGetMyInChargedEducations()
-  @Get('schedules/educations')
-  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
-  getMyInChargedEducations(
-    @PermissionManager() pm: ChurchUserModel,
-    @Query() dto: GetMyInChargedSchedulesDto,
-  ) {
-    if ((dto.from && !dto.to) || (!dto.from && dto.to)) {
-      throw new BadRequestException('from, to 에러');
-    }
-
-    return this.homeService.getMyInChargedEducations(pm, dto);
-  }*/
+    return this.homeService.getMyScheduleReports(pm, dto);
+  }
 }

--- a/backend/src/home/dto/request/get-my-reports.dto.ts
+++ b/backend/src/home/dto/request/get-my-reports.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { WidgetRangeEnum } from '../../const/widget-range.enum';
+import { IsDateString, IsEnum, IsNumber, IsOptional } from 'class-validator';
+import { IsYYYYMMDD } from '../../../common/decorator/validator/is-yyyy-mm-dd.validator';
+import { IsAfterDate } from '../../../common/decorator/validator/is-after-date.decorator';
+
+export class GetMyReportsDto {
+  @ApiProperty({
+    description: '검색 단위 (주간 / 월간)',
+    enum: WidgetRangeEnum,
+  })
+  @IsEnum(WidgetRangeEnum)
+  range: WidgetRangeEnum;
+
+  @ApiProperty({
+    description: '조회할 페이지',
+    default: 1,
+  })
+  @IsNumber()
+  page: number = 1;
+
+  @ApiProperty({
+    description: '검색 시작일(YYYY-MM-DD)',
+    required: false,
+  })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('from')
+  from?: string;
+
+  @ApiProperty({
+    description: '검색 종료일(YYYY-MM-DD)',
+    required: false,
+  })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsAfterDate('from')
+  @IsYYYYMMDD('to')
+  to?: string;
+}

--- a/backend/src/home/dto/response/get-my-schedule-reports-response.dto.ts
+++ b/backend/src/home/dto/response/get-my-schedule-reports-response.dto.ts
@@ -1,0 +1,8 @@
+import { ScheduleReportDto } from '../schedule-report.dto';
+
+export class GetMyScheduleReportsResponseDto {
+  constructor(
+    public readonly data: ScheduleReportDto[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/home/dto/schedule-report.dto.ts
+++ b/backend/src/home/dto/schedule-report.dto.ts
@@ -1,0 +1,12 @@
+import { ScheduleDto } from './schedule.dto';
+import { MemberModel } from '../../members/entity/member.entity';
+import { ScheduleType } from '../const/schedule-type.enum';
+
+export class ScheduleReportDto {
+  constructor(
+    public readonly id: number,
+    public readonly type: ScheduleType,
+    public readonly inCharge: MemberModel,
+    public readonly schedule: ScheduleDto,
+  ) {}
+}

--- a/backend/src/home/home.module.ts
+++ b/backend/src/home/home.module.ts
@@ -10,6 +10,9 @@ import { HomeService } from './service/home.service';
 import { TaskDomainModule } from '../task/task-domain/task-domain.module';
 import { VisitationDomainModule } from '../visitation/visitation-domain/visitation-domain.module';
 import { EducationDomainModule } from '../management/educations/service/education-domain/education-domain.module';
+import { TaskReportDomainModule } from '../report/report-domain/task-report-domain.module';
+import { VisitationReportDomainModule } from '../report/report-domain/visitation-report-domain.module';
+import { EducationSessionReportDomainModule } from '../report/report-domain/education-session-report-domain.module';
 
 @Module({
   imports: [
@@ -20,9 +23,14 @@ import { EducationDomainModule } from '../management/educations/service/educatio
     ManagerDomainModule,
 
     MembersDomainModule,
+
     TaskDomainModule,
     VisitationDomainModule,
     EducationDomainModule,
+
+    TaskReportDomainModule,
+    VisitationReportDomainModule,
+    EducationSessionReportDomainModule,
   ],
   controllers: [HomeController],
   providers: [

--- a/backend/src/home/swagger/home.swagger.ts
+++ b/backend/src/home/swagger/home.swagger.ts
@@ -39,38 +39,16 @@ export const ApiGetMyInChargedSchedules = () =>
     }),
   );
 
-export const ApiGetMyInChargedTasks = () =>
+export const ApiGetMyScheduleReports = () =>
   applyDecorators(
     ApiParam({ name: 'churchId' }),
     ApiOperation({
-      summary: '내가 담당한 업무 목록 조회',
+      summary: '보고받은 일정',
       description:
-        '<h2>이번주/이번달 내가 담당한 업무 목록을 조회합니다.</h2>' +
-        '<p>range: 월간 / 주간 선택</p>' +
-        '<p>from, to: 수동으로 기간을 선택, 값이 없을 경우 이번주 or 이번달 (선택값)</p>',
-    }),
-  );
-
-export const ApiGetMyInChargedVisitations = () =>
-  applyDecorators(
-    ApiParam({ name: 'churchId' }),
-    ApiOperation({
-      summary: '내가 담당한 심방 목록 조회',
-      description:
-        '<h2>이번주/이번달 내가 담당한 심방 목록을 조회합니다.</h2>' +
-        '<p>range: 월간 / 주간 선택</p>' +
-        '<p>from, to: 수동으로 기간을 선택, 값이 없을 경우 이번주 or 이번달 (선택값)</p>',
-    }),
-  );
-
-export const ApiGetMyInChargedEducations = () =>
-  applyDecorators(
-    ApiParam({ name: 'churchId' }),
-    ApiOperation({
-      summary: '내가 담당한 교육 목록 조회',
-      description:
-        '<h2>이번주/이번달 내가 담당한 심방 목록을 조회합니다.</h2>' +
-        '<p>range: 월간 / 주간 선택</p>' +
-        '<p>from, to: 수동으로 기간을 선택, 값이 없을 경우 이번주 or 이번달 (선택값)</p>',
+        '<h2>이번주/이번달 보고받은 일정을 조회합니다.</h2>' +
+        '<p>각 조회마다 보고는 50개씩 조회됩니다.</p>' +
+        '<p>이번주 조회 시 각 최대 50개씩 총 150개 보고 조회 가능</p>' +
+        '<p>이번달 조회 시 각 최대 100개씩 총 300개 보고 조회 가능</p>' +
+        '<p>page 쿼리 파라미터로 페이징 처리</p>',
     }),
   );

--- a/backend/src/management/educations/service/education-domain/service/education-session-domain.service.ts
+++ b/backend/src/management/educations/service/education-domain/service/education-session-domain.service.ts
@@ -490,13 +490,20 @@ export class EducationSessionDomainService
         endDate: MoreThanOrEqual(from),
       },
       order: {
-        //[dto.order]: dto.orderDirection,
         endDate: 'ASC',
       },
       relations: {
         educationTerm: true,
       },
       select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        session: true,
+        title: true,
+        startDate: true,
+        endDate: true,
+        status: true,
         educationTerm: {
           id: true,
           educationId: true,

--- a/backend/src/report/entity/report.entity.ts
+++ b/backend/src/report/entity/report.entity.ts
@@ -5,13 +5,6 @@ import { Column, Entity, Index, ManyToOne, TableInheritance } from 'typeorm';
 @Entity()
 @TableInheritance({ column: { type: 'varchar', name: 'reportType' } })
 export abstract class ReportModel extends BaseModel {
-  /*@Index()
-  @Column({ nullable: true })
-  senderId: number;
-
-  @ManyToOne(() => MemberModel)
-  sender: MemberModel;*/
-
   @Index()
   @Column()
   receiverId: number;

--- a/backend/src/report/report-domain/interface/education-session-report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/education-session-report-domain.service.interface.ts
@@ -62,4 +62,10 @@ export interface IEducationSessionReportDomainService {
     deleteReceiverIds: number[],
     qr?: QueryRunner,
   ): Promise<UpdateResult>;
+
+  findMyReports(
+    receiver: MemberModel,
+    from: Date,
+    to: Date,
+  ): Promise<EducationSessionReportModel[]>;
 }

--- a/backend/src/report/report-domain/interface/task-report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/task-report-domain.service.interface.ts
@@ -59,4 +59,10 @@ export interface ITaskReportDomainService {
     receiverIds: number[],
     qr?: QueryRunner,
   ): Promise<UpdateResult>;
+
+  findMyReports(
+    receiver: MemberModel,
+    from: Date,
+    to: Date,
+  ): Promise<TaskReportModel[]>;
 }

--- a/backend/src/report/report-domain/interface/visitation-report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/visitation-report-domain.service.interface.ts
@@ -58,4 +58,10 @@ export interface IVisitationReportDomainService {
     receiverIds: number[],
     qr?: QueryRunner,
   ): Promise<UpdateResult>;
+
+  findMyReports(
+    receiver: MemberModel,
+    from: Date,
+    to: Date,
+  ): Promise<VisitationReportModel[]>;
 }


### PR DESCRIPTION
## 주요 내용
- 로그인 사용자가 보고받은 Task, Visitation, Education 일정을 조회하는 API 추가
- 보고 일정의 양이 많아질 수 있어 페이징 처리 및 정렬 기준 명확화

## 세부 내용
### API: GET /churches/{churchId}/home/reports
- 쿼리 파라미터
  - `range`: 'weekly' | 'monthly' (기준 데이터 수 결정)
  - `from`, `to`: 조회 범위 (`YYYY-MM-DD`)
  - `page`: 응답 페이징 (50개 단위)
- 일정 유형별(Task, Visitation, Education)로 보고 데이터를 각각 조회 후 병합
  - `weekly`: 각 유형별 최대 50개씩 조회 후 병합 → endDate 오름차순 정렬 → page 단위 응답
  - `monthly`: 각 유형별 최대 100개씩 조회 후 병합 → endDate 오름차순 정렬 → page 단위 응답
- 응답 항목
  - `id`, `type`, `inCharge`(담당자), `schedule`(일정 요약)
  - 일정의 상세 내용은 `schedule` 내부에서 제공 (`startDate`, `endDate`, `status`, 등)

## 목적 및 의도
- 사용자가 보고받은 일정(Task, 심방, 교육)을 한눈에 확인할 수 있는 홈화면 기능 강화
- 대량의 보고 데이터 처리에 대비하여 구조적으로 페이징과 정렬을 명확히 분리