### PR TITLE
## feat: 그룹 리더 변경 시 날짜 검증 로직 추가

### DIFF
--- a/backend/src/member-history/group-history/exception/group-history.exception.ts
+++ b/backend/src/member-history/group-history/exception/group-history.exception.ts
@@ -5,11 +5,13 @@ export const GroupHistoryException = {
   DELETE_ERROR: '그룹 이력 삭제 도중 에러 발생',
   NOT_FOUND: '그룹 이력을 찾을 수 없습니다.',
 
-  NOT_FOUND_CURRENT_DETAIL: '진행중인 그룹 상세 이력을 찾을 수 없습니다.',
-
   CANNOT_UPDATE_END_DATE:
     '종료되지 않은 그룹 이력의 종료 날짜를 수정할 수 없습니다.',
   INVALID_START_DATE: '이력 시작일은 종료일보다 늦을 수 없습니다.',
   INVALID_END_DATE: '이력 종료일은 시작일보다 빠를 수 없습니다.',
   CANNOT_DELETE: '종료되지 않은 이력을 삭제할 수 없습니다.',
+
+  NOT_FOUND_CURRENT_DETAIL: '진행중인 그룹 상세 이력을 찾을 수 없습니다.',
+  INVALID_DETAIL_START_DATE:
+    '그룹 리더 이력 시작일이 그룹 이력 시작일보다 빠릅니다.',
 };

--- a/backend/src/member-history/group-history/group-history-domain/interface/group-detail-history-domain.service.interface.ts
+++ b/backend/src/member-history/group-history/group-history-domain/interface/group-detail-history-domain.service.interface.ts
@@ -9,6 +9,12 @@ export const IGROUP_DETAIL_HISTORY_DOMAIN_SERVICE = Symbol(
 );
 
 export interface IGroupDetailHistoryDomainService {
+  findCurrentGroupDetailHistory(
+    member: MemberModel,
+    groupHistory: GroupHistoryModel,
+    qr?: QueryRunner,
+  ): Promise<GroupDetailHistoryModel>;
+
   startGroupDetailHistory(
     member: MemberModel,
     groupHistory: GroupHistoryModel,

--- a/backend/src/member-history/group-history/group-history-domain/service/group-detail-history-domain.service.ts
+++ b/backend/src/member-history/group-history/group-history-domain/service/group-detail-history-domain.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Injectable,
   InternalServerErrorException,
   NotFoundException,
@@ -58,6 +59,12 @@ export class GroupDetailHistoryDomainService
     startDate: Date,
     qr?: QueryRunner,
   ) {
+    if (startDate < groupHistory.startDate) {
+      throw new BadRequestException(
+        GroupHistoryException.INVALID_DETAIL_START_DATE,
+      );
+    }
+
     const repository = this.getRepository(qr);
 
     return repository.save({

--- a/backend/src/member-history/history-date.utils.ts
+++ b/backend/src/member-history/history-date.utils.ts
@@ -14,10 +14,36 @@ export function convertHistoryStartDate(
   startDateStr: string,
   timeZone: TIME_ZONE,
 ) {
+  const today = fromZonedTime(
+    endOfDay(toZonedTime(new Date(), timeZone)),
+    timeZone,
+  );
+
+  const startDate = fromZonedTime(startOfDay(startDateStr), timeZone);
+
+  if (startDate > today) {
+    throw new BadRequestException(
+      '시작 날짜는 현재 날짜를 넘어설 수 없습니다.',
+    );
+  }
+
   return fromZonedTime(startOfDay(startDateStr), timeZone);
 }
 
 export function convertHistoryEndDate(endDateStr: string, timeZone: TIME_ZONE) {
+  const today = fromZonedTime(
+    endOfDay(toZonedTime(new Date(), timeZone)),
+    timeZone,
+  );
+
+  const endDate = fromZonedTime(endOfDay(endDateStr), timeZone);
+
+  if (endDate > today) {
+    throw new BadRequestException(
+      '종료 날짜는 현재 날짜를 넘어설 수 없습니다.',
+    );
+  }
+
   return fromZonedTime(endOfDay(endDateStr), timeZone);
 }
 


### PR DESCRIPTION
### 주요 내용
그룹 리더 지정 시 날짜 유효성 검증을 통해 데이터 무결성을 보장하는 제약 조건을 추가했습니다.

### 세부 내용
- 새로운 리더의 시작일이 기존 리더의 시작일보다 이전일 수 없도록 검증
 - 기존 리더가 2024-01-01부터 리더인 경우, 새 리더는 그 이후 날짜부터만 지정 가능
- 리더 시작일이 해당 교인의 그룹 가입일보다 이전일 수 없도록 검증
 - 그룹에 가입하지 않은 상태에서 리더가 될 수 없는 논리적 제약 반영
- 잘못된 날짜 입력 시 명확한 에러 메시지와 함께 BadRequestException 발생