### PR TITLE
feat: 예배 출석 통계 API 구현 및 그룹 필터링 기능 추가

### DIFF
--- a/backend/src/worship/dto/request/worship/get-worship-stats.dto.ts
+++ b/backend/src/worship/dto/request/worship/get-worship-stats.dto.ts
@@ -1,0 +1,9 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNumber, IsOptional } from 'class-validator';
+
+export class GetWorshipStatsDto {
+  @ApiPropertyOptional({ description: '조회할 그룹' })
+  @IsOptional()
+  @IsNumber()
+  groupId?: number;
+}

--- a/backend/src/worship/service/worship-enrollment.service.ts
+++ b/backend/src/worship/service/worship-enrollment.service.ts
@@ -169,18 +169,6 @@ export class WorshipEnrollmentService {
       (enrollment: WorshipEnrollmentModel) => enrollment.id,
     );
 
-    /*if (dto.fromSessionDate && !dto.toSessionDate) {
-      dto.toSessionDate = new Date(
-        dto.fromSessionDate.getTime() + 100 * 24 * 60 * 60 * 1000,
-      );
-    }
-
-    if (!dto.fromSessionDate && dto.toSessionDate) {
-      dto.fromSessionDate = new Date(
-        dto.toSessionDate.getTime() - 100 * 24 * 60 * 60 * 1000,
-      );
-    }*/
-
     const attendances =
       await this.worshipAttendanceDomainService.joinAttendance(
         enrollmentIds,

--- a/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
@@ -5,6 +5,7 @@ import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { WorshipAttendanceModel } from '../../entity/worship-attendance.entity';
 import { WorshipEnrollmentModel } from '../../entity/worship-enrollment.entity';
 import { UpdateWorshipAttendanceDto } from '../../dto/request/worship-attendance/update-worship-attendance.dto';
+import { WorshipModel } from '../../entity/worship.entity';
 
 export const IWORSHIP_ATTENDANCE_DOMAIN_SERVICE = Symbol(
   'IWORSHIP_ATTENDANCE_DOMAIN_SERVICE',
@@ -65,8 +66,17 @@ export interface IWorshipAttendanceDomainService {
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 
-  /*countPresentAndAbsent(enrollment: WorshipEnrollmentModel): Promise<{
+  getAttendanceStatsByWorship(
+    worship: WorshipModel,
+    requestGroupIds: number[] | undefined,
+  ): Promise<{
     presentCount: number;
     absentCount: number;
-  }>;*/
+    unknownCount: number;
+  }>;
+
+  getMovingAverageAttendance(
+    worship: WorshipModel,
+    requestGroupIds: number[] | undefined,
+  ): Promise<{ last4Weeks: number; last12Weeks: number }>;
 }

--- a/backend/src/worship/worship-domain/interface/worship-session-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-session-domain.service.interface.ts
@@ -66,4 +66,6 @@ export interface IWorshipSessionDomainService {
     worship: WorshipModel,
     qr: QueryRunner,
   ): Promise<number[]>;
+
+  countByWorship(worship: WorshipModel): Promise<number>;
 }

--- a/backend/src/worship/worship-domain/service/worship-session-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-session-domain.service.ts
@@ -324,4 +324,14 @@ export class WorshipSessionDomainService
 
     return deletedSessionIds;
   }
+
+  async countByWorship(worship: WorshipModel): Promise<number> {
+    const repository = this.getRepository();
+
+    return repository.count({
+      where: {
+        worshipId: worship.id,
+      },
+    });
+  }
 }


### PR DESCRIPTION
## 주요 내용
예배 출석률 통계를 조회하는 엔드포인트를 구현하고, 특정 그룹별 필터링 기능을 추가했습니다.

## 세부 내용
- GET `churches/:churchId/worship/:id/statistics` 엔드포인트 구현
- 전체 기간, 최근 12주, 최근 4주 출석률 제공
- 구간별 변화율 계산을 통한 트렌드 분석 기능 추가
 - 장기 변화율: 전체 → 12주
 - 단기 변화율: 12주 → 4주
 - 전체 변화율: 전체 → 4주
- 그룹 ID 쿼리 파라미터를 통한 특정 그룹 필터링 지원
- 하위 그룹을 포함한 재귀적 통계 집계

## 변경사항
- WorshipController에 통계 조회 메소드 추가
- WorshipService에 이동평균 및 트렌드 분석 로직 구현
- WorshipAttendanceDomainService에 그룹 필터링 쿼리 추가