### PR TITLE
feat: 교인 목록 조회 API 필터링 및 검색 기능 구현

### DIFF
--- a/backend/src/educations/education-session/dto/request/update-education-session.dto.ts
+++ b/backend/src/educations/education-session/dto/request/update-education-session.dto.ts
@@ -42,7 +42,7 @@ export class UpdateEducationSessionDto {
   @IsOptionalNotNull()
   @IsDateString({ strict: true })
   @IsDateTime('startDate')
-  startDate?: Date;
+  startDate?: string;
 
   utcStartDate: Date | undefined;
 
@@ -54,7 +54,7 @@ export class UpdateEducationSessionDto {
   @IsDateString({ strict: true })
   @IsDateTime('endDate')
   @IsAfterDate('startDate')
-  endDate?: Date;
+  endDate?: string;
 
   utcEndDate: Date | undefined;
 

--- a/backend/src/educations/education-session/service/educaiton-session.service.ts
+++ b/backend/src/educations/education-session/service/educaiton-session.service.ts
@@ -303,9 +303,12 @@ export class EducationSessionService {
       }
     }
 
-    dto.utcStartDate =
-      dto.startDate && fromZonedTime(dto.startDate, TIME_ZONE.SEOUL);
-    dto.utcEndDate = dto.endDate && fromZonedTime(dto.endDate, TIME_ZONE.SEOUL);
+    dto.utcStartDate = dto.startDate
+      ? fromZonedTime(dto.startDate, TIME_ZONE.SEOUL)
+      : undefined;
+    dto.utcEndDate = dto.endDate
+      ? fromZonedTime(dto.endDate, TIME_ZONE.SEOUL)
+      : undefined;
 
     await this.educationSessionDomainService.updateEducationSession(
       targetSession,

--- a/backend/src/management/groups/groups-domain/service/groups-domain.service.ts
+++ b/backend/src/management/groups/groups-domain/service/groups-domain.service.ts
@@ -206,6 +206,12 @@ export class GroupsDomainService implements IGroupsDomainService {
       }
     }
 
+    rootGroupIds.forEach((rootGroupId) => {
+      if (!groupMap.get(rootGroupId)) {
+        throw new NotFoundException(GroupException.NOT_FOUND);
+      }
+    });
+
     const visited = new Set<number>();
     const resultIds: number[] = [];
     const queue = [...rootGroupIds];

--- a/backend/src/member-history/history-date.utils.ts
+++ b/backend/src/member-history/history-date.utils.ts
@@ -97,3 +97,19 @@ export function getHistoryStartDate(timeZone: TIME_ZONE) {
 export function getHistoryEndDate(timeZone: TIME_ZONE) {
   return fromZonedTime(endOfDay(toZonedTime(new Date(), timeZone)), timeZone);
 }
+
+export function getFromDate(date: string, timeZone: TIME_ZONE) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new BadRequestException('YYYY-MM-DD 형식이 아님');
+  }
+
+  return fromZonedTime(startOfDay(date), timeZone);
+}
+
+export function getToDate(date: string, timeZone: TIME_ZONE) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new BadRequestException('YYYY-MM-DD 형식이 아님');
+  }
+
+  return fromZonedTime(endOfDay(date), timeZone);
+}

--- a/backend/src/members/const/enum/list/baptism-status-filter.enum.ts
+++ b/backend/src/members/const/enum/list/baptism-status-filter.enum.ts
@@ -1,0 +1,8 @@
+export enum BaptismStatusFilter {
+  BAPTIZED = 'baptized',
+  IMMERSION_BAPTISM = 'immersionBaptism',
+  INFANT_BAPTISM = 'infantBaptism',
+  CONFIRMATION = 'confirmation',
+  CATECHUMENATE = 'catechumenate',
+  NONE = 'none',
+}

--- a/backend/src/members/const/enum/list/gender-filter.enum.ts
+++ b/backend/src/members/const/enum/list/gender-filter.enum.ts
@@ -1,0 +1,5 @@
+export enum GenderFilter {
+  MALE = 'male',
+  FEMALE = 'female',
+  NULL = 'null',
+}

--- a/backend/src/members/const/enum/list/marriage-status-filter.enum.ts
+++ b/backend/src/members/const/enum/list/marriage-status-filter.enum.ts
@@ -1,0 +1,5 @@
+export enum MarriageStatusFilter {
+  MARRIED = 'married',
+  SINGLE = 'single',
+  NULL = 'null',
+}

--- a/backend/src/members/dto/list/get-member-list.dto.ts
+++ b/backend/src/members/dto/list/get-member-list.dto.ts
@@ -2,15 +2,21 @@ import { ApiPropertyOptional } from '@nestjs/swagger';
 import {
   ArrayUnique,
   IsArray,
+  IsDateString,
   IsEnum,
   IsIn,
   IsNumber,
   IsOptional,
   IsString,
+  MinLength,
 } from 'class-validator';
 import { SortColumn } from '../../const/enum/list/sort-column.enum';
 import { DisplayColumn } from '../../const/enum/list/display-column.enum';
 import { Transform } from 'class-transformer';
+import { MarriageStatusFilter } from '../../const/enum/list/marriage-status-filter.enum';
+import { BaptismStatusFilter } from '../../const/enum/list/baptism-status-filter.enum';
+import { IsYYYYMMDD } from '../../../common/decorator/validator/is-yyyy-mm-dd.validator';
+import { IsAfterDate } from '../../../common/decorator/validator/is-after-date.decorator';
 
 export class GetMemberListDto {
   @ApiPropertyOptional({ description: '페이지 크기', default: 20 })
@@ -51,4 +57,112 @@ export class GetMemberListDto {
   @ArrayUnique()
   @IsEnum(DisplayColumn, { each: true })
   displayColumns: DisplayColumn[] = [];
+
+  @ApiPropertyOptional({
+    description: '그룹 ID 목록 ("null" 포함 시 그룹 없는 교인 조회)',
+    type: [String],
+    example: ['1', '2', 'null'],
+  })
+  @Transform(({ value }) => {
+    if (!value) return undefined;
+    const arr = Array.isArray(value) ? value : [value];
+    return arr.map((v) => (v === 'null' ? 'null' : Number(v)));
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayUnique()
+  groupIds?: (number | 'null')[];
+
+  @ApiPropertyOptional({
+    description: '직분 ID 목록 ("null" 포함 시 직분 없는 교인 조회)',
+    type: [String],
+    example: ['1', '2', 'null'],
+  })
+  @Transform(({ value }) => {
+    if (!value) return undefined;
+    const arr = Array.isArray(value) ? value : [value];
+    return arr.map((v) => (v === 'null' ? 'null' : Number(v)));
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayUnique()
+  officerIds?: (number | 'null')[];
+
+  // 결혼 상태 필터 (복수 선택)
+  @ApiPropertyOptional({
+    enum: MarriageStatusFilter,
+    isArray: true,
+    description: '결혼 상태 (null: 값 없음)',
+  })
+  @Transform(({ value }) => {
+    if (!value) return undefined;
+    return Array.isArray(value) ? value : [value];
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayUnique()
+  @IsEnum(MarriageStatusFilter, { each: true })
+  marriageStatuses?: MarriageStatusFilter[];
+
+  // 신급 필터 (복수 선택)
+  @ApiPropertyOptional({
+    enum: BaptismStatusFilter,
+    isArray: true,
+    description: '신급 상태',
+  })
+  @Transform(({ value }) => {
+    if (!value) return undefined;
+    return Array.isArray(value) ? value : [value];
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayUnique()
+  @IsEnum(BaptismStatusFilter, { each: true })
+  baptismStatuses?: BaptismStatusFilter[];
+
+  // 생년월일 범위 필터
+  @ApiPropertyOptional({
+    description: '생년월일 시작 (yyyy-MM-dd)',
+    example: '1990-01-01',
+  })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('birthFrom')
+  birthFrom?: string;
+
+  @ApiPropertyOptional({
+    description: '생년월일 끝 (yyyy-MM-dd)',
+    example: '2000-12-31',
+  })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('birthTo')
+  @IsAfterDate('birthFrom')
+  birthTo?: string;
+
+  // 등록일 범위 필터
+  @ApiPropertyOptional({
+    description: '등록일 시작 (yyyy-MM-dd)',
+    example: '2020-01-01',
+  })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('registeredFrom')
+  registeredFrom?: string;
+
+  @ApiPropertyOptional({
+    description: '등록일 끝 (yyyy-MM-dd)',
+    example: '2023-12-31',
+  })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('registeredTo')
+  @IsAfterDate('registeredFrom')
+  registeredTo?: string;
+
+  @ApiPropertyOptional({ description: '검색어 (최소 2글자)' })
+  @IsOptional()
+  @Transform(({ value }) => (value ? value.trim() : value))
+  @MinLength(2, { message: '검색어는 최소 2글자 이상이어야 합니다.' })
+  search?: string;
 }

--- a/backend/src/members/service/members.service.ts
+++ b/backend/src/members/service/members.service.ts
@@ -47,6 +47,10 @@ import { fromZonedTime } from 'date-fns-tz';
 import { TIME_ZONE } from '../../common/const/time-zone.const';
 import { getHistoryStartDate } from '../../member-history/history-date.utils';
 import { GetMemberListDto } from '../dto/list/get-member-list.dto';
+import {
+  IGROUPS_DOMAIN_SERVICE,
+  IGroupsDomainService,
+} from '../../management/groups/groups-domain/interface/groups-domain.service.interface';
 
 @Injectable()
 export class MembersService {
@@ -68,6 +72,8 @@ export class MembersService {
 
     @Inject(IMEMBER_FILTER_SERVICE)
     private readonly memberFilterService: IMemberFilterService,
+    @Inject(IGROUPS_DOMAIN_SERVICE)
+    private readonly groupsDomainService: IGroupsDomainService,
   ) {}
 
   async getMembers(


### PR DESCRIPTION
## 주요 내용
교인 목록 조회 시 다양한 조건으로 필터링하고 통합 검색할 수 있는 기능을 추가했습니다.

## 세부 내용

### 필터링 기능
- 직분: 복수 선택, NULL 값 포함 옵션
- 그룹: 복수 선택, NULL 값 포함 옵션
- 결혼상태: 복수 선택, NULL 값 포함 옵션 (married, single)
- 신급: 복수 선택 (none 포함되어 NULL 옵션 불필요)
- 생년월일 범위: yyyy-MM-dd 형식, getFromDate/getToDate 유틸 활용
- 등록일 범위: yyyy-MM-dd 형식, 시간대 처리 포함

### 검색 기능
- 통합 검색: 단일 검색어로 여러 필드 동시 검색
- 검색 대상: 이름, 직분명, 그룹명, 전화번호(휴대폰/집), 주소, 학교, 직업, 차량번호
- 공백 처리: 검색어와 DB 값 모두 공백 제거 후 비교
- 최소 검색어: 2글자 이상
- 검색 필드는 SELECT하지 않음 (displayColumns와 독립적)

### 구현 특징
- 필터 간 AND 조건, 필터 내 복수 선택은 OR 조건
- 검색과 필터 AND 조건으로 결합
- Brackets 활용으로 복잡한 WHERE 절 관리
- 중복 JOIN 방지 로직으로 쿼리 최적화

### 기술적 개선
- GetMemberListDto에 필터와 검색 필드 통합
- applyFilters, applySearch 메서드 분리로 관심사 분리
- 헬퍼 메서드(addSearchCondition)로 코드 재사용성 향상