### PR TITLE
## feat: 그룹 이동 시 날짜 검증 로직 강화 및 개별 처리 방식 변경

### DIFF
--- a/backend/src/member-history/group-history/entity/group-history.entity.ts
+++ b/backend/src/member-history/group-history/entity/group-history.entity.ts
@@ -46,9 +46,6 @@ export class GroupHistoryModel extends BaseModel {
   @Column({ type: 'timestamptz', nullable: true })
   endDate: Date | null;
 
-  @Column({ default: false })
-  hasDetailHistory: boolean;
-
   @OneToMany(
     () => GroupDetailHistoryModel,
     (detailHistory) => detailHistory.groupHistory,

--- a/backend/src/member-history/group-history/group-history-domain/interface/group-history-domain.service.interface.ts
+++ b/backend/src/member-history/group-history/group-history-domain/interface/group-history-domain.service.interface.ts
@@ -23,6 +23,13 @@ export interface IGroupHistoryDomainService {
     qr: QueryRunner,
   ): Promise<GroupHistoryModel[]>;
 
+  endCurrentGroupHistory(
+    member: MemberModel,
+    groupSnapShot: string,
+    endDate: Date,
+    qr: QueryRunner,
+  ): Promise<UpdateResult | void>;
+
   endGroupHistories(
     members: MemberModel[],
     endDate: Date,


### PR DESCRIPTION
### 주요 내용
그룹 이동 시 모든 교인(리더/일반)에 대해 날짜 유효성 검증을 적용하고, 정확한 검증을 위해 일괄 처리에서 개별 처리 방식으로 변경했습니다.

### 세부 내용
- 일반 그룹원 이동 시에도 새 그룹 시작일이 기존 그룹 시작일보다 이전일 수 없도록 검증 추가
 - 기존에는 리더 변경 시에만 적용되던 날짜 제약을 모든 그룹 이동에 확대 적용
- 그룹 이동 처리 방식을 일괄 처리에서 개별 처리로 변경
 - 기존: 여러 교인의 그룹 이력을 한 번에 처리
 - 변경: 각 교인별로 개별적으로 이력 검증 및 처리
 - 개별 교인의 그룹 이력에 대한 정확한 날짜 검증 가능
- 각 교인별로 기존 그룹 이력을 조회하여 날짜 유효성 검증 수행