### PR TITLE
feat: 직분 할당/해제 시 날짜 유효성 검증 추가

### DIFF
--- a/backend/src/management/officers/service/officer-members.service.ts
+++ b/backend/src/management/officers/service/officer-members.service.ts
@@ -112,7 +112,11 @@ export class OfficerMembersService {
     if (changeOfficerMembers.length > 0) {
       const endDate = convertHistoryEndDate(dto.startDate, TIME_ZONE.SEOUL);
 
-      // TODO endDate 검증 필요
+      await this.officerHistoryDomainService.validateOfficerEndDates(
+        changeOfficerMembers,
+        endDate,
+        qr,
+      );
 
       // 기존 직분 이력 종료 처리
       await this.officerHistoryDomainService.endOfficerHistories(
@@ -183,7 +187,11 @@ export class OfficerMembersService {
 
     const endDate = convertHistoryEndDate(dto.endDate, TIME_ZONE.SEOUL);
 
-    // TODO endDate 검증 필요
+    await this.officerHistoryDomainService.validateOfficerEndDates(
+      removeMembers,
+      endDate,
+      qr,
+    );
 
     await this.officerHistoryDomainService.endOfficerHistories(
       removeMembers,

--- a/backend/src/member-history/officer-history/officer-history-domain/interface/officer-history-domain.service.interface.ts
+++ b/backend/src/member-history/officer-history/officer-history-domain/interface/officer-history-domain.service.interface.ts
@@ -38,6 +38,12 @@ export interface IOfficerHistoryDomainService {
     qr: QueryRunner,
   ): Promise<OfficerHistoryModel[]>;
 
+  validateOfficerEndDates(
+    members: MemberModel[],
+    endDate: Date,
+    qr: QueryRunner,
+  ): Promise<void>;
+
   endOfficerHistories(
     members: MemberModel[],
     endDate: Date,


### PR DESCRIPTION
## 주요 내용
직분 변경 시 날짜의 논리적 일관성을 보장하기 위한 검증 로직을 추가했습니다.

## 세부 내용
### 직분 할당 시 날짜 검증
- 새로운 직분의 시작일이 이전 직분의 시작일보다 늦은지 검증
- 시간 역행 방지로 데이터 무결성 보장

### 직분 해제 시 날짜 검증
- 해제일(endDate)이 시작일(startDate)보다 늦은지 검증
- 논리적으로 불가능한 날짜 설정 방지