### PR TITLE
feat: 심방 목록 조회 시 심방 대상자 필터링 기능 추가

### DIFF
--- a/backend/src/members/const/member-find-options.const.ts
+++ b/backend/src/members/const/member-find-options.const.ts
@@ -40,6 +40,27 @@ export const MemberSummarizedSelectQB: string[] = [
   'member.ministryGroupRole',
 ];
 
+export const MemberSimpleSelect: FindOptionsSelect<MemberModel> = {
+  id: true,
+  name: true,
+  profileImageUrl: true,
+  registeredAt: true,
+  //mobilePhone: true,
+  //birth: true,
+  //isLunar: true,
+  //isLeafMonth: true,
+  officer: {
+    id: true,
+    name: true,
+  },
+  group: {
+    id: true,
+    name: true,
+  },
+  groupRole: true,
+  ministryGroupRole: true,
+};
+
 export const MemberSimpleSelectQB: string[] = [
   'member.id',
   'member.name',

--- a/backend/src/visitation/const/visitation-find-options.const.ts
+++ b/backend/src/visitation/const/visitation-find-options.const.ts
@@ -1,7 +1,7 @@
 import { FindOptionsRelations, FindOptionsSelect } from 'typeorm';
 import { VisitationMetaModel } from '../entity/visitation-meta.entity';
 import { VisitationDetailModel } from '../entity/visitation-detail.entity';
-import { MemberSummarizedSelect } from '../../members/const/member-find-options.const';
+import { MemberSimpleSelect } from '../../members/const/member-find-options.const';
 
 export const VisitationRelationOptions: FindOptionsRelations<VisitationMetaModel> =
   {
@@ -26,27 +26,34 @@ export const VisitationRelationOptions: FindOptionsRelations<VisitationMetaModel
     visitationDetails: true,
   };
 
+export const VisitationListRelationOptions: FindOptionsRelations<VisitationMetaModel> =
+  {
+    members: {
+      officer: true,
+      group: true,
+    },
+    inCharge: {
+      officer: true,
+      group: true,
+    },
+    //visitationDetails: true,
+  };
+
+export const VisitationListSelectOptions: FindOptionsSelect<VisitationMetaModel> =
+  {
+    inCharge: MemberSimpleSelect,
+    members: MemberSimpleSelect,
+  };
+
 export const VisitationSelectOptions: FindOptionsSelect<VisitationMetaModel> = {
-  creator: MemberSummarizedSelect,
-  inCharge: MemberSummarizedSelect,
-  members: MemberSummarizedSelect,
+  creator: MemberSimpleSelect,
+  inCharge: MemberSimpleSelect,
+  members: MemberSimpleSelect,
   reports: {
     id: true,
     isRead: true,
     isConfirmed: true,
-    receiver: {
-      id: true,
-      name: true,
-      officer: {
-        id: true,
-        name: true,
-      },
-      group: {
-        id: true,
-        name: true,
-      },
-      groupRole: true,
-    },
+    receiver: MemberSimpleSelect,
   },
   visitationDetails: {
     id: true,

--- a/backend/src/visitation/dto/request/get-visitation.dto.ts
+++ b/backend/src/visitation/dto/request/get-visitation.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsDate,
   IsEnum,
@@ -121,4 +121,10 @@ export class GetVisitationDto {
   @IsNumber()
   @Min(1)
   inChargeId?: number;
+
+  @ApiPropertyOptional({ description: '심방 대상자 교인 ID' })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  memberId?: number;
 }

--- a/backend/src/visitation/dto/response/visitation-pagination-result.dto.ts
+++ b/backend/src/visitation/dto/response/visitation-pagination-result.dto.ts
@@ -1,14 +1,8 @@
-import { BaseOffsetPaginationResponseDto } from '../../../common/dto/reponse/base-offset-pagination-response.dto';
 import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
 
-export class VisitationPaginationResultDto extends BaseOffsetPaginationResponseDto<VisitationMetaModel> {
+export class VisitationPaginationResultDto {
   constructor(
     public readonly data: VisitationMetaModel[],
-    public readonly totalCount: number,
-    public readonly count: number,
-    public readonly page: number,
-    public readonly totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/visitation/service/visitation.service.ts
+++ b/backend/src/visitation/service/visitation.service.ts
@@ -71,16 +71,10 @@ export class VisitationService {
     const church =
       await this.churchesDomainService.findChurchModelById(churchId);
 
-    const { visitations, totalCount } =
+    const visitations =
       await this.visitationMetaDomainService.paginateVisitations(church, dto);
 
-    return new VisitationPaginationResultDto(
-      visitations,
-      totalCount,
-      visitations.length,
-      dto.page,
-      Math.ceil(totalCount / dto.take),
-    );
+    return new VisitationPaginationResultDto(visitations);
   }
 
   async getVisitationById(

--- a/backend/src/visitation/visitation-domain/interface/visitation-meta-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/interface/visitation-meta-domain.service.interface.ts
@@ -14,7 +14,7 @@ export interface IVisitationMetaDomainService {
   paginateVisitations(
     church: ChurchModel,
     dto: GetVisitationDto,
-  ): Promise<{ visitations: VisitationMetaModel[]; totalCount: number }>;
+  ): Promise<VisitationMetaModel[]>;
 
   findVisitationMetaById(
     church: ChurchModel,

--- a/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
@@ -27,6 +27,8 @@ import { VisitationException } from '../../const/exception/visitation.exception'
 import { UpdateVisitationMetaDto } from '../../dto/internal/meta/update-visitation-meta.dto';
 import { GetVisitationDto } from '../../dto/request/get-visitation.dto';
 import {
+  VisitationListRelationOptions,
+  VisitationListSelectOptions,
   VisitationRelationOptions,
   VisitationSelectOptions,
 } from '../../const/visitation-find-options.const';
@@ -72,6 +74,7 @@ export class VisitationMetaDomainService
       visitationType: dto.visitationType && In(dto.visitationType),
       title: dto.title && ILike(`%${dto.title}%`),
       inChargeId: dto.inChargeId,
+      members: dto.memberId ? { id: dto.memberId } : undefined,
     };
   }
 
@@ -88,30 +91,20 @@ export class VisitationMetaDomainService
   async paginateVisitations(
     church: ChurchModel,
     dto: GetVisitationDto,
-  ): Promise<{ visitations: VisitationMetaModel[]; totalCount: number }> {
+  ): Promise<VisitationMetaModel[]> {
     const repository = this.getVisitationMetaRepository();
 
-    const [visitations, totalCount] = await Promise.all([
-      repository.find({
-        where: {
-          churchId: church.id,
-          ...this.parseWhereOptions(dto),
-        },
-        relations: VisitationRelationOptions,
-        select: VisitationSelectOptions,
-        order: { [dto.order]: dto.orderDirection },
-        take: dto.take,
-        skip: dto.take * (dto.page - 1),
-      }),
-      repository.count({
-        where: {
-          churchId: church.id,
-          ...this.parseWhereOptions(dto),
-        },
-      }),
-    ]);
-
-    return { visitations, totalCount };
+    return repository.find({
+      where: {
+        churchId: church.id,
+        ...this.parseWhereOptions(dto),
+      },
+      relations: VisitationListRelationOptions,
+      select: VisitationListSelectOptions,
+      order: { [dto.order]: dto.orderDirection, id: dto.orderDirection },
+      take: dto.take,
+      skip: dto.take * (dto.page - 1),
+    });
   }
 
   async findVisitationMetaById(


### PR DESCRIPTION
## 주요 내용
심방 목록 조회 API에 특정 교인을 대상으로 하는 심방만 필터링할 수 있는 기능을 추가했습니다.

## 세부 내용
### 구현 내용
- VisitationMetaModel과 MemberModel의 N:N 관계를 활용한 필터링
- TypeORM find 메소드를 사용하여 간단하게 구현
- 특정 교인 ID로 해당 교인이 포함된 심방만 조회 가능

### 사용 예시
- 특정 교인의 심방 이력 확인
- 교인별 심방 계획 조회