### PR TITLE
feat: 교육 기수 보고 관리 엔드포인트 추가

### DIFF
--- a/backend/src/educations/education-term/service/education-term.service.ts
+++ b/backend/src/educations/education-term/service/education-term.service.ts
@@ -472,7 +472,7 @@ export class EducationTermService {
       );
 
     const result =
-      await this.educationTermReportDomainService.deleteEducationSessionReports(
+      await this.educationTermReportDomainService.deleteEducationTermReports(
         targetReports,
         qr,
       );

--- a/backend/src/report/const/report-order.enum.ts
+++ b/backend/src/report/const/report-order.enum.ts
@@ -1,0 +1,7 @@
+export enum ReportOrder {
+  START_DATE = 'startDate',
+  END_DATE = 'endDate',
+  REPORTED_AT = 'reportedAt',
+  CREATED_AT = 'createdAt',
+  UPDATED_AT = 'updatedAt',
+}

--- a/backend/src/report/controller/education-term-report.controller.ts
+++ b/backend/src/report/controller/education-term-report.controller.ts
@@ -1,23 +1,77 @@
-import { Controller, Delete, Get, Patch, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { EducationTermReportService } from '../service/education-term-report.service';
+import { Token } from '../../auth/decorator/jwt.decorator';
+import { AuthType } from '../../auth/const/enum/auth-type.enum';
+import { JwtAccessPayload } from '../../auth/type/jwt';
+import { GetEducationTermReportsDto } from '../dto/education-report/term/request/get-education-term-reports.dto';
+import { UpdateEducationTermReportDto } from '../dto/education-report/term/request/update-education-term-report.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('MyPage:Reports:Education-Terms')
 @Controller('education-term')
 export class EducationTermReportController {
-  constructor() {}
+  constructor(
+    private readonly educationTermReportService: EducationTermReportService,
+  ) {}
 
   @UseGuards(AccessTokenGuard)
   @Get()
-  getEducationTermReport() {}
+  getEducationTermReport(
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @Query() dto: GetEducationTermReportsDto,
+  ) {
+    return this.educationTermReportService.getEducationTermReports(
+      accessToken.id,
+      dto,
+    );
+  }
 
   @UseGuards(AccessTokenGuard)
   @Get(':educationTermReportId')
-  getEducationTermReportById() {}
+  getEducationTermReportById(
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @Param('educationTermReportId', ParseIntPipe) reportId: number,
+  ) {
+    return this.educationTermReportService.getEducationTermReportById(
+      accessToken.id,
+      reportId,
+    );
+  }
 
   @UseGuards(AccessTokenGuard)
   @Patch(':educationTermReportId')
-  patchEducationTermReport() {}
+  patchEducationTermReport(
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @Param('educationTermReportId', ParseIntPipe) reportId: number,
+    @Body() dto: UpdateEducationTermReportDto,
+  ) {
+    return this.educationTermReportService.patchEducationTermReport(
+      accessToken.id,
+      reportId,
+      dto,
+    );
+  }
 
   @UseGuards(AccessTokenGuard)
   @Delete(':educationTermReportId')
-  deleteEducationTermReport() {}
+  deleteEducationTermReport(
+    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @Param('educationTermReportId', ParseIntPipe) reportId: number,
+  ) {
+    return this.educationTermReportService.deleteEducationTermReport(
+      accessToken.id,
+      reportId,
+    );
+  }
 }

--- a/backend/src/report/dto/education-report/term/request/get-education-term-reports.dto.ts
+++ b/backend/src/report/dto/education-report/term/request/get-education-term-reports.dto.ts
@@ -1,0 +1,35 @@
+import { BaseOffsetPaginationRequestDto } from '../../../../../common/dto/request/base-offset-pagination-request.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsEnum, IsOptional } from 'class-validator';
+import { QueryBoolean } from '../../../../../common/decorator/transformer/query-boolean.decorator';
+import { ReportOrder } from '../../../../const/report-order.enum';
+
+export class GetEducationTermReportsDto extends BaseOffsetPaginationRequestDto<ReportOrder> {
+  @ApiProperty({
+    description: '정렬 기준',
+    enum: ReportOrder,
+    default: ReportOrder.REPORTED_AT,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(ReportOrder)
+  order: ReportOrder = ReportOrder.REPORTED_AT;
+
+  @ApiProperty({
+    description: '읽은 보고 or 읽지 않은 보고',
+    required: false,
+  })
+  @IsOptional()
+  @QueryBoolean()
+  @IsBoolean()
+  isRead?: boolean;
+
+  @ApiProperty({
+    description: '확인 처리한 보고 or 하지 않은 보고',
+    required: false,
+  })
+  @IsOptional()
+  @QueryBoolean()
+  @IsBoolean()
+  isConfirmed?: boolean;
+}

--- a/backend/src/report/dto/education-report/term/request/update-education-term-report.dto.ts
+++ b/backend/src/report/dto/education-report/term/request/update-education-term-report.dto.ts
@@ -1,0 +1,3 @@
+import { BaseUpdateReportDto } from '../../../base-update-report.dto';
+
+export class UpdateEducationTermReportDto extends BaseUpdateReportDto {}

--- a/backend/src/report/dto/education-report/term/response/delete-education-term-report-response.dto.ts
+++ b/backend/src/report/dto/education-report/term/response/delete-education-term-report-response.dto.ts
@@ -1,0 +1,13 @@
+import { BaseDeleteResponseDto } from '../../../../../common/dto/reponse/base-delete-response.dto';
+
+export class DeleteEducationTermReportResponseDto extends BaseDeleteResponseDto {
+  constructor(
+    public readonly timestamp: Date,
+    public readonly id: number,
+    public readonly educationId: number,
+    public readonly educationTermId: number,
+    public readonly success: boolean,
+  ) {
+    super(timestamp, id, success);
+  }
+}

--- a/backend/src/report/dto/education-report/term/response/education-term-report-pagination-response.dto.ts
+++ b/backend/src/report/dto/education-report/term/response/education-term-report-pagination-response.dto.ts
@@ -1,0 +1,8 @@
+import { EducationTermReportModel } from '../../../../entity/education-term-report.entity';
+
+export class EducationTermReportPaginationResponseDto {
+  constructor(
+    public readonly data: EducationTermReportModel[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/report/dto/education-report/term/response/get-education-term-report-response.dto.ts
+++ b/backend/src/report/dto/education-report/term/response/get-education-term-report-response.dto.ts
@@ -1,0 +1,8 @@
+import { BaseGetResponseDto } from '../../../../../common/dto/reponse/base-get-response.dto';
+import { EducationTermReportModel } from '../../../../entity/education-term-report.entity';
+
+export class GetEducationTermReportResponseDto extends BaseGetResponseDto<EducationTermReportModel> {
+  constructor(data: EducationTermReportModel) {
+    super(data);
+  }
+}

--- a/backend/src/report/dto/education-report/term/response/patch-education-term-report-response.dto.ts
+++ b/backend/src/report/dto/education-report/term/response/patch-education-term-report-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePatchResponseDto } from '../../../../../common/dto/reponse/base-patch-response.dto';
+import { EducationTermReportModel } from '../../../../entity/education-term-report.entity';
+
+export class PatchEducationTermReportResponseDto extends BasePatchResponseDto<EducationTermReportModel> {
+  constructor(data: EducationTermReportModel) {
+    super(data);
+  }
+}

--- a/backend/src/report/report-domain/interface/education-term-report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/education-term-report-domain.service.interface.ts
@@ -3,12 +3,35 @@ import { EducationTermModel } from '../../../educations/education-term/entity/ed
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { EducationTermReportModel } from '../../entity/education-term-report.entity';
+import { MemberModel } from '../../../members/entity/member.entity';
+import { GetEducationTermReportsDto } from '../../dto/education-report/term/request/get-education-term-reports.dto';
+import { UpdateEducationTermReportDto } from '../../dto/education-report/term/request/update-education-term-report.dto';
 
 export const IEDUCATION_TERM_REPORT_DOMAIN_SERVICE = Symbol(
   'IEDUCATION_TERM_REPORT_DOMAIN_SERVICE',
 );
 
 export interface IEducationTermReportDomainService {
+  findEducationTermReports(
+    currentMember: MemberModel,
+    dto: GetEducationTermReportsDto,
+    qr?: QueryRunner,
+  ): Promise<EducationTermReportModel[]>;
+
+  findEducationTermReportModelById(
+    receiver: MemberModel,
+    reportId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<EducationTermReportModel>,
+  ): Promise<EducationTermReportModel>;
+
+  findEducationTermReportById(
+    receiver: MemberModel,
+    reportId: number,
+    checkIsRead: boolean,
+    qr?: QueryRunner,
+  ): Promise<EducationTermReportModel>;
+
   findEducationTermReportModelsByReceiverIds(
     educationTerm: EducationTermModel,
     receiverIds: number[],
@@ -23,13 +46,24 @@ export interface IEducationTermReportDomainService {
     qr: QueryRunner,
   ): Promise<EducationTermReportModel[]>;
 
+  updateEducationTermReport(
+    targetReport: EducationTermReportModel,
+    dto: UpdateEducationTermReportDto,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+
   deleteEducationTermReportsCascade(
     educationTerm: EducationTermModel,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 
-  deleteEducationSessionReports(
+  deleteEducationTermReports(
     targetReports: EducationTermReportModel[],
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  deleteEducationTermReport(
+    targetReport: EducationTermReportModel,
     qr?: QueryRunner,
   ): Promise<UpdateResult>;
 }

--- a/backend/src/report/service/education-term-report.service.ts
+++ b/backend/src/report/service/education-term-report.service.ts
@@ -1,6 +1,133 @@
-import { Injectable } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
+import {
+  IEDUCATION_TERM_REPORT_DOMAIN_SERVICE,
+  IEducationTermReportDomainService,
+} from '../report-domain/interface/education-term-report-domain.service.interface';
+import {
+  IUSER_DOMAIN_SERVICE,
+  IUserDomainService,
+} from '../../user/user-domain/interface/user-domain.service.interface';
+import { MemberModel } from '../../members/entity/member.entity';
+import { GetEducationTermReportsDto } from '../dto/education-report/term/request/get-education-term-reports.dto';
+import { EducationTermReportPaginationResponseDto } from '../dto/education-report/term/response/education-term-report-pagination-response.dto';
+import { GetEducationTermReportResponseDto } from '../dto/education-report/term/response/get-education-term-report-response.dto';
+import { UpdateEducationTermReportDto } from '../dto/education-report/term/request/update-education-term-report.dto';
+import { PatchEducationTermReportResponseDto } from '../dto/education-report/term/response/patch-education-term-report-response.dto';
+import { QueryRunner } from 'typeorm';
+import { DeleteEducationTermReportResponseDto } from '../dto/education-report/term/response/delete-education-term-report-response.dto';
 
 @Injectable()
 export class EducationTermReportService {
-  constructor() {}
+  constructor(
+    @Inject(IUSER_DOMAIN_SERVICE)
+    private readonly userDomainService: IUserDomainService,
+
+    @Inject(IEDUCATION_TERM_REPORT_DOMAIN_SERVICE)
+    private readonly educationTermReportDomainService: IEducationTermReportDomainService,
+  ) {}
+
+  private async getCurrentMember(userId: number): Promise<MemberModel> {
+    const user = await this.userDomainService.findUserById(userId);
+
+    const currentChurchUser = user.churchUser.find(
+      (churchUser) => churchUser.leftAt === null,
+    );
+
+    if (!currentChurchUser) {
+      throw new ForbiddenException('교회에 가입되지 않은 사용자');
+    }
+
+    if (!currentChurchUser.member) {
+      throw new ForbiddenException('교인 정보 없음');
+    }
+
+    return currentChurchUser.member;
+  }
+
+  async getEducationTermReports(
+    userId: number,
+    dto: GetEducationTermReportsDto,
+  ) {
+    const currentMember = await this.getCurrentMember(userId);
+
+    const data =
+      await this.educationTermReportDomainService.findEducationTermReports(
+        currentMember,
+        dto,
+      );
+
+    return new EducationTermReportPaginationResponseDto(data);
+  }
+
+  async getEducationTermReportById(userId: number, reportId: number) {
+    const currentMember = await this.getCurrentMember(userId);
+
+    const report =
+      await this.educationTermReportDomainService.findEducationTermReportById(
+        currentMember,
+        reportId,
+        true,
+      );
+
+    return new GetEducationTermReportResponseDto(report);
+  }
+
+  async patchEducationTermReport(
+    userId: number,
+    reportId: number,
+    dto: UpdateEducationTermReportDto,
+  ) {
+    const receiver = await this.getCurrentMember(userId);
+
+    const targetReport =
+      await this.educationTermReportDomainService.findEducationTermReportModelById(
+        receiver,
+        reportId,
+      );
+
+    await this.educationTermReportDomainService.updateEducationTermReport(
+      targetReport,
+      dto,
+    );
+
+    const updatedReport =
+      await this.educationTermReportDomainService.findEducationTermReportById(
+        receiver,
+        reportId,
+        false,
+      );
+
+    return new PatchEducationTermReportResponseDto(updatedReport);
+  }
+
+  async deleteEducationTermReport(
+    userId: number,
+    reportId: number,
+    qr?: QueryRunner,
+  ) {
+    const receiver = await this.getCurrentMember(userId);
+
+    const targetReport =
+      await this.educationTermReportDomainService.findEducationTermReportModelById(
+        receiver,
+        reportId,
+        qr,
+        {
+          educationTerm: true,
+        },
+      );
+
+    await this.educationTermReportDomainService.deleteEducationTermReport(
+      targetReport,
+      qr,
+    );
+
+    return new DeleteEducationTermReportResponseDto(
+      new Date(),
+      targetReport.id,
+      targetReport.educationId,
+      targetReport.educationTermId,
+      true,
+    );
+  }
 }

--- a/backend/src/user/user-domain/service/user-domain.service.ts
+++ b/backend/src/user/user-domain/service/user-domain.service.ts
@@ -54,7 +54,7 @@ export class UserDomainService implements IUserDomainService {
 
     const user = await repository
       .createQueryBuilder('user')
-      .leftJoin('user.churchUser', 'churchUser', 'churchUser.leftAt IS NULL')
+      .innerJoin('user.churchUser', 'churchUser', 'churchUser.leftAt IS NULL')
       .addSelect([
         'churchUser.id',
         'churchUser.createdAt',
@@ -77,17 +77,11 @@ export class UserDomainService implements IUserDomainService {
         'church.detailAddress',
       ])
       .leftJoin('churchUser.member', 'member') // 교인
-      .addSelect(
-        MemberSummarizedSelectQB /*['member.id', 'member.name', 'member.profileImageUrl']*/,
-      )
+      .addSelect(MemberSummarizedSelectQB)
       .leftJoin('member.group', 'group') // 교인 - 그룹
-      .addSelect(MemberSummarizedGroupSelectQB /*['group.id', 'group.name']*/)
+      .addSelect(MemberSummarizedGroupSelectQB)
       .leftJoin('member.officer', 'officer') // 교인 - 직분
-      .addSelect(
-        MemberSummarizedOfficerSelectQB /*['officer.id', 'officer.name']*/,
-      )
-      //.leftJoin('member.groupRole', 'groupRole') // 교인 - 그룹 역할
-      //.addSelect(['groupRole.id', 'groupRole.role'])
+      .addSelect(MemberSummarizedOfficerSelectQB)
       .leftJoin('churchUser.permissionTemplate', 'permissionTemplate') // 관리자 - 권한 유형
       .addSelect(['permissionTemplate.id', 'permissionTemplate.title'])
       .leftJoinAndSelect(


### PR DESCRIPTION
## 주요 내용
수신받은 EducationTerm 보고를 조회하고 관리할 수 있는 엔드포인트를 구현했습니다.

## 세부 내용
### API 엔드포인트
- `GET /me/reports/education-term`: 내가 받은 교육 기수 보고 목록 조회
- `GET /me/reports/education-term/{educationTermReportId}`: 특정 보고 상세 조회
- `PATCH /me/reports/education-term/{educationTermReportId}`: 보고 상태 수정
- `DELETE /me/reports/education-term/{educationTermReportId}`: 보고 삭제

### 구현 기능
- 보고 목록 조회 시 다양한 정렬 옵션 지원
 - EducationTerm: startDate, endDate
 - Report: reportedAt, createdAt, updatedAt
- 보고 상태 변경 기능
 - isRead: 읽음/안읽음 상태 변경
 - isConfirmed: 확인/미확인 상태 변경

### 변경 사항
- EducationTermReportController: 보고 관리 엔드포인트 추가
- EducationTermReportService: 조회 및 상태 변경 로직 구현
- EducationTermReportDomainService: 정렬 조건 처리 및 상태 업데이트 구현