### PR TITLE
feat: 교육 수강(EducationEnrollment) 기능 개선 및 미등록 교인 조회 추가

### DIFF
--- a/backend/src/educations/education-domain/interface/education-enrollment-domain.service.interface.ts
+++ b/backend/src/educations/education-domain/interface/education-enrollment-domain.service.interface.ts
@@ -2,9 +2,8 @@ import { EducationTermModel } from '../../education-term/entity/education-term.e
 import { GetEducationEnrollmentDto } from '../../education-enrollment/dto/request/get-education-enrollment.dto';
 import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { EducationEnrollmentModel } from '../../education-enrollment/entity/education-enrollment.entity';
-import { CreateEducationEnrollmentDto } from '../../education-enrollment/dto/request/create-education-enrollment.dto';
-import { UpdateEducationEnrollmentDto } from '../../education-enrollment/dto/request/update-education-enrollment.dto';
 import { MemberModel } from '../../../members/entity/member.entity';
+import { EducationEnrollmentStatus } from '../../education-enrollment/const/education-enrollment-status.enum';
 
 export const IEDUCATION_ENROLLMENT_DOMAIN_SERVICE = Symbol(
   'IEDUCATION_ENROLLMENT_DOMAIN_SERVICE',
@@ -34,6 +33,12 @@ export interface IEducationEnrollmentsDomainService {
     qr?: QueryRunner,
   ): Promise<EducationEnrollmentModel>;
 
+  findEducationEnrollmentsByIds(
+    educationTerm: EducationTermModel,
+    ids: number[],
+    qr?: QueryRunner,
+  ): Promise<EducationEnrollmentModel[]>;
+
   findEducationEnrollmentModelById(
     educationEnrollmentId: number,
     qr?: QueryRunner,
@@ -42,16 +47,16 @@ export interface IEducationEnrollmentsDomainService {
 
   createEducationEnrollment(
     educationTerm: EducationTermModel,
-    member: MemberModel,
-    dto: CreateEducationEnrollmentDto,
+    members: MemberModel[],
     qr: QueryRunner,
-  ): Promise<EducationEnrollmentModel>;
+  ): Promise<EducationEnrollmentModel[]>;
 
   updateEducationEnrollment(
     educationEnrollment: EducationEnrollmentModel,
-    dto: UpdateEducationEnrollmentDto,
+    //dto: UpdateEducationEnrollmentDto,
+    status: EducationEnrollmentStatus,
     qr: QueryRunner,
-  ): Promise<EducationEnrollmentModel>;
+  ): Promise<UpdateResult>;
 
   deleteEducationEnrollment(
     educationEnrollment: EducationEnrollmentModel,

--- a/backend/src/educations/education-domain/interface/education-enrollment-domain.service.interface.ts
+++ b/backend/src/educations/education-domain/interface/education-enrollment-domain.service.interface.ts
@@ -14,7 +14,7 @@ export interface IEducationEnrollmentsDomainService {
     educationTerm: EducationTermModel,
     dto: GetEducationEnrollmentDto,
     qr?: QueryRunner,
-  ): Promise<{ data: EducationEnrollmentModel[]; totalCount: number }>;
+  ): Promise<EducationEnrollmentModel[]>;
 
   findEducationEnrollmentModels(
     educationTerm: EducationTermModel,

--- a/backend/src/educations/education-domain/interface/education-session-domain.service.interface.ts
+++ b/backend/src/educations/education-domain/interface/education-session-domain.service.interface.ts
@@ -26,6 +26,11 @@ export interface IEducationSessionDomainService {
     sessionId: number,
   ): Promise<EducationSessionModel>;
 
+  findEducationSessionIds(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ): Promise<EducationSessionModel[]>;
+
   findEducationSessions(
     educationTerm: EducationTermModel,
     dto: GetEducationSessionDto,

--- a/backend/src/educations/education-domain/interface/education-term-domain.service.interface.ts
+++ b/backend/src/educations/education-domain/interface/education-term-domain.service.interface.ts
@@ -68,23 +68,27 @@ export interface IEducationTermDomainService {
 
   incrementEnrollmentCount(
     educationTerm: EducationTermModel,
+    count: number,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 
   decrementEnrollmentCount(
     educationTerm: EducationTermModel,
+    count: number,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 
   incrementEducationStatusCount(
     educationTerm: EducationTermModel,
     status: EducationEnrollmentStatus,
+    count: number,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 
   decrementEducationStatusCount(
     educationTerm: EducationTermModel,
     status: EducationEnrollmentStatus,
+    count: number,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 

--- a/backend/src/educations/education-domain/interface/session-attendance-domain.service.interface.ts
+++ b/backend/src/educations/education-domain/interface/session-attendance-domain.service.interface.ts
@@ -18,7 +18,7 @@ export interface ISessionAttendanceDomainService {
   ): Promise<SessionAttendanceModel[]>;
 
   createSessionAttendanceForNewEnrollment(
-    enrollment: EducationEnrollmentModel,
+    enrollments: EducationEnrollmentModel[],
     educationSessionIds: number[],
     qr: QueryRunner,
   ): Promise<SessionAttendanceModel[]>;

--- a/backend/src/educations/education-domain/service/educaiton-term-domain.service.ts
+++ b/backend/src/educations/education-domain/service/educaiton-term-domain.service.ts
@@ -36,7 +36,6 @@ import {
 } from '../../../members/const/member-find-options.const';
 import { EducationTermException } from '../../education-term/exception/education-term.exception';
 import { EducationTermStatus } from '../../education-term/const/education-term-status.enum';
-import { EducationTermOrder } from '../../education-term/const/education-term-order.enum';
 import { EducationEnrollmentStatus } from '../../education-enrollment/const/education-enrollment-status.enum';
 import {
   EducationTermRelationOptions,
@@ -385,14 +384,21 @@ export class EducationTermDomainService implements IEducationTermDomainService {
 
   async incrementEnrollmentCount(
     educationTerm: EducationTermModel,
+    count: number,
     qr: QueryRunner,
   ) {
+    if (count < 1) {
+      throw new InternalServerErrorException(
+        EducationTermException.INVALID_INCREMENT_COUNT,
+      );
+    }
+
     const educationTermsRepository = this.getEducationTermsRepository(qr);
 
     const result = await educationTermsRepository.increment(
       { id: educationTerm.id },
       EducationTermColumns.enrollmentCount, //'enrollmentCount',
-      1,
+      count,
     );
 
     if (result.affected === 0) {
@@ -406,14 +412,21 @@ export class EducationTermDomainService implements IEducationTermDomainService {
 
   async decrementEnrollmentCount(
     educationTerm: EducationTermModel,
+    count: number,
     qr: QueryRunner,
   ) {
+    if (count < 1) {
+      throw new InternalServerErrorException(
+        EducationTermException.INVALID_DECREMENT_COUNT,
+      );
+    }
+
     const educationTermsRepository = this.getEducationTermsRepository(qr);
 
     const result = await educationTermsRepository.decrement(
       { id: educationTerm.id },
       EducationTermColumns.enrollmentCount, //'enrollmentCount',
-      1,
+      count,
     );
 
     if (result.affected === 0) {
@@ -428,8 +441,15 @@ export class EducationTermDomainService implements IEducationTermDomainService {
   async incrementEducationStatusCount(
     educationTerm: EducationTermModel,
     status: EducationEnrollmentStatus,
+    count: number,
     qr: QueryRunner,
   ) {
+    if (count < 1) {
+      throw new InternalServerErrorException(
+        EducationTermException.INVALID_INCREMENT_COUNT,
+      );
+    }
+
     const educationTermsRepository = this.getEducationTermsRepository(qr);
 
     const result = await educationTermsRepository.increment(
@@ -437,7 +457,7 @@ export class EducationTermDomainService implements IEducationTermDomainService {
         id: educationTerm.id,
       },
       this.CountColumnMap[status],
-      1,
+      count,
     );
 
     if (result.affected === 0) {
@@ -452,8 +472,15 @@ export class EducationTermDomainService implements IEducationTermDomainService {
   async decrementEducationStatusCount(
     educationTerm: EducationTermModel,
     status: EducationEnrollmentStatus,
+    count: number,
     qr: QueryRunner,
   ) {
+    if (count < 1) {
+      throw new InternalServerErrorException(
+        EducationTermException.INVALID_DECREMENT_COUNT,
+      );
+    }
+
     const educationTermsRepository = this.getEducationTermsRepository(qr);
 
     const result = await educationTermsRepository.decrement(
@@ -461,7 +488,7 @@ export class EducationTermDomainService implements IEducationTermDomainService {
         id: educationTerm.id,
       },
       this.CountColumnMap[status],
-      1,
+      count,
     );
 
     if (result.affected === 0) {

--- a/backend/src/educations/education-domain/service/education-enrollments-domain.service.ts
+++ b/backend/src/educations/education-domain/service/education-enrollments-domain.service.ts
@@ -75,38 +75,23 @@ export class EducationEnrollmentsDomainService
       id: dto.orderDirection,
     };
 
-    const [result, totalCount] = await Promise.all([
-      educationEnrollmentsRepository.find({
-        where: {
-          educationTermId: educationTerm.id,
-          member: {
-            name: dto.memberName && ILike(`%${dto.memberName}%`),
-          },
+    return educationEnrollmentsRepository.find({
+      where: {
+        educationTermId: educationTerm.id,
+        member: {
+          name: dto.memberName && ILike(`%${dto.memberName}%`),
         },
-        relations: {
-          member: MemberSummarizedRelation,
-        },
-        select: {
-          member: MemberSummarizedSelect,
-        },
-        order,
-        take: dto.take,
-        skip: dto.take * (dto.page - 1),
-      }),
-      educationEnrollmentsRepository.count({
-        where: {
-          educationTermId: educationTerm.id,
-          member: {
-            name: dto.memberName && ILike(`%${dto.memberName}%`),
-          },
-        },
-      }),
-    ]);
-
-    return {
-      data: result,
-      totalCount,
-    };
+      },
+      relations: {
+        member: MemberSummarizedRelation,
+      },
+      select: {
+        member: MemberSummarizedSelect,
+      },
+      order,
+      take: dto.take,
+      skip: dto.take * (dto.page - 1),
+    });
   }
 
   findEducationEnrollmentModels(

--- a/backend/src/educations/education-domain/service/education-session-domain.service.ts
+++ b/backend/src/educations/education-domain/service/education-session-domain.service.ts
@@ -159,6 +159,23 @@ export class EducationSessionDomainService
     return educationSession;
   }
 
+  findEducationSessionIds(
+    educationTerm: EducationTermModel,
+    qr: QueryRunner,
+  ): Promise<EducationSessionModel[]> {
+    const repository = this.getEducationSessionsRepository(qr);
+
+    return repository.find({
+      where: {
+        educationTermId: educationTerm.id,
+      },
+      select: { id: true },
+      order: {
+        session: 'ASC',
+      },
+    });
+  }
+
   async findEducationSessions(
     educationTerm: EducationTermModel,
     dto: GetEducationSessionDto,

--- a/backend/src/educations/education-domain/service/session-attendance-domain.service.ts
+++ b/backend/src/educations/education-domain/service/session-attendance-domain.service.ts
@@ -55,20 +55,24 @@ export class SessionAttendanceDomainService
   }
 
   createSessionAttendanceForNewEnrollment(
-    enrollment: EducationEnrollmentModel,
+    enrollments: EducationEnrollmentModel[],
     educationSessionIds: number[],
     qr: QueryRunner,
   ): Promise<SessionAttendanceModel[]> {
-    const sessionAttendanceRepository = this.getSessionAttendanceRepository(qr);
+    const repository = this.getSessionAttendanceRepository(qr);
 
-    return sessionAttendanceRepository.save(
-      educationSessionIds.map((sessionSessionId) => {
-        return {
-          educationSessionId: sessionSessionId,
-          educationEnrollmentId: enrollment.id,
-        };
-      }),
+    const attendances = repository.create(
+      enrollments
+        .map((enrollment) =>
+          educationSessionIds.map((sessionId) => ({
+            educationSessionId: sessionId,
+            educationEnrollmentId: enrollment.id,
+          })),
+        )
+        .flat(),
     );
+
+    return repository.save(attendances);
   }
 
   async createAdditionalSessionAttendance(
@@ -136,7 +140,7 @@ export class SessionAttendanceDomainService
             educationTermId: true,
             status: true,
             attendanceCount: true,
-            note: true,
+            //note: true,
             member: MemberSummarizedSelect,
           },
         },

--- a/backend/src/educations/education-enrollment/const/not-enrolled-members-order.enum.ts
+++ b/backend/src/educations/education-enrollment/const/not-enrolled-members-order.enum.ts
@@ -1,0 +1,3 @@
+export enum NotEnrolledMembersOrder {
+  REGISTERED_AT = 'registeredAt',
+}

--- a/backend/src/educations/education-enrollment/controller/education-enrollments.controller.ts
+++ b/backend/src/educations/education-enrollment/controller/education-enrollments.controller.ts
@@ -20,6 +20,7 @@ import { EducationReadGuard } from '../../guard/education-read.guard';
 import { EducationWriteGuard } from '../../guard/education-write.guard';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
+import { GetNotEnrolledMembersDto } from '../dto/request/get-not-enrolled-members.dto';
 
 @ApiTags('Educations:Enrollments')
 @Controller('educations/:educationId/terms/:educationTermId/enrollments')
@@ -63,6 +64,21 @@ export class EducationEnrollmentsController {
     );
   }
 
+  @Get('not-enrolled-members')
+  getNotEnrolledMembers(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('educationId', ParseIntPipe) educationId: number,
+    @Param('educationTermId', ParseIntPipe) educationTermId: number,
+    @Query() dto: GetNotEnrolledMembersDto,
+  ) {
+    return this.educationEnrollmentsService.getNotEnrolledMembers(
+      churchId,
+      educationId,
+      educationTermId,
+      dto,
+    );
+  }
+
   @EducationWriteGuard()
   @Patch(':educationEnrollmentId')
   @UseInterceptors(TransactionInterceptor)
@@ -79,7 +95,7 @@ export class EducationEnrollmentsController {
       educationId,
       educationTermId,
       educationEnrollmentId,
-      dto,
+      dto.status,
       qr,
     );
   }

--- a/backend/src/educations/education-enrollment/dto/request/create-education-enrollment.dto.ts
+++ b/backend/src/educations/education-enrollment/dto/request/create-education-enrollment.dto.ts
@@ -1,40 +1,37 @@
-import { ApiProperty, PickType } from '@nestjs/swagger';
-import { EducationEnrollmentModel } from '../../entity/education-enrollment.entity';
+import { ApiProperty } from '@nestjs/swagger';
 import {
-  IsEnum,
-  IsNotEmpty,
+  ArrayMinSize,
+  ArrayUnique,
+  IsArray,
   IsNumber,
-  IsOptional,
-  IsString,
-  MaxLength,
   Min,
 } from 'class-validator';
 import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
-import { EducationEnrollmentStatus } from '../../const/education-enrollment-status.enum';
 
 @SanitizeDto()
-export class CreateEducationEnrollmentDto extends PickType(
-  EducationEnrollmentModel,
-  ['memberId', 'status', 'note'],
-) {
+export class CreateEducationEnrollmentDto {
   @ApiProperty({
-    description: '수강 대상자 ID',
+    description: '수강 대상자 ID 배열',
+    isArray: true,
   })
-  @IsNumber()
-  @Min(1)
-  override memberId: number;
+  @IsNumber({}, { each: true })
+  @IsArray()
+  @ArrayUnique()
+  @ArrayMinSize(1)
+  @Min(1, { each: true })
+  memberIds: number[];
 
-  @ApiProperty({
+  /*@ApiProperty({
     description: '교육 상태 (수료중/수료/미수료)',
     enum: EducationEnrollmentStatus,
-    default: EducationEnrollmentStatus.INCOMPLETE, //IN_PROGRESS,
+    default: EducationEnrollmentStatus.INCOMPLETE,
     required: false,
   })
   @IsOptional()
   @IsEnum(EducationEnrollmentStatus)
-  status: EducationEnrollmentStatus = EducationEnrollmentStatus.INCOMPLETE; //IN_PROGRESS;
+  status: EducationEnrollmentStatus = EducationEnrollmentStatus.INCOMPLETE;*/
 
-  @ApiProperty({
+  /*@ApiProperty({
     description: '비고',
     required: false,
     maxLength: 120,
@@ -43,5 +40,5 @@ export class CreateEducationEnrollmentDto extends PickType(
   @IsOptional()
   @IsNotEmpty()
   @MaxLength(120)
-  note: string;
+  note: string;*/
 }

--- a/backend/src/educations/education-enrollment/dto/request/get-not-enrolled-members.dto.ts
+++ b/backend/src/educations/education-enrollment/dto/request/get-not-enrolled-members.dto.ts
@@ -1,0 +1,57 @@
+import { BaseOffsetPaginationRequestDto } from '../../../../common/dto/request/base-offset-pagination-request.dto';
+import { NotEnrolledMembersOrder } from '../../const/not-enrolled-members-order.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsEnum,
+  IsIn,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
+
+export class GetNotEnrolledMembersDto extends BaseOffsetPaginationRequestDto<NotEnrolledMembersOrder> {
+  @ApiProperty({
+    description: '정렬 조건 (등록일 고정)',
+    enum: NotEnrolledMembersOrder,
+    default: NotEnrolledMembersOrder.REGISTERED_AT,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(NotEnrolledMembersOrder)
+  order: NotEnrolledMembersOrder = NotEnrolledMembersOrder.REGISTERED_AT;
+
+  @ApiProperty({
+    description: '조회할 데이터 개수',
+    default: 20,
+    example: 20,
+    required: false,
+  })
+  @IsNumber()
+  @Min(1)
+  @IsOptional()
+  override take: number = 20;
+
+  @ApiProperty({
+    name: 'orderDirection',
+    description: '정렬 오름차순 / 내림차순',
+    default: 'DESC',
+    required: false,
+  })
+  @IsIn(['ASC', 'DESC'])
+  @IsOptional()
+  orderDirection: 'ASC' | 'DESC' = 'DESC';
+
+  @ApiProperty({
+    description: '교인 이름',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  name?: string;
+}

--- a/backend/src/educations/education-enrollment/dto/request/update-education-enrollment.dto.ts
+++ b/backend/src/educations/education-enrollment/dto/request/update-education-enrollment.dto.ts
@@ -1,7 +1,6 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { EducationEnrollmentModel } from '../../entity/education-enrollment.entity';
-import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
-import { Transform } from 'class-transformer';
+import { IsEnum } from 'class-validator';
 import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
 import { EducationEnrollmentStatus } from '../../const/education-enrollment-status.enum';
 
@@ -13,20 +12,7 @@ export class UpdateEducationEnrollmentDto extends PickType(
   @ApiProperty({
     description: '교육 이수 상태',
     enum: EducationEnrollmentStatus,
-    required: false,
   })
   @IsEnum(EducationEnrollmentStatus)
-  @IsOptional()
   override status: EducationEnrollmentStatus;
-
-  @ApiProperty({
-    description: '비고',
-    required: false,
-    maxLength: 120,
-  })
-  @IsString()
-  @IsOptional()
-  @MaxLength(120)
-  @Transform(({ value }) => value?.trim() ?? '')
-  note: string;
 }

--- a/backend/src/educations/education-enrollment/dto/response/education-enrollment-pagination-response.dto.ts
+++ b/backend/src/educations/education-enrollment/dto/response/education-enrollment-pagination-response.dto.ts
@@ -1,10 +1,7 @@
 import { EducationEnrollmentModel } from '../../entity/education-enrollment.entity';
 import { BaseOffsetPaginationResponseDto } from '../../../../common/dto/reponse/base-offset-pagination-response.dto';
 
-/*export interface EducationEnrollmentPaginationResultDto
-  extends BaseOffsetPaginationResultDto<EducationEnrollmentModel> {}*/
-
-export class EducationEnrollmentPaginationResultDto extends BaseOffsetPaginationResponseDto<EducationEnrollmentModel> {
+export class EducationEnrollmentPaginationResponseDto extends BaseOffsetPaginationResponseDto<EducationEnrollmentModel> {
   constructor(
     public readonly data: EducationEnrollmentModel[],
     public readonly totalCount: number,

--- a/backend/src/educations/education-enrollment/dto/response/education-enrollment-pagination-response.dto.ts
+++ b/backend/src/educations/education-enrollment/dto/response/education-enrollment-pagination-response.dto.ts
@@ -1,14 +1,8 @@
 import { EducationEnrollmentModel } from '../../entity/education-enrollment.entity';
-import { BaseOffsetPaginationResponseDto } from '../../../../common/dto/reponse/base-offset-pagination-response.dto';
 
-export class EducationEnrollmentPaginationResponseDto extends BaseOffsetPaginationResponseDto<EducationEnrollmentModel> {
+export class EducationEnrollmentPaginationResponseDto {
   constructor(
     public readonly data: EducationEnrollmentModel[],
-    public readonly totalCount: number,
-    public readonly count: number,
-    public readonly page: number,
-    public readonly totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/educations/education-enrollment/dto/response/not-enrolled-members-pagination-response.dto.ts
+++ b/backend/src/educations/education-enrollment/dto/response/not-enrolled-members-pagination-response.dto.ts
@@ -1,0 +1,8 @@
+import { MemberModel } from '../../../../members/entity/member.entity';
+
+export class NotEnrolledMembersPaginationResponseDto {
+  constructor(
+    public readonly data: MemberModel[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/educations/education-enrollment/dto/response/patch-education-enrollment-response.dto.ts
+++ b/backend/src/educations/education-enrollment/dto/response/patch-education-enrollment-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePatchResponseDto } from '../../../../common/dto/reponse/base-patch-response.dto';
+import { EducationEnrollmentModel } from '../../entity/education-enrollment.entity';
+
+export class PatchEducationEnrollmentResponseDto extends BasePatchResponseDto<EducationEnrollmentModel> {
+  constructor(data: EducationEnrollmentModel) {
+    super(data);
+  }
+}

--- a/backend/src/educations/education-enrollment/dto/response/post-education-enrollments-response.dto.ts
+++ b/backend/src/educations/education-enrollment/dto/response/post-education-enrollments-response.dto.ts
@@ -1,0 +1,10 @@
+import { EducationEnrollmentModel } from '../../entity/education-enrollment.entity';
+import { BasePostResponseDto } from '../../../../common/dto/reponse/base-post-response.dto';
+
+export class PostEducationEnrollmentsResponseDto extends BasePostResponseDto<
+  EducationEnrollmentModel[]
+> {
+  constructor(data: EducationEnrollmentModel[]) {
+    super(data);
+  }
+}

--- a/backend/src/educations/education-enrollment/entity/education-enrollment.entity.ts
+++ b/backend/src/educations/education-enrollment/entity/education-enrollment.entity.ts
@@ -11,7 +11,7 @@ export class EducationEnrollmentModel extends BaseModel {
   @Column({ comment: '교육 대상자 ID' })
   memberId: number;
 
-  @ManyToOne(() => MemberModel, (member) => member.educations)
+  @ManyToOne(() => MemberModel, (member) => member.educationEnrollments)
   member: MemberModel;
 
   @Index()
@@ -25,15 +25,12 @@ export class EducationEnrollmentModel extends BaseModel {
   @Column({
     enum: EducationEnrollmentStatus,
     comment: '교육 상태 (수료중/수료/미수료)',
-    default: EducationEnrollmentStatus.INCOMPLETE, //IN_PROGRESS,
+    default: EducationEnrollmentStatus.INCOMPLETE,
   })
   status: EducationEnrollmentStatus;
 
   @Column({ default: 0, comment: '출석 횟수' })
   attendanceCount: number;
-
-  @Column({ type: 'varchar', length: 120, nullable: true, comment: '비고' })
-  note: string | null;
 
   @OneToMany(
     () => SessionAttendanceModel,

--- a/backend/src/educations/education-enrollment/exception/education-enrollment.exception.ts
+++ b/backend/src/educations/education-enrollment/exception/education-enrollment.exception.ts
@@ -3,4 +3,5 @@ export const EducationEnrollmentException = {
   NOT_FOUND: '해당 교육 대상자 내역을 찾을 수 없습니다.',
   UPDATE_ERROR: '교육 대상자 업데이트 도중 에러 발생',
   DELETE_ERROR: '교육 대상자 삭제 도중 에러 발생',
+  SAME_STATUS: '기존과 동일한 상태값입니다.',
 };

--- a/backend/src/educations/education-enrollment/service/education-enrollment.service.ts
+++ b/backend/src/educations/education-enrollment/service/education-enrollment.service.ts
@@ -1,8 +1,7 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { QueryRunner } from 'typeorm';
 import { GetEducationEnrollmentDto } from '../dto/request/get-education-enrollment.dto';
 import { CreateEducationEnrollmentDto } from '../dto/request/create-education-enrollment.dto';
-import { UpdateEducationEnrollmentDto } from '../dto/request/update-education-enrollment.dto';
 import {
   IEDUCATION_ENROLLMENT_DOMAIN_SERVICE,
   IEducationEnrollmentsDomainService,
@@ -19,7 +18,7 @@ import {
   ISESSION_ATTENDANCE_DOMAIN_SERVICE,
   ISessionAttendanceDomainService,
 } from '../../education-domain/interface/session-attendance-domain.service.interface';
-import { EducationEnrollmentPaginationResultDto } from '../dto/response/education-enrollment-pagination-result.dto';
+import { EducationEnrollmentPaginationResponseDto } from '../dto/response/education-enrollment-pagination-response.dto';
 import {
   IMEMBERS_DOMAIN_SERVICE,
   IMembersDomainService,
@@ -28,12 +27,28 @@ import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
 } from '../../../churches/churches-domain/interface/churches-domain.service.interface';
+import { EducationEnrollmentStatus } from '../const/education-enrollment-status.enum';
+import { PostEducationEnrollmentsResponseDto } from '../dto/response/post-education-enrollments-response.dto';
+import {
+  IEDUCATION_SESSION_DOMAIN_SERVICE,
+  IEducationSessionDomainService,
+} from '../../education-domain/interface/education-session-domain.service.interface';
+import { EducationEnrollmentException } from '../exception/education-enrollment.exception';
+import { PatchEducationEnrollmentResponseDto } from '../dto/response/patch-education-enrollment-response.dto';
+import {
+  IEDUCATION_MEMBERS_DOMAIN_SERVICE,
+  IEducationMembersDomainService,
+} from '../../../members/member-domain/interface/education-members-domain.service.interface';
+import { GetNotEnrolledMembersDto } from '../dto/request/get-not-enrolled-members.dto';
+import { NotEnrolledMembersPaginationResponseDto } from '../dto/response/not-enrolled-members-pagination-response.dto';
 
 @Injectable()
 export class EducationEnrollmentService {
   constructor(
     @Inject(IMEMBERS_DOMAIN_SERVICE)
     private readonly membersDomainService: IMembersDomainService,
+    @Inject(IEDUCATION_MEMBERS_DOMAIN_SERVICE)
+    private readonly educationMembersDomainService: IEducationMembersDomainService,
 
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,
@@ -43,9 +58,46 @@ export class EducationEnrollmentService {
     private readonly educationTermDomainService: IEducationTermDomainService,
     @Inject(IEDUCATION_ENROLLMENT_DOMAIN_SERVICE)
     private readonly educationEnrollmentsDomainService: IEducationEnrollmentsDomainService,
+    @Inject(IEDUCATION_SESSION_DOMAIN_SERVICE)
+    private readonly educationSessionDomainService: IEducationSessionDomainService,
     @Inject(ISESSION_ATTENDANCE_DOMAIN_SERVICE)
     private readonly sessionAttendanceDomainService: ISessionAttendanceDomainService,
   ) {}
+
+  async getNotEnrolledMembers(
+    churchId: number,
+    educationId: number,
+    educationTermId: number,
+    dto: GetNotEnrolledMembersDto,
+    qr?: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+    const education = await this.educationDomainService.findEducationModelById(
+      church,
+      educationId,
+      qr,
+    );
+
+    const educationTerm =
+      await this.educationTermDomainService.findEducationTermModelById(
+        education,
+        educationTermId,
+        qr,
+      );
+
+    const members =
+      await this.educationMembersDomainService.findNotEnrolledMembers(
+        church,
+        educationTerm,
+        dto,
+        qr,
+      );
+
+    return new NotEnrolledMembersPaginationResponseDto(members);
+  }
 
   async getEducationEnrollments(
     churchId: number,
@@ -78,7 +130,7 @@ export class EducationEnrollmentService {
         qr,
       );
 
-    return new EducationEnrollmentPaginationResultDto(
+    return new EducationEnrollmentPaginationResponseDto(
       data,
       totalCount,
       data.length,
@@ -104,12 +156,6 @@ export class EducationEnrollmentService {
       qr,
     );
 
-    const member = await this.membersDomainService.findMemberModelById(
-      church,
-      dto.memberId,
-      qr,
-    );
-
     const educationTerm =
       await this.educationTermDomainService.findEducationTermModelById(
         education,
@@ -118,47 +164,60 @@ export class EducationEnrollmentService {
         { educationSessions: true },
       );
 
+    const members = await this.membersDomainService.findMembersById(
+      church,
+      dto.memberIds,
+      qr,
+    );
+
     const enrollment =
       await this.educationEnrollmentsDomainService.createEducationEnrollment(
         educationTerm,
-        member,
-        dto,
+        members,
         qr,
       );
 
-    // 교육 등록 생성 후속 작업
-    const educationSessionIds = educationTerm.educationSessions.map(
-      (session) => session.id,
-    );
-
-    // 수강 대상 교인 수 증가 + 세션의 출석 정보 생성
-    await Promise.all([
-      // 교육 수강자 수 증가
-      this.educationTermDomainService.incrementEnrollmentCount(
-        educationTerm,
-        qr,
-      ),
-
-      // 교육 수강자 상태 통계값 업데이트
-      this.educationTermDomainService.incrementEducationStatusCount(
-        educationTerm,
-        dto.status,
-        qr,
-      ),
-
-      // 수강자의 출석 정보 생성
-      this.sessionAttendanceDomainService.createSessionAttendanceForNewEnrollment(
-        enrollment,
-        educationSessionIds,
-        qr,
-      ),
-    ]);
-
-    return this.educationEnrollmentsDomainService.findEducationEnrollmentById(
+    // 교육 수강자 수 증가
+    await this.educationTermDomainService.incrementEnrollmentCount(
       educationTerm,
-      enrollment.id,
+      members.length,
       qr,
     );
+
+    // 교육 수강자 상태 통계값 업데이트
+    await this.educationTermDomainService.incrementEducationStatusCount(
+      educationTerm,
+      EducationEnrollmentStatus.INCOMPLETE,
+      members.length,
+      qr,
+    );
+
+    // 기수 하위에 세션이 존재할 경우 출석 정보 생성
+    if (educationTerm.sessionsCount > 0) {
+      const educationSessionIds = (
+        await this.educationSessionDomainService.findEducationSessionIds(
+          educationTerm,
+          qr,
+        )
+      ).map((session) => session.id);
+
+      if (educationSessionIds.length > 0) {
+        await this.sessionAttendanceDomainService.createSessionAttendanceForNewEnrollment(
+          enrollment,
+          educationSessionIds,
+          qr,
+        );
+      }
+    }
+
+    const newEnrollments =
+      await this.educationEnrollmentsDomainService.findEducationEnrollmentsByIds(
+        educationTerm,
+        enrollment.map((e) => e.id),
+        qr,
+      );
+
+    return new PostEducationEnrollmentsResponseDto(newEnrollments);
   }
 
   async updateEducationEnrollment(
@@ -166,7 +225,7 @@ export class EducationEnrollmentService {
     educationId: number,
     educationTermId: number,
     educationEnrollmentId: number,
-    dto: UpdateEducationEnrollmentDto,
+    status: EducationEnrollmentStatus,
     qr: QueryRunner,
   ) {
     const church = await this.churchesDomainService.findChurchModelById(
@@ -186,42 +245,58 @@ export class EducationEnrollmentService {
       );
 
     const targetEducationEnrollment =
-      await this.educationEnrollmentsDomainService.findEducationEnrollmentModelById(
+      await this.educationEnrollmentsDomainService.findEducationEnrollmentById(
+        educationTerm,
         educationEnrollmentId,
         qr,
       );
 
-    // 교육 이수 상태 변경 시 해당 기수의 이수자 통계 업데이트
-    // 교육 이수 상태를 변경 && 기존 이수 상태와 다를 경우
-    if (dto.status && dto.status !== targetEducationEnrollment.status) {
-      await Promise.all([
-        // 기존 status 감소
-        this.educationTermDomainService.decrementEducationStatusCount(
-          educationTerm,
-          targetEducationEnrollment.status,
-          qr,
-        ),
+    if (status === targetEducationEnrollment.status) {
+      throw new BadRequestException(EducationEnrollmentException.SAME_STATUS);
+    }
 
-        // 새 status 증가
-        this.educationTermDomainService.incrementEducationStatusCount(
-          educationTerm,
-          dto.status,
-          qr,
-        ),
-      ]);
+    // 기존 status 감소
+    await this.educationTermDomainService.decrementEducationStatusCount(
+      educationTerm,
+      targetEducationEnrollment.status,
+      1,
+      qr,
+    );
+
+    // 새 status 증가
+    await this.educationTermDomainService.incrementEducationStatusCount(
+      educationTerm,
+      status,
+      1,
+      qr,
+    );
+
+    // 총 이수자 수 증가
+    if (status === EducationEnrollmentStatus.COMPLETED) {
+      await this.educationDomainService.incrementCompletionMembersCount(
+        education,
+        qr,
+      );
+    }
+
+    // 수료 --> 미수료 변경 시 총 이수자 감소
+    if (status === EducationEnrollmentStatus.INCOMPLETE) {
+      await this.educationDomainService.decrementCompletionMembersCount(
+        education,
+        qr,
+      );
     }
 
     await this.educationEnrollmentsDomainService.updateEducationEnrollment(
       targetEducationEnrollment,
-      dto,
+      status,
       qr,
     );
 
-    return this.educationEnrollmentsDomainService.findEducationEnrollmentById(
-      educationTerm,
-      educationEnrollmentId,
-      qr,
-    );
+    // 변경값 적용
+    targetEducationEnrollment.status = status;
+
+    return new PatchEducationEnrollmentResponseDto(targetEducationEnrollment);
   }
 
   async deleteEducationEnrollment(
@@ -230,7 +305,6 @@ export class EducationEnrollmentService {
     educationTermId: number,
     educationEnrollmentId: number,
     qr: QueryRunner,
-    //memberDeleted: boolean = false,
   ) {
     const church = await this.churchesDomainService.findChurchModelById(
       churchId,
@@ -254,46 +328,40 @@ export class EducationEnrollmentService {
         qr,
       );
 
-    /*const member = memberDeleted
-      ? await this.membersDomainService.findDeleteMemberModelById(
-          church,
-          targetEnrollment.memberId,
-          { educations: true },
-          qr,
-        )
-      : await this.membersDomainService.findMemberModelById(
-          church,
-          targetEnrollment.memberId,
-          qr,
-          { educations: true },
-        );*/
+    // 등록 인원 감소
+    await this.educationTermDomainService.decrementEnrollmentCount(
+      educationTerm,
+      1,
+      qr,
+    );
 
-    await Promise.all([
-      // 등록 인원 감소
-      this.educationTermDomainService.decrementEnrollmentCount(
-        educationTerm,
-        qr,
-      ),
+    // 상태별 카운트 감소
+    await this.educationTermDomainService.decrementEducationStatusCount(
+      educationTerm,
+      targetEnrollment.status,
+      1,
+      qr,
+    );
 
-      // 상태별 카운트 감소
-      this.educationTermDomainService.decrementEducationStatusCount(
-        educationTerm,
-        targetEnrollment.status,
+    // 총 이수자 감소
+    if ((targetEnrollment.status = EducationEnrollmentStatus.COMPLETED)) {
+      await this.educationDomainService.decrementCompletionMembersCount(
+        education,
         qr,
-      ),
+      );
+    }
 
-      // 교육 등록 삭제
-      this.educationEnrollmentsDomainService.deleteEducationEnrollment(
-        targetEnrollment,
-        qr,
-      ),
+    // 교육 등록 삭제
+    await this.educationEnrollmentsDomainService.deleteEducationEnrollment(
+      targetEnrollment,
+      qr,
+    );
 
-      // 출석 정보 삭제
-      this.sessionAttendanceDomainService.deleteSessionAttendanceByEnrollmentDeletion(
-        targetEnrollment,
-        qr,
-      ),
-    ]);
+    // 출석 정보 삭제
+    await this.sessionAttendanceDomainService.deleteSessionAttendanceByEnrollmentDeletion(
+      targetEnrollment,
+      qr,
+    );
 
     return {
       timestamp: new Date(),

--- a/backend/src/educations/education-enrollment/service/education-enrollment.service.ts
+++ b/backend/src/educations/education-enrollment/service/education-enrollment.service.ts
@@ -123,20 +123,14 @@ export class EducationEnrollmentService {
         qr,
       );
 
-    const { data, totalCount } =
+    const data =
       await this.educationEnrollmentsDomainService.findEducationEnrollments(
         educationTerm,
         dto,
         qr,
       );
 
-    return new EducationEnrollmentPaginationResponseDto(
-      data,
-      totalCount,
-      data.length,
-      dto.page,
-      Math.ceil(totalCount / dto.take),
-    );
+    return new EducationEnrollmentPaginationResponseDto(data);
   }
 
   async createEducationEnrollment(

--- a/backend/src/educations/education-term/entity/education-term.entity.ts
+++ b/backend/src/educations/education-term/entity/education-term.entity.ts
@@ -67,9 +67,6 @@ export class EducationTermModel extends BaseModel {
   @Column({ default: 0, comment: '수강 대상 교인 수' })
   enrollmentCount: number;
 
-  /*@Column({ default: 0, comment: '수료중인 교인 수' })
-  inProgressCount: number;*/
-
   @Column({ default: 0, comment: '수료한 교인 수' })
   completedCount: number;
 

--- a/backend/src/educations/education-term/exception/education-term.exception.ts
+++ b/backend/src/educations/education-term/exception/education-term.exception.ts
@@ -13,4 +13,7 @@ export const EducationTermException = {
   UPDATE_ERROR: '교육 기수 업데이트 도중 에러 발생',
   DELETE_ERROR: '교육 기수 삭제 도중 에러 발생',
   MAX_TERMS_COUNT_REACHED: `더 이상 교육 기수를 만들 수 없습니다. (교육 당 최대 ${EducationTermConstraints.MAX_COUNT}개)`,
+
+  INVALID_INCREMENT_COUNT: '옳지 않은 증가값',
+  INVALID_DECREMENT_COUNT: '올지 않은 감소값',
 };

--- a/backend/src/members/const/default-find-options.const.ts
+++ b/backend/src/members/const/default-find-options.const.ts
@@ -9,7 +9,7 @@ export const DefaultMemberRelationOption: FindOptionsRelations<MemberModel> = {
   },
   officer: true,
   ministries: true,
-  educations: {
+  educationEnrollments: {
     educationTerm: true,
   },
   group: true,
@@ -30,7 +30,7 @@ export const DefaultMemberSelectOption: FindOptionsSelect<MemberModel> = {
     id: true,
     name: true,
   },
-  educations: {
+  educationEnrollments: {
     id: true,
     status: true,
     educationTerm: {
@@ -56,7 +56,7 @@ export const DefaultMembersRelationOption: FindOptionsRelations<MemberModel> = {
   group: true,
   //groupRole: true,
   ministries: true,
-  educations: {
+  educationEnrollments: {
     educationTerm: true,
   },
   officer: true,
@@ -87,7 +87,7 @@ export const DefaultMembersSelectOption: FindOptionsSelect<MemberModel> = {
     id: true,
     name: true,
   },
-  educations: {
+  educationEnrollments: {
     id: true,
     status: true,
     educationTerm: {

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -194,7 +194,7 @@ export class MemberModel extends BaseModel {
     () => EducationEnrollmentModel,
     (educationEnrollment) => educationEnrollment.member,
   )
-  educations: EducationEnrollmentModel[];
+  educationEnrollments: EducationEnrollmentModel[];
 
   @OneToMany(() => EducationTermModel, (term) => term.inCharge)
   inChargeEducationTerm: EducationTermModel[];

--- a/backend/src/members/member-domain/interface/education-members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/education-members-domain.service.interface.ts
@@ -1,0 +1,18 @@
+import { MemberModel } from '../../entity/member.entity';
+import { EducationTermModel } from '../../../educations/education-term/entity/education-term.entity';
+import { QueryRunner } from 'typeorm';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { GetNotEnrolledMembersDto } from '../../../educations/education-enrollment/dto/request/get-not-enrolled-members.dto';
+
+export const IEDUCATION_MEMBERS_DOMAIN_SERVICE = Symbol(
+  'IEDUCATION_MEMBERS_DOMAIN_SERVICE',
+);
+
+export interface IEducationMembersDomainService {
+  findNotEnrolledMembers(
+    church: ChurchModel,
+    educationTerm: EducationTermModel,
+    dto: GetNotEnrolledMembersDto,
+    qr?: QueryRunner,
+  ): Promise<MemberModel[]>;
+}

--- a/backend/src/members/member-domain/members-domain.module.ts
+++ b/backend/src/members/member-domain/members-domain.module.ts
@@ -11,6 +11,8 @@ import { IOFFICER_MEMBERS_DOMAIN_SERVICE } from './interface/officer-members-dom
 import { OfficerMembersDomainService } from './service/officer-members-domain.service';
 import { IGROUP_MEMBERS_DOMAIN_SERVICE } from './interface/group-members.domain.service.interface';
 import { GroupMembersDomainService } from './service/group-members-domain.service';
+import { IEDUCATION_MEMBERS_DOMAIN_SERVICE } from './interface/education-members-domain.service.interface';
+import { EducationMembersDomainService } from './service/education-members-domain.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([MemberModel])],
@@ -35,6 +37,10 @@ import { GroupMembersDomainService } from './service/group-members-domain.servic
       provide: IGROUP_MEMBERS_DOMAIN_SERVICE,
       useClass: GroupMembersDomainService,
     },
+    {
+      provide: IEDUCATION_MEMBERS_DOMAIN_SERVICE,
+      useClass: EducationMembersDomainService,
+    },
   ],
   exports: [
     IMEMBERS_DOMAIN_SERVICE,
@@ -42,6 +48,7 @@ import { GroupMembersDomainService } from './service/group-members-domain.servic
     IMINISTRY_MEMBERS_DOMAIN_SERVICE,
     IOFFICER_MEMBERS_DOMAIN_SERVICE,
     IGROUP_MEMBERS_DOMAIN_SERVICE,
+    IEDUCATION_MEMBERS_DOMAIN_SERVICE,
   ],
 })
 export class MembersDomainModule {}

--- a/backend/src/members/member-domain/service/education-members-domain.service.ts
+++ b/backend/src/members/member-domain/service/education-members-domain.service.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@nestjs/common';
+import { IEducationMembersDomainService } from '../interface/education-members-domain.service.interface';
+import { EducationTermModel } from '../../../educations/education-term/entity/education-term.entity';
+import { QueryRunner, Repository } from 'typeorm';
+import { MemberModel } from '../../entity/member.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import {
+  MemberSummarizedGroupSelectQB,
+  MemberSummarizedOfficerSelectQB,
+  MemberSummarizedSelectQB,
+} from '../../const/member-find-options.const';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { GetNotEnrolledMembersDto } from '../../../educations/education-enrollment/dto/request/get-not-enrolled-members.dto';
+
+@Injectable()
+export class EducationMembersDomainService
+  implements IEducationMembersDomainService
+{
+  constructor(
+    @InjectRepository(MemberModel)
+    private readonly repository: Repository<MemberModel>,
+  ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr ? qr.manager.getRepository(MemberModel) : this.repository;
+  }
+
+  findNotEnrolledMembers(
+    church: ChurchModel,
+    educationTerm: EducationTermModel,
+    dto: GetNotEnrolledMembersDto,
+    qr?: QueryRunner,
+  ): Promise<MemberModel[]> {
+    const repository = this.getRepository(qr);
+
+    return repository
+      .createQueryBuilder('member')
+      .leftJoin('member.officer', 'officer')
+      .leftJoin('member.group', 'group')
+      .select(MemberSummarizedSelectQB)
+      .addSelect(MemberSummarizedOfficerSelectQB)
+      .addSelect(MemberSummarizedGroupSelectQB)
+      .leftJoin(
+        'member.educationEnrollments',
+        'enrollment',
+        'enrollment.educationTermId IN (SELECT id FROM education_term_model WHERE "educationId" = :educationId AND id != :currentTermId)',
+        {
+          educationId: educationTerm.educationId,
+          currentTermId: educationTerm.id,
+        },
+      )
+      .addSelect([
+        'enrollment.id',
+        'enrollment.status',
+        'enrollment.createdAt',
+        'enrollment.updatedAt',
+      ])
+      .leftJoin('enrollment.educationTerm', 'educationTerm')
+      .addSelect([
+        'educationTerm.id',
+        'educationTerm.createdAt',
+        'educationTerm.updatedAt',
+        'educationTerm.educationId',
+        'educationTerm.educationName',
+        'educationTerm.term',
+      ])
+      .where('member.churchId = :churchId', { churchId: church.id })
+      .andWhere(
+        `NOT EXISTS (
+          SELECT 1
+          FROM education_enrollment_model ee
+          WHERE ee."memberId" = member.id
+          AND ee."educationTermId" = :educationTermId
+          )`,
+        { educationTermId: educationTerm.id },
+      )
+      .andWhere('member.name ILIKE :name', { name: `%${dto.name}%` })
+      .orderBy(`member.${dto.order}`, dto.orderDirection)
+      .limit(dto.take)
+      .offset(dto.take * (dto.page - 1))
+      .getMany();
+  }
+}

--- a/backend/src/members/service/search-members.service.ts
+++ b/backend/src/members/service/search-members.service.ts
@@ -284,7 +284,7 @@ export class SearchMembersService implements ISearchMembersService {
       groupId: dto.group && In(dto.group),
       officerId: dto.officer && In(dto.officer),
       ministries: dto.ministries && { id: In(dto.ministries) },
-      educations: dto.educations && {
+      educationEnrollments: dto.educations && {
         educationTerm: {
           educationId: In(dto.educations),
         },


### PR DESCRIPTION
## 주요 내용
교육 수강 관리 기능을 개선하여 다중 등록을 지원하고, 미등록 교인 조회 기능을 추가했습니다.

## 세부 내용

**엔티티 변경사항**
- 삭제: `note` 컬럼 제거
- 변경: `status` enum에서 `inProgress` 제거 (completed, incomplete만 유지)

**수강 등록 개선**
- 단일 등록 → 다중 등록 지원
 - 요청: `memberId` (number) → `memberIds` (number[])
 - 한 번에 여러 교인 등록 가능
- 신규 등록 시 status 입력 제거 (기본값: incomplete)
- 검증: 이미 등록된 교인 또는 교회 미소속 교인 예외 처리

**수강 정보 수정**
- 수정 가능 항목: status만 가능 (note 제거)
- 동일 값 수정 요청 시 예외 처리
- status 변경 시 EducationModel.completionMemberCount 자동 업데이트

**수강 정보 삭제**
- completed 상태 삭제 시 EducationModel.completionMemberCount 감소

**신규 API 추가**
- GET `/churches/{churchId}/educations/{educationId}/terms/{educationTermId}/enrollments/not-enrolled-members`
- 기능: 해당 교육 기수에 미등록된 교인 조회
- 쿼리 파라미터: `name` (교인 이름 검색)
- 특징: 동일 교육의 다른 기수 등록 정보 포함
 - `educationEnrollments` 배열이 비어있으면: 해당 교육 미등록
 - `educationEnrollments` 배열에 데이터 있으면: 다른 기수 등록 정보 표시