### PR TITLE
fix: 그룹 이동 시 날짜 검증을 일괄 처리 방식으로 개선

### DIFF
--- a/backend/src/management/groups/service/group-members.service.ts
+++ b/backend/src/management/groups/service/group-members.service.ts
@@ -160,6 +160,12 @@ export class GroupMembersService {
   ) {
     const endDate = convertHistoryEndDate(startDate, TIME_ZONE.SEOUL);
 
+    await this.groupHistoryDomainService.validateGroupStartDates(
+      changeGroupMembers,
+      endDate,
+      qr,
+    );
+
     // 교인 수 감소
     await this.decrementOldGroups(church, changeGroupMembers, qr);
 

--- a/backend/src/member-history/group-history/group-history-domain/interface/group-history-domain.service.interface.ts
+++ b/backend/src/member-history/group-history/group-history-domain/interface/group-history-domain.service.interface.ts
@@ -23,6 +23,12 @@ export interface IGroupHistoryDomainService {
     qr: QueryRunner,
   ): Promise<GroupHistoryModel[]>;
 
+  validateGroupStartDates(
+    members: MemberModel[],
+    newStartDate: Date,
+    qr: QueryRunner,
+  ): Promise<void>;
+
   endCurrentGroupHistory(
     member: MemberModel,
     groupSnapShot: string,


### PR DESCRIPTION
## 주요 내용
그룹 이동 시 각 교인의 기존 그룹 시작일 검증을 개별 처리에서 일괄 검증 방식으로 개선하여 성능과 트랜잭션 안정성을 향상시켰습니다.

## 세부 내용
- 단일 쿼리로 모든 교인의 기존 그룹 시작일 검증 수행
 - 기존: 교인별 개별 쿼리로 검증 (N번 쿼리)
 - 개선: 한 번의 쿼리로 모든 교인 검증 (1번 쿼리)
- 검증 실패 시 구체적인 오류 정보 제공
 - 날짜 조건을 위반한 교인 이름과 기존 시작일을 함께 표시
 - 예: "다음 교인들의 기존 그룹 시작일이 새 그룹 시작일(2024-01-01)보다 늦습니다: 홍길동(2024-02-01), 김철수(2024-03-01)"
- 트랜잭션 내에서 검증과 업데이트를 분리하여 처리
 - 검증 통과 시에만 일괄 업데이트 수행
 - 검증 실패 시 모든 변경사항 롤백으로 데이터 일관성 보장