### PR TITLE
fix: 계정 정보 조회 시 현재 교회 가입 정보 누락 문제 해결

### DIFF
--- a/backend/src/user/user-domain/service/user-domain.service.ts
+++ b/backend/src/user/user-domain/service/user-domain.service.ts
@@ -12,6 +12,11 @@ import { ChurchModel } from '../../../churches/entity/church.entity';
 import { UpdateUserDto } from '../../dto/update-user.dto';
 import { UserRole } from '../../const/user-role.enum';
 import { UserException } from '../../const/exception/user.exception';
+import {
+  MemberSummarizedGroupSelectQB,
+  MemberSummarizedOfficerSelectQB,
+  MemberSummarizedSelectQB,
+} from '../../../members/const/member-find-options.const';
 
 @Injectable()
 export class UserDomainService implements IUserDomainService {
@@ -58,6 +63,7 @@ export class UserDomainService implements IUserDomainService {
         'churchUser.memberId',
         'churchUser.role',
         'churchUser.joinedAt',
+        'churchUser.leftAt',
       ])
       .leftJoin('churchUser.church', 'church') // 교회
       .addSelect([
@@ -71,13 +77,17 @@ export class UserDomainService implements IUserDomainService {
         'church.detailAddress',
       ])
       .leftJoin('churchUser.member', 'member') // 교인
-      .addSelect(['member.id', 'member.name', 'member.profileImageUrl'])
+      .addSelect(
+        MemberSummarizedSelectQB /*['member.id', 'member.name', 'member.profileImageUrl']*/,
+      )
       .leftJoin('member.group', 'group') // 교인 - 그룹
-      .addSelect(['group.id', 'group.name'])
+      .addSelect(MemberSummarizedGroupSelectQB /*['group.id', 'group.name']*/)
       .leftJoin('member.officer', 'officer') // 교인 - 직분
-      .addSelect(['officer.id', 'officer.name'])
-      .leftJoin('member.groupRole', 'groupRole') // 교인 - 그룹 역할
-      .addSelect(['groupRole.id', 'groupRole.role'])
+      .addSelect(
+        MemberSummarizedOfficerSelectQB /*['officer.id', 'officer.name']*/,
+      )
+      //.leftJoin('member.groupRole', 'groupRole') // 교인 - 그룹 역할
+      //.addSelect(['groupRole.id', 'groupRole.role'])
       .leftJoin('churchUser.permissionTemplate', 'permissionTemplate') // 관리자 - 권한 유형
       .addSelect(['permissionTemplate.id', 'permissionTemplate.title'])
       .leftJoinAndSelect(


### PR DESCRIPTION
## 주요 내용
계정 정보를 불러올 때 현재 가입된 교회 정보가 조회되지 않는 버그를 수정했습니다.

## 세부 내용
- churchUser 조회 시 leftAt 필드를 select하지 않아 발생한 문제
- 코드에서 leftAt 값으로 현재 가입 교회를 판단하는데, 해당 필드가 조회되지 않아 정상 동작하지 않음
- DB 조회 시 leftAt 필드를 select에 포함하도록 수정하여 해결