### PR TITLE
feat: 교인 날짜 처리 및 차량번호 입력 방식 개선

### DIFF
--- a/backend/src/dummy-data.service.ts
+++ b/backend/src/dummy-data.service.ts
@@ -57,11 +57,11 @@ export class DummyDataService {
 
       return this.dummyMembersDomainService.createDummyMemberModel({
         churchId: church.id,
-        registeredAt,
+        utcRegisteredAt: registeredAt,
         name,
         mobilePhone,
         isLunar,
-        birth,
+        utcBirth: birth,
         gender,
         address,
         detailAddress,

--- a/backend/src/educations/education-session/controller/education-sessions.controller.ts
+++ b/backend/src/educations/education-session/controller/education-sessions.controller.ts
@@ -28,7 +28,7 @@ import {
 import { EducationReadGuard } from '../../guard/education-read.guard';
 import { EducationWriteGuard } from '../../guard/education-write.guard';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
-import { PermissionManager } from '../../../permission/decorator/permission-manager.decorator';
+import { RequestManager } from '../../../permission/decorator/permission-manager.decorator';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 import { AddEducationSessionReportDto } from '../../../report/education-report/dto/session/request/add-education-session-report.dto';
@@ -64,7 +64,7 @@ export class EducationSessionsController {
   //@UseGuards(AccessTokenGuard, ChurchManagerGuard)
   @UseInterceptors(TransactionInterceptor)
   postEducationSession(
-    @PermissionManager() manager: ChurchUserModel,
+    @RequestManager() manager: ChurchUserModel,
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('educationId', ParseIntPipe) educationId: number,
     @Param('educationTermId', ParseIntPipe) educationTermId: number,

--- a/backend/src/educations/education-term/controller/education-terms.controller.ts
+++ b/backend/src/educations/education-term/controller/education-terms.controller.ts
@@ -27,7 +27,7 @@ import {
 import { EducationReadGuard } from '../../guard/education-read.guard';
 import { EducationWriteGuard } from '../../guard/education-write.guard';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
-import { PermissionManager } from '../../../permission/decorator/permission-manager.decorator';
+import { RequestManager } from '../../../permission/decorator/permission-manager.decorator';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 import { PermissionChurch } from '../../../permission/decorator/permission-church.decorator';
@@ -61,7 +61,7 @@ export class EducationTermsController {
   @Post()
   @UseInterceptors(TransactionInterceptor)
   postEducationTerms(
-    @PermissionManager() manager: ChurchUserModel,
+    @RequestManager() manager: ChurchUserModel,
     @PermissionChurch() church: ChurchModel,
     @Param('churchId', ParseIntPipe)
     churchId: number,

--- a/backend/src/educations/education/controller/educations.controller.ts
+++ b/backend/src/educations/education/controller/educations.controller.ts
@@ -30,7 +30,7 @@ import { GetInProgressEducationTermDto } from '../../education-term/dto/request/
 import { EducationReadGuard } from '../../guard/education-read.guard';
 import { EducationWriteGuard } from '../../guard/education-write.guard';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
-import { PermissionManager } from '../../../permission/decorator/permission-manager.decorator';
+import { RequestManager } from '../../../permission/decorator/permission-manager.decorator';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 import { PermissionChurch } from '../../../permission/decorator/permission-church.decorator';
@@ -59,7 +59,7 @@ export class EducationsController {
   @EducationWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   postEducation(
-    @PermissionManager() pm: ChurchUserModel,
+    @RequestManager() pm: ChurchUserModel,
     @Param('churchId', ParseIntPipe) churchId: number,
     @Body() dto: CreateEducationDto,
     @QueryRunner() qr: QR,

--- a/backend/src/home/controller/home.controller.ts
+++ b/backend/src/home/controller/home.controller.ts
@@ -19,7 +19,7 @@ import {
   ApiGetNewMemberDetail,
   ApiGetNewMemberSummary,
 } from '../swagger/home.swagger';
-import { PermissionManager } from '../../permission/decorator/permission-manager.decorator';
+import { RequestManager } from '../../permission/decorator/permission-manager.decorator';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { GetMyInChargedSchedulesDto } from '../dto/request/get-my-in-charged-schedules.dto';
 import { GetMyReportsDto } from '../dto/request/get-my-reports.dto';
@@ -54,7 +54,7 @@ export class HomeController {
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   getMyInChargedSchedules(
     @Query() dto: GetMyInChargedSchedulesDto,
-    @PermissionManager() pm: ChurchUserModel,
+    @RequestManager() pm: ChurchUserModel,
   ) {
     if ((dto.from && !dto.to) || (!dto.from && dto.to)) {
       throw new BadRequestException('from, to 에러');
@@ -67,7 +67,7 @@ export class HomeController {
   @Get('reports')
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   getMyScheduleReports(
-    @PermissionManager() pm: ChurchUserModel,
+    @RequestManager() pm: ChurchUserModel,
     @Query() dto: GetMyReportsDto,
   ) {
     if ((dto.from && !dto.to) || (!dto.from && dto.to)) {
@@ -83,7 +83,7 @@ export class HomeController {
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   getLowWorshipAttendanceMembers(
     @PermissionChurch() church: ChurchModel,
-    @PermissionManager() pm: ChurchUserModel,
+    @RequestManager() pm: ChurchUserModel,
     @Query() dto: GetLowWorshipAttendanceMembersDto,
   ) {
     return this.homeService.getLowWorshipAttendanceMembers(church, pm, dto);

--- a/backend/src/members/controller/members.controller.ts
+++ b/backend/src/members/controller/members.controller.ts
@@ -22,7 +22,7 @@ import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { GetSimpleMembersDto } from '../dto/request/get-simple-members.dto';
 import { MemberReadGuard } from '../guard/member-read.guard';
 import { MemberWriteGuard } from '../guard/member-write.guard';
-import { PermissionManager } from '../../permission/decorator/permission-manager.decorator';
+import { RequestManager } from '../../permission/decorator/permission-manager.decorator';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { TargetMember } from '../decorator/target-member.decorator';
 import { MemberModel } from '../entity/member.entity';
@@ -41,7 +41,7 @@ export class MembersController {
   getMembers(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Query() dto: GetMemberDto,
-    @PermissionManager() pm: ChurchUserModel,
+    @RequestManager() pm: ChurchUserModel,
   ) {
     return this.membersService.getMembers(churchId, pm, dto);
   }
@@ -71,7 +71,7 @@ export class MembersController {
   getMemberById(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
-    @PermissionManager() pm: ChurchUserModel,
+    @RequestManager() pm: ChurchUserModel,
   ) {
     return this.membersService.getMemberById(churchId, memberId, pm);
   }

--- a/backend/src/members/dto/request/create-member.dto.ts
+++ b/backend/src/members/dto/request/create-member.dto.ts
@@ -1,9 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
   ArrayMaxSize,
+  ArrayUnique,
   IsArray,
   IsBoolean,
-  IsDate,
+  IsDateString,
   IsEnum,
   IsIn,
   IsNotEmpty,
@@ -24,16 +25,23 @@ import { MarriageOptions } from '../../member-domain/const/marriage-options.cons
 import { RemoveSpaces } from '../../../common/decorator/transformer/remove-spaces';
 import { IsNoSpecialChar } from '../../../common/decorator/validator/is-no-special-char.validator';
 import { IsOptionalNotNull } from '../../../common/decorator/validator/is-optional-not.null.validator';
+import { IsYYYYMMDD } from '../../../common/decorator/validator/is-yyyy-mm-dd.validator';
+import { getHistoryStartDate } from '../../../member-history/history-date.utils';
+import { TIME_ZONE } from '../../../common/const/time-zone.const';
+import { Transform } from 'class-transformer';
 
 export class CreateMemberDto {
   @ApiProperty({
     name: 'registeredAt',
-    description: '교회 등록일자',
-    default: new Date(),
+    description: '교회 등록일자 (YYYY-MM-DD)',
+    default: new Date().toISOString().slice(0, 10),
   })
-  @IsDate()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('registeredAt')
   @IsOptional()
-  registeredAt?: Date;
+  registeredAt?: string;
+
+  utcRegisteredAt?: Date;
 
   @ApiProperty({
     description: '프로필 이미지 url',
@@ -119,13 +127,16 @@ export class CreateMemberDto {
 
   @ApiProperty({
     name: 'birth',
-    description: '생년월일',
+    description: '생년월일 (YYYY-MM-DD)',
     example: '2000-01-01',
     required: false,
   })
-  @IsDate()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('birth')
   @IsOptional()
-  birth?: Date;
+  birth?: string;
+
+  utcBirth?: Date;
 
   @ApiProperty({
     name: 'gender',
@@ -218,17 +229,19 @@ export class CreateMemberDto {
 
   @ApiProperty({
     name: 'vehicleNumber',
-    description: '차량번호 4자리',
-    example: ['1234', '5432'],
+    description: '차량번호',
+    example: ['1234', '141부5432'],
     type: 'array',
     required: false,
   })
+  @Transform(({ value }) => value.map((item) => item.replace(' ', '')))
   @IsArray()
+  @ArrayUnique()
   @ArrayMaxSize(3)
   @IsString({ each: true })
-  @Length(4, 4, { each: true })
+  @Length(4, 10, { each: true })
   @IsNotEmpty({ each: true })
-  @IsValidVehicleNumber()
+  //@IsValidVehicleNumber()
   @IsOptional()
   vehicleNumber?: string[];
 

--- a/backend/src/members/member-domain/service/dummy-members-domain.service.ts
+++ b/backend/src/members/member-domain/service/dummy-members-domain.service.ts
@@ -23,7 +23,9 @@ export class DummyMembersDomainService implements IDummyMembersDomainService {
 
     return membersRepository.create({
       ...dto,
-      birthdayMMDD: dto.birth?.toISOString().slice(5, 10),
+      birth: dto.utcBirth,
+      registeredAt: dto.utcRegisteredAt,
+      birthdayMMDD: dto.utcBirth?.toISOString().slice(5, 10),
     });
   }
 

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -30,8 +30,6 @@ import {
 import { MemberException } from '../../exception/member.exception';
 import { CreateMemberDto } from '../../dto/request/create-member.dto';
 import { UpdateMemberDto } from '../../dto/request/update-member.dto';
-import { OfficerModel } from '../../../management/officers/entity/officer.entity';
-import { GroupModel } from '../../../management/groups/entity/group.entity';
 import { MembersDomainPaginationResultDto } from '../dto/members-domain-pagination-result.dto';
 import { GetSimpleMembersDto } from '../../dto/request/get-simple-members.dto';
 import {
@@ -435,8 +433,10 @@ export class MembersDomainService implements IMembersDomainService {
 
     return membersRepository.save({
       ...dto,
-      birthdayMMDD: dto.birth
-        ? dto.birth.toISOString().slice(5, 10)
+      registeredAt: dto.utcRegisteredAt,
+      birth: dto.utcBirth,
+      birthdayMMDD: dto.utcBirth
+        ? dto.utcBirth.toISOString().slice(5, 10)
         : undefined,
       churchId: church.id,
     });
@@ -471,8 +471,10 @@ export class MembersDomainService implements IMembersDomainService {
       },
       {
         ...dto,
-        birthdayMMDD: dto.birth
-          ? dto.birth.toISOString().slice(5, 10)
+        registeredAt: dto.utcRegisteredAt,
+        birth: dto.utcBirth,
+        birthdayMMDD: dto.utcBirth
+          ? dto.utcBirth.toISOString().slice(5, 10)
           : undefined,
       },
     );
@@ -503,71 +505,6 @@ export class MembersDomainService implements IMembersDomainService {
 
     return result;
   }
-
-  /*async startMemberOfficer(
-    member: MemberModel,
-    officer: OfficerModel,
-    officerStartDate: Date,
-    officerStartChurch: string,
-    qr: QueryRunner,
-  ) {
-    const membersRepository = this.getMembersRepository(qr);
-
-    return membersRepository.update(
-      { id: member.id },
-      {
-        officerId: officer.id,
-        officerStartDate,
-        officerStartChurch,
-      },
-    );
-  }*/
-
-  /*async endMemberOfficer(member: MemberModel, qr: QueryRunner) {
-    const membersRepository = this.getMembersRepository(qr);
-
-    return membersRepository.update(
-      { id: member.id },
-      {
-        officerId: null,
-        officerStartDate: null,
-        officerStartChurch: null,
-      },
-    );
-  }*/
-
-  /*async startMemberGroup(
-    member: MemberModel,
-    group: GroupModel,
-    groupRole: GroupRole,
-    qr: QueryRunner,
-  ) {
-    const membersRepository = this.getMembersRepository(qr);
-
-    return membersRepository.update(
-      {
-        id: member.id,
-      },
-      {
-        group,
-        groupRole,
-      },
-    );
-  }*/
-
-  /*async endMemberGroup(member: MemberModel, qr: QueryRunner) {
-    const membersRepository = this.getMembersRepository(qr);
-
-    return membersRepository.update(
-      {
-        id: member.id,
-      },
-      {
-        groupId: null,
-        groupRole: GroupRole.NONE,
-      },
-    );
-  }*/
 
   async updateGroupRole(
     member: MemberModel,

--- a/backend/src/members/service/members.service.ts
+++ b/backend/src/members/service/members.service.ts
@@ -43,6 +43,9 @@ import {
   IWORSHIP_ENROLLMENT_DOMAIN_SERVICE,
   IWorshipEnrollmentDomainService,
 } from '../../worship/worship-domain/interface/worship-enrollment-domain.service.interface';
+import { fromZonedTime } from 'date-fns-tz';
+import { TIME_ZONE } from '../../common/const/time-zone.const';
+import { getHistoryStartDate } from '../../member-history/history-date.utils';
 
 @Injectable()
 export class MembersService {
@@ -148,6 +151,14 @@ export class MembersService {
     await this.churchesDomainService.incrementMemberCount(church, qr);
     church.memberCount++;
 
+    dto.utcRegisteredAt = dto.registeredAt
+      ? fromZonedTime(dto.registeredAt, TIME_ZONE.SEOUL)
+      : getHistoryStartDate(TIME_ZONE.SEOUL);
+
+    dto.utcBirth = dto.birth
+      ? fromZonedTime(dto.birth, TIME_ZONE.SEOUL)
+      : undefined;
+
     const newMember = await this.membersDomainService.createMember(
       church,
       dto,
@@ -185,22 +196,18 @@ export class MembersService {
   }
 
   async updateMember(
-    //churchId: number,
-    //memberId: number,
     church: ChurchModel,
     targetMember: MemberModel,
     dto: UpdateMemberDto,
     qr?: QueryRunner,
   ) {
-    /*const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-    const targetMember = await this.membersDomainService.findMemberModelById(
-      church,
-      memberId,
-      qr,
-    );*/
+    dto.utcRegisteredAt = dto.registeredAt
+      ? fromZonedTime(dto.registeredAt, TIME_ZONE.SEOUL)
+      : undefined;
+
+    dto.utcBirth = dto.birth
+      ? fromZonedTime(dto.birth, TIME_ZONE.SEOUL)
+      : undefined;
 
     const updatedMember = await this.membersDomainService.updateMember(
       church,
@@ -215,9 +222,7 @@ export class MembersService {
   // 교인 soft delete
   // 교육 등록도 soft delete
   async softDeleteMember(
-    //churchId: number,
     church: ChurchModel,
-    //memberId: number,
     targetMember: MemberModel,
     qr: QueryRunner,
   ): Promise<DeleteMemberResponseDto> {

--- a/backend/src/members/service/search-members-v2.service.ts
+++ b/backend/src/members/service/search-members-v2.service.ts
@@ -1,0 +1,3 @@
+import { ISearchMembersService } from './interface/search-members.service.interface';
+
+export class SearchMemberServiceV2 {}

--- a/backend/src/permission/decorator/permission-manager.decorator.ts
+++ b/backend/src/permission/decorator/permission-manager.decorator.ts
@@ -4,7 +4,7 @@ import {
   InternalServerErrorException,
 } from '@nestjs/common';
 
-export const PermissionManager = createParamDecorator(
+export const RequestManager = createParamDecorator(
   (_, ctx: ExecutionContext) => {
     const req = ctx.switchToHttp().getRequest();
 

--- a/backend/src/task/controller/task.controller.ts
+++ b/backend/src/task/controller/task.controller.ts
@@ -33,7 +33,7 @@ import { AddTaskReportReceiverDto } from '../../report/task-report/dto/request/a
 import { DeleteTaskReportReceiverDto } from '../../report/task-report/dto/request/delete-task-report-receiver.dto';
 import { TaskReadGuard } from '../guard/task-read.guard';
 import { TaskWriteGuard } from '../guard/task-write.guard';
-import { PermissionManager } from '../../permission/decorator/permission-manager.decorator';
+import { RequestManager } from '../../permission/decorator/permission-manager.decorator';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../churches/entity/church.entity';
@@ -58,7 +58,7 @@ export class TaskController {
   @Post()
   @UseInterceptors(TransactionInterceptor)
   postTask(
-    @PermissionManager() manager: ChurchUserModel,
+    @RequestManager() manager: ChurchUserModel,
     @Param('churchId', ParseIntPipe) churchId: number,
     @Body() dto: CreateTaskDto,
     @QueryRunner() qr: QR,

--- a/backend/src/visitation/controller/visitation.controller.ts
+++ b/backend/src/visitation/controller/visitation.controller.ts
@@ -30,7 +30,7 @@ import { AddReceiverDto } from '../dto/receiever/add-receiver.dto';
 import { DeleteReceiverDto } from '../dto/receiever/delete-receiver.dto';
 import { VisitationReadGuard } from '../guard/visitation-read.guard';
 import { VisitationWriteGuard } from '../guard/visitation-write.guard';
-import { PermissionManager } from '../../permission/decorator/permission-manager.decorator';
+import { RequestManager } from '../../permission/decorator/permission-manager.decorator';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../churches/entity/church.entity';
@@ -55,7 +55,7 @@ export class VisitationController {
   @Post()
   @UseInterceptors(TransactionInterceptor)
   postVisitationReservation(
-    @PermissionManager() manager: ChurchUserModel,
+    @RequestManager() manager: ChurchUserModel,
     @Param('churchId', ParseIntPipe) churchId: number,
     @Body() dto: CreateVisitationDto,
     @QueryRunner() qr: QR,


### PR DESCRIPTION
## 주요 내용
교인 관련 데이터 처리 방식을 개선하여 날짜 형식 표준화 및 차량번호 입력 유연성을 향상시켰습니다.

## 세부 내용

### 날짜 처리 개선
- registeredAt, birth 필드를 yyyy-MM-dd 형식으로 받도록 변경
- 입력받은 KST 시간을 UTC로 변환하여 DB 저장
- API 응답 시 UTC 형식으로 일관되게 응답
- 시간대 처리로 인한 날짜 불일치 문제 해결

### 차량번호 입력 개선
- 기존 4자리 제한에서 전체 차량번호 입력 가능하도록 확장 (예: 123가5432)
- 입력 시 공백 자동 제거 처리 추가
- 다양한 차량번호 형식 지원으로 사용자 편의성 향상

### 영향 범위
- MemberModel 엔티티 수정
- MemberDomainService 날짜 변환 로직 추가
- CreateMemberDto, UpdateMemberDto validation 규칙 수정