### PR TITLE
feat: 교인 목록 조회 API 커서 기반 페이지네이션 구현

### DIFF
--- a/backend/src/dummy-data.service.ts
+++ b/backend/src/dummy-data.service.ts
@@ -13,9 +13,9 @@ import {
   incheonRoads,
   occupations,
 } from './const/dummy-data/dummy-member.const';
-import { GenderEnum } from './members/const/enum/gender.enum';
-import { MarriageOptions } from './members/member-domain/const/marriage-options.const';
-import { BaptismEnum } from './members/const/enum/baptism.enum';
+import { Gender } from './members/const/enum/gender.enum';
+import { Marriage } from './members/const/enum/marriage.enum';
+import { Baptism } from './members/const/enum/baptism.enum';
 import {
   IDUMMY_MEMBERS_DOMAIN_SERVICE,
   IDummyMembersDomainService,
@@ -123,7 +123,7 @@ export class DummyDataService {
   private getRandomGender() {
     const num = Math.random();
 
-    return num > 0.5 ? GenderEnum.male : GenderEnum.female;
+    return num > 0.5 ? Gender.MALE : Gender.FEMALE;
   }
 
   private generateRandomAddress(): string {
@@ -161,19 +161,17 @@ export class DummyDataService {
   }
 
   private generateRandomMarriage() {
-    return Math.random() > 0.6
-      ? MarriageOptions.Married
-      : MarriageOptions.Single;
+    return Math.random() > 0.6 ? Marriage.MARRIED : Marriage.SINGLE;
   }
 
   private generateRandomBaptism() {
     const baptisms = [
-      BaptismEnum.baptized,
-      BaptismEnum.immersionBaptism,
-      BaptismEnum.infantBaptism,
-      BaptismEnum.confirmation,
-      BaptismEnum.catechumenate,
-      BaptismEnum.default,
+      Baptism.BAPTIZED,
+      Baptism.IMMERSION_BAPTISM,
+      Baptism.INFANT_BAPTISM,
+      Baptism.CONFIRMATION,
+      Baptism.CATECHUMENATE,
+      Baptism.NONE,
     ];
 
     return baptisms[Math.floor(Math.random() * baptisms.length)];

--- a/backend/src/family-relation/family-relation-domain/service/family-relation-domain.service.ts
+++ b/backend/src/family-relation/family-relation-domain/service/family-relation-domain.service.ts
@@ -10,7 +10,7 @@ import {
 } from '@nestjs/common';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { FamilyRelationException } from '../../const/exception/family-relation.exception';
-import { GenderEnum } from '../../../members/const/enum/gender.enum';
+import { Gender } from '../../../members/const/enum/gender.enum';
 import {
   GenderBasedRelations,
   NeutralRelations,
@@ -203,7 +203,7 @@ export class FamilyRelationDomainService
     }
 
     if (GenderBasedRelations[relation]) {
-      return me.gender === GenderEnum.male
+      return me.gender === Gender.MALE
         ? GenderBasedRelations[relation][0]
         : GenderBasedRelations[relation][1];
     }

--- a/backend/src/members/const/enum/baptism.enum.ts
+++ b/backend/src/members/const/enum/baptism.enum.ts
@@ -1,8 +1,8 @@
-export enum BaptismEnum {
-  baptized = 'baptized', // 세례
-  immersionBaptism = 'immersionBaptism', // 침례
-  infantBaptism = 'infantBaptism', // 유아세례
-  confirmation = 'confirmation', // 입교
-  catechumenate = 'catechumenate', // 학습
-  default = 'none', // 없음
+export enum Baptism {
+  BAPTIZED = 'baptized', // 세례
+  IMMERSION_BAPTISM = 'immersionBaptism', // 침례
+  INFANT_BAPTISM = 'infantBaptism', // 유아세례
+  CONFIRMATION = 'confirmation', // 입교
+  CATECHUMENATE = 'catechumenate', // 학습
+  NONE = 'none', // 없음
 }

--- a/backend/src/members/const/enum/gender.enum.ts
+++ b/backend/src/members/const/enum/gender.enum.ts
@@ -1,4 +1,4 @@
-export enum GenderEnum {
-  male = 'male',
-  female = 'female',
+export enum Gender {
+  MALE = 'male',
+  FEMALE = 'female',
 }

--- a/backend/src/members/const/enum/list/display-column.enum.ts
+++ b/backend/src/members/const/enum/list/display-column.enum.ts
@@ -1,0 +1,15 @@
+export enum DisplayColumn {
+  OFFICER = 'officer',
+  GROUP = 'group',
+  BIRTH = 'birth', // 클라이언트에서 나이 계산용
+  MOBILE_PHONE = 'mobilePhone',
+  ADDRESS = 'address',
+  VEHICLE_NUMBER = 'vehicleNumber',
+  SCHOOL = 'school',
+  MARRIAGE = 'marriage',
+  OCCUPATION = 'occupation',
+  BAPTISM = 'baptism',
+  GENDER = 'gender',
+  REGISTERED_AT = 'registeredAt',
+  UPDATED_AT = 'updatedAt',
+}

--- a/backend/src/members/const/enum/list/sort-column.enum.ts
+++ b/backend/src/members/const/enum/list/sort-column.enum.ts
@@ -1,0 +1,16 @@
+export enum SortColumn {
+  NAME = 'name',
+  OFFICER = 'officer',
+  GROUP = 'group',
+  BIRTH = 'birth', // 생년월일
+  MOBILE_PHONE = 'mobilePhone',
+  HOME_PHONE = 'homePhone',
+  ADDRESS = 'address',
+  SCHOOL = 'school',
+  MARRIAGE = 'marriage',
+  OCCUPATION = 'occupation',
+  BAPTISM = 'baptism',
+  GENDER = 'gender',
+  REGISTERED_AT = 'registeredAt',
+  UPDATED_AT = 'updatedAt',
+}

--- a/backend/src/members/const/enum/marriage.enum.ts
+++ b/backend/src/members/const/enum/marriage.enum.ts
@@ -1,0 +1,4 @@
+export enum Marriage {
+  MARRIED = 'married',
+  SINGLE = 'single',
+}

--- a/backend/src/members/controller/members.controller.ts
+++ b/backend/src/members/controller/members.controller.ts
@@ -30,6 +30,8 @@ import { PermissionChurch } from '../../permission/decorator/permission-church.d
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../permission/guard/church-manager.guard';
+import { GetMemberListDto } from '../dto/list/get-member-list.dto';
+import { DisplayColumn } from '../const/enum/list/display-column.enum';
 
 @ApiTags('Churches:Members')
 @Controller('members')
@@ -55,6 +57,27 @@ export class MembersController {
     @QueryRunner() qr: QR,
   ) {
     return this.membersService.createMember(churchId, dto, qr);
+  }
+
+  @Get('v2')
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
+  getMemberList(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @PermissionChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
+    @Query() query: GetMemberListDto,
+  ) {
+    if (query.displayColumns.length === 0) {
+      query.displayColumns = [
+        DisplayColumn.OFFICER,
+        DisplayColumn.BIRTH,
+        DisplayColumn.GROUP,
+        DisplayColumn.MOBILE_PHONE,
+        DisplayColumn.ADDRESS,
+      ];
+    }
+
+    return this.membersService.getMemberList(church, requestManager, query);
   }
 
   @Get('simple')

--- a/backend/src/members/dto/list/get-member-list.dto.ts
+++ b/backend/src/members/dto/list/get-member-list.dto.ts
@@ -1,0 +1,54 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayUnique,
+  IsArray,
+  IsEnum,
+  IsIn,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+import { SortColumn } from '../../const/enum/list/sort-column.enum';
+import { DisplayColumn } from '../../const/enum/list/display-column.enum';
+import { Transform } from 'class-transformer';
+
+export class GetMemberListDto {
+  @ApiPropertyOptional({ description: '페이지 크기', default: 20 })
+  @IsOptional()
+  @IsNumber()
+  limit: number = 20;
+
+  @ApiPropertyOptional({ description: '커서 (마지막 항목의 ID)' })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @ApiPropertyOptional({
+    enum: SortColumn,
+    description: '정렬 기준 컬럼',
+    default: SortColumn.REGISTERED_AT,
+  })
+  @IsOptional()
+  @IsEnum(SortColumn)
+  sortBy: SortColumn = SortColumn.REGISTERED_AT;
+
+  @ApiPropertyOptional({ description: '정렬 방향', default: 'ASC' })
+  @IsOptional()
+  @IsIn(['ASC', 'DESC'])
+  sortDirection: 'ASC' | 'DESC' = 'ASC';
+
+  @ApiPropertyOptional({
+    enum: DisplayColumn,
+    isArray: true,
+    description: '표시할 컬럼 목록 (사진, 이름은 항상 포함)',
+  })
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (!value) return [];
+    return Array.isArray(value) ? value : [value];
+  })
+  @IsArray()
+  @ArrayUnique()
+  @IsEnum(DisplayColumn, { each: true })
+  displayColumns: DisplayColumn[] = [];
+}

--- a/backend/src/members/dto/list/member-list-item.dto.ts
+++ b/backend/src/members/dto/list/member-list-item.dto.ts
@@ -1,0 +1,33 @@
+// 조회한 교인 개별 데이터
+import { Marriage } from '../../const/enum/marriage.enum';
+import { Gender } from '../../const/enum/gender.enum';
+
+export class MemberListItemDto {
+  id: number;
+  name: string;
+  profileImage?: string;
+
+  // Optional fields based on displayColumns
+  officer?: {
+    id: number;
+    name: string;
+  };
+  group?: {
+    id: number;
+    name: string;
+  };
+  birth?: Date;
+  isLunar?: boolean;
+  isLeafMonth?: boolean;
+  mobilePhone?: string;
+  homePhone?: string;
+  address?: string;
+  school?: string;
+  marriage?: Marriage; // 'married' | 'single'
+  occupation?: string;
+  baptism?: string;
+  gender?: Gender; // 'male' | 'female'
+  vehicleNumber?: string[];
+  updatedAt?: Date;
+  registeredAt?: Date;
+}

--- a/backend/src/members/dto/list/member-list-response.dto.ts
+++ b/backend/src/members/dto/list/member-list-response.dto.ts
@@ -1,0 +1,7 @@
+import { MemberListItemDto } from './member-list-item.dto';
+
+export class MemberListResponseDto {
+  data: MemberListItemDto[];
+  nextCursor?: string;
+  hasMore: boolean;
+}

--- a/backend/src/members/dto/request/create-member.dto.ts
+++ b/backend/src/members/dto/request/create-member.dto.ts
@@ -17,11 +17,11 @@ import {
   MaxLength,
   ValidateIf,
 } from 'class-validator';
-import { GenderEnum } from '../../const/enum/gender.enum';
+import { Gender } from '../../const/enum/gender.enum';
 import { IsValidVehicleNumber } from '../../decorator/is-valid-vehicle-number.decorator';
-import { BaptismEnum } from '../../const/enum/baptism.enum';
+import { Baptism } from '../../const/enum/baptism.enum';
 import { FamilyRelationConst } from '../../../family-relation/family-relation-domain/const/family-relation.const';
-import { MarriageOptions } from '../../member-domain/const/marriage-options.const';
+import { Marriage } from '../../const/enum/marriage.enum';
 import { RemoveSpaces } from '../../../common/decorator/transformer/remove-spaces';
 import { IsNoSpecialChar } from '../../../common/decorator/validator/is-no-special-char.validator';
 import { IsOptionalNotNull } from '../../../common/decorator/validator/is-optional-not.null.validator';
@@ -141,13 +141,13 @@ export class CreateMemberDto {
   @ApiProperty({
     name: 'gender',
     description: '성별',
-    enum: GenderEnum,
-    example: GenderEnum.male,
+    enum: Gender,
+    example: Gender.MALE,
     required: false,
   })
-  @IsEnum(GenderEnum)
+  @IsEnum(Gender)
   @IsOptional()
-  gender?: GenderEnum;
+  gender?: Gender;
 
   @ApiProperty({
     name: 'address',
@@ -219,13 +219,13 @@ export class CreateMemberDto {
     name: 'marriage',
     description: '결혼',
     example: '미혼',
-    enum: MarriageOptions,
+    enum: Marriage,
     required: false,
   })
-  @IsEnum(MarriageOptions)
+  @IsEnum(Marriage)
   @IsNotEmpty()
   @IsOptional()
-  marriage?: MarriageOptions;
+  marriage?: Marriage;
 
   @ApiProperty({
     name: 'vehicleNumber',
@@ -248,14 +248,14 @@ export class CreateMemberDto {
   @ApiProperty({
     name: 'baptism',
     description: '신급',
-    enum: BaptismEnum,
-    example: BaptismEnum.baptized,
-    default: BaptismEnum.default,
+    enum: Baptism,
+    example: Baptism.BAPTIZED,
+    default: Baptism.NONE,
     required: false,
   })
-  @IsEnum(BaptismEnum)
+  @IsEnum(Baptism)
   @IsOptional()
-  baptism?: BaptismEnum = BaptismEnum.default;
+  baptism?: Baptism = Baptism.NONE;
 
   @ApiProperty({
     name: 'previousChurch',

--- a/backend/src/members/dto/request/get-member.dto.ts
+++ b/backend/src/members/dto/request/get-member.dto.ts
@@ -11,14 +11,14 @@ import {
   IsString,
   Length,
 } from 'class-validator';
-import { GenderEnum } from '../../const/enum/gender.enum';
-import { BaptismEnum } from '../../const/enum/baptism.enum';
+import { Gender } from '../../const/enum/gender.enum';
+import { Baptism } from '../../const/enum/baptism.enum';
 import { GetMemberOrderEnum } from '../../const/enum/get-member-order.enum';
 import {
   TransformNumberArray,
   TransformStringArray,
 } from '../../../common/decorator/transformer/transform-array';
-import { MarriageOptions } from '../../member-domain/const/marriage-options.const';
+import { Marriage } from '../../const/enum/marriage.enum';
 import { QueryBoolean } from '../../../common/decorator/transformer/query-boolean.decorator';
 import { RemoveSpaces } from '../../../common/decorator/transformer/remove-spaces';
 
@@ -214,14 +214,14 @@ export class GetMemberDto {
 
   @ApiProperty({
     description: '결혼 여부',
-    enum: MarriageOptions,
+    enum: Marriage,
     isArray: true,
     required: false,
   })
   @TransformStringArray()
-  @IsEnum(MarriageOptions, { each: true })
+  @IsEnum(Marriage, { each: true })
   @IsOptional()
-  marriage?: MarriageOptions[];
+  marriage?: Marriage[];
 
   @ApiProperty({
     name: 'birthAfter',
@@ -243,14 +243,14 @@ export class GetMemberDto {
 
   @ApiProperty({
     description: '성별',
-    enum: GenderEnum,
+    enum: Gender,
     isArray: true,
     required: false,
   })
   @TransformStringArray()
-  @IsEnum(GenderEnum, { each: true })
+  @IsEnum(Gender, { each: true })
   @IsOptional()
-  gender?: GenderEnum[];
+  gender?: Gender[];
 
   @ApiProperty({
     name: 'school',
@@ -369,12 +369,12 @@ export class GetMemberDto {
   @ApiProperty({
     name: 'baptism',
     description: '신급',
-    enum: BaptismEnum,
+    enum: Baptism,
     isArray: true,
     required: false,
   })
   @TransformStringArray()
-  @IsEnum(BaptismEnum, { each: true })
+  @IsEnum(Baptism, { each: true })
   @IsOptional()
-  baptism?: BaptismEnum[];
+  baptism?: Baptism[];
 }

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -9,10 +9,10 @@ import {
   OneToMany,
   OneToOne,
 } from 'typeorm';
-import { GenderEnum } from '../const/enum/gender.enum';
-import { BaptismEnum } from '../const/enum/baptism.enum';
+import { Gender } from '../const/enum/gender.enum';
+import { Baptism } from '../const/enum/baptism.enum';
 import { FamilyRelationModel } from '../../family-relation/entity/family-relation.entity';
-import { MarriageOptions } from '../member-domain/const/marriage-options.const';
+import { Marriage } from '../const/enum/marriage.enum';
 import { Exclude } from 'class-transformer';
 import { BaseModel } from '../../common/entity/base.entity';
 import { ChurchModel } from '../../churches/entity/church.entity';
@@ -80,8 +80,8 @@ export class MemberModel extends BaseModel {
   birthdayMMDD: string;
 
   @Index()
-  @Column({ enum: GenderEnum, nullable: true, comment: '성별' })
-  gender: GenderEnum;
+  @Column({ enum: Gender, nullable: true, comment: '성별' })
+  gender: Gender;
 
   @Column({ length: 50, nullable: true, comment: '도로명 주소' })
   address: string;
@@ -109,8 +109,8 @@ export class MemberModel extends BaseModel {
   school: string;
 
   @Index()
-  @Column({ enum: MarriageOptions, nullable: true, comment: '결혼 정보' })
-  marriage: MarriageOptions;
+  @Column({ enum: Marriage, nullable: true, comment: '결혼 정보' })
+  marriage: Marriage;
 
   @Column({ nullable: true, comment: '세부 결혼 정보' })
   marriageDetail: string;
@@ -137,11 +137,11 @@ export class MemberModel extends BaseModel {
 
   @Index()
   @Column({
-    enum: BaptismEnum,
-    default: BaptismEnum.default,
+    enum: Baptism,
+    default: Baptism.NONE,
     comment: '신급',
   })
-  baptism: BaptismEnum;
+  baptism: Baptism;
 
   @ManyToMany(
     () => MinistryGroupModel,

--- a/backend/src/members/member-domain/const/marriage-options.const.ts
+++ b/backend/src/members/member-domain/const/marriage-options.const.ts
@@ -1,4 +1,0 @@
-export enum MarriageOptions {
-  Married = 'married',
-  Single = 'single',
-}

--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -11,8 +11,6 @@ import { MemberModel } from '../../entity/member.entity';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { CreateMemberDto } from '../../dto/request/create-member.dto';
 import { UpdateMemberDto } from '../../dto/request/update-member.dto';
-import { OfficerModel } from '../../../management/officers/entity/officer.entity';
-import { GroupModel } from '../../../management/groups/entity/group.entity';
 import { MembersDomainPaginationResultDto } from '../dto/members-domain-pagination-result.dto';
 import { GetSimpleMembersDto } from '../../dto/request/get-simple-members.dto';
 import { GetRecommendLinkMemberDto } from '../../dto/request/get-recommend-link-member.dto';
@@ -20,6 +18,7 @@ import { GetBirthdayMembersDto } from '../../../calendar/dto/request/birthday/ge
 import { WidgetRange } from '../../../home/const/widget-range.enum';
 import { GetNewMemberDetailDto } from '../../../home/dto/request/get-new-member-detail.dto';
 import { GroupRole } from '../../../management/groups/const/group-role.enum';
+import { GetMemberListDto } from '../../dto/list/get-member-list.dto';
 
 export const IMEMBERS_DOMAIN_SERVICE = Symbol('IMEMBERS_DOMAIN_SERVICE');
 
@@ -61,12 +60,6 @@ export interface IMembersDomainService {
     qr?: QueryRunner,
     relationOptions?: FindOptionsRelations<MemberModel>,
   ): Promise<MemberModel[]>;
-
-  /*findMinistryGroupMembersByIds(
-    ministryGroup: MinistryGroupModel,
-    memberIds: number[],
-    qr?: QueryRunner,
-  ): Promise<MemberModel[]>;*/
 
   countAllMembers(church: ChurchModel, qr?: QueryRunner): Promise<number>;
 
@@ -130,25 +123,6 @@ export interface IMembersDomainService {
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 
-  /*startMemberOfficer(
-    member: MemberModel,
-    officer: OfficerModel,
-    officerStartDate: Date,
-    officerStartChurch: string,
-    qr: QueryRunner,
-  ): Promise<UpdateResult>;*/
-
-  /*endMemberOfficer(member: MemberModel, qr: QueryRunner): Promise<UpdateResult>;*/
-
-  /*startMemberGroup(
-    member: MemberModel,
-    group: GroupModel,
-    groupRole: GroupRole,
-    qr: QueryRunner,
-  ): Promise<UpdateResult>;*/
-
-  /*endMemberGroup(member: MemberModel, qr: QueryRunner): Promise<UpdateResult>;*/
-
   updateGroupRole(
     member: MemberModel,
     groupRole: GroupRole,
@@ -168,4 +142,9 @@ export interface IMembersDomainService {
     from: Date,
     to: Date,
   ): Promise<MemberModel[]>;
+
+  getMemberListWithPagination(
+    church: ChurchModel,
+    dto: GetMemberListDto,
+  ): Promise<any>;
 }

--- a/backend/src/members/service/members.service.ts
+++ b/backend/src/members/service/members.service.ts
@@ -46,6 +46,7 @@ import {
 import { fromZonedTime } from 'date-fns-tz';
 import { TIME_ZONE } from '../../common/const/time-zone.const';
 import { getHistoryStartDate } from '../../member-history/history-date.utils';
+import { GetMemberListDto } from '../dto/list/get-member-list.dto';
 
 @Injectable()
 export class MembersService {
@@ -274,5 +275,29 @@ export class MembersService {
       dto.page,
       Math.ceil(totalCount / dto.take),
     );
+  }
+
+  async getMemberList(
+    church: ChurchModel,
+    requestManager: ChurchUserModel,
+    dto: GetMemberListDto,
+  ) {
+    const result = await this.membersDomainService.getMemberListWithPagination(
+      church,
+      dto,
+    );
+
+    return {
+      items: result.items,
+      /*items: result.items.map((member) => ({
+        id: member.id,
+        name: member.name,
+        profileImage: member.profileImage,
+        registeredAt: member.registeredAt,
+        birth: member.birth,
+      })),*/
+      nextCursor: result.nextCursor,
+      hasMore: result.hasMore,
+    };
   }
 }


### PR DESCRIPTION
## 주요 내용
교인 목록을 효율적으로 조회하기 위한 커서 기반 페이지네이션과 동적 컬럼 선택 기능을 구현했습니다.

## 세부 내용

### 페이지네이션
- 커서 기반 페이지네이션으로 대용량 데이터 처리 최적화
- 정렬 조건 변경 시 커서 검증 로직 추가
- 커서에 column 정보 포함하여 정렬 일관성 보장
- limit + 1 조회로 다음 페이지 존재 여부 확인

### 동적 컬럼 선택
- 사용자가 필요한 컬럼만 선택하여 조회 가능
- DB 레벨에서 SELECT 최적화로 성능 향상
- 기본 컬럼: officer, birth, group, mobilePhone, address
- vehicleNumber(string[]) 추가 - 표시만 가능, 정렬 불가

### 정렬 기능
- 모든 표시 가능 컬럼에 대해 정렬 지원 (vehicleNumber 제외)
- 1순위: 사용자 지정 컬럼, 2순위: ID (안정성 보장)
- NULL 값 처리는 DB 기본 동작 따름

### DTO 개선
- Transform 데코레이터로 단일 값도 배열로 변환
- ArrayUnique로 중복 컬럼 방지
- 기본값이 있는 필드는 옵셔널 제거로 타입 안전성 향상

### 기타
- 교회별 교인 조회 (churchId 필터)
- profileImageUrl, groupRole, ministryGroupRole 기본 포함