### PR TITLE
feat: 교인 가족관계 조회 페이지네이션 및 권한 체크 구현

### DIFF
--- a/backend/src/common/custom-request.ts
+++ b/backend/src/common/custom-request.ts
@@ -3,6 +3,7 @@ import { ChurchModel } from '../churches/entity/church.entity';
 import { WorshipModel } from '../worship/entity/worship.entity';
 import { ChurchUserModel } from '../church-user/entity/church-user.entity';
 import { JwtAccessPayload } from '../auth/type/jwt';
+import { MemberModel } from '../members/entity/member.entity';
 
 export interface CustomRequest extends Request {
   church: ChurchModel;
@@ -11,4 +12,6 @@ export interface CustomRequest extends Request {
   requestManager: ChurchUserModel;
   permissionScopeGroupIds: number[];
   tokenPayload: JwtAccessPayload;
+
+  targetMember: MemberModel;
 }

--- a/backend/src/educations/education-term/controller/education-terms.controller.ts
+++ b/backend/src/educations/education-term/controller/education-terms.controller.ts
@@ -30,7 +30,7 @@ import { TransactionInterceptor } from '../../../common/interceptor/transaction.
 import { RequestManager } from '../../../permission/decorator/permission-manager.decorator';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
-import { PermissionChurch } from '../../../permission/decorator/permission-church.decorator';
+import { RequestChurch } from '../../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { AddEducationTermReportDto } from '../dto/request/add-education-term-report.dto';
 import { DeleteEducationTermReportDto } from '../dto/request/delete-education-term-report.dto';
@@ -46,7 +46,7 @@ export class EducationTermsController {
   getEducationTerms(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('educationId', ParseIntPipe) educationId: number,
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @Query() dto: GetEducationTermDto,
   ) {
     return this.educationTermService.getEducationTerms(
@@ -62,7 +62,7 @@ export class EducationTermsController {
   @UseInterceptors(TransactionInterceptor)
   postEducationTerms(
     @RequestManager() manager: ChurchUserModel,
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @Param('churchId', ParseIntPipe)
     churchId: number,
     @Param('educationId', ParseIntPipe) educationId: number,

--- a/backend/src/educations/education/controller/educations.controller.ts
+++ b/backend/src/educations/education/controller/educations.controller.ts
@@ -33,7 +33,7 @@ import { TransactionInterceptor } from '../../../common/interceptor/transaction.
 import { RequestManager } from '../../../permission/decorator/permission-manager.decorator';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
-import { PermissionChurch } from '../../../permission/decorator/permission-church.decorator';
+import { RequestChurch } from '../../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 
 @ApiTags('Educations')
@@ -82,7 +82,7 @@ export class EducationsController {
   @EducationWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   refreshEducationCount(
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @QueryRunner() qr: QR,
   ) {
     return this.educationsService.refreshEducationCount(church, qr);

--- a/backend/src/family-relation/dto/delete-family-relation-response.dto.ts
+++ b/backend/src/family-relation/dto/delete-family-relation-response.dto.ts
@@ -1,0 +1,7 @@
+import { BaseDeleteResponseDto } from '../../common/dto/reponse/base-delete-response.dto';
+
+export class DeleteFamilyRelationResponseDto extends BaseDeleteResponseDto {
+  constructor(timestamp: Date, id: number, success: boolean) {
+    super(timestamp, id, success);
+  }
+}

--- a/backend/src/family-relation/dto/family-relation-cursor-pagination-result.dto.ts
+++ b/backend/src/family-relation/dto/family-relation-cursor-pagination-result.dto.ts
@@ -1,0 +1,13 @@
+import { BaseCursorPaginationResponseDto } from '../../common/dto/base-cursor-pagination-response.dto';
+import { FamilyRelationModel } from '../entity/family-relation.entity';
+
+export class FamilyRelationCursorPaginationResultDto extends BaseCursorPaginationResponseDto<FamilyRelationModel> {
+  constructor(
+    data: FamilyRelationModel[],
+    count: number,
+    nextCursor: string | undefined,
+    hasMore: boolean,
+  ) {
+    super(data, count, nextCursor, hasMore);
+  }
+}

--- a/backend/src/family-relation/dto/get-family-relation-list.dto.ts
+++ b/backend/src/family-relation/dto/get-family-relation-list.dto.ts
@@ -1,0 +1,19 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class GetFamilyRelationListDto {
+  @ApiPropertyOptional({ description: '페이지 크기', default: 20 })
+  @IsOptional()
+  @IsNumber()
+  limit: number = 20;
+
+  @ApiPropertyOptional({ description: '커서 (마지막 항목의 ID)' })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @ApiPropertyOptional({ description: '정렬 방향', default: 'ASC' })
+  @IsOptional()
+  @IsIn(['ASC', 'DESC'])
+  sortDirection: 'ASC' | 'DESC' = 'ASC';
+}

--- a/backend/src/family-relation/dto/patch-family-relation-response.dto.ts
+++ b/backend/src/family-relation/dto/patch-family-relation-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePatchResponseDto } from '../../common/dto/reponse/base-patch-response.dto';
+import { FamilyRelationModel } from '../entity/family-relation.entity';
+
+export class PatchFamilyRelationResponseDto extends BasePatchResponseDto<FamilyRelationModel> {
+  constructor(data: FamilyRelationModel) {
+    super(data);
+  }
+}

--- a/backend/src/family-relation/dto/post-family-relation-response.dto.ts
+++ b/backend/src/family-relation/dto/post-family-relation-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePostResponseDto } from '../../common/dto/reponse/base-post-response.dto';
+import { FamilyRelationModel } from '../entity/family-relation.entity';
+
+export class PostFamilyRelationResponseDto extends BasePostResponseDto<FamilyRelationModel> {
+  constructor(data: FamilyRelationModel) {
+    super(data);
+  }
+}

--- a/backend/src/family-relation/entity/family-relation.entity.ts
+++ b/backend/src/family-relation/entity/family-relation.entity.ts
@@ -1,28 +1,19 @@
-import {
-  Column,
-  CreateDateColumn,
-  DeleteDateColumn,
-  Entity,
-  Index,
-  JoinColumn,
-  ManyToOne,
-  PrimaryColumn,
-  UpdateDateColumn,
-} from 'typeorm';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { MemberModel } from '../../members/entity/member.entity';
+import { BaseModel } from '../../common/entity/base.entity';
 
 @Entity()
-export class FamilyRelationModel {
-  @PrimaryColumn()
+export class FamilyRelationModel extends BaseModel {
   @Index()
+  @Column()
   meId: number;
 
   @ManyToOne(() => MemberModel, (member) => member.family)
   @JoinColumn({ name: 'meId' })
   me: MemberModel;
 
-  @PrimaryColumn()
   @Index()
+  @Column()
   familyMemberId: number;
 
   @ManyToOne(() => MemberModel, (member) => member.counterFamily)
@@ -31,13 +22,4 @@ export class FamilyRelationModel {
 
   @Column({ default: '가족 관계' })
   relation: string;
-
-  @CreateDateColumn()
-  createdAt: Date;
-
-  @UpdateDateColumn()
-  updatedAt: Date;
-
-  @DeleteDateColumn()
-  deletedAt: Date;
 }

--- a/backend/src/family-relation/family-relation-domain/service/interface/family-relation-domain.service.interface.ts
+++ b/backend/src/family-relation/family-relation-domain/service/interface/family-relation-domain.service.interface.ts
@@ -1,6 +1,8 @@
 import { MemberModel } from '../../../../members/entity/member.entity';
 import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { FamilyRelationModel } from '../../../entity/family-relation.entity';
+import { GetFamilyRelationListDto } from '../../../dto/get-family-relation-list.dto';
+import { DomainCursorPaginationResultDto } from '../../../../common/dto/domain-cursor-pagination-result.dto';
 
 export const IFAMILY_RELATION_DOMAIN_SERVICE = Symbol(
   'IFAMILY_RELATION_DOMAIN_SERVICE',
@@ -9,8 +11,15 @@ export const IFAMILY_RELATION_DOMAIN_SERVICE = Symbol(
 export interface IFamilyRelationDomainService {
   findFamilyRelations(
     member: MemberModel,
+    dto: GetFamilyRelationListDto,
     qr?: QueryRunner,
-  ): Promise<FamilyRelationModel[]>;
+  ): Promise<DomainCursorPaginationResultDto<FamilyRelationModel>>;
+
+  findFamilyRelationById(
+    meId: number,
+    familyId: number,
+    qr?: QueryRunner,
+  ): Promise<FamilyRelationModel>;
 
   findFamilyRelationModelById(
     meId: number,
@@ -30,12 +39,12 @@ export interface IFamilyRelationDomainService {
     familyRelation: FamilyRelationModel,
     relation: string,
     qr?: QueryRunner,
-  ): Promise<FamilyRelationModel>;
+  ): Promise<UpdateResult>;
 
   deleteFamilyRelation(
     familyRelation: FamilyRelationModel,
     qr?: QueryRunner,
-  ): Promise<string>;
+  ): Promise<UpdateResult>;
 
   createFamilyRelation(
     me: MemberModel,

--- a/backend/src/family-relation/family-relation.module.ts
+++ b/backend/src/family-relation/family-relation.module.ts
@@ -8,6 +8,9 @@ import { RouterModule } from '@nestjs/core';
 import { IDOMAIN_PERMISSION_SERVICE } from '../permission/service/domain-permission.service.interface';
 import { FamilyPermissionService } from './service/family-permission.service';
 import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
+import { IMEMBER_FILTER_SERVICE } from '../members/service/interface/member-filter.service.interface';
+import { MemberFilterService } from '../members/service/member-filter.service';
+import { GroupsDomainModule } from '../management/groups/groups-domain/groups-domain.module';
 
 @Module({
   imports: [
@@ -18,11 +21,16 @@ import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.mo
     ManagerDomainModule,
     MembersDomainModule,
     FamilyRelationDomainModule,
+    GroupsDomainModule,
   ],
   controllers: [FamilyRelationController],
   providers: [
     FamilyRelationService,
     { provide: IDOMAIN_PERMISSION_SERVICE, useClass: FamilyPermissionService },
+    {
+      provide: IMEMBER_FILTER_SERVICE,
+      useClass: MemberFilterService,
+    },
   ],
   exports: [],
 })

--- a/backend/src/family-relation/guard/family-write.guard.ts
+++ b/backend/src/family-relation/guard/family-write.guard.ts
@@ -4,6 +4,8 @@ import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
 import { DomainType } from '../../permission/const/domain-type.enum';
 import { DomainName } from '../../permission/const/domain-name.enum';
 import { DomainAction } from '../../permission/const/domain-action.enum';
+import { createScopeGuard } from '../../permission/guard/generic-scope.guard';
+import { HttpMethod } from '../../common/const/http-method.enum';
 
 export const FamilyWriteGuard = () =>
   applyDecorators(
@@ -14,5 +16,6 @@ export const FamilyWriteGuard = () =>
         DomainName.MEMBER,
         DomainAction.WRITE,
       ),
+      createScopeGuard([HttpMethod.GET]),
     ),
   );

--- a/backend/src/family-relation/service/family-relation.service.ts
+++ b/backend/src/family-relation/service/family-relation.service.ts
@@ -14,6 +14,17 @@ import {
   IFamilyRelationDomainService,
 } from '../family-relation-domain/service/interface/family-relation-domain.service.interface';
 import { CreateFamilyRelationDto } from '../dto/create-family-relation.dto';
+import { GetFamilyRelationListDto } from '../dto/get-family-relation-list.dto';
+import { FamilyRelationCursorPaginationResultDto } from '../dto/family-relation-cursor-pagination-result.dto';
+import { PatchFamilyRelationResponseDto } from '../dto/patch-family-relation-response.dto';
+import { DeleteFamilyRelationResponseDto } from '../dto/delete-family-relation-response.dto';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import {
+  IMEMBER_FILTER_SERVICE,
+  IMemberFilterService,
+} from '../../members/service/interface/member-filter.service.interface';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { PostFamilyRelationResponseDto } from '../dto/post-family-relation-response.dto';
 
 @Injectable()
 export class FamilyRelationService {
@@ -24,159 +35,164 @@ export class FamilyRelationService {
     private readonly membersDomainService: IMembersDomainService,
     @Inject(IFAMILY_RELATION_DOMAIN_SERVICE)
     private readonly familyDomainService: IFamilyRelationDomainService,
+
+    @Inject(IMEMBER_FILTER_SERVICE)
+    private readonly memberFilterService: IMemberFilterService,
   ) {}
 
   async getFamilyRelations(
-    churchId: number,
+    requestManager: ChurchUserModel,
+    church: ChurchModel,
     memberId: number,
+    dto: GetFamilyRelationListDto,
     qr?: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
     const member = await this.membersDomainService.findMemberModelById(
       church,
       memberId,
       qr,
     );
 
-    return this.familyDomainService.findFamilyRelations(member, qr);
-  }
-
-  async fetchAndCreateFamilyRelation(
-    churchId: number,
-    memberId: number,
-    familyMemberId: number,
-    relation: string,
-    qr: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
+    const result = await this.familyDomainService.findFamilyRelations(
+      member,
+      dto,
       qr,
     );
 
-    const [me, newFamilyMember] = await Promise.all([
-      this.membersDomainService.findMemberModelById(church, memberId, qr, {}),
-      this.membersDomainService.findMemberModelById(
-        church,
-        familyMemberId,
-        qr,
-        {},
-      ),
-    ]);
-    return this.familyDomainService.fetchAndCreateFamilyRelations(
-      me,
-      newFamilyMember,
-      relation,
-      qr,
-    );
-  }
-
-  async updateFamilyRelation(
-    churchId: number,
-    memberId: number,
-    familyMemberId: number,
-    relation: string,
-    qr: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
+    const familyRelations = result.items;
+    const familyMembers = familyRelations.map(
+      (familyRelation) => familyRelation.familyMember,
     );
 
-    const [me, family] = await Promise.all([
-      this.membersDomainService.findMemberModelById(church, memberId, qr, {}),
-      this.membersDomainService.findMemberModelById(
-        church,
-        familyMemberId,
-        qr,
-        {},
-      ),
-    ]);
-
-    const familyRelation =
-      await this.familyDomainService.findFamilyRelationModelById(
-        me.id,
-        family.id,
-        qr,
-      );
-
-    return this.familyDomainService.updateFamilyRelation(
-      familyRelation,
-      relation,
-      qr,
-    );
-  }
-
-  async deleteFamilyRelation(
-    churchId: number,
-    memberId: number,
-    familyMemberId: number,
-    qr?: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
+    const scopeGroupIds = await this.memberFilterService.getScopeGroupIds(
+      church,
+      requestManager,
     );
 
-    const [me, family] = await Promise.all([
-      this.membersDomainService.findMemberModelById(church, memberId, qr, {}),
-      this.membersDomainService.findMemberModelById(
-        church,
-        familyMemberId,
-        qr,
-        {},
-      ),
-    ]);
+    const filteredFamilyMembers = this.memberFilterService.filterMembers(
+      requestManager,
+      familyMembers,
+      scopeGroupIds,
+    );
 
-    const familyRelation =
-      await this.familyDomainService.findFamilyRelationModelById(
-        me.id,
-        family.id,
-        qr,
-      );
+    familyRelations.forEach((familyRelation, index) => {
+      familyRelation.familyMember = filteredFamilyMembers[index];
+    });
 
-    return this.familyDomainService.deleteFamilyRelation(familyRelation, qr);
+    return new FamilyRelationCursorPaginationResultDto(
+      result.items,
+      result.items.length,
+      result.nextCursor,
+      result.hasMore,
+    );
   }
 
   async createFamilyMember(
-    churchId: number,
-    memberId: number,
+    requestManager: ChurchUserModel,
+    church: ChurchModel,
+    me: MemberModel,
     dto: CreateFamilyRelationDto,
     qr: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
+    const familyMember = await this.membersDomainService.findMemberModelById(
+      church,
+      dto.familyMemberId,
       qr,
     );
-    const [me, familyMember] = await Promise.all([
-      this.membersDomainService.findMemberModelById(church, memberId, qr, {}),
-      this.membersDomainService.findMemberModelById(
-        church,
-        dto.familyMemberId,
-        qr,
-        {},
-      ),
-    ]);
 
-    return this.familyDomainService.createFamilyRelation(
+    await this.familyDomainService.createFamilyRelation(
       me,
       familyMember,
       dto.relation,
       qr,
     );
+
+    const relation = await this.familyDomainService.findFamilyRelationById(
+      me.id,
+      familyMember.id,
+      qr,
+    );
+
+    const scopeGroupIds = await this.memberFilterService.getScopeGroupIds(
+      church,
+      requestManager,
+      qr,
+    );
+
+    relation.familyMember = this.memberFilterService.filterMember(
+      requestManager,
+      relation.familyMember,
+      scopeGroupIds,
+    );
+
+    return new PostFamilyRelationResponseDto(relation);
   }
 
-  /**
-   * 가족 관계 soft delete - 복구 가능
-   * @param deletedMember
-   * @param qr
-   */
-  async cascadeDeleteAllFamilyRelation(
-    deletedMember: MemberModel,
+  async updateFamilyRelation(
+    //churchId: number,
+    //memberId: number,
+    requestManager: ChurchUserModel,
+    church: ChurchModel,
+    me: MemberModel,
+    familyMemberId: number,
+    relation: string,
     qr: QueryRunner,
   ) {
-    return this.familyDomainService.deleteAllFamilyRelations(deletedMember, qr);
+    const targetRelation =
+      await this.familyDomainService.findFamilyRelationModelById(
+        me.id,
+        familyMemberId,
+        qr,
+      );
+
+    await this.familyDomainService.updateFamilyRelation(
+      targetRelation,
+      relation,
+      qr,
+    );
+
+    const updatedRelation =
+      await this.familyDomainService.findFamilyRelationById(
+        me.id,
+        familyMemberId,
+        qr,
+      );
+
+    const familyMember = updatedRelation.familyMember;
+
+    const scopeGroupIds = await this.memberFilterService.getScopeGroupIds(
+      church,
+      requestManager,
+      qr,
+    );
+
+    updatedRelation.familyMember = this.memberFilterService.filterMember(
+      requestManager,
+      familyMember,
+      scopeGroupIds,
+    );
+
+    return new PatchFamilyRelationResponseDto(updatedRelation);
+  }
+
+  async deleteFamilyRelation(
+    me: MemberModel,
+    familyMemberId: number,
+    qr?: QueryRunner,
+  ) {
+    const familyRelation =
+      await this.familyDomainService.findFamilyRelationModelById(
+        me.id,
+        familyMemberId,
+        qr,
+      );
+
+    await this.familyDomainService.deleteFamilyRelation(familyRelation, qr);
+
+    return new DeleteFamilyRelationResponseDto(
+      new Date(),
+      familyRelation.id,
+      true,
+    );
   }
 }

--- a/backend/src/home/controller/home.controller.ts
+++ b/backend/src/home/controller/home.controller.ts
@@ -7,7 +7,7 @@ import {
 } from '@nestjs/common';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../permission/guard/church-manager.guard';
-import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
+import { RequestChurch } from '../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { HomeService } from '../service/home.service';
 import { GetNewMemberSummaryDto } from '../dto/request/get-new-member-summary.dto';
@@ -33,7 +33,7 @@ export class HomeController {
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   @Get('members/new/summary')
   getNewMemberSummary(
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @Query() dto: GetNewMemberSummaryDto,
   ) {
     return this.homeService.getNewMemberSummary(church, dto);
@@ -43,7 +43,7 @@ export class HomeController {
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   @Get('members/new/details')
   getNewMemberDetails(
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @Query() dto: GetNewMemberDetailDto,
   ) {
     return this.homeService.getNewMemberDetails(church, dto);
@@ -82,7 +82,7 @@ export class HomeController {
   @Get('worship-attendances')
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   getLowWorshipAttendanceMembers(
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @RequestManager() pm: ChurchUserModel,
     @Query() dto: GetLowWorshipAttendanceMembersDto,
   ) {

--- a/backend/src/management/groups/controller/groups.controller.ts
+++ b/backend/src/management/groups/controller/groups.controller.ts
@@ -35,7 +35,7 @@ import { GroupWriteGuard } from '../guard/group-write.guard';
 import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../../permission/guard/church-manager.guard';
 import { UpdateGroupStructureDto } from '../dto/request/update-group-structure.dto';
-import { PermissionChurch } from '../../../permission/decorator/permission-church.decorator';
+import { RequestChurch } from '../../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { UpdateGroupLeaderDto } from '../dto/request/update-group-leader.dto';
 import { GetUnassignedMembersDto } from '../../ministries/dto/ministry-group/request/member/get-unassigned-members.dto';
@@ -72,7 +72,7 @@ export class GroupsController {
   @GroupWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   refreshGroupCount(
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @QueryRunner() qr: QR,
   ) {
     return this.groupsService.refreshGroupCount(church, qr);
@@ -114,7 +114,7 @@ export class GroupsController {
   @GroupWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   patchGroupLeader(
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @Param('groupId', ParseIntPipe) groupId: number,
     @Body() dto: UpdateGroupLeaderDto,
     @QueryRunner() qr: QR,

--- a/backend/src/management/ministries/controller/ministries.controller.ts
+++ b/backend/src/management/ministries/controller/ministries.controller.ts
@@ -29,7 +29,7 @@ import {
 import { MinistryWriteGuard } from '../guard/ministry-write.guard';
 import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../../permission/guard/church-manager.guard';
-import { PermissionChurch } from '../../../permission/decorator/permission-church.decorator';
+import { RequestChurch } from '../../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 
 @ApiTags('Management:MinistryGroups:Ministries')
@@ -71,7 +71,7 @@ export class MinistriesController {
   @UseInterceptors(TransactionInterceptor)
   @Patch('refresh-count')
   refreshMinistryCount(
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @Param('ministryGroupId', ParseIntPipe) ministryGroupId: number,
     @QueryRunner() qr: QR,
   ) {

--- a/backend/src/management/ministries/controller/ministry-groups.controller.ts
+++ b/backend/src/management/ministries/controller/ministry-groups.controller.ts
@@ -29,7 +29,7 @@ import {
   ApiPatchMinistryGroupStructure,
   ApiRefreshMinistryGroupCount,
 } from '../const/swagger/ministry-group.swagger';
-import { PermissionChurch } from '../../../permission/decorator/permission-church.decorator';
+import { RequestChurch } from '../../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { UpdateMinistryGroupLeaderDto } from '../dto/ministry-group/request/update-ministry-group-leader.dto';
 import { GetUnassignedMembersDto } from '../dto/ministry-group/request/member/get-unassigned-members.dto';
@@ -64,7 +64,7 @@ export class MinistryGroupsController {
   @MinistryWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   refreshMinistryGroupCount(
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @QueryRunner() qr: QR,
   ) {
     return this.ministryGroupService.refreshMinistryGroupCount(church, qr);

--- a/backend/src/management/officers/controller/officers.controller.ts
+++ b/backend/src/management/officers/controller/officers.controller.ts
@@ -31,7 +31,7 @@ import { OfficerWriteGuard } from '../guard/officer-write.guard';
 import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../../permission/guard/church-manager.guard';
 import { UpdateOfficerStructureDto } from '../dto/request/update-officer-structure.dto';
-import { PermissionChurch } from '../../../permission/decorator/permission-church.decorator';
+import { RequestChurch } from '../../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { GetUnassignedMembersDto } from '../../ministries/dto/ministry-group/request/member/get-unassigned-members.dto';
 
@@ -67,7 +67,7 @@ export class OfficersController {
   @OfficerWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   refreshOfficerCount(
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @QueryRunner() qr: QR,
   ) {
     return this.officersService.refreshOfficerCount(church, qr);

--- a/backend/src/members/controller/members.controller.ts
+++ b/backend/src/members/controller/members.controller.ts
@@ -26,7 +26,7 @@ import { RequestManager } from '../../permission/decorator/permission-manager.de
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { TargetMember } from '../decorator/target-member.decorator';
 import { MemberModel } from '../entity/member.entity';
-import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
+import { RequestChurch } from '../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../permission/guard/church-manager.guard';
@@ -39,7 +39,8 @@ export class MembersController {
   constructor(private readonly membersService: MembersService) {}
 
   @Get()
-  @MemberReadGuard()
+  //@MemberReadGuard()
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   getMembers(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Query() dto: GetMemberDto,
@@ -63,7 +64,7 @@ export class MembersController {
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   getMemberList(
     @Param('churchId', ParseIntPipe) churchId: number,
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @RequestManager() requestManager: ChurchUserModel,
     @Query() query: GetMemberListDto,
   ) {
@@ -105,7 +106,7 @@ export class MembersController {
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
     @Body() dto: UpdateMemberDto,
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @TargetMember() targetMember: MemberModel,
   ) {
     return this.membersService.updateMember(church, targetMember, dto);
@@ -118,7 +119,7 @@ export class MembersController {
   deleteMember(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @TargetMember() targetMember: MemberModel,
     @QueryRunner() qr: QR,
   ) {

--- a/backend/src/members/decorator/target-member.decorator.ts
+++ b/backend/src/members/decorator/target-member.decorator.ts
@@ -1,7 +1,16 @@
-import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import {
+  createParamDecorator,
+  ExecutionContext,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { CustomRequest } from '../../common/custom-request';
 
 export const TargetMember = createParamDecorator((_, ctx: ExecutionContext) => {
-  const req = ctx.switchToHttp().getRequest();
+  const req: CustomRequest = ctx.switchToHttp().getRequest();
 
-  return req.targetMember;
+  if (req.targetMember) {
+    return req.targetMember;
+  } else {
+    throw new InternalServerErrorException('요청 처리 대상 교인 처리 누락');
+  }
 });

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -179,12 +179,6 @@ export class MemberModel extends BaseModel {
   @JoinColumn({ name: 'officerId' })
   officer: OfficerModel;
 
-  /*@Column({ type: 'timestamptz', nullable: true, comment: '임직일' })
-  officerStartDate: Date | null;*/
-
-  /*@Column({ type: 'varchar', nullable: true, comment: '임직교회' })
-  officerStartChurch: string | null;*/
-
   @OneToMany(
     () => OfficerHistoryModel,
     (officerHistory) => officerHistory.member,

--- a/backend/src/members/service/interface/member-filter.service.interface.ts
+++ b/backend/src/members/service/interface/member-filter.service.interface.ts
@@ -1,6 +1,8 @@
 import { MemberModel } from '../../entity/member.entity';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { ConcealedMemberDto } from '../../dto/response/get-member-response.dto';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { QueryRunner } from 'typeorm';
 
 export const IMEMBER_FILTER_SERVICE = Symbol('MEMBER_FILTER_SERVICE');
 
@@ -9,11 +11,17 @@ export interface IMemberFilterService {
     requestManager: ChurchUserModel,
     members: MemberModel[],
     scopeGroupIds: number[],
-  ): Promise<ConcealedMemberDto[]>;
+  ): ConcealedMemberDto[];
 
   filterMember(
     requestManager: ChurchUserModel,
     member: MemberModel,
     scopeGroupIds: number[],
-  ): Promise<ConcealedMemberDto>;
+  ): ConcealedMemberDto;
+
+  getScopeGroupIds(
+    church: ChurchModel,
+    requestManager: ChurchUserModel,
+    qr?: QueryRunner,
+  ): Promise<number[]>;
 }

--- a/backend/src/members/service/members.service.ts
+++ b/backend/src/members/service/members.service.ts
@@ -56,7 +56,6 @@ import {
   IMinistryGroupHistoryDomainService,
 } from '../../member-history/ministry-history/ministry-history-domain/interface/ministry-group-history-domain.service.interface';
 import { MemberCursorPaginationResponseDto } from '../dto/response/member-cursor-pagination-response.dto';
-import { filter } from 'rxjs';
 
 @Injectable()
 export class MembersService {
@@ -115,19 +114,13 @@ export class MembersService {
       qr,
     );
 
-    const permissionScopeIds = requestManager.permissionScopes.map(
-      (scope) => scope.groupId,
+    const possibleGroupIds = await this.memberFilterService.getScopeGroupIds(
+      church,
+      requestManager,
+      qr,
     );
 
-    const possibleGroups =
-      await this.groupsDomainService.findGroupAndDescendantsByIds(
-        church,
-        permissionScopeIds,
-      );
-
-    const possibleGroupIds = possibleGroups.map((group) => group.id);
-
-    const filteredMember = await this.memberFilterService.filterMembers(
+    const filteredMember = this.memberFilterService.filterMembers(
       requestManager,
       data,
       possibleGroupIds,
@@ -166,9 +159,13 @@ export class MembersService {
       )
     ).items;
 
-    const scopeGroupIds = await this.getScopeGroupIds(church, requestManager);
+    const scopeGroupIds = await this.memberFilterService.getScopeGroupIds(
+      church,
+      requestManager,
+      qr,
+    );
 
-    const filteredMember = await this.memberFilterService.filterMember(
+    const filteredMember = this.memberFilterService.filterMember(
       requestManager,
       member,
       scopeGroupIds,
@@ -261,7 +258,7 @@ export class MembersService {
     church: ChurchModel,
     targetMember: MemberModel,
     qr: QueryRunner,
-  ): Promise<DeleteMemberResponseDto> {
+  ) {
     // 교인 삭제
     await this.membersDomainService.deleteMember(church, targetMember, qr);
 
@@ -317,7 +314,7 @@ export class MembersService {
       requestManager,
     );
 
-    const filteredMembers = await this.memberFilterService.filterMembers(
+    const filteredMembers = this.memberFilterService.filterMembers(
       requestManager,
       result.items,
       possibleGroupIds,

--- a/backend/src/permission/decorator/permission-church.decorator.ts
+++ b/backend/src/permission/decorator/permission-church.decorator.ts
@@ -4,7 +4,7 @@ import {
   InternalServerErrorException,
 } from '@nestjs/common';
 
-export const PermissionChurch = createParamDecorator(
+export const RequestChurch = createParamDecorator(
   (_, ctx: ExecutionContext) => {
     const req = ctx.switchToHttp().getRequest();
 

--- a/backend/src/permission/guard/generic-domain.guard.ts
+++ b/backend/src/permission/guard/generic-domain.guard.ts
@@ -14,6 +14,7 @@ import {
   IDomainPermissionService,
   IDOMAIN_PERMISSION_SERVICE,
 } from '../service/domain-permission.service.interface';
+import { CustomRequest } from '../../common/custom-request';
 
 export function createDomainGuard(
   domainType: DomainType,
@@ -28,7 +29,7 @@ export function createDomainGuard(
     ) {}
 
     async canActivate(context: ExecutionContext): Promise<boolean> {
-      const req = context.switchToHttp().getRequest();
+      const req: CustomRequest = context.switchToHttp().getRequest();
 
       const token = req.tokenPayload;
 

--- a/backend/src/task/controller/task.controller.ts
+++ b/backend/src/task/controller/task.controller.ts
@@ -35,7 +35,7 @@ import { TaskReadGuard } from '../guard/task-read.guard';
 import { TaskWriteGuard } from '../guard/task-write.guard';
 import { RequestManager } from '../../permission/decorator/permission-manager.decorator';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
-import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
+import { RequestChurch } from '../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../churches/entity/church.entity';
 
 @ApiTags('Tasks')
@@ -71,7 +71,7 @@ export class TaskController {
   @Patch('refresh-count')
   @UseInterceptors(TransactionInterceptor)
   refreshTaskCount(
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @QueryRunner() qr: QR,
   ) {
     return this.taskService.refreshTaskCount(church, qr);

--- a/backend/src/visitation/controller/visitation.controller.ts
+++ b/backend/src/visitation/controller/visitation.controller.ts
@@ -32,7 +32,7 @@ import { VisitationReadGuard } from '../guard/visitation-read.guard';
 import { VisitationWriteGuard } from '../guard/visitation-write.guard';
 import { RequestManager } from '../../permission/decorator/permission-manager.decorator';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
-import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
+import { RequestChurch } from '../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../churches/entity/church.entity';
 
 @ApiTags('Visitations')
@@ -69,7 +69,7 @@ export class VisitationController {
   @UseInterceptors(TransactionInterceptor)
   refreshVisitationCount(
     //@Param('churchId', ParseIntPipe) churchId: number,
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @QueryRunner() qr: QR,
   ) {
     return this.visitationService.refreshVisitationCount(church, qr);

--- a/backend/src/worship/controller/worship-attendance.controller.ts
+++ b/backend/src/worship/controller/worship-attendance.controller.ts
@@ -28,7 +28,7 @@ import { DomainName } from '../../permission/const/domain-name.enum';
 import { DomainAction } from '../../permission/const/domain-action.enum';
 import { WorshipAttendanceWriteScopeGuard } from '../guard/worship-attendance-write-scope.guard';
 import { PermissionScopeGroups } from '../decorator/permission-scope-groups.decorator';
-import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
+import { RequestChurch } from '../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { RequestWorship } from '../decorator/request-worship.decorator';
 import { WorshipModel } from '../entity/worship.entity';
@@ -57,7 +57,7 @@ export class WorshipAttendanceController {
     @Param('worshipId', ParseIntPipe) worshipId: number,
     @Param('sessionId', ParseIntPipe) sessionId: number,
     @Query() dto: GetWorshipAttendancesDto,
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @RequestWorship() worship: WorshipModel,
     @PermissionScopeGroups() permissionScopeGroupIds?: number[],
   ) {

--- a/backend/src/worship/controller/worship-enrollment.controller.ts
+++ b/backend/src/worship/controller/worship-enrollment.controller.ts
@@ -18,7 +18,7 @@ import { WorshipWriteGuard } from '../guard/worship-write.guard';
 import { WorshipGroupFilterGuard } from '../guard/worship-group-filter.guard';
 import { RequestWorship } from '../decorator/request-worship.decorator';
 import { WorshipModel } from '../entity/worship.entity';
-import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
+import { RequestChurch } from '../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { WorshipReadScopeGuard } from '../guard/worship-read-scope.guard';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
@@ -51,7 +51,7 @@ export class WorshipEnrollmentController {
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('worshipId', ParseIntPipe) worshipId: number,
     @Query() dto: GetWorshipEnrollmentsDto,
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @RequestWorship() worship: WorshipModel,
     @PermissionScopeGroups() permissionScopeGroupIds?: number[],
   ) {

--- a/backend/src/worship/controller/worship.controller.ts
+++ b/backend/src/worship/controller/worship.controller.ts
@@ -21,7 +21,7 @@ import { QueryRunner as QR } from 'typeorm';
 import { UpdateWorshipDto } from '../dto/request/worship/update-worship.dto';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../permission/guard/church-manager.guard';
-import { PermissionChurch } from '../../permission/decorator/permission-church.decorator';
+import { RequestChurch } from '../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { WorshipWriteGuard } from '../guard/worship-write.guard';
 import { WorshipReadGuard } from '../guard/worship-read.guard';
@@ -36,7 +36,7 @@ export class WorshipController {
   getWorships(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Query() dto: GetWorshipsDto,
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
   ) {
     return this.worshipService.findWorships(church, dto);
   }
@@ -48,7 +48,7 @@ export class WorshipController {
     @Param('churchId', ParseIntPipe) churchId: number,
     @Body() dto: CreateWorshipDto,
     @QueryRunner() qr: QR,
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
   ) {
     return this.worshipService.postWorship(church, dto, qr);
   }
@@ -58,7 +58,7 @@ export class WorshipController {
   @WorshipWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   refreshWorshipCount(
-    @PermissionChurch() church: ChurchModel,
+    @RequestChurch() church: ChurchModel,
     @QueryRunner() qr: QR,
   ) {
     return this.worshipService.refreshWorshipCount(church, qr);


### PR DESCRIPTION
## 주요 내용
교인 가족관계 목록 조회에 커서 기반 페이지네이션을 추가하고, 가족관계 관리 시 권한 체크 로직을 강화했습니다.

## 세부 내용

### 가족관계 목록 페이지네이션
- 커서 기반 페이지네이션 구현
- 쿼리 파라미터:
  - limit: 페이지 크기 (기본값 20)
  - cursor: 다음 페이지 커서
  - sortDirection: 정렬 방향 (ASC/DESC)
- 정렬 기준:
  - 1순위: 가족 교인의 생년월일 (NULL 처리 포함)
  - 2순위: 가족 교인의 ID
- NULL birth 처리: ASC는 마지막, DESC는 처음 위치

### 개인정보 보호 강화
- 권한 범위 외 가족 교인 조회 시 개인정보 'CONCEALED' 처리
- 노출 정보: 이름, 프로필 이미지, 관계
- 차단 정보: 전화번호, 주소, 생년월일 등 민감 정보

### 가족관계 CUD 권한 체크
- 생성/수정/삭제 시 2단계 권한 검증:
  1. 교인 관리 권한 보유 여부 확인
  2. 대상 교인이 권한 범위 내 존재 여부 확인
- 권한 없는 접근 시 403 Forbidden 응답

### 기술적 개선
- 가족 교인의 birth NULL 값 고려한 커서 페이지네이션 로직
- N:1 관계 조인으로 페이징 정확도 보장
- 권한 체크 미들웨어 분리로 재사용성 향상