### PR TITLE
feat: 내가 받은 보고 목록 조회 페이징 및 응답 포맷 개선

### DIFF
--- a/backend/src/home/dto/request/get-my-reports.dto.ts
+++ b/backend/src/home/dto/request/get-my-reports.dto.ts
@@ -1,6 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { WidgetRange } from '../../const/widget-range.enum';
-import { IsDateString, IsEnum, IsNumber, IsOptional } from 'class-validator';
+import {
+  IsDateString,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  Min,
+} from 'class-validator';
 import { IsYYYYMMDD } from '../../../common/decorator/validator/is-yyyy-mm-dd.validator';
 import { IsAfterDate } from '../../../common/decorator/validator/is-after-date.decorator';
 
@@ -18,6 +24,16 @@ export class GetMyReportsDto {
   })
   @IsNumber()
   page: number = 1;
+
+  @ApiProperty({
+    description: '요청 데이터 개수',
+    default: 20,
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  take: number = 20;
 
   @ApiProperty({
     description: '검색 시작일(YYYY-MM-DD)',

--- a/backend/src/home/dto/schedule.dto.ts
+++ b/backend/src/home/dto/schedule.dto.ts
@@ -18,6 +18,7 @@ export class ScheduleDto {
   educationTermId?: number;
   educationId?: number;
   educationName?: string;
+  educationTerm?: number;
 
   constructor(
     id: number,
@@ -33,6 +34,7 @@ export class ScheduleDto {
     educationTermId?: number,
     educationId?: number,
     educationName?: string,
+    educationTerm?: number,
   ) {
     this.id = id;
     this.type = type;
@@ -43,5 +45,6 @@ export class ScheduleDto {
     this.educationTermId = educationTermId;
     this.educationId = educationId;
     this.educationName = educationName;
+    this.educationTerm = educationTerm;
   }
 }

--- a/backend/src/home/service/home.service.ts
+++ b/backend/src/home/service/home.service.ts
@@ -77,6 +77,7 @@ import {
   IREPORT_DOMAIN_SERVICE,
   IReportDomainService,
 } from '../../report/report-domain/interface/report-domain.service.interface';
+import { GetMySchedulesResponseDto } from '../dto/response/get-my-schedules-response.dto';
 
 @Injectable()
 export class HomeService {
@@ -281,7 +282,7 @@ export class HomeService {
 
     schedules.sort((a, b) => a.endDate.getTime() - b.endDate.getTime());
 
-    return schedules;
+    return new GetMySchedulesResponseDto(dto.range, from, to, schedules);
   }
 
   async getMyReports(pm: ChurchUserModel, dto: GetMyReportsDto) {
@@ -297,9 +298,14 @@ export class HomeService {
           ]
         : [defaultRange.from, defaultRange.to];
 
-    console.log(from, to);
+    const reports = await this.reportDomainService.paginateReports(
+      receiver,
+      from,
+      to,
+      dto,
+    );
 
-    return this.reportDomainService.paginateReports(receiver, from, to);
+    return new GetMyScheduleReportsResponseDto(reports);
   }
 
   async getMyScheduleReports(pm: ChurchUserModel, dto: GetMyReportsDto) {

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -31,7 +31,7 @@ async function bootstrap() {
     new XssSanitizerPipe(),
   );
 
-  //app.useGlobalFilters(new TypeOrmExceptionFilter());
+  app.useGlobalFilters(new TypeOrmExceptionFilter());
 
   app.useGlobalGuards(new GetHandlerGuard());
 

--- a/backend/src/report/report-domain/interface/report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/report-domain.service.interface.ts
@@ -1,5 +1,6 @@
 import { MemberModel } from '../../../members/entity/member.entity';
 import { QueryRunner } from 'typeorm';
+import { GetMyReportsDto } from '../../../home/dto/request/get-my-reports.dto';
 
 export const IREPORT_DOMAIN_SERVICE = Symbol('IREPORT_DOMAIN_SERVICE');
 
@@ -8,6 +9,7 @@ export interface IReportDomainService {
     receiver: MemberModel,
     from: Date,
     to: Date,
+    dto: GetMyReportsDto,
     qr?: QueryRunner,
   ): Promise<any[]>;
 }


### PR DESCRIPTION
## 주요 내용
내가 받은 보고 목록 조회 API에 페이징 처리를 추가하고 응답 포맷을 구조화했습니다.

## 세부 내용
### 기능 개선
- 페이징 파라미터 추가 (page, take)
- 대량의 보고 데이터 처리를 위한 페이지네이션 구현

### 응답 포맷 구조화
- 보고 타입별 통합 응답 구조 적용
- 담당자(inCharge) 정보 포함 (프로필, 소속 그룹, 직책 등)
- 일정(schedule) 정보 포함
 - Task: id, type, title, startDate, endDate, status
 - Visitation: id, type, title, startDate, endDate, status
 - EducationSession: id, type, title, startDate, endDate, status
 - EducationTerm: id, type, startDate, endDate, status, educationName, educationTerm
- timestamp 필드 추가로 응답 시점 명시

### 변경 사항
- ReportDomainService: 페이징 로직 추가
- ReportController: page, take 파라미터 처리
- 응답 DTO 구조 정규화 및 타입별 필드 매핑