### PR TITLE
feat: 교육 회차(EducationSession) 상태 관리 및 날짜 처리 개선

### DIFF
--- a/backend/src/educations/education-domain/interface/education-session-domain.service.interface.ts
+++ b/backend/src/educations/education-domain/interface/education-session-domain.service.interface.ts
@@ -3,7 +3,6 @@ import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { EducationSessionModel } from '../../education-session/entity/education-session.entity';
 import { UpdateEducationSessionDto } from '../../education-session/dto/request/update-education-session.dto';
 import { CreateEducationSessionDto } from '../../education-session/dto/request/create-education-session.dto';
-import { EducationSessionDomainPaginationResultDto } from '../dto/sessions/education-session-domain-pagination-result.dto';
 import { GetEducationSessionDto } from '../../education-session/dto/request/get-education-session.dto';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { GetEducationSessionForCalendarDto } from '../../../calendar/dto/request/education/get-education-session-for-calendar.dto';
@@ -35,7 +34,7 @@ export interface IEducationSessionDomainService {
     educationTerm: EducationTermModel,
     dto: GetEducationSessionDto,
     qr?: QueryRunner,
-  ): Promise<EducationSessionDomainPaginationResultDto>;
+  ): Promise<EducationSessionModel[]>;
 
   findEducationSessionModelById(
     educationTerm: EducationTermModel,
@@ -62,11 +61,11 @@ export interface IEducationSessionDomainService {
     qr: QueryRunner,
   ): Promise<EducationSessionModel[]>;
 
-  createSingleEducationSession(
+  createEducationSession(
     educationTerm: EducationTermModel,
-    creatorMember: ChurchUserModel, //MemberModel,
+    creatorMember: ChurchUserModel,
     dto: CreateEducationSessionDto,
-    inCharge: ChurchUserModel | null, //MemberModel | null,
+    inCharge: ChurchUserModel | null,
     qr: QueryRunner,
   ): Promise<EducationSessionModel>;
 

--- a/backend/src/educations/education-session/const/education-session-constraints.const.ts
+++ b/backend/src/educations/education-session/const/education-session-constraints.const.ts
@@ -1,5 +1,5 @@
 export const EducationSessionConstraints = {
   MAX_SESSION_NAME_LENGTH: 50,
-  MAX_SESSION_NUMBER: 30,
+  MAX_SESSION_NUMBER: 50,
   MAX_SESSION_CONTENT_LENGTH: 1000,
 };

--- a/backend/src/educations/education-session/const/education-session-status.enum.ts
+++ b/backend/src/educations/education-session/const/education-session-status.enum.ts
@@ -1,5 +1,6 @@
 export enum EducationSessionStatus {
   RESERVE = 'reserve',
+  IN_PROGRESS = 'inProgress',
   DONE = 'done',
   PENDING = 'pending',
 }

--- a/backend/src/educations/education-session/controller/education-sessions.controller.ts
+++ b/backend/src/educations/education-session/controller/education-sessions.controller.ts
@@ -64,7 +64,6 @@ export class EducationSessionsController {
   //@UseGuards(AccessTokenGuard, ChurchManagerGuard)
   @UseInterceptors(TransactionInterceptor)
   postEducationSession(
-    //@Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
     @PermissionManager() manager: ChurchUserModel,
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('educationId', ParseIntPipe) educationId: number,
@@ -72,10 +71,7 @@ export class EducationSessionsController {
     @Body() dto: CreateEducationSessionDto,
     @QueryRunner() qr: QR,
   ) {
-    //const userId = accessPayload.id;
-
-    return this.educationSessionsService.createSingleEducationSession(
-      //userId,
+    return this.educationSessionsService.createEducationSession(
       manager,
       churchId,
       educationId,

--- a/backend/src/educations/education-session/dto/request/create-education-session.dto.ts
+++ b/backend/src/educations/education-session/dto/request/create-education-session.dto.ts
@@ -1,9 +1,7 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { EducationSessionModel } from '../../entity/education-session.entity';
-import { EducationSessionStatus } from '../../const/education-session-status.enum';
 import {
-  IsDate,
-  IsEnum,
+  IsDateString,
   IsNotEmpty,
   IsNumber,
   IsOptional,
@@ -14,19 +12,17 @@ import {
 import { EducationSessionConstraints } from '../../const/education-session-constraints.const';
 import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
 import { RemoveSpaces } from '../../../../common/decorator/transformer/remove-spaces';
-import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import { IsBasicText } from '../../../../common/decorator/validator/is-no-special-char.validator';
 import { IsAfterDate } from '../../../../common/decorator/validator/is-after-date.decorator';
 import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
 import { PlainTextMaxLength } from '../../../../common/decorator/validator/plain-text-max-length.validator';
+import { IsDateTime } from '../../../../common/decorator/validator/is-date-time.validator';
 
 @SanitizeDto()
 export class CreateEducationSessionDto extends PickType(EducationSessionModel, [
   'title',
-  'startDate',
-  'endDate',
   'inChargeId',
   'content',
-  'status',
 ]) {
   @ApiProperty({
     description: '교육 회차명',
@@ -35,22 +31,28 @@ export class CreateEducationSessionDto extends PickType(EducationSessionModel, [
   @IsString()
   @IsNotEmpty()
   @RemoveSpaces()
-  @IsNoSpecialChar()
+  @IsBasicText('title')
   @MaxLength(EducationSessionConstraints.MAX_SESSION_NAME_LENGTH)
   override title: string;
 
   @ApiProperty({
-    description: '시작 날짜',
+    description: '시작 날짜 (yyyy-MM-ddTHH:MM:SS)',
   })
-  @IsDate()
-  override startDate: Date;
+  @IsDateString({ strict: true })
+  @IsDateTime('startDate')
+  startDate: string;
+
+  utcStartDate: Date;
 
   @ApiProperty({
-    description: '종료 날짜',
+    description: '종료 날짜 (yyyy-MM-ddTHH:MM:SS)',
   })
-  @IsDate()
+  @IsDateString({ strict: true })
+  @IsDateTime('endDate')
   @IsAfterDate('startDate')
-  override endDate: Date;
+  endDate: string;
+
+  utcEndDate: Date;
 
   @ApiProperty({
     description: '담당자 교인 ID',
@@ -70,13 +72,13 @@ export class CreateEducationSessionDto extends PickType(EducationSessionModel, [
   @PlainTextMaxLength(EducationSessionConstraints.MAX_SESSION_CONTENT_LENGTH)
   override content: string;
 
-  @ApiProperty({
+  /*@ApiProperty({
     description: '진행 상태',
     enum: EducationSessionStatus,
     default: EducationSessionStatus.RESERVE,
   })
   @IsEnum(EducationSessionStatus)
-  override status: EducationSessionStatus = EducationSessionStatus.RESERVE;
+  override status: EducationSessionStatus = EducationSessionStatus.RESERVE;*/
 
   @ApiProperty({
     description: '피보고자 ID',

--- a/backend/src/educations/education-session/dto/request/update-education-session.dto.ts
+++ b/backend/src/educations/education-session/dto/request/update-education-session.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
   IsDate,
+  IsDateString,
   IsEnum,
   IsNotEmpty,
   IsNumber,
@@ -17,6 +18,7 @@ import { RemoveSpaces } from '../../../../common/decorator/transformer/remove-sp
 import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
 import { IsAfterDate } from '../../../../common/decorator/validator/is-after-date.decorator';
 import { PlainTextMaxLength } from '../../../../common/decorator/validator/plain-text-max-length.validator';
+import { IsDateTime } from '../../../../common/decorator/validator/is-date-time.validator';
 
 @SanitizeDto()
 export class UpdateEducationSessionDto {
@@ -38,8 +40,11 @@ export class UpdateEducationSessionDto {
     required: false,
   })
   @IsOptionalNotNull()
-  @IsDate()
+  @IsDateString({ strict: true })
+  @IsDateTime('startDate')
   startDate?: Date;
+
+  utcStartDate: Date | undefined;
 
   @ApiProperty({
     description: '종료 날짜',
@@ -49,6 +54,8 @@ export class UpdateEducationSessionDto {
   @IsDate()
   @IsAfterDate('startDate')
   endDate?: Date;
+
+  utcEndDate: Date | undefined;
 
   @ApiProperty({
     description: '담당자 교인 ID (담당자 삭제 시 null)',

--- a/backend/src/educations/education-session/dto/response/education-session-pagination-response.dto.ts
+++ b/backend/src/educations/education-session/dto/response/education-session-pagination-response.dto.ts
@@ -1,14 +1,8 @@
 import { EducationSessionModel } from '../../entity/education-session.entity';
-import { BaseOffsetPaginationResponseDto } from '../../../../common/dto/reponse/base-offset-pagination-response.dto';
 
-export class EducationSessionPaginationResponseDto extends BaseOffsetPaginationResponseDto<EducationSessionModel> {
+export class EducationSessionPaginationResponseDto {
   constructor(
-    data: EducationSessionModel[],
-    totalCount: number,
-    count: number,
-    page: number,
-    totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly data: EducationSessionModel[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/educations/education-session/entity/education-session.entity.ts
+++ b/backend/src/educations/education-session/entity/education-session.entity.ts
@@ -44,7 +44,7 @@ export class EducationSessionModel extends BaseModel {
   @Column({
     enum: EducationSessionStatus,
     default: EducationSessionStatus.RESERVE,
-    comment: '교육 진행 상태 (예정, 완료, 지연)',
+    comment: '교육 진행 상태 (예정, 진행중, 완료, 지연)',
   })
   status: EducationSessionStatus;
 


### PR DESCRIPTION
## 주요 내용
교육 회차의 상태값을 확장하고 날짜/시간 처리 방식을 개선했습니다.

## 세부 내용

**상태값 추가**
- EducationSessionStatus에 `inProgress` 추가
- 기존: reserve, done, pending
- 변경: reserve, inProgress, done, pending

**날짜/시간 처리 방식 변경**
- 입력 형식: `yyyy-MM-ddTHH:mm:ss` (문자열)
- 처리: 한국 시간(KST)으로 입력받아 UTC로 변환하여 DB 저장
- 응답: UTC 형식으로 반환
- 적용 필드: startDate, endDate

**생성 로직 변경**
- 기존: 생성 시 status 값을 입력받음
- 변경: status 입력 제거, 자동으로 `reserve` 상태로 생성

**영향받는 기능**
- 회차 생성 API
- 회차 목록/상세 조회 시 시간 표시