### PR TITLE
feat: Task 날짜/시간 입력 형식 변경 및 KST 기준 처리

### DIFF
--- a/backend/src/task/dto/request/create-task.dto.ts
+++ b/backend/src/task/dto/request/create-task.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty, PickType } from '@nestjs/swagger';
 import { TaskModel } from '../../entity/task.entity';
 import {
   IsArray,
-  IsDate,
+  IsDateString,
   IsEnum,
   IsNotEmpty,
   IsNumber,
@@ -17,14 +17,13 @@ import { SanitizeDto } from '../../../common/decorator/sanitize-target.decorator
 import { TaskStatus } from '../../const/task-status.enum';
 import { IsAfterDate } from '../../../common/decorator/validator/is-after-date.decorator';
 import { Transform } from 'class-transformer';
+import { IsDateTime } from '../../../common/decorator/validator/is-date-time.validator';
 
 @SanitizeDto()
 export class CreateTaskDto extends PickType(TaskModel, [
   'parentTaskId',
   'title',
   'status',
-  'startDate',
-  'endDate',
   'content',
   'inChargeId',
 ]) {
@@ -57,17 +56,23 @@ export class CreateTaskDto extends PickType(TaskModel, [
   override status: TaskStatus = TaskStatus.RESERVE;
 
   @ApiProperty({
-    description: '업무 시작 일자',
+    description: '업무 시작 일자 (yyyy-MM-ddTHH:MM:SS)',
   })
-  @IsDate()
-  override startDate: Date;
+  @IsDateString({ strict: true })
+  @IsDateTime('startDate')
+  startDate: string;
+
+  utcStartDate: Date;
 
   @ApiProperty({
-    description: '업무 종료 일자',
+    description: '업무 종료 일자 (yyyy-MM-ddTHH:MM:SS)',
   })
-  @IsDate()
-  @IsAfterDate('taskStartDate')
-  override endDate: Date;
+  @IsDateString({ strict: true })
+  @IsDateTime('endDate')
+  @IsAfterDate('startDate')
+  endDate: string;
+
+  utcEndDate: Date;
 
   @ApiProperty({
     description: '업무 내용',

--- a/backend/src/task/dto/request/update-task.dto.ts
+++ b/backend/src/task/dto/request/update-task.dto.ts
@@ -1,4 +1,6 @@
-import { PartialType } from '@nestjs/swagger';
+import { OmitType, PartialType } from '@nestjs/swagger';
 import { CreateTaskDto } from './create-task.dto';
 
-export class UpdateTaskDto extends PartialType(CreateTaskDto) {}
+export class UpdateTaskDto extends PartialType(
+  OmitType(CreateTaskDto, ['receiverIds']),
+) {}

--- a/backend/src/task/service/task.service.ts
+++ b/backend/src/task/service/task.service.ts
@@ -33,6 +33,8 @@ import {
 import { GetSubTaskResponseDto } from '../dto/response/get-sub-task-response.dto';
 import { TaskModel } from '../entity/task.entity';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { fromZonedTime } from 'date-fns-tz';
+import { TIME_ZONE } from '../../common/const/time-zone.const';
 
 @Injectable()
 export class TaskService {
@@ -88,7 +90,6 @@ export class TaskService {
 
   async postTask(
     churchId: number,
-    //creatorUserId: number,
     creatorManager: ChurchUserModel,
     dto: CreateTaskDto,
     qr: QueryRunner,
@@ -97,12 +98,6 @@ export class TaskService {
       churchId,
       qr,
     );
-
-    /*const creator = await this.managerDomainService.findManagerByUserId(
-      church,
-      creatorUserId,
-      qr,
-    );*/
 
     const inCharge = dto.inChargeId
       ? await this.managerDomainService.findManagerByMemberId(
@@ -121,9 +116,11 @@ export class TaskService {
         )
       : null;
 
+    dto.utcStartDate = fromZonedTime(dto.startDate, TIME_ZONE.SEOUL);
+    dto.utcEndDate = fromZonedTime(dto.endDate, TIME_ZONE.SEOUL);
+
     const newTask = await this.taskDomainService.createTask(
       church,
-      //creator,
       creatorManager,
       parentTask,
       inCharge,
@@ -182,6 +179,13 @@ export class TaskService {
           qr,
         )
       : null;
+
+    dto.utcStartDate = dto.startDate
+      ? fromZonedTime(dto.startDate, TIME_ZONE.SEOUL)
+      : undefined;
+    dto.utcEndDate = dto.endDate
+      ? fromZonedTime(dto.endDate, TIME_ZONE.SEOUL)
+      : undefined;
 
     await this.taskDomainService.updateTask(
       targetTask,

--- a/backend/src/task/task-domain/service/task-domain.service.ts
+++ b/backend/src/task/task-domain/service/task-domain.service.ts
@@ -322,22 +322,22 @@ export class TaskDomainService implements ITaskDomainService {
       taskType: parentTask ? TaskType.subTask : TaskType.parent,
       title: dto.title,
       status: dto.status,
-      startDate: dto.startDate,
-      endDate: dto.endDate,
+      startDate: dto.utcStartDate, //dto.startDate,
+      endDate: dto.utcEndDate, //dto.endDate,
       content: dto.content,
     });
   }
 
   private assertValidTaskDate(targetTask: TaskModel, dto: UpdateTaskDto) {
     // 시작 날짜 변경 시
-    if (dto.startDate && !dto.endDate) {
-      if (dto.startDate > targetTask.endDate) {
+    if (dto.utcStartDate && !dto.utcEndDate) {
+      if (dto.utcStartDate > targetTask.endDate) {
         throw new ConflictException(TaskException.INVALID_START_DATE);
       }
     }
     // 종료 날짜 변경 시
-    else if (!dto.startDate && dto.endDate) {
-      if (targetTask.startDate > dto.endDate) {
+    else if (!dto.utcStartDate && dto.utcEndDate) {
+      if (targetTask.startDate > dto.utcEndDate) {
         throw new ConflictException(TaskException.INVALID_END_DATE);
       }
     } else {
@@ -384,8 +384,8 @@ export class TaskDomainService implements ITaskDomainService {
         parentTaskId: newParentTask ? newParentTask.id : undefined,
         title: dto.title,
         status: dto.status,
-        startDate: dto.startDate,
-        endDate: dto.endDate,
+        startDate: dto.utcStartDate,
+        endDate: dto.utcEndDate,
         content: dto.content,
       },
     );


### PR DESCRIPTION
## 주요 내용
Task 생성/수정 시 날짜 입력 형식을 변경하고 한국 시간 기준으로 처리하도록 개선했습니다.

## 세부 내용
### 변경 사항
- 입력 형식: yyyy-MM-ddTHH:mm:ss (KST 기준)
- 서버 처리: KST → UTC 변환 후 DB 저장
- 응답: UTC 시간 그대로 반환
- 적용 필드: startDate, endDate

### 구현 내용
- CreateTaskDto: 날짜 입력 형식 검증 추가
- UpdateTaskDto: 날짜 입력 형식 검증 추가
- TaskService: KST → UTC 변환 로직 구현