### PR TITLE
fix: 예배 출석 통계 시간대 및 요일 기준 계산 로직 개선

### DIFF
--- a/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
@@ -69,11 +69,7 @@ export interface IWorshipAttendanceDomainService {
   getAttendanceStatsByWorship(
     worship: WorshipModel,
     requestGroupIds: number[] | undefined,
-  ): Promise<{
-    presentCount: number;
-    absentCount: number;
-    unknownCount: number;
-  }>;
+  ): Promise<number>;
 
   getMovingAverageAttendance(
     worship: WorshipModel,


### PR DESCRIPTION
## 주요 내용
예배 출석 통계의 이동평균 계산 시 시간대와 예배 요일을 고려한 정확한 주차 계산 로직으로 개선했습니다.

## 세부 내용
- 한국 시간대(KST) 기준으로 예배 요일 계산 적용
- 현재 날짜에서 가장 최근 예배일을 찾아 4주/12주 전 날짜 계산
- date-fns-tz를 활용한 시간대 변환 처리 (KST ↔ UTC)
- 세션 생성 여부와 무관하게 정확한 주 단위 통계 제공
- totalSessions, overallRate, movingAverage 계산을 병렬 처리로 최적화

## 변경사항
- WorshipAttendanceDomainService의 getMovingAverageAttendance 메소드 수정
- 예배 요일(worshipDay) 기준 정확한 주차 계산 로직 추가
- Promise.all을 활용한 통계 조회 병렬화
- UTC 저장 데이터를 한국 시간 기준으로 올바르게 처리