### PR TITLE
feat: 교인-사역 직접 관리 기능 구현

### DIFF
--- a/backend/src/management/ministries/const/exception/ministry.exception.ts
+++ b/backend/src/management/ministries/const/exception/ministry.exception.ts
@@ -4,4 +4,5 @@ export const MinistryException = {
   UPDATE_ERROR: '사역 업데이트 도중 에러 발생',
   EMPTY_MEMBER_COUNT:
     '해당 사역을 수행하는 교인 수에 오류가 있습니다.\n사역 관리 화면에서 교인 수를 새로고침 해주세요.',
+  ALREADY_ASSIGNED_MINISTRY: '이미 부여된 사역입니다.',
 };

--- a/backend/src/management/ministries/const/ministry-order.enum.ts
+++ b/backend/src/management/ministries/const/ministry-order.enum.ts
@@ -1,5 +1,6 @@
-export enum MinistryOrderEnum {
-  createdAt = 'createdAt',
-  updatedAt = 'updatedAt',
-  name = 'name',
+export enum MinistryOrder {
+  CREATED_AT = 'createdAt',
+  UPDATED_AT = 'updatedAt',
+  MEMBER_COUNT = 'membersCount',
+  NAME = 'name',
 }

--- a/backend/src/management/ministries/const/swagger/ministry.swagger.ts
+++ b/backend/src/management/ministries/const/swagger/ministry.swagger.ts
@@ -7,8 +7,8 @@ export const ApiGetMinistries = () =>
       summary: '사역 조회',
       description:
         '<h2>사역 그룹 내의 직분을 조회합니다.</h2>' +
-        '<p>ministryGroupId 에 속한 사역을 조회합니다.</p>' +
-        '<p>ministryGroupId 값을 포함하지 않을 경우 그룹에 속하지 않은 사역을 조회</p>',
+        '<p>ministryGroupId 에 속한 사역을 조회합니다.</p>',
+      //'<p>ministryGroupId 값을 포함하지 않을 경우 그룹에 속하지 않은 사역을 조회</p>',
     }),
     ApiParam({
       name: 'churchId',

--- a/backend/src/management/ministries/controller/ministries.controller.ts
+++ b/backend/src/management/ministries/controller/ministries.controller.ts
@@ -11,7 +11,7 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { MinistryService } from '../service/ministry.service';
 import { CreateMinistryDto } from '../dto/ministry/create-ministry.dto';
 import { UpdateMinistryDto } from '../dto/ministry/update-ministry.dto';
@@ -32,9 +32,11 @@ import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../../permission/guard/church-manager.guard';
 import { PermissionChurch } from '../../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../../churches/entity/church.entity';
+import { AssignMinistryToMemberDto } from '../dto/ministry/assign-ministry-to-member.dto';
+import { RemoveMinistryFromMember } from '../dto/ministry/remove-ministry-from-member.dto';
 
-@ApiTags('Management:Ministries')
-@Controller('ministries')
+@ApiTags('Management:MinistryGroups:Ministries')
+@Controller('ministry-groups/:ministryGroupId/ministries')
 export class MinistriesController {
   constructor(private readonly ministryService: MinistryService) {}
 
@@ -43,9 +45,10 @@ export class MinistriesController {
   @Get()
   getMinistries(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('ministryGroupId', ParseIntPipe) ministryGroupId: number,
     @Query() dto: GetMinistryDto,
   ) {
-    return this.ministryService.getMinistries(churchId, dto);
+    return this.ministryService.getMinistries(churchId, ministryGroupId, dto);
   }
 
   @ApiPostMinistry()
@@ -54,10 +57,16 @@ export class MinistriesController {
   @UseInterceptors(TransactionInterceptor)
   postMinistries(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('ministryGroupId', ParseIntPipe) ministryGroupId: number,
     @Body() dto: CreateMinistryDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.ministryService.createMinistry(churchId, dto, qr);
+    return this.ministryService.createMinistry(
+      churchId,
+      ministryGroupId,
+      dto,
+      qr,
+    );
   }
 
   @ApiRefreshMinistryCount()
@@ -77,11 +86,18 @@ export class MinistriesController {
   @UseInterceptors(TransactionInterceptor)
   patchMinistry(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('ministryGroupId', ParseIntPipe) ministryGroupId: number,
     @Param('ministryId', ParseIntPipe) ministryId: number,
     @Body() dto: UpdateMinistryDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.ministryService.updateMinistry(churchId, ministryId, dto, qr);
+    return this.ministryService.updateMinistry(
+      churchId,
+      ministryGroupId,
+      ministryId,
+      dto,
+      qr,
+    );
   }
 
   @ApiDeleteMinistry()
@@ -90,10 +106,16 @@ export class MinistriesController {
   @UseInterceptors(TransactionInterceptor)
   deleteMinistry(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('ministryGroupId', ParseIntPipe) ministryGroupId: number,
     @Param('ministryId', ParseIntPipe) ministryId: number,
     @QueryRunner() qr: QR,
   ) {
-    return this.ministryService.deleteMinistry(churchId, ministryId, qr);
+    return this.ministryService.deleteMinistry(
+      churchId,
+      ministryGroupId,
+      ministryId,
+      qr,
+    );
   }
 
   @ApiRefreshMinistryMembersCount()
@@ -101,23 +123,56 @@ export class MinistriesController {
   @Patch(':ministryId/refresh-members-count')
   refreshMembersCount(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('ministryGroupId', ParseIntPipe) ministryGroupId: number,
     @Param('ministryId', ParseIntPipe) ministryId: number,
   ) {
     return this.ministryService.refreshMinistryMemberCount(
       churchId,
+      ministryGroupId,
       ministryId,
     );
   }
 
-  /*@ApiGetMinistryById()
-  @MinistryReadGuard()
-  @Get(':ministryId')
-  getMinistryById(
+  @ApiOperation({
+    summary: '교인에게 사역 부여',
+    description:
+      '<h2>교인에게 사역을 부여</h2>' +
+      '<p>같은 사역 그룹에 속한 교인 + 사역만 가능</p>' +
+      '<p>기존 사역이 있을 경우, 기존 사역은 종료 처리</p>',
+  })
+  @Patch(':ministryId/members')
+  @UseInterceptors(TransactionInterceptor)
+  addMemberToMinistry(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('ministryGroupId', ParseIntPipe) ministryGroupId: number,
     @Param('ministryId', ParseIntPipe) ministryId: number,
+    @Body() dto: AssignMinistryToMemberDto,
+    @QueryRunner() qr: QR,
   ) {
-    throw new GoneException('더 이상 사용되지 않는 요청');
+    return this.ministryService.assignMemberToMinistry(
+      churchId,
+      ministryGroupId,
+      ministryId,
+      dto,
+      qr,
+    );
+  }
 
-    //return this.ministryService.getMinistryById(churchId, ministryId);
-  }*/
+  @Delete(':ministryId/members')
+  @UseInterceptors(TransactionInterceptor)
+  removeMemberFromMinistry(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('ministryGroupId', ParseIntPipe) ministryGroupId: number,
+    @Param('ministryId', ParseIntPipe) ministryId: number,
+    @Body() dto: RemoveMinistryFromMember,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.ministryService.removeMemberFromMinistry(
+      churchId,
+      ministryGroupId,
+      ministryId,
+      dto,
+      qr,
+    );
+  }
 }

--- a/backend/src/management/ministries/controller/ministry-groups.controller.ts
+++ b/backend/src/management/ministries/controller/ministry-groups.controller.ts
@@ -133,6 +133,7 @@ export class MinistryGroupsController {
     );
   }
 
+  @ApiOperation({ summary: '사역그룹장 지정' })
   @Patch(':ministryGroupId/leader')
   @UseInterceptors(TransactionInterceptor)
   patchMinistryGroupLeader(

--- a/backend/src/management/ministries/dto/ministry/assign-ministry-to-member.dto.ts
+++ b/backend/src/management/ministries/dto/ministry/assign-ministry-to-member.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, Min } from 'class-validator';
+
+export class AssignMinistryToMemberDto {
+  @ApiProperty({
+    description: '교인 ID',
+  })
+  @IsNumber()
+  @Min(1)
+  memberId: number;
+}

--- a/backend/src/management/ministries/dto/ministry/create-ministry.dto.ts
+++ b/backend/src/management/ministries/dto/ministry/create-ministry.dto.ts
@@ -1,12 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import {
-  IsNotEmpty,
-  IsNumber,
-  IsOptional,
-  IsString,
-  MaxLength,
-  Min,
-} from 'class-validator';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
 import { RemoveSpaces } from '../../../../common/decorator/transformer/remove-spaces';
 import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
 
@@ -24,14 +17,11 @@ export class CreateMinistryDto {
   @IsNoSpecialChar()
   name: string;
 
-  @ApiProperty({
-    description:
-      '지정/변경할 사역 그룹 ID (0 또는 undefined 일 경우 사역 그룹에 속하지 않음)',
-    minimum: 0,
-    //required: false,
+  /*@ApiProperty({
+    description: '지정할 사역 그룹 ID',
+    minimum: 1,
   })
-  @Min(0)
+  @Min(1)
   @IsNumber()
-  @IsOptional()
-  ministryGroupId: number;
+  ministryGroupId: number;*/
 }

--- a/backend/src/management/ministries/dto/ministry/get-ministry.dto.ts
+++ b/backend/src/management/ministries/dto/ministry/get-ministry.dto.ts
@@ -1,25 +1,33 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsNumber, IsOptional } from 'class-validator';
 import { BaseOffsetPaginationRequestDto } from '../../../../common/dto/request/base-offset-pagination-request.dto';
-import { MinistryOrderEnum } from '../../const/ministry-order.enum';
+import { MinistryOrder } from '../../const/ministry-order.enum';
 
-export class GetMinistryDto extends BaseOffsetPaginationRequestDto<MinistryOrderEnum> {
+export class GetMinistryDto extends BaseOffsetPaginationRequestDto<MinistryOrder> {
+  /*@ApiProperty({
+    description: '사역 그룹 ID ',
+    required: true,
+  })
+  @IsNumber()
+  @Min(1)
+  ministryGroupId: number;*/
+
   @ApiProperty({
-    description:
-      '사역 그룹 ID (값이 없을 경우 사역 그룹에 속하지 않은 사역 조회)',
+    description: '조회할 데이터 개수',
+    example: 20,
     required: false,
   })
   @IsOptional()
   @IsNumber()
-  ministryGroupId: number = 0;
+  override take: number = 20;
 
   @ApiProperty({
     description: '정렬 기준 (생성일, 수정일, 이름)',
-    enum: MinistryOrderEnum,
-    default: MinistryOrderEnum.createdAt,
+    enum: MinistryOrder,
+    default: MinistryOrder.CREATED_AT,
     required: false,
   })
-  @IsEnum(MinistryOrderEnum)
+  @IsEnum(MinistryOrder)
   @IsOptional()
-  order: MinistryOrderEnum = MinistryOrderEnum.createdAt;
+  order: MinistryOrder = MinistryOrder.CREATED_AT;
 }

--- a/backend/src/management/ministries/dto/ministry/remove-ministry-from-member.dto.ts
+++ b/backend/src/management/ministries/dto/ministry/remove-ministry-from-member.dto.ts
@@ -1,0 +1,3 @@
+import { AssignMinistryToMemberDto } from './assign-ministry-to-member.dto';
+
+export class RemoveMinistryFromMember extends AssignMinistryToMemberDto {}

--- a/backend/src/management/ministries/dto/ministry/update-ministry.dto.ts
+++ b/backend/src/management/ministries/dto/ministry/update-ministry.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/swagger';
+import { PickType } from '@nestjs/swagger';
 import { CreateMinistryDto } from './create-ministry.dto';
 
-export class UpdateMinistryDto extends PartialType(CreateMinistryDto) {}
+export class UpdateMinistryDto extends PickType(CreateMinistryDto, ['name']) {}

--- a/backend/src/management/ministries/entity/ministry-group.entity.ts
+++ b/backend/src/management/ministries/entity/ministry-group.entity.ts
@@ -57,6 +57,9 @@ export class MinistryGroupModel extends BaseModel {
   @Column({ type: 'int', nullable: true })
   leaderMemberId: number | null;
 
+  @Column({ default: 0 })
+  ministriesCount: number;
+
   @OneToMany(() => MinistryModel, (ministry) => ministry.ministryGroup)
   ministries: MinistryModel[];
 }

--- a/backend/src/management/ministries/ministries-domain/interface/ministries-domain.service.interface.ts
+++ b/backend/src/management/ministries/ministries-domain/interface/ministries-domain.service.interface.ts
@@ -1,23 +1,25 @@
 import { ChurchModel } from '../../../../churches/entity/church.entity';
 import { GetMinistryDto } from '../../dto/ministry/get-ministry.dto';
-import { FindOptionsRelations, QueryRunner } from 'typeorm';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { MinistryModel } from '../../entity/ministry.entity';
 import { CreateMinistryDto } from '../../dto/ministry/create-ministry.dto';
 import { MinistryGroupModel } from '../../entity/ministry-group.entity';
 import { UpdateMinistryDto } from '../../dto/ministry/update-ministry.dto';
-import { MinistryDomainPaginationResponseDto } from '../../dto/ministry/response/ministry-domain-pagination-response.dto';
+import { MemberModel } from '../../../../members/entity/member.entity';
 
 export const IMINISTRIES_DOMAIN_SERVICE = Symbol('IMINISTRIES_DOMAIN_SERVICE');
 
 export interface IMinistriesDomainService {
   findMinistries(
     church: ChurchModel,
+    ministryGroup: MinistryGroupModel,
     dto: GetMinistryDto,
     qr?: QueryRunner,
-  ): Promise<MinistryDomainPaginationResponseDto>;
+  ): Promise<MinistryModel[]>;
 
   findMinistryModelById(
-    church: ChurchModel,
+    //church: ChurchModel,
+    ministryGroup: MinistryGroupModel,
     ministryId: number,
     qr?: QueryRunner,
     relationOptions?: FindOptionsRelations<MinistryModel>,
@@ -44,12 +46,10 @@ export interface IMinistriesDomainService {
   ): Promise<MinistryModel>;
 
   updateMinistry(
-    church: ChurchModel,
     targetMinistry: MinistryModel,
     dto: UpdateMinistryDto,
     qr: QueryRunner,
-    newMinistryGroup?: MinistryGroupModel | null,
-  ): Promise<MinistryModel>;
+  ): Promise<UpdateResult>;
 
   deleteMinistry(ministry: MinistryModel, qr?: QueryRunner): Promise<void>;
 
@@ -70,4 +70,17 @@ export interface IMinistriesDomainService {
   ): Promise<MinistryModel>;
 
   countAllMinistries(church: ChurchModel, qr: QueryRunner): Promise<number>;
+
+  assignMemberToMinistry(
+    member: MemberModel,
+    oldMinistry: MinistryModel[],
+    newMinistry: MinistryModel,
+    qr: QueryRunner,
+  ): Promise<void>;
+
+  removeMemberFromMinistry(
+    member: MemberModel,
+    ministry: MinistryModel,
+    qr: QueryRunner,
+  ): Promise<void>;
 }

--- a/backend/src/management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface.ts
+++ b/backend/src/management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface.ts
@@ -109,4 +109,9 @@ export interface IMinistryGroupsDomainService {
     newLeaderMember: MemberModel,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
+
+  incrementMinistriesCount(
+    ministryGroup: MinistryGroupModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
 }

--- a/backend/src/management/ministries/ministries-domain/service/ministries-domain.service.ts
+++ b/backend/src/management/ministries/ministries-domain/service/ministries-domain.service.ts
@@ -26,8 +26,7 @@ import { CreateMinistryDto } from '../../dto/ministry/create-ministry.dto';
 import { MinistryGroupModel } from '../../entity/ministry-group.entity';
 import { UpdateMinistryDto } from '../../dto/ministry/update-ministry.dto';
 import { OfficersException } from '../../../officers/const/exception/officers.exception';
-import { MinistryDomainPaginationResponseDto } from '../../dto/ministry/response/ministry-domain-pagination-response.dto';
-import { MinistryOrderEnum } from '../../const/ministry-order.enum';
+import { MemberModel } from '../../../../members/entity/member.entity';
 
 @Injectable()
 export class MinistriesDomainService implements IMinistriesDomainService {
@@ -81,6 +80,7 @@ export class MinistriesDomainService implements IMinistriesDomainService {
 
   async findMinistries(
     church: ChurchModel,
+    ministryGroup: MinistryGroupModel,
     dto: GetMinistryDto,
     qr?: QueryRunner,
   ) {
@@ -88,38 +88,23 @@ export class MinistriesDomainService implements IMinistriesDomainService {
 
     const order: FindOptionsOrder<MinistryModel> = {
       [dto.order]: dto.orderDirection,
+      id: dto.orderDirection,
     };
 
-    if (dto.order !== MinistryOrderEnum.createdAt) {
-      order.createdAt = 'asc';
-    }
-
-    const [data, totalCount] = await Promise.all([
-      ministriesRepository.find({
-        where: {
-          churchId: church.id,
-          ministryGroupId:
-            dto.ministryGroupId === 0 ? IsNull() : dto.ministryGroupId,
-        },
-        order,
-        take: dto.take,
-        skip: dto.take * (dto.page - 1),
-      }),
-
-      ministriesRepository.count({
-        where: {
-          churchId: church.id,
-          ministryGroupId:
-            dto.ministryGroupId === 0 ? IsNull() : dto.ministryGroupId,
-        },
-      }),
-    ]);
-
-    return new MinistryDomainPaginationResponseDto(data, totalCount);
+    return ministriesRepository.find({
+      where: {
+        churchId: church.id,
+        ministryGroupId: ministryGroup.id,
+      },
+      order,
+      take: dto.take,
+      skip: dto.take * (dto.page - 1),
+    });
   }
 
   async findMinistryModelById(
-    church: ChurchModel,
+    //church: ChurchModel,
+    ministryGroup: MinistryGroupModel,
     ministryId: number,
     qr?: QueryRunner,
     relationOptions?: FindOptionsRelations<MinistryModel>,
@@ -129,7 +114,8 @@ export class MinistriesDomainService implements IMinistriesDomainService {
     const ministry = await ministriesRepository.findOne({
       where: {
         id: ministryId,
-        churchId: church.id,
+        //churchId: church.id,
+        ministryGroupId: ministryGroup.id,
       },
       relations: relationOptions ? relationOptions : { ministryGroup: true },
     });
@@ -215,22 +201,21 @@ export class MinistriesDomainService implements IMinistriesDomainService {
   }
 
   async updateMinistry(
-    church: ChurchModel,
     targetMinistry: MinistryModel,
     dto: UpdateMinistryDto,
     qr: QueryRunner,
-    newMinistryGroup: MinistryGroupModel,
   ) {
     const ministriesRepository = this.getMinistriesRepository(qr);
 
     const newName = dto.name ? dto.name : targetMinistry.name;
 
-    const isExist = await this.isExistMinistry(
-      church.id,
-      newMinistryGroup,
-      newName,
-      qr,
-    );
+    const isExist = await ministriesRepository.findOne({
+      where: {
+        id: targetMinistry.id,
+        ministryGroupId: targetMinistry.ministryGroupId,
+        name: newName,
+      },
+    });
 
     if (isExist) {
       throw new BadRequestException(MinistryException.ALREADY_EXIST);
@@ -242,8 +227,7 @@ export class MinistriesDomainService implements IMinistriesDomainService {
         deletedAt: IsNull(),
       },
       {
-        name: dto.name,
-        ministryGroupId: newMinistryGroup.id,
+        name: newName,
       },
     );
 
@@ -251,7 +235,7 @@ export class MinistriesDomainService implements IMinistriesDomainService {
       throw new NotFoundException(MinistryException.NOT_FOUND);
     }
 
-    return this.findMinistryById(church, targetMinistry.id, qr);
+    return result;
   }
 
   async deleteMinistry(ministry: MinistryModel, qr?: QueryRunner) {
@@ -326,5 +310,54 @@ export class MinistriesDomainService implements IMinistriesDomainService {
     }
 
     return updatedMinistry;
+  }
+
+  async assignMemberToMinistry(
+    member: MemberModel,
+    oldMinistry: MinistryModel[],
+    newMinistry: MinistryModel,
+    qr: QueryRunner,
+  ): Promise<void> {
+    try {
+      const memberId = member.id;
+
+      // 기존 사역 제거
+      if (oldMinistry.length > 0) {
+        const oldMinistryIds = oldMinistry.map((ministry) => ministry.id);
+
+        await qr.manager
+          .createQueryBuilder()
+          .relation(MinistryModel, 'members')
+          .of(oldMinistryIds)
+          .remove(memberId);
+      }
+
+      // 새로운 사역 등록
+      await qr.manager
+        .createQueryBuilder()
+        .relation(MinistryModel, 'members')
+        .of(newMinistry.id)
+        .add(memberId);
+
+      return;
+    } catch (error) {
+      if (error.code === '23505') {
+        throw new ConflictException(
+          MinistryException.ALREADY_ASSIGNED_MINISTRY,
+        );
+      }
+    }
+  }
+
+  async removeMemberFromMinistry(
+    member: MemberModel,
+    ministry: MinistryModel,
+    qr: QueryRunner,
+  ): Promise<void> {
+    await qr.manager
+      .createQueryBuilder()
+      .relation(MinistryModel, 'members')
+      .of(ministry)
+      .remove(member.id);
   }
 }

--- a/backend/src/management/ministries/ministries-domain/service/ministry-groups-domain.service.ts
+++ b/backend/src/management/ministries/ministries-domain/service/ministry-groups-domain.service.ts
@@ -783,4 +783,25 @@ export class MinistryGroupsDomainService
 
     return result;
   }
+
+  async incrementMinistriesCount(
+    ministryGroup: MinistryGroupModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getMinistryGroupsRepository(qr);
+
+    const result = await repository.increment(
+      { id: ministryGroup.id },
+      'ministriesCount',
+      1,
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        MinistryGroupException.UPDATE_ERROR,
+      );
+    }
+
+    return result;
+  }
 }

--- a/backend/src/management/ministries/ministries.module.ts
+++ b/backend/src/management/ministries/ministries.module.ts
@@ -27,7 +27,7 @@ import { MembersDomainModule } from '../../members/member-domain/members-domain.
     MinistriesDomainModule,
     MembersDomainModule,
   ],
-  controllers: [MinistriesController, MinistryGroupsController],
+  controllers: [MinistryGroupsController, MinistriesController],
   providers: [
     MinistryService,
     MinistryGroupService,

--- a/backend/src/member-history/controller/ministry-history.controller.ts
+++ b/backend/src/member-history/controller/ministry-history.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  GoneException,
   Param,
   ParseIntPipe,
   Patch,
@@ -65,12 +66,14 @@ export class MinistryHistoryController {
     @Body() dto: CreateMemberMinistryDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.ministryHistoryService.createMemberMinistry(
+    throw new GoneException('더 이상 사용되지 않는 엔드포인트');
+
+    /*return this.ministryHistoryService.createMemberMinistry(
       churchId,
       memberId,
       dto,
       qr,
-    );
+    );*/
   }
 
   // 교인의 사역 이력 수정
@@ -107,13 +110,15 @@ export class MinistryHistoryController {
     @Body() dto: EndMemberMinistryDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.ministryHistoryService.endMemberMinistry(
+    throw new GoneException('더 이상 사용되지 않는 엔드포인트');
+
+    /*return this.ministryHistoryService.endMemberMinistry(
       churchId,
       memberId,
       ministryHistoryId,
       dto,
       qr,
-    );
+    );*/
   }
 
   // 교인의 사역 이력 삭제

--- a/backend/src/member-history/dto/ministry/create-member-ministry.dto.ts
+++ b/backend/src/member-history/dto/ministry/create-member-ministry.dto.ts
@@ -5,6 +5,13 @@ import { TransformStartDate } from '../../decorator/transform-start-date.decorat
 
 export class CreateMemberMinistryDto {
   @ApiProperty({
+    description: '사역 그룹 Id',
+  })
+  @IsNumber()
+  @Min(1)
+  ministryGroupId: number;
+
+  @ApiProperty({
     description: '교인에게 부여할 사역의 ID',
   })
   @IsNumber()

--- a/backend/src/member-history/service/ministry-history.service.ts
+++ b/backend/src/member-history/service/ministry-history.service.ts
@@ -158,13 +158,20 @@ export class MinistryHistoryService {
       churchId,
       qr,
     );
+    const ministryGroup =
+      await this.ministryGroupsDomainService.findMinistryGroupModelById(
+        church,
+        dto.ministryGroupId,
+        qr,
+      );
 
     const [member, ministry] = await Promise.all([
       this.membersDomainService.findMemberModelById(church, memberId, qr, {
         ministries: true,
       }),
       this.ministriesDomainService.findMinistryModelById(
-        church,
+        //church,
+        ministryGroup,
         dto.ministryId,
         qr,
         { ministryGroup: true },

--- a/backend/src/member-history/swagger/ministry-history.swagger.ts
+++ b/backend/src/member-history/swagger/ministry-history.swagger.ts
@@ -15,6 +15,7 @@ export const ApiGetMemberMinistry = () =>
 export const ApiPostMemberMinistry = () =>
   applyDecorators(
     ApiOperation({
+      deprecated: true,
       summary: '교인에게 사역 부여',
       description:
         '<p>교인에게 새로운 사역을 부여합니다.</p>' +
@@ -27,6 +28,7 @@ export const ApiPostMemberMinistry = () =>
 export const ApiDeleteMemberMinistry = () =>
   applyDecorators(
     ApiOperation({
+      deprecated: true,
       summary: '교인의 사역 종료',
       description:
         '<p>교인에게 부여된 현재 사역을 종료합니다.</p>' +

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -299,6 +299,13 @@ export class MembersDomainService implements IMembersDomainService {
       .createQueryBuilder('member')
       .select(['member.id', 'member.name'])
       .innerJoin('member.ministryGroups', 'ministryGroup')
+      .leftJoin(
+        'member.ministries',
+        'ministry',
+        'ministry.ministryGroupId = :ministryGroupId',
+        { ministryGroupId: ministryGroup.id },
+      )
+      .addSelect(['ministry.id', 'ministry.name'])
       .where('ministryGroup.id = :ministryGroupId', {
         ministryGroupId: ministryGroup.id,
       })


### PR DESCRIPTION
주요 내용
- 교인에게 사역을 직접 부여/종료하는 API 추가
- 사역그룹 가입 시 사역 동시 할당 기능 구현
- 사역별 인원수(membersCount) 자동 관리

세부 내용
### 도메인 규칙
- 사역은 반드시 사역그룹에 속해야 함
- 교인과 사역이 같은 사역그룹에 속한 경우에만 부여 가능
- 사역그룹 내에서는 하나의 사역만 보유 가능 (타 그룹에서는 추가 사역 가능)

### 사역 부여 (PATCH /ministry-groups/{groupId}/ministries/{ministryId}/members)
- 요청: { "memberId": number }
- 기존 사역이 있을 경우 자동으로 종료 처리 후 새 사역 부여
- 사역의 membersCount 자동 증가

### 사역 종료 (DELETE /ministry-groups/{groupId}/ministries/{ministryId}/members)
- 요청: { "memberId": number }
- 실제 부여된 사역인지 검증 후 종료
- 사역의 membersCount 자동 감소

### 연관 기능 개선
- 사역그룹 가입 시: ministryId 지정하면 동시에 사역 부여
- 사역그룹 탈퇴 시: 보유한 사역 자동 종료 처리

### 기술적 변경사항
- TypeORM relation()을 활용한 교인-사역 관계 관리
- 트랜잭션으로 사역 변경 시 일관성 보장
- 사역별 인원수 실시간 동기화