### PR TITLE
feat: 그룹 리더 이력 관리를 위한 GroupDetailHistory 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -70,6 +70,7 @@ import { MyPageModule } from './my-page/my-page.module';
 import { HomeModule } from './home/home.module';
 import { MinistryGroupHistoryModel } from './member-history/ministry-history/entity/ministry-group-history.entity';
 import { MinistryGroupRoleHistoryModel } from './member-history/ministry-history/entity/ministry-group-role-history.entity';
+import { GroupDetailHistoryModel } from './member-history/group-history/entity/group-detail-history.entity';
 
 @Module({
   imports: [
@@ -155,7 +156,6 @@ import { MinistryGroupRoleHistoryModel } from './member-history/ministry-history
           EducationSessionModel,
           SessionAttendanceModel,
           EducationEnrollmentModel,
-          //EducationHistoryModel,
           // 직분 관련 엔티티
           OfficerModel,
           OfficerHistoryModel,
@@ -167,8 +167,8 @@ import { MinistryGroupRoleHistoryModel } from './member-history/ministry-history
           MinistryHistoryModel,
           // 그룹 관련 엔티티
           GroupModel,
-          //GroupRoleModel,
           GroupHistoryModel,
+          GroupDetailHistoryModel,
           // 심방 관련 엔티티
           VisitationMetaModel,
           VisitationDetailModel,

--- a/backend/src/management/groups/const/swagger/group.swagger.ts
+++ b/backend/src/management/groups/const/swagger/group.swagger.ts
@@ -36,6 +36,13 @@ export const ApiRefreshGroupCount = () =>
     }),
   );
 
+export const ApiGetUnassignedMembers = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '그룹에 속하지 않은 교인 조회',
+    }),
+  );
+
 export const ApiGetGroupById = () =>
   applyDecorators(
     ApiOperation({

--- a/backend/src/management/groups/controller/groups.controller.ts
+++ b/backend/src/management/groups/controller/groups.controller.ts
@@ -22,6 +22,7 @@ import {
   ApiDeleteGroup,
   ApiGetGroupById,
   ApiGetGroups,
+  ApiGetUnassignedMembers,
   ApiPatchGroupLeader,
   ApiPatchGroupName,
   ApiPatchGroupStructure,
@@ -37,6 +38,7 @@ import { UpdateGroupStructureDto } from '../dto/request/update-group-structure.d
 import { PermissionChurch } from '../../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { UpdateGroupLeaderDto } from '../dto/request/update-group-leader.dto';
+import { GetUnassignedMembersDto } from '../../ministries/dto/ministry-group/request/member/get-unassigned-members.dto';
 
 @ApiTags('Management:Groups')
 @Controller('groups')
@@ -74,6 +76,15 @@ export class GroupsController {
     @QueryRunner() qr: QR,
   ) {
     return this.groupsService.refreshGroupCount(church, qr);
+  }
+
+  @ApiGetUnassignedMembers()
+  @Get('unassigned-member')
+  getUnassignedMembers(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Query() dto: GetUnassignedMembersDto,
+  ) {
+    return this.groupsService.getUnassignedMembers(churchId, dto);
   }
 
   @ApiGetGroupById()

--- a/backend/src/management/groups/dto/request/update-group-leader.dto.ts
+++ b/backend/src/management/groups/dto/request/update-group-leader.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, Min } from 'class-validator';
+import { IsDateString, IsNumber, Min } from 'class-validator';
+import { IsYYYYMMDD } from '../../../../common/decorator/validator/is-yyyy-mm-dd.validator';
 
 export class UpdateGroupLeaderDto {
   @ApiProperty({
@@ -8,4 +9,12 @@ export class UpdateGroupLeaderDto {
   @IsNumber()
   @Min(1)
   newLeaderMemberId: number;
+
+  @ApiProperty({
+    description: '이력 시작 날짜',
+    required: true,
+  })
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('startDate')
+  startDate: string;
 }

--- a/backend/src/management/groups/entity/group.entity.ts
+++ b/backend/src/management/groups/entity/group.entity.ts
@@ -6,7 +6,6 @@ import { MemberModel } from '../../../members/entity/member.entity';
 import { GroupHistoryModel } from '../../../member-history/group-history/entity/group-history.entity';
 
 @Entity()
-//@Unique(['name', 'parentGroupId', 'churchId'])
 export class GroupModel extends BaseModel {
   @Column()
   name: string;

--- a/backend/src/member-history/group-history/controller/group-history.controller.ts
+++ b/backend/src/member-history/group-history/controller/group-history.controller.ts
@@ -15,8 +15,11 @@ import { GetGroupHistoryDto } from '../dto/get-group-history.dto';
 import { GroupHistoryService } from '../service/group-history.service';
 import { UpdateGroupHistoryDto } from '../dto/update-group-history.dto';
 import {
+  ApiDeleteGroupDetailHistory,
   ApiDeleteGroupHistory,
+  ApiGetGroupDetailHistory,
   ApiGetMemberGroupHistory,
+  ApiPatchGroupDetailHistory,
   ApiPatchGroupHistory,
 } from '../swagger/group-history.swagger';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
@@ -78,4 +81,30 @@ export class GroupHistoryController {
       groupHistoryId,
     );
   }
+
+  @ApiGetGroupDetailHistory()
+  @Get(':groupHistoryId/details')
+  getGroupDetailHistories(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Param('groupHistoryId', ParseIntPipe) groupHistoryId: number,
+    @Query() dto: GetGroupHistoryDto,
+  ) {}
+
+  @ApiPatchGroupDetailHistory()
+  @Patch(':groupHistoryId/details/:detailHistoryId')
+  patchGroupDetailHistory(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Param('groupHistoryId', ParseIntPipe) groupHistoryId: number,
+    @Body() dto: UpdateGroupHistoryDto,
+  ) {}
+
+  @ApiDeleteGroupDetailHistory()
+  @Delete(':groupHistoryId/details/:detailHistoryId')
+  deleteGroupDetailHistory(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Param('groupHistoryId', ParseIntPipe) groupHistoryId: number,
+  ) {}
 }

--- a/backend/src/member-history/group-history/entity/group-detail-history.entity.ts
+++ b/backend/src/member-history/group-history/entity/group-detail-history.entity.ts
@@ -1,0 +1,35 @@
+import { BaseModel } from '../../../common/entity/base.entity';
+import { GroupHistoryModel } from './group-history.entity';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { GroupRole } from '../../../management/groups/const/group-role.enum';
+import { MemberModel } from '../../../members/entity/member.entity';
+
+@Entity()
+export class GroupDetailHistoryModel extends BaseModel {
+  @Index()
+  @Column()
+  memberId: number;
+
+  @ManyToOne(() => MemberModel)
+  @JoinColumn({ name: 'memberId' })
+  member: MemberModel;
+
+  @Index()
+  @Column()
+  groupHistoryId: number;
+
+  @ManyToOne(() => GroupHistoryModel)
+  @JoinColumn({ name: 'groupHistoryId' })
+  groupHistory: GroupHistoryModel;
+
+  @Column()
+  role: GroupRole;
+
+  @Index()
+  @Column({ type: 'timestamptz' })
+  startDate: Date;
+
+  @Index()
+  @Column({ type: 'timestamptz', nullable: true })
+  endDate: Date | null;
+}

--- a/backend/src/member-history/group-history/entity/group-history.entity.ts
+++ b/backend/src/member-history/group-history/entity/group-history.entity.ts
@@ -1,7 +1,15 @@
-import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+} from 'typeorm';
 import { BaseModel } from '../../../common/entity/base.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { GroupModel } from '../../../management/groups/entity/group.entity';
+import { GroupDetailHistoryModel } from './group-detail-history.entity';
 
 @Entity()
 export class GroupHistoryModel extends BaseModel {
@@ -37,4 +45,13 @@ export class GroupHistoryModel extends BaseModel {
   @Index()
   @Column({ type: 'timestamptz', nullable: true })
   endDate: Date | null;
+
+  @Column({ default: false })
+  hasDetailHistory: boolean;
+
+  @OneToMany(
+    () => GroupDetailHistoryModel,
+    (detailHistory) => detailHistory.groupHistory,
+  )
+  groupDetailHistory: GroupDetailHistoryModel[];
 }

--- a/backend/src/member-history/group-history/exception/group-history.exception.ts
+++ b/backend/src/member-history/group-history/exception/group-history.exception.ts
@@ -5,6 +5,8 @@ export const GroupHistoryException = {
   DELETE_ERROR: '그룹 이력 삭제 도중 에러 발생',
   NOT_FOUND: '그룹 이력을 찾을 수 없습니다.',
 
+  NOT_FOUND_CURRENT_DETAIL: '진행중인 그룹 상세 이력을 찾을 수 없습니다.',
+
   CANNOT_UPDATE_END_DATE:
     '종료되지 않은 그룹 이력의 종료 날짜를 수정할 수 없습니다.',
   INVALID_START_DATE: '이력 시작일은 종료일보다 늦을 수 없습니다.',

--- a/backend/src/member-history/group-history/group-history-domain/group-history-domain.module.ts
+++ b/backend/src/member-history/group-history/group-history-domain/group-history-domain.module.ts
@@ -3,15 +3,27 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { GroupHistoryModel } from '../entity/group-history.entity';
 import { IGROUP_HISTORY_DOMAIN_SERVICE } from './interface/group-history-domain.service.interface';
 import { GroupHistoryDomainService } from './service/group-history-domain.service';
+import { GroupDetailHistoryModel } from '../entity/group-detail-history.entity';
+import { IGROUP_DETAIL_HISTORY_DOMAIN_SERVICE } from './interface/group-detail-history-domain.service.interface';
+import { GroupDetailHistoryDomainService } from './service/group-detail-history-domain.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([GroupHistoryModel])],
+  imports: [
+    TypeOrmModule.forFeature([GroupHistoryModel, GroupDetailHistoryModel]),
+  ],
   providers: [
     {
       provide: IGROUP_HISTORY_DOMAIN_SERVICE,
       useClass: GroupHistoryDomainService,
     },
+    {
+      provide: IGROUP_DETAIL_HISTORY_DOMAIN_SERVICE,
+      useClass: GroupDetailHistoryDomainService,
+    },
   ],
-  exports: [IGROUP_HISTORY_DOMAIN_SERVICE],
+  exports: [
+    IGROUP_HISTORY_DOMAIN_SERVICE,
+    IGROUP_DETAIL_HISTORY_DOMAIN_SERVICE,
+  ],
 })
 export class GroupHistoryDomainModule {}

--- a/backend/src/member-history/group-history/group-history-domain/interface/group-detail-history-domain.service.interface.ts
+++ b/backend/src/member-history/group-history/group-history-domain/interface/group-detail-history-domain.service.interface.ts
@@ -1,0 +1,25 @@
+import { MemberModel } from '../../../../members/entity/member.entity';
+import { GroupHistoryModel } from '../../entity/group-history.entity';
+import { GroupRole } from '../../../../management/groups/const/group-role.enum';
+import { QueryRunner, UpdateResult } from 'typeorm';
+import { GroupDetailHistoryModel } from '../../entity/group-detail-history.entity';
+
+export const IGROUP_DETAIL_HISTORY_DOMAIN_SERVICE = Symbol(
+  'IGROUP_DETAIL_HISTORY_DOMAIN_SERVICE',
+);
+
+export interface IGroupDetailHistoryDomainService {
+  startGroupDetailHistory(
+    member: MemberModel,
+    groupHistory: GroupHistoryModel,
+    groupRole: GroupRole,
+    startDate: Date,
+    qr?: QueryRunner,
+  ): Promise<GroupDetailHistoryModel>;
+
+  endGroupDetailHistory(
+    oldLeaderMembers: MemberModel[],
+    date: Date,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+}

--- a/backend/src/member-history/group-history/group-history-domain/service/group-detail-history-domain.service.ts
+++ b/backend/src/member-history/group-history/group-history-domain/service/group-detail-history-domain.service.ts
@@ -1,0 +1,98 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { IGroupDetailHistoryDomainService } from '../interface/group-detail-history-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { GroupDetailHistoryModel } from '../../entity/group-detail-history.entity';
+import { In, IsNull, QueryRunner, Repository } from 'typeorm';
+import { MemberModel } from '../../../../members/entity/member.entity';
+import { GroupHistoryModel } from '../../entity/group-history.entity';
+import { GroupHistoryException } from '../../exception/group-history.exception';
+import { GroupRole } from '../../../../management/groups/const/group-role.enum';
+
+@Injectable()
+export class GroupDetailHistoryDomainService
+  implements IGroupDetailHistoryDomainService
+{
+  constructor(
+    @InjectRepository(GroupDetailHistoryModel)
+    private readonly repository: Repository<GroupDetailHistoryModel>,
+  ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr
+      ? qr.manager.getRepository(GroupDetailHistoryModel)
+      : this.repository;
+  }
+
+  async findCurrentGroupDetailHistory(
+    member: MemberModel,
+    groupHistory: GroupHistoryModel,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    const history = await repository.findOne({
+      where: {
+        groupHistoryId: groupHistory.id,
+        memberId: member.id,
+        endDate: IsNull(),
+      },
+    });
+
+    if (!history) {
+      throw new NotFoundException(
+        GroupHistoryException.NOT_FOUND_CURRENT_DETAIL,
+      );
+    }
+
+    return history;
+  }
+
+  startGroupDetailHistory(
+    member: MemberModel,
+    groupHistory: GroupHistoryModel,
+    groupRole: GroupRole,
+    startDate: Date,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    return repository.save({
+      member: { id: member.id },
+      groupHistory: { id: groupHistory.id },
+      role: groupRole,
+      startDate: startDate,
+    });
+  }
+
+  async endGroupDetailHistory(
+    members: MemberModel[],
+    endDate: Date,
+    qr?: QueryRunner,
+  ) {
+    const repository = this.getRepository(qr);
+
+    const memberIds = members.map((m) => m.id);
+
+    const result = await repository.update(
+      {
+        memberId: In(memberIds),
+        endDate: IsNull(),
+      },
+      {
+        endDate: endDate,
+      },
+    );
+
+    if (result.affected !== members.length) {
+      throw new InternalServerErrorException(
+        GroupHistoryException.UPDATE_ERROR,
+      );
+    }
+
+    return result;
+  }
+}

--- a/backend/src/member-history/group-history/swagger/group-history.swagger.ts
+++ b/backend/src/member-history/group-history/swagger/group-history.swagger.ts
@@ -69,3 +69,24 @@ export const ApiDeleteGroupHistory = () =>
         '<p>종료되지 않은 이력 삭제 시 --> BadRequestException</p>',
     }),
   );
+
+export const ApiGetGroupDetailHistory = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교인 그룹 상세 이력 조회 (groupRole 이력)',
+    }),
+  );
+
+export const ApiPatchGroupDetailHistory = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교인 그룹 상세 이력 수정 (groupRole 이력)',
+    }),
+  );
+
+export const ApiDeleteGroupDetailHistory = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교인 그룹 상세 이력 삭제 (groupRole 이력)',
+    }),
+  );

--- a/backend/src/members/member-domain/interface/group-members.domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/group-members.domain.service.interface.ts
@@ -3,6 +3,7 @@ import { GroupModel } from '../../../management/groups/entity/group.entity';
 import { GetGroupMembersDto } from '../../../management/groups/dto/request/members/get-group-members.dto';
 import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { MemberModel } from '../../entity/member.entity';
+import { GetUnassignedMembersDto } from '../../../management/ministries/dto/ministry-group/request/member/get-unassigned-members.dto';
 
 export const IGROUP_MEMBERS_DOMAIN_SERVICE = Symbol(
   'IGROUP_MEMBERS_DOMAIN_SERVICE',
@@ -37,4 +38,10 @@ export interface IGroupMembersDomainService {
     group: GroupModel,
     qr?: QueryRunner,
   ): Promise<number>;
+
+  findUnassignedMembers(
+    church: ChurchModel,
+    dto: GetUnassignedMembersDto,
+    qr?: QueryRunner,
+  ): Promise<MemberModel[]>;
 }

--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -150,8 +150,8 @@ export interface IMembersDomainService {
   endMemberGroup(member: MemberModel, qr: QueryRunner): Promise<UpdateResult>;
 
   updateGroupRole(
-    group: GroupModel,
-    newLeaderMember: MemberModel,
+    member: MemberModel,
+    groupRole: GroupRole,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -570,23 +570,14 @@ export class MembersDomainService implements IMembersDomainService {
   }
 
   async updateGroupRole(
-    group: GroupModel,
-    newLeaderMember: MemberModel,
+    member: MemberModel,
+    groupRole: GroupRole,
     qr: QueryRunner,
   ): Promise<UpdateResult> {
     const repository = this.getMembersRepository(qr);
 
-    // 기존 리더를 다시 그룹원으로 수정
-    await repository.update(
-      { groupId: group.id, groupRole: GroupRole.LEADER },
-      { groupRole: GroupRole.MEMBER },
-    );
-
     // 새로운 리더 지정
-    const result = await repository.update(
-      { id: newLeaderMember.id },
-      { groupRole: GroupRole.LEADER },
-    );
+    const result = await repository.update({ id: member.id }, { groupRole });
 
     if (result.affected === 0) {
       throw new InternalServerErrorException(MemberException.UPDATE_ERROR);

--- a/backend/src/members/member-domain/service/officer-members-domain.service.ts
+++ b/backend/src/members/member-domain/service/officer-members-domain.service.ts
@@ -52,6 +52,7 @@ export class OfficerMembersDomainService
       select: MemberSummarizedSelect,
       order: {
         [dto.order]: dto.orderDirection,
+        id: dto.orderDirection,
       },
       take: dto.take,
       skip: dto.take * (dto.page - 1),


### PR DESCRIPTION
주요 내용
- GroupDetailHistory 엔티티 추가로 그룹 내 리더 이력 관리
- 그룹 리더 변경 시 자동 이력 생성/종료
- 그룹 상세 이력 CRUD API 구현

세부 내용
### GroupDetailHistory 구조
- GroupHistory와 1:N 관계 (그룹 이력의 하위 이력)
- 그룹 내에서 리더 역할 기간 추적
- 리더 지정 시 생성, 리더 해제 시 종료

### 이력 생성/종료 시점
- 생성: 그룹 리더로 지정될 때
- 종료:
 - 다른 멤버가 리더로 지정될 때
 - 다른 그룹으로 이동하여 리더 자격 상실 시
 - 그룹에서 제거될 때

### API 엔드포인트
- 조회: GET /members/{memberId}/histories/groups/{groupHistoryId}/details
- 수정: PATCH /members/{memberId}/histories/groups/{groupHistoryId}/details/{detailHistoryId}
- 삭제: DELETE /members/{memberId}/histories/groups/{groupHistoryId}/details/{detailHistoryId}

### 관리 정책
- 날짜 형식: YYYY-MM-DD (한국 시간 기준)
- 수정: 시작날짜는 모든 이력, 종료날짜는 종료된 이력만 수정 가능
- 삭제: 종료된 이력만 삭제 가능 (소프트 삭제)
- 다른 이력들과 동일한 규칙 적용