### PR TITLE
feat: 페이지네이션 count 쿼리 제거 및 교회 가입 정보 가드/데코레이터 추가

### DIFF
--- a/backend/src/church-user/church-user-domain/service/church-user-domain.service.ts
+++ b/backend/src/church-user/church-user-domain/service/church-user-domain.service.ts
@@ -133,6 +133,12 @@ export class ChurchUserDomainService implements IChurchUserDomainService {
         userId: userId,
         leftAt: IsNull(),
       },
+      relations: {
+        member: MemberSummarizedRelation,
+      },
+      select: {
+        member: MemberSummarizedSelect,
+      },
     });
 
     if (!churchUser) {

--- a/backend/src/church-user/guard/church-user.guard.ts
+++ b/backend/src/church-user/guard/church-user.guard.ts
@@ -1,0 +1,37 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { CustomRequest } from '../../common/custom-request';
+import {
+  ICHURCH_USER_DOMAIN_SERVICE,
+  IChurchUserDomainService,
+} from '../church-user-domain/service/interface/church-user-domain.service.interface';
+
+@Injectable()
+export class ChurchUserGuard implements CanActivate {
+  constructor(
+    @Inject(ICHURCH_USER_DOMAIN_SERVICE)
+    private readonly churchUserDomainService: IChurchUserDomainService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req: CustomRequest = context.switchToHttp().getRequest();
+
+    const token = req.tokenPayload;
+
+    if (!token) {
+      throw new InternalServerErrorException('JWT 처리 과정 누락');
+    }
+
+    const requestUserId = token.id;
+
+    req.requestChurchUser =
+      await this.churchUserDomainService.findChurchUserByUserId(requestUserId);
+
+    return true;
+  }
+}

--- a/backend/src/common/custom-request.ts
+++ b/backend/src/common/custom-request.ts
@@ -1,0 +1,14 @@
+import { Request } from 'express';
+import { ChurchModel } from '../churches/entity/church.entity';
+import { WorshipModel } from '../worship/entity/worship.entity';
+import { ChurchUserModel } from '../church-user/entity/church-user.entity';
+import { JwtAccessPayload } from '../auth/type/jwt';
+
+export interface CustomRequest extends Request {
+  church: ChurchModel;
+  worship: WorshipModel;
+  requestChurchUser: ChurchUserModel;
+  requestManager: ChurchUserModel;
+  permissionScopeGroupIds: number[];
+  tokenPayload: JwtAccessPayload;
+}

--- a/backend/src/common/decorator/request-church-user.decorator.ts
+++ b/backend/src/common/decorator/request-church-user.decorator.ts
@@ -1,0 +1,18 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { CustomRequest } from '../custom-request';
+
+export const RequestChurchUser = createParamDecorator(
+  (_, ctx: ExecutionContext) => {
+    const req: CustomRequest = ctx.switchToHttp().getRequest();
+
+    if (!req.requestChurchUser) {
+      throw new InternalServerErrorException('Request 내 ChurchUser 누락');
+    }
+
+    return req.requestChurchUser;
+  },
+);

--- a/backend/src/report/const/education-session-report-order.enum.ts
+++ b/backend/src/report/const/education-session-report-order.enum.ts
@@ -1,4 +1,0 @@
-export enum EducationSessionReportOrderEnum {
-  createdAt = 'createdAt',
-  updatedAt = 'updatedAt',
-}

--- a/backend/src/report/const/task-report-order.enum.ts
+++ b/backend/src/report/const/task-report-order.enum.ts
@@ -1,6 +1,0 @@
-export enum TaskReportOrderEnum {
-  taskStartDate = 'taskStartDate',
-  taskEndDate = 'taskEndDate',
-  createdAt = 'createdAt',
-  updatedAt = 'updatedAt',
-}

--- a/backend/src/report/const/visitation-report-order.enum.ts
+++ b/backend/src/report/const/visitation-report-order.enum.ts
@@ -1,5 +1,0 @@
-export enum VisitationReportOrderEnum {
-  createdAt = 'createdAt',
-  updatedAt = 'updatedAt',
-  reportedAt = 'reportedAt',
-}

--- a/backend/src/report/controller/education-session-report.controller.ts
+++ b/backend/src/report/controller/education-session-report.controller.ts
@@ -23,6 +23,9 @@ import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
 import { Token } from '../../auth/decorator/jwt.decorator';
 import { AuthType } from '../../auth/const/enum/auth-type.enum';
 import { JwtAccessPayload } from '../../auth/type/jwt';
+import { ChurchUserGuard } from '../../church-user/guard/church-user.guard';
+import { RequestChurchUser } from '../../common/decorator/request-church-user.decorator';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 
 @ApiTags('MyPage:Reports:Education-Sessions')
 @Controller('education-session')
@@ -32,55 +35,55 @@ export class EducationSessionReportController {
   ) {}
 
   @ApiGetEducationSessionReports()
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
   @Get()
   getEducationSessionReport(
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @RequestChurchUser() user: ChurchUserModel,
     @Query() dto: GetEducationSessionReportDto,
   ) {
     return this.educationSessionReportService.getEducationSessionReports(
-      accessToken.id,
+      user,
       dto,
     );
   }
 
   @ApiGetEducationSessionReportById()
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
   @Get(':educationSessionReportId')
   getEducationSessionReportById(
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @RequestChurchUser() churchUser: ChurchUserModel,
     @Param('educationSessionReportId', ParseIntPipe) reportId: number,
   ) {
     return this.educationSessionReportService.getEducationSessionReportById(
-      accessToken.id,
+      churchUser,
       reportId,
     );
   }
 
   @ApiPatchEducationSessionReport()
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
   @Patch(':educationSessionReportId')
   patchEducationSessionReport(
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @RequestChurchUser() churchUser: ChurchUserModel,
     @Param('educationSessionReportId', ParseIntPipe) reportId: number,
     @Body() dto: UpdateEducationSessionReportDto,
   ) {
     return this.educationSessionReportService.patchEducationSessionReport(
-      accessToken.id,
+      churchUser,
       reportId,
       dto,
     );
   }
 
   @ApiDeleteEducationSessionReport()
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
   @Delete(':educationSessionReportId')
   deleteEducationSessionReport(
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @RequestChurchUser() churchUser: ChurchUserModel,
     @Param('educationSessionReportId', ParseIntPipe) reportId: number,
   ) {
     return this.educationSessionReportService.deleteEducationSessionReport(
-      accessToken.id,
+      churchUser,
       reportId,
     );
   }

--- a/backend/src/report/controller/education-term-report.controller.ts
+++ b/backend/src/report/controller/education-term-report.controller.ts
@@ -17,6 +17,9 @@ import { JwtAccessPayload } from '../../auth/type/jwt';
 import { GetEducationTermReportsDto } from '../dto/education-report/term/request/get-education-term-reports.dto';
 import { UpdateEducationTermReportDto } from '../dto/education-report/term/request/update-education-term-report.dto';
 import { ApiTags } from '@nestjs/swagger';
+import { ChurchUserGuard } from '../../church-user/guard/church-user.guard';
+import { RequestChurchUser } from '../../common/decorator/request-church-user.decorator';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 
 @ApiTags('MyPage:Reports:Education-Terms')
 @Controller('education-term')
@@ -25,52 +28,52 @@ export class EducationTermReportController {
     private readonly educationTermReportService: EducationTermReportService,
   ) {}
 
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
   @Get()
   getEducationTermReport(
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @RequestChurchUser() churchUser: ChurchUserModel,
     @Query() dto: GetEducationTermReportsDto,
   ) {
     return this.educationTermReportService.getEducationTermReports(
-      accessToken.id,
+      churchUser,
       dto,
     );
   }
 
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
   @Get(':educationTermReportId')
   getEducationTermReportById(
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @RequestChurchUser() churchUser: ChurchUserModel,
     @Param('educationTermReportId', ParseIntPipe) reportId: number,
   ) {
     return this.educationTermReportService.getEducationTermReportById(
-      accessToken.id,
+      churchUser,
       reportId,
     );
   }
 
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
   @Patch(':educationTermReportId')
   patchEducationTermReport(
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @RequestChurchUser() churchUser: ChurchUserModel,
     @Param('educationTermReportId', ParseIntPipe) reportId: number,
     @Body() dto: UpdateEducationTermReportDto,
   ) {
     return this.educationTermReportService.patchEducationTermReport(
-      accessToken.id,
+      churchUser,
       reportId,
       dto,
     );
   }
 
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
   @Delete(':educationTermReportId')
   deleteEducationTermReport(
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @RequestChurchUser() churchUser: ChurchUserModel,
     @Param('educationTermReportId', ParseIntPipe) reportId: number,
   ) {
     return this.educationTermReportService.deleteEducationTermReport(
-      accessToken.id,
+      churchUser,
       reportId,
     );
   }

--- a/backend/src/report/controller/task-report.controller.ts
+++ b/backend/src/report/controller/task-report.controller.ts
@@ -24,9 +24,9 @@ import {
   ApiPatchTaskReport,
 } from '../swagger/task-report.swagger';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
-import { AuthType } from '../../auth/const/enum/auth-type.enum';
-import { Token } from '../../auth/decorator/jwt.decorator';
-import { JwtAccessPayload } from '../../auth/type/jwt';
+import { ChurchUserGuard } from '../../church-user/guard/church-user.guard';
+import { RequestChurchUser } from '../../common/decorator/request-church-user.decorator';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 
 @ApiTags('MyPage:Reports:Tasks')
 @Controller('tasks')
@@ -35,55 +35,52 @@ export class TaskReportController {
 
   @ApiGetTaskReports()
   @Get()
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
   getTaskReports(
+    @RequestChurchUser() churchUser: ChurchUserModel,
     @Query() dto: GetTaskReportDto,
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
   ) {
-    return this.taskReportService.getTaskReports(accessToken.id, dto);
+    return this.taskReportService.getTaskReports(churchUser, dto);
   }
 
   @ApiGetTaskReportById()
   @Get(':taskReportId')
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
   @UseInterceptors(TransactionInterceptor)
   getTaskReportById(
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @RequestChurchUser() churchUser: ChurchUserModel,
     @Param('taskReportId', ParseIntPipe) taskReportId: number,
     @QueryRunner() qr: QR,
   ) {
     return this.taskReportService.getTaskReportById(
-      accessToken.id,
+      churchUser,
       taskReportId,
       qr,
     );
   }
 
   @ApiPatchTaskReport()
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
   @Patch(':taskReportId')
   patchTaskReport(
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @RequestChurchUser() churchUser: ChurchUserModel,
     @Param('taskReportId', ParseIntPipe) taskReportId: number,
     @Body() dto: UpdateTaskReportDto,
   ) {
     return this.taskReportService.patchTaskReport(
-      accessToken.id,
+      churchUser,
       taskReportId,
       dto,
     );
   }
 
   @ApiDeleteTaskReport()
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
   @Delete(':taskReportId')
   deleteTaskReport(
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @RequestChurchUser() churchUser: ChurchUserModel,
     @Param('taskReportId', ParseIntPipe) taskReportId: number,
   ) {
-    return this.taskReportService.deleteTaskReport(
-      accessToken.id,
-      taskReportId,
-    );
+    return this.taskReportService.deleteTaskReport(churchUser, taskReportId);
   }
 }

--- a/backend/src/report/controller/visitation-report.controller.ts
+++ b/backend/src/report/controller/visitation-report.controller.ts
@@ -24,9 +24,9 @@ import {
 } from '../swagger/visitation-report.swagger';
 import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
-import { AuthType } from '../../auth/const/enum/auth-type.enum';
-import { Token } from '../../auth/decorator/jwt.decorator';
-import { JwtAccessPayload } from '../../auth/type/jwt';
+import { ChurchUserGuard } from '../../church-user/guard/church-user.guard';
+import { RequestChurchUser } from '../../common/decorator/request-church-user.decorator';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 
 @ApiTags('MyPage:Reports:Visitations')
 @Controller('visitations')
@@ -34,55 +34,55 @@ export class VisitationReportController {
   constructor(private readonly reportService: VisitationReportService) {}
 
   @ApiGetVisitationReports()
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
   @Get()
   getVisitationReports(
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @RequestChurchUser() churchUser: ChurchUserModel,
     @Query() dto: GetVisitationReportDto,
   ) {
-    return this.reportService.getVisitationReport(accessToken.id, dto);
+    return this.reportService.getVisitationReport(churchUser, dto);
   }
 
   @ApiGetVisitationReportById()
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
   @Get(':visitationReportId')
   @UseInterceptors(TransactionInterceptor)
   getVisitationReportById(
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @RequestChurchUser() churchUser: ChurchUserModel,
     @Param('visitationReportId', ParseIntPipe) visitationReportId: number,
     @QueryRunner() qr: QR,
   ) {
     return this.reportService.getVisitationReportById(
-      accessToken.id,
+      churchUser,
       visitationReportId,
       qr,
     );
   }
 
   @ApiPatchVisitationReport()
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
   @Patch(':visitationReportId')
   patchVisitationReport(
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @RequestChurchUser() churchUser: ChurchUserModel,
     @Param('visitationReportId', ParseIntPipe) visitationReportId: number,
     @Body() dto: UpdateVisitationReportDto,
   ) {
     return this.reportService.updateVisitationReport(
-      accessToken.id,
+      churchUser,
       visitationReportId,
       dto,
     );
   }
 
   @ApiDeleteVisitationReport()
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
   @Delete(':visitationReportId')
   deleteVisitationReport(
-    @Token(AuthType.ACCESS) accessToken: JwtAccessPayload,
+    @RequestChurchUser() churchUser: ChurchUserModel,
     @Param('visitationReportId', ParseIntPipe) visitationReportId: number,
   ) {
     return this.reportService.deleteVisitationReport(
-      accessToken.id,
+      churchUser,
       visitationReportId,
     );
   }

--- a/backend/src/report/dto/education-report/session/request/get-education-session-report.dto.ts
+++ b/backend/src/report/dto/education-report/session/request/get-education-session-report.dto.ts
@@ -1,20 +1,19 @@
 import { BaseOffsetPaginationRequestDto } from '../../../../../common/dto/request/base-offset-pagination-request.dto';
-import { EducationSessionReportOrderEnum } from '../../../../const/education-session-report-order.enum';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsEnum, IsOptional } from 'class-validator';
 import { QueryBoolean } from '../../../../../common/decorator/transformer/query-boolean.decorator';
+import { ReportOrder } from '../../../../const/report-order.enum';
 
-export class GetEducationSessionReportDto extends BaseOffsetPaginationRequestDto<EducationSessionReportOrderEnum> {
+export class GetEducationSessionReportDto extends BaseOffsetPaginationRequestDto<ReportOrder> {
   @ApiProperty({
     description: '정렬 기준',
-    enum: EducationSessionReportOrderEnum,
-    default: EducationSessionReportOrderEnum.createdAt,
+    enum: ReportOrder,
+    default: ReportOrder.CREATED_AT,
     required: false,
   })
   @IsOptional()
-  @IsEnum(EducationSessionReportOrderEnum)
-  order: EducationSessionReportOrderEnum =
-    EducationSessionReportOrderEnum.createdAt;
+  @IsEnum(ReportOrder)
+  order: ReportOrder = ReportOrder.CREATED_AT;
 
   @ApiProperty({
     description: '읽은 보고 or 읽지 않은 보고',

--- a/backend/src/report/dto/education-report/session/response/education-session-report-pagination-result.dto.ts
+++ b/backend/src/report/dto/education-report/session/response/education-session-report-pagination-result.dto.ts
@@ -1,14 +1,9 @@
 import { BaseOffsetPaginationResponseDto } from '../../../../../common/dto/reponse/base-offset-pagination-response.dto';
 import { EducationSessionReportModel } from '../../../../entity/education-session-report.entity';
 
-export class EducationSessionReportPaginationResultDto extends BaseOffsetPaginationResponseDto<EducationSessionReportModel> {
+export class EducationSessionReportPaginationResultDto {
   constructor(
-    data: EducationSessionReportModel[],
-    totalCount: number,
-    count: number,
-    page: number,
-    totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly data: EducationSessionReportModel[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/report/dto/task-report/get-task-report.dto.ts
+++ b/backend/src/report/dto/task-report/get-task-report.dto.ts
@@ -1,19 +1,19 @@
 import { BaseOffsetPaginationRequestDto } from '../../../common/dto/request/base-offset-pagination-request.dto';
-import { TaskReportOrderEnum } from '../../const/task-report-order.enum';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsEnum, IsOptional } from 'class-validator';
 import { QueryBoolean } from '../../../common/decorator/transformer/query-boolean.decorator';
+import { ReportOrder } from '../../const/report-order.enum';
 
-export class GetTaskReportDto extends BaseOffsetPaginationRequestDto<TaskReportOrderEnum> {
+export class GetTaskReportDto extends BaseOffsetPaginationRequestDto<ReportOrder> {
   @ApiProperty({
     description: '정렬 기준',
-    enum: TaskReportOrderEnum,
-    default: TaskReportOrderEnum.createdAt,
+    enum: ReportOrder,
+    default: ReportOrder.REPORTED_AT,
     required: false,
   })
   @IsOptional()
-  @IsEnum(TaskReportOrderEnum)
-  order: TaskReportOrderEnum = TaskReportOrderEnum.createdAt;
+  @IsEnum(ReportOrder)
+  order: ReportOrder = ReportOrder.REPORTED_AT;
 
   @ApiProperty({
     description: '읽은 보고 or 읽지 않은 보고',

--- a/backend/src/report/dto/task-report/task-report-pagination-result.dto.ts
+++ b/backend/src/report/dto/task-report/task-report-pagination-result.dto.ts
@@ -1,14 +1,9 @@
 import { TaskReportModel } from '../../entity/task-report.entity';
 import { BaseOffsetPaginationResponseDto } from '../../../common/dto/reponse/base-offset-pagination-response.dto';
 
-export class TaskReportPaginationResultDto extends BaseOffsetPaginationResponseDto<TaskReportModel> {
+export class TaskReportPaginationResultDto {
   constructor(
-    data: TaskReportModel[],
-    totalCount: number,
-    count: number,
-    page: number,
-    totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly data: TaskReportModel[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/report/dto/visitation-report/get-visitation-report.dto.ts
+++ b/backend/src/report/dto/visitation-report/get-visitation-report.dto.ts
@@ -1,46 +1,19 @@
 import { ApiProperty } from '@nestjs/swagger';
-import {
-  IsBoolean,
-  IsEnum,
-  IsIn,
-  IsNumber,
-  IsOptional,
-  Min,
-} from 'class-validator';
-import { VisitationOrderEnum } from '../../../visitation/const/visitation-order.enum';
-import { VisitationReportOrderEnum } from '../../const/visitation-report-order.enum';
+import { IsBoolean, IsEnum, IsIn, IsOptional } from 'class-validator';
 import { QueryBoolean } from '../../../common/decorator/transformer/query-boolean.decorator';
+import { BaseOffsetPaginationRequestDto } from '../../../common/dto/request/base-offset-pagination-request.dto';
+import { ReportOrder } from '../../const/report-order.enum';
 
-export class GetVisitationReportDto {
-  @ApiProperty({
-    description: '요청 데이터 개수',
-    default: 20,
-    required: false,
-  })
-  @IsOptional()
-  @IsNumber()
-  @Min(1)
-  take: number = 20;
-
-  @ApiProperty({
-    description: '요청 페이지',
-    default: 1,
-    required: false,
-  })
-  @IsOptional()
-  @IsNumber()
-  @Min(1)
-  page: number = 1;
-
+export class GetVisitationReportDto extends BaseOffsetPaginationRequestDto<ReportOrder> {
   @ApiProperty({
     description: '정렬 기준',
-    enum: VisitationOrderEnum,
-    default: VisitationReportOrderEnum.createdAt,
+    enum: ReportOrder,
+    default: ReportOrder.REPORTED_AT,
     required: false,
   })
   @IsOptional()
-  @IsEnum(VisitationReportOrderEnum)
-  order: VisitationReportOrderEnum = VisitationReportOrderEnum.createdAt;
+  @IsEnum(ReportOrder)
+  order: ReportOrder = ReportOrder.REPORTED_AT;
 
   @ApiProperty({
     description: '정렬 오름차순 / 내림차순',

--- a/backend/src/report/dto/visitation-report/visitation-report-pagination-result.dto.ts
+++ b/backend/src/report/dto/visitation-report/visitation-report-pagination-result.dto.ts
@@ -1,19 +1,9 @@
 import { BaseOffsetPaginationResponseDto } from '../../../common/dto/reponse/base-offset-pagination-response.dto';
 import { VisitationReportModel } from '../../entity/visitation-report.entity';
 
-/*export interface VisitationReportPaginationResultDto
-  extends BaseOffsetPaginationResultDto<VisitationReportModel> {
-  totalPage: number;
-}*/
-
-export class VisitationReportPaginationResultDto extends BaseOffsetPaginationResponseDto<VisitationReportModel> {
+export class VisitationReportPaginationResultDto {
   constructor(
     public readonly data: VisitationReportModel[],
-    public readonly totalCount: number,
-    public readonly count: number,
-    public readonly page: number,
-    public readonly totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/report/report-domain/interface/education-session-report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/education-session-report-domain.service.interface.ts
@@ -17,7 +17,7 @@ export interface IEducationSessionReportDomainService {
   findEducationSessionReports(
     receiver: MemberModel,
     dto: GetEducationSessionReportDto,
-  ): Promise<EducationSessionReportDomainPaginationResultDto>;
+  ): Promise<EducationSessionReportModel[]>;
 
   findEducationSessionReportById(
     receiver: MemberModel,

--- a/backend/src/report/report-domain/interface/task-report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/task-report-domain.service.interface.ts
@@ -22,7 +22,7 @@ export interface ITaskReportDomainService {
     receiver: MemberModel,
     dto: GetTaskReportDto,
     qr?: QueryRunner,
-  ): Promise<TaskReportDomainPaginationResultDto>;
+  ): Promise<TaskReportModel[]>;
 
   findTaskReportById(
     receiver: MemberModel,

--- a/backend/src/report/report-domain/interface/visitation-report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/visitation-report-domain.service.interface.ts
@@ -15,7 +15,7 @@ export interface IVisitationReportDomainService {
     receiver: MemberModel,
     dto: GetVisitationReportDto,
     qr?: QueryRunner,
-  ): Promise<{ data: VisitationReportModel[]; totalCount: number }>;
+  ): Promise<VisitationReportModel[]>;
 
   createVisitationReports(
     visitation: VisitationMetaModel,

--- a/backend/src/report/report.module.ts
+++ b/backend/src/report/report.module.ts
@@ -12,6 +12,7 @@ import { EducationReportDomainModule } from './report-domain/education-report-do
 import { UserDomainModule } from '../user/user-domain/user-domain.module';
 import { EducationTermReportController } from './controller/education-term-report.controller';
 import { EducationTermReportService } from './service/education-term-report.service';
+import { ChurchUserDomainModule } from '../church-user/church-user-domain/church-user-domain.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { EducationTermReportService } from './service/education-term-report.serv
       },
     ]),
     UserDomainModule,
+    ChurchUserDomainModule,
     VisitationReportDomainModule,
     TaskReportDomainModule,
     EducationReportDomainModule,

--- a/backend/src/report/service/education-session-report.service.ts
+++ b/backend/src/report/service/education-session-report.service.ts
@@ -15,58 +15,45 @@ import {
   IUserDomainService,
 } from '../../user/user-domain/interface/user-domain.service.interface';
 import { MemberModel } from '../../members/entity/member.entity';
+import { UserModel } from '../../user/entity/user.entity';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { ChurchUserGuard } from '../../church-user/guard/church-user.guard';
 
 @Injectable()
 export class EducationSessionReportService {
   constructor(
-    @Inject(IUSER_DOMAIN_SERVICE)
-    private readonly userDomainService: IUserDomainService,
-
     @Inject(IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE)
     private readonly educationSessionReportDomainService: IEducationSessionReportDomainService,
   ) {}
 
-  private async getCurrentMember(userId: number): Promise<MemberModel> {
-    const user = await this.userDomainService.findUserById(userId);
+  async getEducationSessionReports(
+    churchUser: ChurchUserModel,
+    dto: GetEducationSessionReportDto,
+  ) {
+    const currentMember = churchUser.member;
 
-    const currentChurchUser = user.churchUser.find(
-      (churchUser) => churchUser.leftAt === null,
-    );
-
-    if (!currentChurchUser) {
-      throw new ForbiddenException('교회에 가입되지 않은 사용자');
-    }
-
-    if (!currentChurchUser.member) {
+    if (!currentMember) {
       throw new ForbiddenException('교인 정보 없음');
     }
 
-    return currentChurchUser.member;
-  }
-
-  async getEducationSessionReports(
-    userId: number,
-    dto: GetEducationSessionReportDto,
-  ) {
-    const currentMember = await this.getCurrentMember(userId);
-
-    const { data, totalCount } =
+    const data =
       await this.educationSessionReportDomainService.findEducationSessionReports(
         currentMember,
         dto,
       );
 
-    return new EducationSessionReportPaginationResultDto(
-      data,
-      totalCount,
-      data.length,
-      dto.page,
-      Math.ceil(totalCount / dto.take),
-    );
+    return new EducationSessionReportPaginationResultDto(data);
   }
 
-  async getEducationSessionReportById(userId: number, reportId: number) {
-    const receiver = await this.getCurrentMember(userId);
+  async getEducationSessionReportById(
+    churchUser: ChurchUserModel,
+    reportId: number,
+  ) {
+    const receiver = churchUser.member;
+
+    if (!receiver) {
+      throw new ForbiddenException('교인 정보 없음');
+    }
 
     const report =
       await this.educationSessionReportDomainService.findEducationSessionReportById(
@@ -79,11 +66,15 @@ export class EducationSessionReportService {
   }
 
   async patchEducationSessionReport(
-    userId: number,
+    churchUser: ChurchUserModel,
     reportId: number,
     dto: UpdateEducationSessionReportDto,
   ) {
-    const receiver = await this.getCurrentMember(userId);
+    const receiver = churchUser.member;
+
+    if (!receiver) {
+      throw new ForbiddenException('교인 정보 없음');
+    }
 
     const targetReport =
       await this.educationSessionReportDomainService.findEducationSessionReportModelById(
@@ -107,11 +98,15 @@ export class EducationSessionReportService {
   }
 
   async deleteEducationSessionReport(
-    userId: number,
+    churchUser: ChurchUserModel,
     reportId: number,
     qr?: QueryRunner,
   ) {
-    const receiver = await this.getCurrentMember(userId);
+    const receiver = churchUser.member;
+
+    if (!receiver) {
+      throw new ForbiddenException('교인 정보 없음');
+    }
 
     const deleteTarget =
       await this.educationSessionReportDomainService.findEducationSessionReportModelById(

--- a/backend/src/worship/decorator/permission-scope-groups.decorator.ts
+++ b/backend/src/worship/decorator/permission-scope-groups.decorator.ts
@@ -1,5 +1,5 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
-import { CustomRequest } from '../guard/worship-read-scope.guard';
+import { CustomRequest } from '../../common/custom-request';
 
 export const PermissionScopeGroups = createParamDecorator(
   (_, ctx: ExecutionContext) => {

--- a/backend/src/worship/guard/worship-attendance-write-scope.guard.ts
+++ b/backend/src/worship/guard/worship-attendance-write-scope.guard.ts
@@ -36,7 +36,7 @@ import { WorshipException } from '../exception/worship.exception';
 import { PermissionScopeException } from '../../permission/exception/permission-scope.exception';
 import { ChurchUserRole } from '../../user/const/user-role.enum';
 import { WorshipModel } from '../entity/worship.entity';
-import { CustomRequest } from './worship-read-scope.guard';
+import { CustomRequest } from '../../common/custom-request';
 
 @Injectable()
 export class WorshipAttendanceWriteScopeGuard implements CanActivate {

--- a/backend/src/worship/guard/worship-group-filter.guard.ts
+++ b/backend/src/worship/guard/worship-group-filter.guard.ts
@@ -18,8 +18,8 @@ import {
   IGroupsDomainService,
 } from '../../management/groups/groups-domain/interface/groups-domain.service.interface';
 import { WorshipException } from '../exception/worship.exception';
-import { CustomRequest } from './worship-read-scope.guard';
 import { ChurchModel } from '../../churches/entity/church.entity';
+import { CustomRequest } from '../../common/custom-request';
 
 /**
  * 필터링 요청한 그룹이 해당 예배의 대상 그룹인지 검사

--- a/backend/src/worship/guard/worship-read-scope.guard.ts
+++ b/backend/src/worship/guard/worship-read-scope.guard.ts
@@ -23,17 +23,7 @@ import { PermissionScopeModel } from '../../permission/entity/permission-scope.e
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { ChurchUserRole } from '../../user/const/user-role.enum';
 import { PermissionScopeException } from '../../permission/exception/permission-scope.exception';
-import { WorshipModel } from '../entity/worship.entity';
-import { Request } from 'express';
-import { JwtAccessPayload } from '../../auth/type/jwt';
-
-export interface CustomRequest extends Request {
-  church: ChurchModel;
-  worship: WorshipModel;
-  requestManager: ChurchUserModel;
-  permissionScopeGroupIds: number[];
-  tokenPayload: JwtAccessPayload;
-}
+import { CustomRequest } from '../../common/custom-request';
 
 /**
  * 필터링 요청한 그룹이 요청자의 권한 범위 내에 속하는지 검사


### PR DESCRIPTION
## 주요 내용
- 기존 페이지네이션 로직에서 전체 데이터 개수를 계산하는 count 쿼리 제거
- 토큰에서 userId를 추출 후, 현재 가입된 교회 정보를 검증하는 Guard 추가
- Request 객체에서 교회 가입 정보를 추출하는 커스텀 데코레이터 추가

## 세부 내용
### 성능 개선
- count 쿼리는 조건에 맞는 모든 행을 스캔해야 하므로 대용량 데이터셋에서 성능 저하를 유발
- 특히 join, 복잡한 where 조건, 인덱스 미활용 상황에서는 쿼리 시간이 급격히 증가
- 불필요한 count 연산 제거로 목록 조회 응답 속도 향상 및 DB 부하 감소

### 인증 및 접근 제어 강화
- JWT 토큰에서 userId를 파싱하여, 해당 사용자가 현재 요청한 교회에 가입된 상태인지 검증
- 가입 이력이 없거나 탈퇴 상태면 접근 차단
- 교회 가입 정보를 Guard에서 Request 객체에 주입하고, 컨트롤러·서비스에서 간단히 주입받아 사용 가능

### 개발 편의성
- `@RequestChurchUser()` 데코레이터 추가: Request에 주입된 교회 가입 정보를 쉽게 파라미터로 바인딩
- Guard와 데코레이터를 조합해 각 엔드포인트에서 교회별 권한·데이터 접근 제어 로직을 단순화