### PR TITLE
feat: 교인 상세 조회 권한 정보 추가 및 커서 기반 간단 검색 API 구현

### DIFF
--- a/backend/src/common/dto/request/base-cursor-pagination-request.dto.ts
+++ b/backend/src/common/dto/request/base-cursor-pagination-request.dto.ts
@@ -1,0 +1,28 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsIn, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export abstract class BaseCursorPaginationRequestDto<TOrder> {
+  @ApiPropertyOptional({ description: '페이지 크기', default: 20 })
+  @IsOptional()
+  @IsNumber()
+  limit: number = 20;
+
+  @ApiPropertyOptional({ description: '커서 (마지막 항목의 ID)' })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @ApiPropertyOptional({ description: '정렬 방향', default: 'ASC' })
+  @IsOptional()
+  @IsIn(['ASC', 'DESC'])
+  sortDirection: 'ASC' | 'DESC' = 'ASC';
+
+  @ApiPropertyOptional({
+    description: '정렬 기준',
+    enum: [],
+    default: undefined,
+  })
+  @IsOptional()
+  @IsEnum(Object)
+  abstract sortBy?: TOrder;
+}

--- a/backend/src/members/const/member-find-options.const.ts
+++ b/backend/src/members/const/member-find-options.const.ts
@@ -40,6 +40,19 @@ export const MemberSummarizedSelectQB: string[] = [
   'member.ministryGroupRole',
 ];
 
+export const MemberSimpleSelectQB: string[] = [
+  'member.id',
+  'member.name',
+  'member.profileImageUrl',
+  //'member.mobilePhone',
+  'member.registeredAt',
+  //'member.birth',
+  //'member.isLunar',
+  //'member.isLeafMonth',
+  'member.groupRole',
+  'member.ministryGroupRole',
+];
+
 export const MemberSummarizedOfficerSelectQB: string[] = [
   'officer.id',
   'officer.name',

--- a/backend/src/members/controller/members.controller.ts
+++ b/backend/src/members/controller/members.controller.ts
@@ -32,6 +32,7 @@ import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
 import { ChurchManagerGuard } from '../../permission/guard/church-manager.guard';
 import { GetMemberListDto } from '../dto/list/get-member-list.dto';
 import { MemberDisplayColumn } from '../const/enum/list/display-column.enum';
+import { GetSimpleMemberListDto } from '../dto/list/get-simple-member-list.dto';
 
 @ApiTags('Churches:Members')
 @Controller('members')
@@ -88,6 +89,16 @@ export class MembersController {
     @Query() dto: GetSimpleMembersDto,
   ) {
     return this.membersService.getSimpleMembers(churchId, dto);
+  }
+
+  @Get('simple/v2')
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
+  getSimpleMemberList(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
+    @Query() query: GetSimpleMemberListDto,
+  ) {
+    return this.membersService.getSimpleMemberList(church, query);
   }
 
   @Get(':memberId')

--- a/backend/src/members/dto/list/get-simple-member-list.dto.ts
+++ b/backend/src/members/dto/list/get-simple-member-list.dto.ts
@@ -1,0 +1,39 @@
+import { BaseCursorPaginationRequestDto } from '../../../common/dto/request/base-cursor-pagination-request.dto';
+import { SimpleMemberOrder } from '../request/get-simple-members.dto';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptionalNotNull } from '../../../common/decorator/validator/is-optional-not.null.validator';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+
+export class GetSimpleMemberListDto extends BaseCursorPaginationRequestDto<SimpleMemberOrder> {
+  @ApiPropertyOptional({
+    enum: SimpleMemberOrder,
+    description: '정렬 기준 컬럼',
+    default: SimpleMemberOrder.REGISTERED_AT,
+  })
+  @IsOptional()
+  @IsEnum(SimpleMemberOrder)
+  sortBy: SimpleMemberOrder = SimpleMemberOrder.REGISTERED_AT;
+
+  @ApiPropertyOptional({
+    description: '교인 이름',
+  })
+  @IsOptionalNotNull()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: '교인 휴대전화 번호',
+  })
+  @IsOptionalNotNull()
+  @IsNotEmpty()
+  @MaxLength(15)
+  mobilePhone?: string;
+}

--- a/backend/src/members/dto/request/get-simple-members.dto.ts
+++ b/backend/src/members/dto/request/get-simple-members.dto.ts
@@ -11,11 +11,11 @@ import {
 import { IsOptionalNotNull } from '../../../common/decorator/validator/is-optional-not.null.validator';
 import { BaseOffsetPaginationRequestDto } from '../../../common/dto/request/base-offset-pagination-request.dto';
 
-export enum GetSimpleMemberOrder {
+export enum SimpleMemberOrder {
   REGISTERED_AT = 'registeredAt',
 }
 
-export class GetSimpleMembersDto extends BaseOffsetPaginationRequestDto<GetSimpleMemberOrder> {
+export class GetSimpleMembersDto extends BaseOffsetPaginationRequestDto<SimpleMemberOrder> {
   @ApiProperty({
     description: '조회할 데이터 개수',
     default: 20,
@@ -38,12 +38,12 @@ export class GetSimpleMembersDto extends BaseOffsetPaginationRequestDto<GetSimpl
   @ApiProperty({
     description: '정렬 기준',
     required: false,
-    enum: GetSimpleMemberOrder,
-    default: GetSimpleMemberOrder.REGISTERED_AT,
+    enum: SimpleMemberOrder,
+    default: SimpleMemberOrder.REGISTERED_AT,
   })
   @IsOptional()
-  @IsEnum(GetSimpleMemberOrder)
-  order: GetSimpleMemberOrder = GetSimpleMemberOrder.REGISTERED_AT;
+  @IsEnum(SimpleMemberOrder)
+  order: SimpleMemberOrder = SimpleMemberOrder.REGISTERED_AT;
 
   @ApiProperty({
     description: '교인 이름',

--- a/backend/src/members/dto/response/simple-members-pagination-response.dto.ts
+++ b/backend/src/members/dto/response/simple-members-pagination-response.dto.ts
@@ -1,14 +1,8 @@
 import { MemberModel } from '../../entity/member.entity';
-import { BaseOffsetPaginationResponseDto } from '../../../common/dto/reponse/base-offset-pagination-response.dto';
 
-export class SimpleMembersPaginationResponseDto extends BaseOffsetPaginationResponseDto<MemberModel> {
+export class SimpleMembersPaginationResponseDto {
   constructor(
-    data: MemberModel[],
-    totalCount: number,
-    count: number,
-    page: number,
-    totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly data: MemberModel[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -11,7 +11,6 @@ import { MemberModel } from '../../entity/member.entity';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { CreateMemberDto } from '../../dto/request/create-member.dto';
 import { UpdateMemberDto } from '../../dto/request/update-member.dto';
-import { MembersDomainPaginationResultDto } from '../dto/members-domain-pagination-result.dto';
 import { GetSimpleMembersDto } from '../../dto/request/get-simple-members.dto';
 import { GetRecommendLinkMemberDto } from '../../dto/request/get-recommend-link-member.dto';
 import { GetBirthdayMembersDto } from '../../../calendar/dto/request/birthday/get-birthday-members.dto';
@@ -20,6 +19,7 @@ import { GetNewMemberDetailDto } from '../../../home/dto/request/get-new-member-
 import { GroupRole } from '../../../management/groups/const/group-role.enum';
 import { GetMemberListDto } from '../../dto/list/get-member-list.dto';
 import { DomainCursorPaginationResultDto } from '../../../common/dto/domain-cursor-pagination-result.dto';
+import { GetSimpleMemberListDto } from '../../dto/list/get-simple-member-list.dto';
 
 export const IMEMBERS_DOMAIN_SERVICE = Symbol('IMEMBERS_DOMAIN_SERVICE');
 
@@ -45,7 +45,12 @@ export interface IMembersDomainService {
     church: ChurchModel,
     dto: GetSimpleMembersDto,
     qr?: QueryRunner,
-  ): Promise<MembersDomainPaginationResultDto>;
+  ): Promise<MemberModel[]>;
+
+  findSimpleMemberList(
+    church: ChurchModel,
+    query: GetSimpleMemberListDto,
+  ): Promise<DomainCursorPaginationResultDto<MemberModel>>;
 
   findAllMembers(church: ChurchModel, qr?: QueryRunner): Promise<MemberModel[]>;
 

--- a/backend/src/members/service/members.service.ts
+++ b/backend/src/members/service/members.service.ts
@@ -56,6 +56,7 @@ import {
   IMinistryGroupHistoryDomainService,
 } from '../../member-history/ministry-history/ministry-history-domain/interface/ministry-group-history-domain.service.interface';
 import { MemberCursorPaginationResponseDto } from '../dto/response/member-cursor-pagination-response.dto';
+import { GetSimpleMemberListDto } from '../dto/list/get-simple-member-list.dto';
 
 @Injectable()
 export class MembersService {
@@ -287,15 +288,25 @@ export class MembersService {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    const { data, totalCount } =
-      await this.membersDomainService.findSimpleMembers(church, dto);
+    const data = await this.membersDomainService.findSimpleMembers(church, dto);
 
-    return new SimpleMembersPaginationResponseDto(
-      data,
-      totalCount,
-      data.length,
-      dto.page,
-      Math.ceil(totalCount / dto.take),
+    return new SimpleMembersPaginationResponseDto(data);
+  }
+
+  async getSimpleMemberList(
+    church: ChurchModel,
+    query: GetSimpleMemberListDto,
+  ) {
+    const result = await this.membersDomainService.findSimpleMemberList(
+      church,
+      query,
+    );
+
+    return new MemberCursorPaginationResponseDto(
+      result.items,
+      result.items.length,
+      result.nextCursor,
+      result.hasMore,
     );
   }
 


### PR DESCRIPTION
## 주요 내용
교인 상세 조회 시 관리자 권한 확인 기능을 추가하고, 성능 개선을 위한 커서 페이지네이션 기반의 교인 간단 검색 API를 새로 구현했습니다.

## 세부 내용
### 교인 상세 조회 개선
- 응답에 "churchUser" 필드 추가로 해당 교인의 권한 정보 제공
- churchUser 객체 구조: {id: number, role: "owner" | "manager"}
- 교인이 교회 관리자인지 즉시 확인 가능

### 커서 기반 교인 검색 API 신규 구현
- 엔드포인트: /churches/{churchId}/members/simple/v2
- 커서 페이지네이션 적용으로 대용량 데이터 조회 성능 개선
- 정렬 기준: registeredAt (고정)
- 응답 데이터: id, 이름, 프로필이미지, 그룹, 직분
- 기존 오프셋 기반 API는 하위 호환성을 위해 유지