### PR TITLE
hotfix: EducationTermReport 도메인 관련 기능 긴급 제거

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -74,7 +74,7 @@ import { EducationTermModel } from './educations/education-term/entity/education
 import { EducationSessionModel } from './educations/education-session/entity/education-session.entity';
 import { SessionAttendanceModel } from './educations/session-attendance/entity/session-attendance.entity';
 import { EducationEnrollmentModel } from './educations/education-enrollment/entity/education-enrollment.entity';
-import { EducationTermReportModel } from './report/education-report/entity/education-term-report.entity';
+//import { EducationTermReportModel } from './report/education-report/entity/education-term-report.entity';
 
 @Module({
   imports: [
@@ -182,7 +182,7 @@ import { EducationTermReportModel } from './report/education-report/entity/educa
           VisitationReportModel,
           TaskReportModel,
           EducationSessionReportModel,
-          EducationTermReportModel,
+          //EducationTermReportModel,
           // 업무 관련 엔티티
           TaskModel,
           // 권한 관련

--- a/backend/src/educations/education-domain/service/educaiton-term-domain.service.ts
+++ b/backend/src/educations/education-domain/service/educaiton-term-domain.service.ts
@@ -182,20 +182,20 @@ export class EducationTermDomainService implements IEducationTermDomainService {
       relations: {
         inCharge: MemberSummarizedRelation,
         creator: MemberSummarizedRelation,
-        reports: {
+        /*reports: {
           receiver: MemberSummarizedRelation,
-        },
+        },*/
       },
       select: {
         inCharge: MemberSummarizedSelect,
         creator: MemberSummarizedSelect,
-        reports: {
+        /*reports: {
           id: true,
           isRead: true,
           isConfirmed: true,
           receiver: MemberSummarizedSelect,
           reportedAt: true,
-        },
+        },*/
       },
     });
 

--- a/backend/src/educations/education-term/controller/education-terms.controller.ts
+++ b/backend/src/educations/education-term/controller/education-terms.controller.ts
@@ -158,13 +158,13 @@ export class EducationTermsController {
     @Body() dto: AddEducationTermReportDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.educationTermService.addReportReceivers(
+    /*return this.educationTermService.addReportReceivers(
       churchId,
       educationId,
       educationTermId,
       dto,
       qr,
-    );
+    );*/
   }
 
   @Patch(':educationTermId/delete-receivers')
@@ -176,12 +176,12 @@ export class EducationTermsController {
     @Body() dto: DeleteEducationTermReportDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.educationTermService.deleteEducationTermReportReceivers(
+    /*return this.educationTermService.deleteEducationTermReportReceivers(
       churchId,
       educationId,
       educationTermId,
       dto,
       qr,
-    );
+    );*/
   }
 }

--- a/backend/src/educations/education-term/entity/education-term.entity.ts
+++ b/backend/src/educations/education-term/entity/education-term.entity.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../common/entity/base.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { EducationTermStatus } from '../const/education-term-status.enum';
-import { EducationTermReportModel } from '../../../report/education-report/entity/education-term-report.entity';
+//import { EducationTermReportModel } from '../../../report/education-report/entity/education-term-report.entity';
 
 @Entity()
 export class EducationTermModel extends BaseModel {
@@ -74,8 +74,8 @@ export class EducationTermModel extends BaseModel {
   )
   educationEnrollments: EducationEnrollmentModel[];
 
-  @OneToMany(() => EducationTermReportModel, (report) => report.educationTerm)
-  reports: EducationTermReportModel[];
+  /*@OneToMany(() => EducationTermReportModel, (report) => report.educationTerm)
+  reports: EducationTermReportModel[];*/
 
   canAddSession(): boolean {
     return this.sessionsCount <= EducationSessionConstraints.MAX_SESSION_NUMBER;

--- a/backend/src/educations/education-term/service/education-term.service.ts
+++ b/backend/src/educations/education-term/service/education-term.service.ts
@@ -71,8 +71,8 @@ export class EducationTermService {
     @Inject(ISESSION_ATTENDANCE_DOMAIN_SERVICE)
     private readonly sessionAttendanceDomainService: ISessionAttendanceDomainService,
 
-    @Inject(IEDUCATION_TERM_REPORT_DOMAIN_SERVICE)
-    private readonly educationTermReportDomainService: IEducationTermReportDomainService,
+    /*@Inject(IEDUCATION_TERM_REPORT_DOMAIN_SERVICE)
+    private readonly educationTermReportDomainService: IEducationTermReportDomainService,*/
   ) {}
 
   async getEducationTerms(
@@ -184,13 +184,13 @@ export class EducationTermService {
     await this.educationDomainService.incrementTermsCount(education, qr);
 
     if (dto.receiverIds && dto.receiverIds.length > 0) {
-      await this.handleAddEducationTermReport(
+      /*await this.handleAddEducationTermReport(
         church,
         education,
         educationTerm,
         dto.receiverIds,
         qr,
-      );
+      );*/
     }
 
     return new PostEducationTermResponseDto(educationTerm);
@@ -312,10 +312,10 @@ export class EducationTermService {
     }
 
     // 기수 보고 삭제
-    await this.educationTermReportDomainService.deleteEducationTermReportsCascade(
+    /*await this.educationTermReportDomainService.deleteEducationTermReportsCascade(
       educationTerm,
       qr,
-    );
+    );*/
 
     await this.educationTermDomainService.deleteEducationTerm(
       educationTerm,
@@ -374,7 +374,7 @@ export class EducationTermService {
     );
   }
 
-  private async handleAddEducationTermReport(
+  /*private async handleAddEducationTermReport(
     church: ChurchModel,
     education: EducationModel,
     educationTerm: EducationTermModel,
@@ -404,9 +404,9 @@ export class EducationTermService {
       })),
       addedCount: newReceivers.length,
     };
-  }
+  }*/
 
-  async addReportReceivers(
+  /*async addReportReceivers(
     churchId: number,
     educationId: number,
     educationTermId: number,
@@ -437,9 +437,9 @@ export class EducationTermService {
       dto.receiverIds,
       qr,
     );
-  }
+  }*/
 
-  async deleteEducationTermReportReceivers(
+  /*async deleteEducationTermReportReceivers(
     churchId: number,
     educationId: number,
     educationTermId: number,
@@ -486,5 +486,5 @@ export class EducationTermService {
       })),
       deletedCount: result.affected,
     };
-  }
+  }*/
 }

--- a/backend/src/home/controller/home.controller.ts
+++ b/backend/src/home/controller/home.controller.ts
@@ -74,8 +74,8 @@ export class HomeController {
       throw new BadRequestException('from, to 에러');
     }
 
-    return this.homeService.getMyReports(pm, dto);
-    //return this.homeService.getMyScheduleReports(pm, dto);
+    //return this.homeService.getMyReports(pm, dto);
+    return this.homeService.getMyScheduleReports(pm, dto);
   }
 
   @ApiGetLowWorshipAttendanceMembers()

--- a/backend/src/report/education-report/controller/education-term-report.controller.ts
+++ b/backend/src/report/education-report/controller/education-term-report.controller.ts
@@ -25,7 +25,7 @@ export class EducationTermReportController {
     private readonly educationTermReportService: EducationTermReportService,
   ) {}
 
-  @UseGuards(AccessTokenGuard, ChurchUserGuard)
+  /*@UseGuards(AccessTokenGuard, ChurchUserGuard)
   @Get()
   getEducationTermReport(
     @RequestChurchUser() churchUser: ChurchUserModel,
@@ -73,5 +73,5 @@ export class EducationTermReportController {
       churchUser,
       reportId,
     );
-  }
+  }*/
 }

--- a/backend/src/report/education-report/dto/term/response/education-term-report-pagination-response.dto.ts
+++ b/backend/src/report/education-report/dto/term/response/education-term-report-pagination-response.dto.ts
@@ -1,3 +1,4 @@
+/*
 import { EducationTermReportModel } from '../../../entity/education-term-report.entity';
 
 export class EducationTermReportPaginationResponseDto {
@@ -6,3 +7,4 @@ export class EducationTermReportPaginationResponseDto {
     public readonly timestamp: Date = new Date(),
   ) {}
 }
+*/

--- a/backend/src/report/education-report/dto/term/response/get-education-term-report-response.dto.ts
+++ b/backend/src/report/education-report/dto/term/response/get-education-term-report-response.dto.ts
@@ -1,3 +1,4 @@
+/*
 import { BaseGetResponseDto } from '../../../../../common/dto/reponse/base-get-response.dto';
 import { EducationTermReportModel } from '../../../entity/education-term-report.entity';
 
@@ -6,3 +7,4 @@ export class GetEducationTermReportResponseDto extends BaseGetResponseDto<Educat
     super(data);
   }
 }
+*/

--- a/backend/src/report/education-report/dto/term/response/patch-education-term-report-response.dto.ts
+++ b/backend/src/report/education-report/dto/term/response/patch-education-term-report-response.dto.ts
@@ -1,3 +1,4 @@
+/*
 import { BasePatchResponseDto } from '../../../../../common/dto/reponse/base-patch-response.dto';
 import { EducationTermReportModel } from '../../../entity/education-term-report.entity';
 
@@ -6,3 +7,4 @@ export class PatchEducationTermReportResponseDto extends BasePatchResponseDto<Ed
     super(data);
   }
 }
+*/

--- a/backend/src/report/education-report/education-report-domain/education-report-domain.module.ts
+++ b/backend/src/report/education-report/education-report-domain/education-report-domain.module.ts
@@ -3,29 +3,29 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { EducationSessionReportModel } from '../entity/education-session-report.entity';
 import { IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE } from './interface/education-session-report-domain.service.interface';
 import { EducationSessionReportDomainService } from './service/education-session-report-domain.service';
-import { EducationTermReportModel } from '../entity/education-term-report.entity';
+//import { EducationTermReportModel } from '../entity/education-term-report.entity';
 import { IEDUCATION_TERM_REPORT_DOMAIN_SERVICE } from './interface/education-term-report-domain.service.interface';
 import { EducationTermReportDomainService } from './service/education-term-report-domain.service';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
-      EducationTermReportModel,
+      //EducationTermReportModel,
       EducationSessionReportModel,
     ]),
   ],
   providers: [
-    {
+    /*{
       provide: IEDUCATION_TERM_REPORT_DOMAIN_SERVICE,
       useClass: EducationTermReportDomainService,
-    },
+    },*/
     {
       provide: IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE,
       useClass: EducationSessionReportDomainService,
     },
   ],
   exports: [
-    IEDUCATION_TERM_REPORT_DOMAIN_SERVICE,
+    //IEDUCATION_TERM_REPORT_DOMAIN_SERVICE,
     IEDUCATION_SESSION_REPORT_DOMAIN_SERVICE,
   ],
 })

--- a/backend/src/report/education-report/education-report-domain/interface/education-term-report-domain.service.interface.ts
+++ b/backend/src/report/education-report/education-report-domain/interface/education-term-report-domain.service.interface.ts
@@ -2,7 +2,7 @@ import { EducationModel } from '../../../../educations/education/entity/educatio
 import { EducationTermModel } from '../../../../educations/education-term/entity/education-term.entity';
 import { ChurchUserModel } from '../../../../church-user/entity/church-user.entity';
 import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
-import { EducationTermReportModel } from '../../entity/education-term-report.entity';
+//import { EducationTermReportModel } from '../../entity/education-term-report.entity';
 import { MemberModel } from '../../../../members/entity/member.entity';
 import { GetEducationTermReportsDto } from '../../dto/term/request/get-education-term-reports.dto';
 import { UpdateEducationTermReportDto } from '../../dto/term/request/update-education-term-report.dto';
@@ -12,7 +12,7 @@ export const IEDUCATION_TERM_REPORT_DOMAIN_SERVICE = Symbol(
 );
 
 export interface IEducationTermReportDomainService {
-  findEducationTermReports(
+  /*findEducationTermReports(
     currentMember: MemberModel,
     dto: GetEducationTermReportsDto,
     qr?: QueryRunner,
@@ -65,5 +65,5 @@ export interface IEducationTermReportDomainService {
   deleteEducationTermReport(
     targetReport: EducationTermReportModel,
     qr?: QueryRunner,
-  ): Promise<UpdateResult>;
+  ): Promise<UpdateResult>;*/
 }

--- a/backend/src/report/education-report/education-report-domain/service/education-term-report-domain.service.ts
+++ b/backend/src/report/education-report/education-report-domain/service/education-term-report-domain.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { IEducationTermReportDomainService } from '../interface/education-term-report-domain.service.interface';
 import { InjectRepository } from '@nestjs/typeorm';
-import { EducationTermReportModel } from '../../entity/education-term-report.entity';
+//import { EducationTermReportModel } from '../../entity/education-term-report.entity';
 import {
   FindOptionsOrder,
   FindOptionsRelations,
@@ -31,9 +31,8 @@ import { UpdateEducationTermReportDto } from '../../dto/term/request/update-educ
 
 @Injectable()
 export class EducationTermReportDomainService
-  implements IEducationTermReportDomainService
-{
-  constructor(
+  implements IEducationTermReportDomainService {
+  /*constructor(
     @InjectRepository(EducationTermReportModel)
     private readonly repository: Repository<EducationTermReportModel>,
   ) {}
@@ -294,5 +293,5 @@ export class EducationTermReportDomainService
     }
 
     return result;
-  }
+  }*/
 }

--- a/backend/src/report/education-report/entity/education-term-report.entity.ts
+++ b/backend/src/report/education-report/entity/education-term-report.entity.ts
@@ -4,7 +4,7 @@ import { ReportModel } from '../../base-report/entity/report.entity';
 import { EducationTermModel } from '../../../educations/education-term/entity/education-term.entity';
 import { EducationModel } from '../../../educations/education/entity/education.entity';
 
-@ChildEntity(ReportType.EDUCATION_TERM)
+/*@ChildEntity(ReportType.EDUCATION_TERM)
 export class EducationTermReportModel extends ReportModel {
   @Index()
   @Column()
@@ -21,4 +21,4 @@ export class EducationTermReportModel extends ReportModel {
   @ManyToOne(() => EducationModel)
   @JoinColumn({ name: 'educationId' })
   education: EducationModel;
-}
+}*/

--- a/backend/src/report/education-report/service/education-term-report.service.ts
+++ b/backend/src/report/education-report/service/education-term-report.service.ts
@@ -6,15 +6,15 @@ import {
 import { QueryRunner } from 'typeorm';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { GetEducationTermReportsDto } from '../dto/term/request/get-education-term-reports.dto';
-import { EducationTermReportPaginationResponseDto } from '../dto/term/response/education-term-report-pagination-response.dto';
-import { GetEducationTermReportResponseDto } from '../dto/term/response/get-education-term-report-response.dto';
+//import { EducationTermReportPaginationResponseDto } from '../dto/term/response/education-term-report-pagination-response.dto';
+//import { GetEducationTermReportResponseDto } from '../dto/term/response/get-education-term-report-response.dto';
 import { UpdateEducationTermReportDto } from '../dto/term/request/update-education-term-report.dto';
-import { PatchEducationTermReportResponseDto } from '../dto/term/response/patch-education-term-report-response.dto';
+//import { PatchEducationTermReportResponseDto } from '../dto/term/response/patch-education-term-report-response.dto';
 import { DeleteEducationTermReportResponseDto } from '../dto/term/response/delete-education-term-report-response.dto';
 
 @Injectable()
 export class EducationTermReportService {
-  constructor(
+  /*constructor(
     @Inject(IEDUCATION_TERM_REPORT_DOMAIN_SERVICE)
     private readonly educationTermReportDomainService: IEducationTermReportDomainService,
   ) {}
@@ -123,5 +123,5 @@ export class EducationTermReportService {
       targetReport.educationTermId,
       true,
     );
-  }
+  }*/
 }

--- a/backend/src/report/report-domain/interface/report-domain.service.interface.ts
+++ b/backend/src/report/report-domain/interface/report-domain.service.interface.ts
@@ -11,5 +11,5 @@ export interface IReportDomainService {
     to: Date,
     dto: GetMyReportsDto,
     qr?: QueryRunner,
-  ): Promise<any[]>;
+  ): any;
 }

--- a/backend/src/report/report-domain/service/report-domain.service.ts
+++ b/backend/src/report/report-domain/service/report-domain.service.ts
@@ -10,7 +10,7 @@ import { ScheduleReportDto } from '../../../home/dto/schedule-report.dto';
 import { ScheduleType } from '../../../home/const/schedule-type.enum';
 import { VisitationReportModel } from '../../visitation-report/entity/visitation-report.entity';
 import { EducationSessionReportModel } from '../../education-report/entity/education-session-report.entity';
-import { EducationTermReportModel } from '../../education-report/entity/education-term-report.entity';
+//import { EducationTermReportModel } from '../../education-report/entity/education-term-report.entity';
 import { ReportType } from '../../base-report/const/report-type.enum';
 import { GetMyReportsDto } from '../../../home/dto/request/get-my-reports.dto';
 
@@ -32,7 +32,7 @@ export class ReportDomainService implements IReportDomainService {
     dto: GetMyReportsDto,
     qr?: QueryRunner,
   ) {
-    const repository = this.getRepository(qr);
+    /*const repository = this.getRepository(qr);
 
     const reportsQb = repository
       .createQueryBuilder('report')
@@ -134,7 +134,7 @@ export class ReportDomainService implements IReportDomainService {
       } else {
         throw new InternalServerErrorException();
       }
-    });
+    });*/
   }
 
   private createQuery(


### PR DESCRIPTION
## 주요 내용
EducationTermReport 도메인에서 발생한 치명적 문제로 인해 관련된 모든 기능을 긴급 제거했습니다.

## 세부 내용

### 제거된 기능
- EducationTermReport 엔티티 및 관련 모델
- EducationTermReport 관련 API 엔드포인트
- EducationTermReport 서비스 및 도메인 서비스
- 관련 DTO 및 타입 정의
- 연관 테이블 관계 및 외래키 참조

### 영향 범위
- 교육 기간 보고서 CRUD 기능 비활성화
- 관련 통계 및 리포트 기능 일시 중단
- 연관된 모듈의 import 제거