### PR TITLE
feat: 심방 기록 구조 단순화 및 대상자 관리 개선

### DIFF
--- a/backend/src/common/decorator/validator/is-date-time.validator.ts
+++ b/backend/src/common/decorator/validator/is-date-time.validator.ts
@@ -1,0 +1,35 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+} from 'class-validator';
+
+export function IsDateTime(
+  fieldLabel: string,
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isDateTime',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: {
+        message: `${fieldLabel}은(는) YYYY-MM-DDTHH:mm:ss 형식이어야 합니다.`,
+        ...validationOptions,
+      },
+      validator: {
+        validate(value: any, _args: ValidationArguments) {
+          if (typeof value !== 'string') return false;
+
+          // ISO 8601 형식 검증 (초까지)
+          const regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/;
+          if (!regex.test(value)) return false;
+
+          // 실제 유효한 날짜인지 검증
+          const date = new Date(value);
+          return !isNaN(date.getTime());
+        },
+      },
+    });
+  };
+}

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -25,7 +25,6 @@ import { RequestInfoModel } from '../../request-info/entity/request-info.entity'
 import { MinistryHistoryModel } from '../../member-history/ministry-history/entity/child/ministry-history.entity';
 import { OfficerHistoryModel } from '../../member-history/officer-history/entity/officer-history.entity';
 import { GroupHistoryModel } from '../../member-history/group-history/entity/group-history.entity';
-import { VisitationDetailModel } from '../../visitation/entity/visitation-detail.entity';
 import { VisitationMetaModel } from '../../visitation/entity/visitation-meta.entity';
 import { TaskModel } from '../../task/entity/task.entity';
 import { EducationSessionModel } from '../../management/educations/entity/education-session.entity';
@@ -242,11 +241,11 @@ export class MemberModel extends BaseModel {
   visitationMetas: VisitationMetaModel[];
 
   // 나의 심방 세부 내용
-  @OneToMany(
+  /*@OneToMany(
     () => VisitationDetailModel,
     (visitingDetail) => visitingDetail.member,
   )
-  visitationDetails: VisitationDetailModel[];
+  visitationDetails: VisitationDetailModel[];*/
 
   // --------------- 심방 -------------------
 

--- a/backend/src/user/user-domain/service/user-domain.service.ts
+++ b/backend/src/user/user-domain/service/user-domain.service.ts
@@ -12,6 +12,11 @@ import { ChurchModel } from '../../../churches/entity/church.entity';
 import { UpdateUserDto } from '../../dto/update-user.dto';
 import { UserRole } from '../../const/user-role.enum';
 import { UserException } from '../../const/exception/user.exception';
+import {
+  MemberSummarizedGroupSelectQB,
+  MemberSummarizedOfficerSelectQB,
+  MemberSummarizedSelectQB,
+} from '../../../members/const/member-find-options.const';
 
 @Injectable()
 export class UserDomainService implements IUserDomainService {
@@ -58,6 +63,7 @@ export class UserDomainService implements IUserDomainService {
         'churchUser.memberId',
         'churchUser.role',
         'churchUser.joinedAt',
+        'churchUser.leftAt',
       ])
       .leftJoin('churchUser.church', 'church') // 교회
       .addSelect([
@@ -71,13 +77,17 @@ export class UserDomainService implements IUserDomainService {
         'church.detailAddress',
       ])
       .leftJoin('churchUser.member', 'member') // 교인
-      .addSelect(['member.id', 'member.name', 'member.profileImageUrl'])
+      .addSelect(
+        MemberSummarizedSelectQB /*['member.id', 'member.name', 'member.profileImageUrl']*/,
+      )
       .leftJoin('member.group', 'group') // 교인 - 그룹
-      .addSelect(['group.id', 'group.name'])
+      .addSelect(MemberSummarizedGroupSelectQB /*['group.id', 'group.name']*/)
       .leftJoin('member.officer', 'officer') // 교인 - 직분
-      .addSelect(['officer.id', 'officer.name'])
-      .leftJoin('member.groupRole', 'groupRole') // 교인 - 그룹 역할
-      .addSelect(['groupRole.id', 'groupRole.role'])
+      .addSelect(
+        MemberSummarizedOfficerSelectQB /*['officer.id', 'officer.name']*/,
+      )
+      //.leftJoin('member.groupRole', 'groupRole') // 교인 - 그룹 역할
+      //.addSelect(['groupRole.id', 'groupRole.role'])
       .leftJoin('churchUser.permissionTemplate', 'permissionTemplate') // 관리자 - 권한 유형
       .addSelect(['permissionTemplate.id', 'permissionTemplate.title'])
       .leftJoinAndSelect(

--- a/backend/src/visitation/const/visitation-find-options.const.ts
+++ b/backend/src/visitation/const/visitation-find-options.const.ts
@@ -1,80 +1,35 @@
 import { FindOptionsRelations, FindOptionsSelect } from 'typeorm';
 import { VisitationMetaModel } from '../entity/visitation-meta.entity';
 import { VisitationDetailModel } from '../entity/visitation-detail.entity';
+import { MemberSummarizedSelect } from '../../members/const/member-find-options.const';
 
 export const VisitationRelationOptions: FindOptionsRelations<VisitationMetaModel> =
   {
     members: {
       officer: true,
       group: true,
-      //groupRole: true,
     },
     inCharge: {
       officer: true,
       group: true,
-      //groupRole: true,
     },
     creator: {
       officer: true,
       group: true,
-      //groupRole: true,
     },
     reports: {
       receiver: {
         officer: true,
         group: true,
-        //groupRole: true,
       },
     },
-    visitationDetails: {
-      member: {
-        group: true,
-        //groupRole: true,
-        officer: true,
-      },
-    },
+    visitationDetails: true,
   };
 
 export const VisitationSelectOptions: FindOptionsSelect<VisitationMetaModel> = {
-  creator: {
-    id: true,
-    name: true,
-    officer: {
-      id: true,
-      name: true,
-    },
-    group: {
-      id: true,
-      name: true,
-    },
-    groupRole: true,
-  },
-  inCharge: {
-    id: true,
-    name: true,
-    officer: {
-      id: true,
-      name: true,
-    },
-    group: {
-      id: true,
-      name: true,
-    },
-    groupRole: true,
-  },
-  members: {
-    id: true,
-    name: true,
-    officer: {
-      id: true,
-      name: true,
-    },
-    group: {
-      id: true,
-      name: true,
-    },
-    groupRole: true,
-  },
+  creator: MemberSummarizedSelect,
+  inCharge: MemberSummarizedSelect,
+  members: MemberSummarizedSelect,
   reports: {
     id: true,
     isRead: true,
@@ -99,34 +54,21 @@ export const VisitationSelectOptions: FindOptionsSelect<VisitationMetaModel> = {
     updatedAt: true,
     visitationPray: true,
     visitationContent: true,
-    member: {
-      id: true,
-      name: true,
-      officer: {
-        id: true,
-        name: true,
-      },
-      group: {
-        id: true,
-        name: true,
-      },
-      groupRole: true,
-    },
   },
 };
 
 export const VisitationDetailRelationOptions: FindOptionsRelations<VisitationDetailModel> =
   {
-    member: {
+    /*member: {
       officer: true,
       group: true,
       //groupRole: true,
-    },
+    },*/
   };
 
 export const VisitationDetailSelectOptions: FindOptionsSelect<VisitationDetailModel> =
   {
-    member: {
+    /*member: {
       id: true,
       name: true,
       officer: {
@@ -138,5 +80,5 @@ export const VisitationDetailSelectOptions: FindOptionsSelect<VisitationDetailMo
         name: true,
       },
       groupRole: true,
-    },
+    },*/
   };

--- a/backend/src/visitation/controller/visitation-detail.controller.ts
+++ b/backend/src/visitation/controller/visitation-detail.controller.ts
@@ -14,17 +14,17 @@ export class VisitationDetailController {
 
   @ApiPatchVisitationDetail()
   @VisitationWriteGuard()
-  @Patch(':memberId')
+  @Patch(/*':memberId'*/)
   patchVisitationDetail(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('visitationId', ParseIntPipe) visitationId: number,
-    @Param('memberId', ParseIntPipe) memberId: number,
+    //@Param('memberId', ParseIntPipe) memberId: number,
     @Body() dto: UpdateVisitationDetailDto,
   ) {
     return this.visitationDetailService.updateVisitationDetail(
       churchId,
       visitationId,
-      memberId,
+      //memberId,
       dto,
     );
   }

--- a/backend/src/visitation/decorator/visitation-detail.validator.ts
+++ b/backend/src/visitation/decorator/visitation-detail.validator.ts
@@ -1,4 +1,4 @@
-import { ValidationOptions } from 'joi';
+/*import { ValidationOptions } from 'joi';
 import {
   registerDecorator,
   ValidationArguments,
@@ -39,4 +39,4 @@ export function VisitationDetailValidator(
       validator: VisitationDetailConstraint,
     });
   };
-}
+}*/

--- a/backend/src/visitation/dto/internal/visittion-detail.dto.ts
+++ b/backend/src/visitation/dto/internal/visittion-detail.dto.ts
@@ -1,15 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, IsOptional, IsString, Min } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 import { SanitizeDto } from '../../../common/decorator/sanitize-target.decorator';
 
 @SanitizeDto()
 export class VisitationDetailDto {
-  @ApiProperty({
+  /*@ApiProperty({
     description: '심방 대상자 ID',
   })
   @IsNumber()
   @Min(1)
-  memberId: number;
+  memberId: number;*/
 
   @ApiProperty({
     description: '심방 내용 (예약 시 생략)',

--- a/backend/src/visitation/dto/request/create-visitation.dto.ts
+++ b/backend/src/visitation/dto/request/create-visitation.dto.ts
@@ -1,7 +1,9 @@
 import {
   ArrayMaxSize,
+  ArrayMinSize,
+  ArrayUnique,
   IsArray,
-  IsDate,
+  IsDateString,
   IsEnum,
   IsNumber,
   IsOptional,
@@ -14,13 +16,12 @@ import { VisitationMethod } from '../../const/visitation-method.enum';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { VisitationStatus } from '../../const/visitation-status.enum';
-import { VisitationDetailValidator } from '../../decorator/visitation-detail.validator';
 import { VisitationDetailDto } from '../internal/visittion-detail.dto';
 import { RemoveSpaces } from '../../../common/decorator/transformer/remove-spaces';
 import { SanitizeDto } from '../../../common/decorator/sanitize-target.decorator';
 import { IsAfterDate } from '../../../common/decorator/validator/is-after-date.decorator';
-import { VisitationException } from '../../const/exception/visitation.exception';
 import { IsNoSpecialChar } from '../../../common/decorator/validator/is-no-special-char.validator';
+import { IsDateTime } from '../../../common/decorator/validator/is-date-time.validator';
 
 @SanitizeDto()
 export class CreateVisitationDto {
@@ -56,17 +57,32 @@ export class CreateVisitationDto {
   inChargeId: number;
 
   @ApiProperty({
-    description: '심방 시작 날짜',
+    description: '심방 시작 날짜 (yyyy-MM-ddTHH:mm:ss)',
   })
-  @IsDate()
-  startDate: Date;
+  @IsDateString({ strict: true })
+  @IsDateTime('startDate')
+  //@IsDate()
+  startDate: string; //Date;
 
   @ApiProperty({
-    description: '심방 종료 날짜',
+    description: '심방 종료 날짜 (yyyy-MM-ddTHH:mm:ss)',
   })
-  @IsDate()
+  //@IsDate()
+  @IsDateString({ strict: true })
+  @IsDateTime('endDate')
   @IsAfterDate('startDate')
-  endDate: Date;
+  endDate: string; //Date;
+
+  @ApiProperty({
+    description: '심방 대상자 교인 ID 배열',
+    isArray: true,
+  })
+  @IsArray()
+  @ArrayUnique()
+  @ArrayMinSize(1)
+  @IsNumber({}, { each: true })
+  @Min(1, { each: true })
+  memberIds: number[];
 
   @ApiProperty({
     description: '심방 세부 정보',
@@ -75,10 +91,12 @@ export class CreateVisitationDto {
   })
   @ValidateNested({ each: true })
   @Type(() => VisitationDetailDto)
-  @ArrayMaxSize(30, {
+  @ArrayMaxSize(
+    1 /*30, {
     message: VisitationException.EXCEED_VISITATION_MEMBER,
-  })
-  @VisitationDetailValidator()
+  }*/,
+  )
+  //@VisitationDetailValidator()
   visitationDetails: VisitationDetailDto[];
 
   @ApiProperty({

--- a/backend/src/visitation/dto/request/update-visitation.dto.ts
+++ b/backend/src/visitation/dto/request/update-visitation.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import {
   ArrayMaxSize,
   IsArray,
-  IsDate,
+  IsDateString,
   IsEnum,
   IsNotEmpty,
   IsNumber,
@@ -17,6 +17,7 @@ import { RemoveSpaces } from '../../../common/decorator/transformer/remove-space
 import { IsAfterDate } from '../../../common/decorator/validator/is-after-date.decorator';
 import { IsNoSpecialChar } from '../../../common/decorator/validator/is-no-special-char.validator';
 import { IsOptionalNotNull } from '../../../common/decorator/validator/is-optional-not.null.validator';
+import { IsDateTime } from '../../../common/decorator/validator/is-date-time.validator';
 
 export class UpdateVisitationDto {
   @ApiProperty({
@@ -59,41 +60,25 @@ export class UpdateVisitationDto {
   inChargeId?: number;
 
   @ApiProperty({
-    description: '심방 날짜',
+    description: '심방 날짜 (yyyy-MM-ddTHH:mm:ss)',
     required: false,
   })
   @IsOptionalNotNull()
-  @IsDate()
-  startDate?: Date;
+  //@IsDate()
+  @IsDateString({ strict: true })
+  @IsDateTime('startDate')
+  startDate?: string; //Date;
 
   @ApiProperty({
-    description: '심방 종료 날짜',
+    description: '심방 종료 날짜 (yyyy-MM-ddTHH:mm:ss)',
     required: false,
   })
   @IsOptionalNotNull()
-  @IsDate()
+  //@IsDate()
+  @IsDateString({ strict: true })
+  @IsDateTime('endDate')
   @IsAfterDate('startDate')
-  endDate?: Date;
-
-  /*@ApiProperty({
-    description: '심방 대상자 추가할 교인 ID 들',
-    isArray: true,
-    required: false,
-  })
-  @IsOptional()
-  @IsArray()
-  @TransformNumberArray()
-  addMemberIds?: number[];
-
-  @ApiProperty({
-    description: '심방 대상자 제거할 교인 ID 들',
-    isArray: true,
-    required: false,
-  })
-  @IsOptional()
-  @IsArray()
-  @TransformNumberArray()
-  deleteMemberIds?: number[];*/
+  endDate?: string; //Date;
 
   @ApiProperty({
     description: '심방 대상자 교인 ID',

--- a/backend/src/visitation/entity/visitation-detail.entity.ts
+++ b/backend/src/visitation/entity/visitation-detail.entity.ts
@@ -1,7 +1,6 @@
 import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { BaseModel } from '../../common/entity/base.entity';
 import { VisitationMetaModel } from './visitation-meta.entity';
-import { MemberModel } from '../../members/entity/member.entity';
 
 @Entity()
 export class VisitationDetailModel extends BaseModel {
@@ -16,13 +15,13 @@ export class VisitationDetailModel extends BaseModel {
   @JoinColumn({ name: 'visitationMetaId' })
   visitationMeta: VisitationMetaModel;
 
-  @Index()
+  /*@Index()
   @Column()
   memberId: number;
 
   @ManyToOne(() => MemberModel, (member) => member.visitationDetails)
   @JoinColumn({ name: 'memberId' })
-  member: MemberModel;
+  member: MemberModel;*/
 
   @Column({ default: '' })
   visitationContent: string;

--- a/backend/src/visitation/service/visitation-detail.service.ts
+++ b/backend/src/visitation/service/visitation-detail.service.ts
@@ -16,19 +16,14 @@ import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
 } from '../../churches/churches-domain/interface/churches-domain.service.interface';
-import {
-  IMEMBERS_DOMAIN_SERVICE,
-  IMembersDomainService,
-} from '../../members/member-domain/interface/members-domain.service.interface';
-import { ChurchModel } from '../../churches/entity/church.entity';
 
 @Injectable()
 export class VisitationDetailService {
   constructor(
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,
-    @Inject(IMEMBERS_DOMAIN_SERVICE)
-    private readonly membersDomainService: IMembersDomainService,
+    /*@Inject(IMEMBERS_DOMAIN_SERVICE)
+    private readonly membersDomainService: IMembersDomainService,*/
     @Inject(IVISITATION_META_DOMAIN_SERVICE)
     private readonly visitationMetaDomainService: IVisitationMetaDomainService,
     @Inject(IVISITATION_DETAIL_DOMAIN_SERVICE)
@@ -52,52 +47,52 @@ export class VisitationDetailService {
   async updateVisitationDetail(
     churchId: number,
     visitationId: number,
-    memberId: number,
     dto: UpdateVisitationDetailDto,
   ) {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    const [metaData, member] = await Promise.all([
-      this.visitationMetaDomainService.findVisitationMetaModelById(
+    const metaData =
+      await this.visitationMetaDomainService.findVisitationMetaModelById(
         church,
         visitationId,
-      ),
-      this.membersDomainService.findMemberModelById(church, memberId),
-    ]);
+      );
 
     const detailData =
-      await this.visitationDetailDomainService.findVisitationDetailByMetaAndMemberId(
+      await this.visitationDetailDomainService.findVisitationDetailsByMeta(
         metaData,
-        member,
       );
 
     await this.visitationDetailDomainService.updateVisitationDetail(
-      metaData,
       detailData,
       dto,
     );
 
-    return this.visitationDetailDomainService.findVisitationDetailByMetaAndMemberId(
-      metaData,
-      member,
-    );
+    if (dto.visitationPray) {
+      detailData.visitationPray = dto.visitationPray;
+    }
+
+    if (dto.visitationContent) {
+      detailData.visitationContent = dto.visitationContent;
+    }
+
+    return detailData;
   }
 
-  async handleUpdateVisitationMembers(
+  /*async handleUpdateVisitationMembers(
     church: ChurchModel,
     visitationMeta: VisitationMetaModel,
     newMemberIds: number[],
     qr: QueryRunner,
   ) {
     const oldVisitationDetails =
-      await this.visitationDetailDomainService.findVisitationDetailsByMetaId(
+      await this.visitationDetailDomainService.findVisitationDetailsByMeta(
         visitationMeta,
         qr,
       );
 
     // 기존 대상자 memberId
-    const oldMemberIds = oldVisitationDetails.map((detail) => detail.memberId);
+    const oldMemberIds = visitationMeta.members.map((m) => m.id); //oldVisitationDetails.map((detail) => detail.memberId);
 
     // 삭제될 detail 의 memberId
     const newMemberIdsSet = new Set(newMemberIds);
@@ -128,5 +123,5 @@ export class VisitationDetailService {
       addedMembers,
       qr,
     );
-  }
+  }*/
 }

--- a/backend/src/visitation/service/visitation.service.ts
+++ b/backend/src/visitation/service/visitation.service.ts
@@ -43,6 +43,8 @@ import { GetVisitationResponseDto } from '../dto/response/get-visitation-respons
 import { PostVisitationResponseDto } from '../dto/response/post-visitation-response.dto';
 import { PatchVisitationResponseDto } from '../dto/response/patch-visitation-response.dto';
 import { DeleteVisitationResponseDto } from '../dto/response/delete-visitation-response.dto';
+import { fromZonedTime } from 'date-fns-tz';
+import { TIME_ZONE } from '../../common/const/time-zone.const';
 
 @Injectable()
 export class VisitationService {
@@ -100,7 +102,6 @@ export class VisitationService {
   }
 
   async createVisitation(
-    //creatorId: number,
     creatorManager: ChurchUserModel,
     churchId: number,
     dto: CreateVisitationDto,
@@ -111,19 +112,13 @@ export class VisitationService {
       qr,
     );
 
-    /*const creator = await this.managerDomainService.findManagerByUserId(
-      church,
-      creatorId,
-      qr,
-    );*/
-
     const inCharge = await this.managerDomainService.findManagerByMemberId(
       church,
       dto.inChargeId,
       qr,
     );
 
-    const memberIds = dto.visitationDetails.map((detail) => detail.memberId);
+    const memberIds = dto.memberIds; //dto.visitationDetails.map((detail) => detail.memberId);
 
     const members = await this.membersDomainService.findMembersById(
       church,
@@ -131,11 +126,16 @@ export class VisitationService {
       qr,
     );
 
+    const startDate = fromZonedTime(dto.startDate, TIME_ZONE.SEOUL);
+    const endDate = fromZonedTime(dto.endDate, TIME_ZONE.SEOUL);
+
     const visitationMeta = await this.createVisitationMeta(
       church,
       creatorManager,
       inCharge,
       members,
+      startDate,
+      endDate,
       dto,
       qr,
     );
@@ -172,6 +172,8 @@ export class VisitationService {
    * @param creator 심방 생성 교인
    * @param inCharge 심방 진행자
    * @param members 심방 대상자 (교인 엔티티 배열)
+   * @param startDate 심방 시작 시간
+   * @param endDate 심방 종료 시간
    * @param dto 심방 생성 DTO
    * @param qr 트랜잭션을 위한 QueryRunner
    * @private
@@ -181,6 +183,8 @@ export class VisitationService {
     creator: ChurchUserModel,
     inCharge: ChurchUserModel,
     members: MemberModel[],
+    startDate: Date,
+    endDate: Date,
     dto: CreateVisitationDto,
     qr: QueryRunner,
   ) {
@@ -190,8 +194,8 @@ export class VisitationService {
       status: dto.status,
       visitationMethod: dto.visitationMethod,
       title: dto.title,
-      startDate: dto.startDate,
-      endDate: dto.endDate,
+      startDate, //: dto.startDate,
+      endDate, //: dto.endDate,
       visitationType:
         members.length > 1 ? VisitationType.GROUP : VisitationType.SINGLE,
     };
@@ -248,12 +252,12 @@ export class VisitationService {
           : VisitationType.SINGLE;
 
       // 변경된 대상자에 맞게 심방 디테일 생성/삭제
-      await this.visitationDetailService.handleUpdateVisitationMembers(
+      /*await this.visitationDetailService.handleUpdateVisitationMembers(
         church,
         targetMetaData,
         dto.memberIds,
         qr,
-      );
+      );*/
 
       // 심방 메타 데이터의 대상자 수정
       await this.visitationMetaDomainService.updateVisitationMember(
@@ -264,8 +268,12 @@ export class VisitationService {
     }
 
     const updateVisitationMetaDto: UpdateVisitationMetaDto = {
-      startDate: dto.startDate,
-      endDate: dto.endDate,
+      startDate: dto.startDate
+        ? fromZonedTime(dto.startDate, TIME_ZONE.SEOUL)
+        : undefined,
+      endDate: dto.endDate
+        ? fromZonedTime(dto.endDate, TIME_ZONE.SEOUL)
+        : undefined,
       visitationMethod: dto.visitationMethod,
       visitationType,
       status: dto.status,

--- a/backend/src/visitation/visitation-domain/interface/visitation-detail-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/interface/visitation-detail-domain.service.interface.ts
@@ -37,11 +37,11 @@ export interface IVisitationDetailDomainService {
     qr?: QueryRunner,
   ): Promise<VisitationDetailModel>;
 
-  findVisitationDetailsByMetaId(
+  findVisitationDetailsByMeta(
     metaData: VisitationMetaModel,
     qr?: QueryRunner,
     relationOptions?: FindOptionsRelations<VisitationDetailModel>,
-  ): Promise<VisitationDetailModel[]>;
+  ): Promise<VisitationDetailModel>;
 
   /*findVisitationDetailById(
     visitationMeta: VisitationMetaModel,
@@ -50,7 +50,7 @@ export interface IVisitationDetailDomainService {
   ): Promise<VisitationDetailModel>;*/
 
   updateVisitationDetail(
-    visitationMeta: VisitationMetaModel,
+    //visitationMeta: VisitationMetaModel,
     visitationDetail: VisitationDetailModel,
     dto: UpdateVisitationDetailDto,
     qr?: QueryRunner,

--- a/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-detail-domain.service.ts
@@ -8,7 +8,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { VisitationDetailModel } from '../../entity/visitation-detail.entity';
 import {
   FindOptionsRelations,
-  In,
   QueryRunner,
   Repository,
   UpdateResult,
@@ -65,7 +64,7 @@ export class VisitationDetailDomainService
 
     await repository.softDelete({
       visitationMetaId: metaData.id,
-      memberId: In(memberIds),
+      //memberId: In(memberIds),
     });
   }
 
@@ -78,6 +77,16 @@ export class VisitationDetailDomainService
     const repository = this.getRepository(qr);
 
     const details = repository.create(
+      dto.map((detail) => ({
+        visitationMetaId: metaData.id,
+        visitationContent: detail.visitationContent,
+        visitationPray: detail.visitationPray,
+      })),
+    );
+
+    return repository.save(details);
+
+    /*const details = repository.create(
       members.map((member) => {
         const detail = dto.find((detail) => detail.memberId === member.id);
 
@@ -95,6 +104,7 @@ export class VisitationDetailDomainService
     );
 
     return repository.save(details);
+     */
   }
 
   async findVisitationDetailByMetaAndMemberId(
@@ -106,7 +116,7 @@ export class VisitationDetailDomainService
 
     const detailData = await repository.findOne({
       where: {
-        memberId: member.id,
+        //memberId: member.id,
         visitationMetaId: metaData.id,
       },
       relations: VisitationDetailRelationOptions,
@@ -120,23 +130,29 @@ export class VisitationDetailDomainService
     return detailData;
   }
 
-  async findVisitationDetailsByMetaId(
+  async findVisitationDetailsByMeta(
     metaData: VisitationMetaModel,
     qr?: QueryRunner,
     relationOptions?: FindOptionsRelations<VisitationDetailModel>,
   ) {
     const repository = this.getRepository(qr);
 
-    return repository.find({
+    const detailData = await repository.findOne({
       where: {
         visitationMetaId: metaData.id,
       },
       relations: relationOptions,
     });
+
+    if (!detailData) {
+      throw new NotFoundException(VisitationDetailException.NOT_FOUND);
+    }
+
+    return detailData;
   }
 
   async updateVisitationDetail(
-    visitationMeta: VisitationMetaModel,
+    //visitationMeta: VisitationMetaModel,
     visitationDetail: VisitationDetailModel,
     dto: UpdateVisitationDetailDto,
     qr?: QueryRunner,
@@ -145,7 +161,7 @@ export class VisitationDetailDomainService
 
     const result = await repository.update(
       {
-        visitationMetaId: visitationMeta.id,
+        //visitationMetaId: visitationMeta.id,
         id: visitationDetail.id,
       },
       {

--- a/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
@@ -128,6 +128,11 @@ export class VisitationMetaDomainService
       },
       relations: VisitationRelationOptions,
       select: VisitationSelectOptions,
+      order: {
+        members: {
+          id: 'ASC',
+        },
+      },
     });
 
     if (!visitation) {


### PR DESCRIPTION
## 주요 내용
심방 기록 방식을 개인/그룹 구분 없이 통일하고, 대상자 관리를 배열 방식으로 변경하여 데이터 구조를 단순화했습니다.

## 세부 내용
### 심방 기록 구조 통일
- 기존: 그룹 심방 시 대상자별로 개별 VisitationDetail 생성
- 변경: 개인/그룹 심방 모두 단일 VisitationDetail만 생성
- 불필요한 중복 데이터 제거로 구조 단순화

### 대상자 지정 방식 변경
- 기존: VisitationDetail에 memberId로 개별 지정
- 변경: memberIds 배열로 모든 대상자를 한 번에 지정
- 그룹 심방 시 여러 대상자를 효율적으로 관리

### 대상자 조회 순서 일관성 보장
- 심방 조회 시 대상자를 ID 오름차순으로 정렬
- 조회할 때마다 동일한 순서 유지로 UI 일관성 향상

### 심방 시간 입력 형식 표준화
- 시작/종료 시간을 YYYY-MM-DDTHH:mm:ss 형식으로 통일
- 사용자는 한국 시간(Asia/Seoul) 기준으로 입력
- 서버에서 자동으로 UTC로 변환하여 DB 저장
- 조회 시 다시 한국 시간으로 변환하여 응답