### PR TITLE
feat: 예배 출석 통계 API 구현 및 그룹 필터링 기능 추가

### DIFF
--- a/backend/src/worship/dto/response/worship/get-worship-stats-response.dto.ts
+++ b/backend/src/worship/dto/response/worship/get-worship-stats-response.dto.ts
@@ -1,0 +1,17 @@
+export class GetWorshipStatsResponseDto {
+  constructor(
+    public readonly worshipId: number,
+    public readonly totalSessions: number,
+    public readonly attendanceRate: {
+      overall: number;
+      last4Weeks: number;
+      last12Weeks: number;
+    },
+    public readonly trend: {
+      longTerm: number;
+      shortTerm: number;
+      overall: number;
+    },
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/worship/service/worship.service.ts
+++ b/backend/src/worship/service/worship.service.ts
@@ -49,6 +49,7 @@ import {
   IWORSHIP_ATTENDANCE_DOMAIN_SERVICE,
   IWorshipAttendanceDomainService,
 } from '../worship-domain/interface/worship-attendance-domain.service.interface';
+import { GetWorshipStatsResponseDto } from '../dto/response/worship/get-worship-stats-response.dto';
 
 @Injectable()
 export class WorshipService {
@@ -393,16 +394,16 @@ export class WorshipService {
       movingAverages.last4Weeks,
     );
 
-    return {
+    return new GetWorshipStatsResponseDto(
       worshipId,
       totalSessions,
-      attendanceRate: {
+      {
         overall: Math.round(overallRate * 100) / 100,
         last4Weeks: Math.round(movingAverages.last4Weeks * 100) / 100,
         last12Weeks: Math.round(movingAverages.last12Weeks * 100) / 100,
       },
       trend,
-    };
+    );
   }
 
   private calculateTrendRates(


### PR DESCRIPTION
## 주요 내용
예배 출석률 통계를 조회하는 엔드포인트를 구현하고, 특정 그룹별 필터링 기능을 추가했습니다.

## 세부 내용
- GET `churches/:churchId/worship/:id/statistics` 엔드포인트 구현
- 전체 기간, 최근 12주, 최근 4주 출석률 제공
- 구간별 변화율 계산을 통한 트렌드 분석 기능 추가
 - 장기 변화율: 전체 → 12주
 - 단기 변화율: 12주 → 4주
 - 전체 변화율: 전체 → 4주
- 그룹 ID 쿼리 파라미터를 통한 특정 그룹 필터링 지원
- 하위 그룹을 포함한 재귀적 통계 집계

## 변경사항
- WorshipController에 통계 조회 메소드 추가
- WorshipService에 이동평균 및 트렌드 분석 로직 구현
- WorshipAttendanceDomainService에 그룹 필터링 쿼리 추가