### PR TITLE
feat: 직분 할당/해제 시 날짜 지정 기능 추가 및 교인 조회 응답 개선

### DIFF
--- a/backend/src/management/groups/dto/response/members/get-group-members-response.dto.ts
+++ b/backend/src/management/groups/dto/response/members/get-group-members-response.dto.ts
@@ -1,8 +1,8 @@
-import { MemberModel } from '../../../../../members/entity/member.entity';
+import { GroupMemberDto } from '../../../../../members/dto/group-member.dto';
 
 export class GetGroupMembersResponseDto {
   constructor(
-    public readonly data: MemberModel[],
+    public readonly data: GroupMemberDto[],
     public readonly timestamp: Date = new Date(),
   ) {}
 }

--- a/backend/src/management/officers/const/officer-member-order.enum.ts
+++ b/backend/src/management/officers/const/officer-member-order.enum.ts
@@ -1,5 +1,4 @@
 export enum OfficerMemberOrder {
-  //OFFICER_NAME = 'officerName',
   REGISTERED_AT = 'registeredAt',
   NAME = 'name',
   BIRTH = 'birth',

--- a/backend/src/management/officers/dto/request/members/add-members-to-officer.dto.ts
+++ b/backend/src/management/officers/dto/request/members/add-members-to-officer.dto.ts
@@ -3,9 +3,11 @@ import {
   ArrayMinSize,
   ArrayUnique,
   IsArray,
+  IsDateString,
   IsNumber,
   Min,
 } from 'class-validator';
+import { IsYYYYMMDD } from '../../../../../common/decorator/validator/is-yyyy-mm-dd.validator';
 
 export class AddMembersToOfficerDto {
   @ApiProperty({
@@ -18,4 +20,11 @@ export class AddMembersToOfficerDto {
   @IsNumber({}, { each: true })
   @Min(1, { each: true })
   memberIds: number[];
+
+  @ApiProperty({
+    description: '그룹 이력 시작 날짜',
+  })
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('startDate')
+  startDate: string;
 }

--- a/backend/src/management/officers/dto/request/members/remove-members-from-officer.dto.ts
+++ b/backend/src/management/officers/dto/request/members/remove-members-from-officer.dto.ts
@@ -3,9 +3,11 @@ import {
   ArrayMinSize,
   ArrayUnique,
   IsArray,
+  IsDateString,
   IsNumber,
   Min,
 } from 'class-validator';
+import { IsYYYYMMDD } from '../../../../../common/decorator/validator/is-yyyy-mm-dd.validator';
 
 export class RemoveMembersFromOfficerDto {
   @ApiProperty({
@@ -18,4 +20,11 @@ export class RemoveMembersFromOfficerDto {
   @IsNumber({}, { each: true })
   @Min(1, { each: true })
   memberIds: number[];
+
+  @ApiProperty({
+    description: '그룹 이력 종료 날짜',
+  })
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('endDate')
+  endDate: string;
 }

--- a/backend/src/management/officers/dto/response/members/get-officer-members-response.dto.ts
+++ b/backend/src/management/officers/dto/response/members/get-officer-members-response.dto.ts
@@ -1,8 +1,8 @@
-import { MemberModel } from '../../../../../members/entity/member.entity';
+import { OfficerMemberDto } from '../../../../../members/dto/officer-member.dto';
 
 export class GetOfficerMembersResponseDto {
   constructor(
-    public readonly data: MemberModel[],
+    public readonly data: OfficerMemberDto[],
     public readonly timestamp: Date = new Date(),
   ) {}
 }

--- a/backend/src/management/officers/service/officer-members.service.ts
+++ b/backend/src/management/officers/service/officer-members.service.ts
@@ -29,6 +29,11 @@ import {
   IOFFICER_HISTORY_DOMAIN_SERVICE,
   IOfficerHistoryDomainService,
 } from '../../../member-history/officer-history/officer-history-domain/interface/officer-history-domain.service.interface';
+import {
+  convertHistoryEndDate,
+  convertHistoryStartDate,
+} from '../../../member-history/history-date.utils';
+import { TIME_ZONE } from '../../../common/const/time-zone.const';
 
 @Injectable()
 export class OfficerMembersService {
@@ -102,10 +107,17 @@ export class OfficerMembersService {
 
     const changeOfficerMembers = members.filter((member) => member.officerId);
 
+    const startDate = convertHistoryStartDate(dto.startDate, TIME_ZONE.SEOUL);
+
     if (changeOfficerMembers.length > 0) {
+      const endDate = convertHistoryEndDate(dto.startDate, TIME_ZONE.SEOUL);
+
+      // TODO endDate 검증 필요
+
       // 기존 직분 이력 종료 처리
       await this.officerHistoryDomainService.endOfficerHistories(
         changeOfficerMembers,
+        endDate,
         qr,
       );
 
@@ -127,6 +139,7 @@ export class OfficerMembersService {
     await this.officerHistoryDomainService.startOfficerHistory(
       members,
       officer,
+      startDate,
       qr,
     );
 
@@ -168,8 +181,13 @@ export class OfficerMembersService {
       qr,
     );
 
+    const endDate = convertHistoryEndDate(dto.endDate, TIME_ZONE.SEOUL);
+
+    // TODO endDate 검증 필요
+
     await this.officerHistoryDomainService.endOfficerHistories(
       removeMembers,
+      endDate,
       qr,
       officer,
     );

--- a/backend/src/member-history/ministry-history/entity/ministry-group-history.entity.ts
+++ b/backend/src/member-history/ministry-history/entity/ministry-group-history.entity.ts
@@ -1,7 +1,15 @@
 import { BaseModel } from '../../../common/entity/base.entity';
-import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+} from 'typeorm';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { MinistryGroupModel } from '../../../management/ministries/entity/ministry-group.entity';
+import { MinistryGroupDetailHistoryModel } from './ministry-group-detail-history.entity';
 
 @Entity()
 export class MinistryGroupHistoryModel extends BaseModel {
@@ -35,4 +43,10 @@ export class MinistryGroupHistoryModel extends BaseModel {
     nullable: true,
   })
   ministryGroupSnapShot: string | null;
+
+  @OneToMany(
+    () => MinistryGroupDetailHistoryModel,
+    (detailHistory) => detailHistory.ministryGroupHistory,
+  )
+  ministryGroupDetailHistory: MinistryGroupDetailHistoryModel[];
 }

--- a/backend/src/member-history/officer-history/officer-history-domain/interface/officer-history-domain.service.interface.ts
+++ b/backend/src/member-history/officer-history/officer-history-domain/interface/officer-history-domain.service.interface.ts
@@ -34,11 +34,13 @@ export interface IOfficerHistoryDomainService {
   startOfficerHistory(
     members: MemberModel[],
     officer: OfficerModel,
+    startDate: Date,
     qr: QueryRunner,
   ): Promise<OfficerHistoryModel[]>;
 
   endOfficerHistories(
     members: MemberModel[],
+    endDate: Date,
     qr: QueryRunner,
     officer?: OfficerModel,
   ): Promise<OfficerHistoryModel[] | UpdateResult>;

--- a/backend/src/member-history/officer-history/officer-history-domain/service/officer-history-domain.service.ts
+++ b/backend/src/member-history/officer-history/officer-history-domain/service/officer-history-domain.service.ts
@@ -21,7 +21,6 @@ import { OfficerModel } from '../../../../management/officers/entity/officer.ent
 import { OfficerHistoryException } from '../../exception/officer-history.exception';
 import {
   getHistoryEndDate,
-  getHistoryStartDate,
   HistoryUpdateDate,
 } from '../../../history-date.utils';
 import { TIME_ZONE } from '../../../../common/const/time-zone.const';
@@ -69,6 +68,7 @@ export class OfficerHistoryDomainService
   startOfficerHistory(
     members: MemberModel[],
     officer: OfficerModel,
+    startDate: Date,
     qr: QueryRunner,
   ): Promise<OfficerHistoryModel[]> {
     const repository = this.getOfficerHistoryRepository(qr);
@@ -77,7 +77,7 @@ export class OfficerHistoryDomainService
       members.map((member) => ({
         member: { id: member.id },
         officer: { id: officer.id },
-        startDate: getHistoryStartDate(TIME_ZONE.SEOUL),
+        startDate: startDate, //getHistoryStartDate(TIME_ZONE.SEOUL),
       })),
     );
 
@@ -86,6 +86,7 @@ export class OfficerHistoryDomainService
 
   async endOfficerHistories(
     members: MemberModel[],
+    endDate: Date,
     qr: QueryRunner,
     officer?: OfficerModel,
   ) {
@@ -109,6 +110,7 @@ export class OfficerHistoryDomainService
         oldHistory.endDate = getHistoryEndDate(TIME_ZONE.SEOUL);
         oldHistory.officerId = null;
         oldHistory.officer = null;
+        oldHistory.endDate = endDate;
       });
 
       return repository.save(oldHistories);
@@ -122,7 +124,8 @@ export class OfficerHistoryDomainService
       },
       {
         officerSnapShot: officer.name,
-        endDate: getHistoryEndDate(TIME_ZONE.SEOUL),
+        endDate,
+        //endDate: getHistoryEndDate(TIME_ZONE.SEOUL),
         officerId: null,
         officer: null,
       },

--- a/backend/src/members/dto/group-member.dto.ts
+++ b/backend/src/members/dto/group-member.dto.ts
@@ -1,0 +1,22 @@
+import { MemberModel } from '../entity/member.entity';
+import { MemberDto } from './member.dto';
+
+export class GroupMemberDto extends MemberDto {
+  public readonly groupStartDate: Date | null;
+  public readonly groupLeaderStartDate: Date | null;
+
+  constructor(member: MemberModel) {
+    super(member);
+
+    if (member.groupHistory[0]) {
+      this.groupStartDate = member.groupHistory[0].startDate;
+
+      this.groupLeaderStartDate = member.groupHistory[0].groupDetailHistory[0]
+        ? member.groupHistory[0].groupDetailHistory[0].startDate
+        : null;
+    } else {
+      this.groupStartDate = null;
+      this.groupLeaderStartDate = null;
+    }
+  }
+}

--- a/backend/src/members/dto/member.dto.ts
+++ b/backend/src/members/dto/member.dto.ts
@@ -1,0 +1,36 @@
+import { GroupRole } from '../../management/groups/const/group-role.enum';
+import { MemberModel } from '../entity/member.entity';
+
+export class MemberDto {
+  public readonly id: number;
+  public readonly registeredAt: Date;
+  public readonly profileImageUrl: string;
+  public readonly name: string;
+  public readonly mobilePhone: string;
+  public readonly isLunar: boolean;
+  public readonly isLeafMonth: boolean;
+  public readonly birth: Date | null;
+  public readonly ministryGroupRole: GroupRole;
+  public readonly groupRole: GroupRole;
+  public readonly officer: { id: number; name: string } | null;
+  public readonly group: { id: number; name: string } | null;
+
+  constructor(member: MemberModel) {
+    this.id = member.id;
+    this.registeredAt = member.registeredAt;
+    this.profileImageUrl = member.profileImageUrl;
+    this.name = member.name;
+    this.mobilePhone = member.mobilePhone;
+    this.isLunar = member.isLunar;
+    this.isLeafMonth = member.isLeafMonth;
+    this.birth = member.birth;
+    this.ministryGroupRole = member.ministryGroupRole;
+    this.groupRole = member.groupRole;
+    this.officer = member.officer
+      ? { id: member.officer.id, name: member.officer.name }
+      : null;
+    this.group = member.group
+      ? { id: member.group.id, name: member.group.name }
+      : null;
+  }
+}

--- a/backend/src/members/dto/ministry-member.dto.ts
+++ b/backend/src/members/dto/ministry-member.dto.ts
@@ -1,0 +1,48 @@
+import { MemberDto } from './member.dto';
+import { MemberModel } from '../entity/member.entity';
+import { MinistryGroupRoleHistoryModel } from '../../member-history/ministry-history/entity/child/ministry-group-role-history.entity';
+import { MinistryHistoryModel } from '../../member-history/ministry-history/entity/child/ministry-history.entity';
+
+export class MinistryMemberDto extends MemberDto {
+  public readonly ministries: { id: number; name: string }[] | null;
+  public readonly ministryGroupStartDate: Date | null;
+  public ministryStartDate: Date | null;
+  public ministryGroupLeaderStartDate: Date | null;
+
+  constructor(member: MemberModel) {
+    super(member);
+
+    this.ministries =
+      member.ministries.length > 0
+        ? member.ministries //{ id: member.ministries[0].id, name: member.ministries[0].name }
+        : null;
+
+    if (member.ministryGroupHistory.length > 0) {
+      this.ministryGroupStartDate = member.ministryGroupHistory[0].startDate;
+
+      if (
+        member.ministryGroupHistory[0].ministryGroupDetailHistory.length > 0
+      ) {
+        member.ministryGroupHistory[0].ministryGroupDetailHistory.forEach(
+          (detail) => {
+            if (detail instanceof MinistryGroupRoleHistoryModel) {
+              this.ministryGroupLeaderStartDate = detail.startDate;
+            }
+
+            if (detail instanceof MinistryHistoryModel) {
+              this.ministryStartDate = detail.startDate;
+            }
+          },
+        );
+      }
+
+      if (!this.ministryStartDate) {
+        this.ministryStartDate = null;
+      }
+
+      if (!this.ministryGroupLeaderStartDate) {
+        this.ministryGroupLeaderStartDate = null;
+      }
+    }
+  }
+}

--- a/backend/src/members/dto/officer-member.dto.ts
+++ b/backend/src/members/dto/officer-member.dto.ts
@@ -1,0 +1,11 @@
+import { MemberModel } from '../entity/member.entity';
+import { MemberDto } from './member.dto';
+
+export class OfficerMemberDto extends MemberDto {
+  public readonly officerStartDate: Date;
+
+  constructor(member: MemberModel) {
+    super(member);
+    this.officerStartDate = member.officerHistory[0].startDate;
+  }
+}

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -32,6 +32,7 @@ import { EducationSessionModel } from '../../management/educations/entity/educat
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { GroupRole } from '../../management/groups/const/group-role.enum';
 import { MinistryGroupModel } from '../../management/ministries/entity/ministry-group.entity';
+import { MinistryGroupHistoryModel } from '../../member-history/ministry-history/entity/ministry-group-history.entity';
 
 @Entity()
 export class MemberModel extends BaseModel {
@@ -156,6 +157,12 @@ export class MemberModel extends BaseModel {
   @ManyToMany(() => MinistryModel, (ministry) => ministry.members)
   @JoinTable()
   ministries: MinistryModel[];
+
+  @OneToMany(
+    () => MinistryGroupHistoryModel,
+    (ministryGroupHistoryModel) => ministryGroupHistoryModel.member,
+  )
+  ministryGroupHistory: MinistryGroupHistoryModel[];
 
   @OneToMany(
     () => MinistryHistoryModel,

--- a/backend/src/members/member-domain/interface/group-members.domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/group-members.domain.service.interface.ts
@@ -4,6 +4,7 @@ import { GetGroupMembersDto } from '../../../management/groups/dto/request/membe
 import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { MemberModel } from '../../entity/member.entity';
 import { GetUnassignedMembersDto } from '../../../management/ministries/dto/ministry-group/request/member/get-unassigned-members.dto';
+import { GroupMemberDto } from '../../dto/group-member.dto';
 
 export const IGROUP_MEMBERS_DOMAIN_SERVICE = Symbol(
   'IGROUP_MEMBERS_DOMAIN_SERVICE',
@@ -15,7 +16,7 @@ export interface IGroupMembersDomainService {
     group: GroupModel,
     dto: GetGroupMembersDto,
     qr?: QueryRunner,
-  ): Promise<MemberModel[]>;
+  ): Promise<GroupMemberDto[]>;
 
   findGroupMembersByIds(
     church: ChurchModel,

--- a/backend/src/members/member-domain/interface/ministry-members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/ministry-members-domain.service.interface.ts
@@ -6,6 +6,7 @@ import { GroupRole } from '../../../management/groups/const/group-role.enum';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { GetUnassignedMembersDto } from '../../../management/ministries/dto/ministry-group/request/member/get-unassigned-members.dto';
 import { SearchMembersForMinistryGroupDto } from '../../../management/ministries/dto/ministry-group/request/member/search-members-for-ministry-group.dto';
+import { MinistryMemberDto } from '../../dto/ministry-member.dto';
 
 export const IMINISTRY_MEMBERS_DOMAIN_SERVICE = Symbol(
   'IMINISTRY_MEMBERS_DOMAIN_SERVICE',
@@ -31,7 +32,7 @@ export interface IMinistryMembersDomainService {
   findMinistryGroupMembers(
     ministryGroup: MinistryGroupModel,
     dto: GetMinistryGroupMembersDto,
-  ): Promise<MemberModel[]>;
+  ): Promise<MinistryMemberDto[]>;
 
   findMinistryGroupMembersByIds(
     ministryGroup: MinistryGroupModel,

--- a/backend/src/members/member-domain/interface/officer-members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/officer-members-domain.service.interface.ts
@@ -4,6 +4,7 @@ import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { MemberModel } from '../../entity/member.entity';
 import { OfficerModel } from '../../../management/officers/entity/officer.entity';
 import { GetOfficerMembersDto } from '../../../management/officers/dto/request/members/get-officer-members.dto';
+import { OfficerMemberDto } from '../../dto/officer-member.dto';
 
 export const IOFFICER_MEMBERS_DOMAIN_SERVICE = Symbol(
   'IOFFICER_MEMBERS_DOMAIN_SERVICE',
@@ -21,7 +22,7 @@ export interface IOfficerMembersDomainService {
     officer: OfficerModel,
     dto: GetOfficerMembersDto,
     qr?: QueryRunner,
-  ): Promise<MemberModel[]>;
+  ): Promise<OfficerMemberDto[]>;
 
   findOfficerMembersByIds(
     church: ChurchModel,

--- a/backend/src/members/member-domain/service/officer-members-domain.service.ts
+++ b/backend/src/members/member-domain/service/officer-members-domain.service.ts
@@ -16,12 +16,16 @@ import {
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { GetUnassignedMembersDto } from '../../../management/ministries/dto/ministry-group/request/member/get-unassigned-members.dto';
 import {
+  MemberSummarizedGroupSelectQB,
+  MemberSummarizedOfficerSelectQB,
   MemberSummarizedRelation,
   MemberSummarizedSelect,
+  MemberSummarizedSelectQB,
 } from '../../const/member-find-options.const';
 import { OfficerModel } from '../../../management/officers/entity/officer.entity';
 import { GetOfficerMembersDto } from '../../../management/officers/dto/request/members/get-officer-members.dto';
 import { MemberException } from '../../exception/member.exception';
+import { OfficerMemberDto } from '../../dto/officer-member.dto';
 
 @Injectable()
 export class OfficerMembersDomainService
@@ -59,15 +63,38 @@ export class OfficerMembersDomainService
     });
   }
 
-  findOfficerMembers(
+  async findOfficerMembers(
     church: ChurchModel,
     officer: OfficerModel,
     dto: GetOfficerMembersDto,
     qr?: QueryRunner,
-  ): Promise<MemberModel[]> {
+  ): Promise<OfficerMemberDto[]> {
     const repository = this.getRepository(qr);
 
-    return repository.find({
+    const members = await repository
+      .createQueryBuilder('member')
+      .innerJoin('member.officer', 'officer')
+      .where('member.churchId = :churchId', { churchId: church.id })
+      .andWhere('officer.id = :officerId', { officerId: officer.id })
+      .leftJoin('member.group', 'group')
+      .select(MemberSummarizedSelectQB)
+      .addSelect(MemberSummarizedOfficerSelectQB)
+      .addSelect(MemberSummarizedGroupSelectQB)
+      .leftJoin(
+        'member.officerHistory',
+        'officerHistory',
+        'officerHistory.endDate IS NULL',
+      )
+      .addSelect(['officerHistory.startDate'])
+      .orderBy(`member.${dto.order}`, dto.orderDirection)
+      .addOrderBy('member.id', dto.orderDirection)
+      .limit(dto.take)
+      .offset(dto.take * (dto.page - 1))
+      .getMany();
+
+    return members.map((member) => new OfficerMemberDto(member));
+
+    /*return repository.find({
       where: {
         churchId: church.id,
         officerId: officer.id,
@@ -80,7 +107,7 @@ export class OfficerMembersDomainService
       },
       take: dto.take,
       skip: dto.take * (dto.page - 1),
-    });
+    });*/
   }
 
   async findOfficerMembersByIds(


### PR DESCRIPTION
## 주요 내용
직분에 교인을 추가하거나 제거할 때 명시적으로 날짜를 지정할 수 있도록 개선하고, 교인 조회 시 관련 이력 날짜 정보를 함께 제공하도록 응답을 강화했습니다.

## 세부 내용
### 직분 할당 시 시작일 지정
- 교인을 직분에 추가할 때 startDate 파라미터 필수
- 직분 이력의 시작일을 명시적으로 관리 가능

### 직분 해제 시 종료일 지정
- 교인을 직분에서 제거할 때 endDate 파라미터 필수
- 직분 이력의 종료일을 명시적으로 관리 가능
- 기존의 자동 날짜 설정 방식에서 수동 지정 방식으로 변경

### 교인 조회 응답 데이터 확장
- 직분별 교인 조회: 각 교인의 직분 시작일 포함
- 그룹별 교인 조회: 각 교인의 그룹 시작일 및 그룹 내 역할 시작일 포함
- 사역그룹별 교인 조회: 각 교인의 사역그룹 시작일, 사역 시작일, 사역그룹 내 역할 시작일 포함
- 클라이언트에서 교인의 현재 상태와 이력 정보를 한 번에 확인 가능