### PR TITLE
feat: 예배 세션 통계 조회 API 구현 및 세션 관리 엔드포인트 통합

### DIFF
--- a/backend/src/common/custom-request.ts
+++ b/backend/src/common/custom-request.ts
@@ -14,4 +14,6 @@ export interface CustomRequest extends Request {
   tokenPayload: JwtAccessPayload;
 
   targetMember: MemberModel;
+
+  worshipTargetGroupIds: number[] | undefined;
 }

--- a/backend/src/worship/controller/worship-session.controller.ts
+++ b/backend/src/worship/controller/worship-session.controller.ts
@@ -4,12 +4,12 @@ import {
   Delete,
   Get,
   GoneException,
-  Headers,
   Param,
   ParseIntPipe,
   Patch,
   Post,
   Query,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
@@ -19,20 +19,33 @@ import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
 import { GetWorshipSessionsDto } from '../dto/request/worship-session/get-worship-sessions.dto';
 import { UpdateWorshipSessionDto } from '../dto/request/worship-session/update-worship-session.dto';
-import { ParseDatePipe } from '../pipe/parse-date.pipe';
 import {
   ApiDeleteSession,
   ApiGetOrPostRecentSession,
   ApiGetOrPostSessionByDate,
   ApiGetSessionById,
   ApiGetSessions,
+  ApiGetWorshipSessionStatistics,
   ApiPatchSession,
   ApiPostSessionManual,
 } from '../swagger/worship-session.swagger';
 import { CreateWorshipSessionDto } from '../dto/request/worship-session/create-worship-session.dto';
 import { WorshipReadGuard } from '../guard/worship-read.guard';
 import { WorshipWriteGuard } from '../guard/worship-write.guard';
-import { TIME_ZONE } from '../../common/const/time-zone.const';
+import { GetWorshipSessionDto } from '../dto/request/worship-session/get-worship-session.dto';
+import { GetWorshipSessionStatsDto } from '../dto/request/worship-session/get-worship-session-stats.dto';
+import { WorshipTargetGroupIds } from '../decorator/worship-target-group-ids.decorator';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
+import { DomainType } from '../../permission/const/domain-type.enum';
+import { DomainName } from '../../permission/const/domain-name.enum';
+import { DomainAction } from '../../permission/const/domain-action.enum';
+import { WorshipGroupFilterGuard } from '../guard/worship-group-filter.guard';
+import { WorshipReadScopeGuard } from '../guard/worship-read-scope.guard';
+import { RequestChurch } from '../../permission/decorator/permission-church.decorator';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { RequestWorship } from '../decorator/request-worship.decorator';
+import { WorshipModel } from '../entity/worship.entity';
 
 @ApiTags('Worships:Sessions')
 @Controller(':worshipId/sessions')
@@ -43,12 +56,12 @@ export class WorshipSessionController {
   @Get()
   @WorshipReadGuard()
   getSessions(
-    @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Param('worshipId', ParseIntPipe) worshipId: number,
     @Query() dto: GetWorshipSessionsDto,
   ) {
     return this.worshipSessionService.getWorshipSessions(
-      churchId,
+      church,
       worshipId,
       dto,
     );
@@ -59,66 +72,45 @@ export class WorshipSessionController {
   @WorshipReadGuard()
   @UseInterceptors(TransactionInterceptor)
   getOrPostSessionByDate(
-    @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Param('worshipId', ParseIntPipe) worshipId: number,
-    @Query('sessionDate', ParseDatePipe) sessionDate: Date,
+    @Query() dto: GetWorshipSessionDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.worshipSessionService.getOrPostWorshipSessionByDate(
-      churchId,
-      worshipId,
-      sessionDate,
-      qr,
-    );
-  }
-
-  @ApiGetOrPostRecentSession()
-  @Post('recent')
-  @WorshipReadGuard()
-  @UseInterceptors(TransactionInterceptor)
-  getOrPostRecentSession(
-    @Headers('time-zone') timeZone: TIME_ZONE = TIME_ZONE.SEOUL,
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('worshipId', ParseIntPipe) worshipId: number,
-    @QueryRunner() qr: QR,
-  ) {
-    return this.worshipSessionService.getOrPostRecentSession(
-      timeZone,
-      churchId,
-      worshipId,
-      qr,
-    );
-  }
-
-  @ApiPostSessionManual()
-  @Post('manual')
-  @WorshipWriteGuard()
-  postSessionManual(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('worshipId', ParseIntPipe) worshipId: number,
-    @Body() dto: CreateWorshipSessionDto,
-  ) {
-    return this.worshipSessionService.postWorshipSessionManual(
-      churchId,
+    return this.worshipSessionService.getOrPostWorshipSession(
+      church,
       worshipId,
       dto,
+      qr,
     );
   }
 
-  @ApiGetSessionById()
-  @Get(':sessionId')
-  getSessionById(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('worshipId', ParseIntPipe) worshipId: number,
+  @ApiGetWorshipSessionStatistics()
+  @Get(':sessionId/statistics')
+  @UseGuards(
+    AccessTokenGuard,
+    createDomainGuard(
+      DomainType.WORSHIP,
+      DomainName.WORSHIP,
+      DomainAction.READ,
+    ),
+    WorshipGroupFilterGuard,
+    WorshipReadScopeGuard,
+  )
+  getWorshipSessionStatistics(
+    @RequestChurch() church: ChurchModel,
+    @RequestWorship() worship: WorshipModel,
     @Param('sessionId', ParseIntPipe) sessionId: number,
+    @WorshipTargetGroupIds() defaultWorshipTargetGroupIds: number[] | undefined,
+    @Query() dto: GetWorshipSessionStatsDto,
   ) {
-    throw new GoneException('더이상 사용되지 않는 엔드포인트');
-
-    /*return this.worshipSessionService.getSessionById(
-      churchId,
-      worshipId,
+    return this.worshipSessionService.getWorshipSessionStatistics(
+      church,
+      worship,
       sessionId,
-    );*/
+      defaultWorshipTargetGroupIds,
+      dto,
+    );
   }
 
   @ApiPatchSession()
@@ -157,5 +149,59 @@ export class WorshipSessionController {
       sessionId,
       qr,
     );
+  }
+
+  @ApiGetOrPostRecentSession()
+  @Post('recent')
+  @WorshipReadGuard()
+  @UseInterceptors(TransactionInterceptor)
+  getOrPostRecentSession(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @QueryRunner() qr: QR,
+  ) {
+    throw new GoneException(
+      '/churches/{churchId}/worships/{worshipId}/sessions 로 요청',
+    );
+
+    /*return this.worshipSessionService.getOrPostWorshipSession(
+      churchId,
+      worshipId,
+      new GetWorshipSessionDto(),
+      qr,
+    );*/
+  }
+
+  @ApiPostSessionManual()
+  @Post('manual')
+  @WorshipWriteGuard()
+  postSessionManual(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @Body() dto: CreateWorshipSessionDto,
+  ) {
+    throw new GoneException('더 이상 사용되지 않는 엔드포인트');
+
+    /*return this.worshipSessionService.postWorshipSessionManual(
+      churchId,
+      worshipId,
+      dto,
+    );*/
+  }
+
+  @ApiGetSessionById()
+  @Get(':sessionId')
+  getSessionById(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @Param('sessionId', ParseIntPipe) sessionId: number,
+  ) {
+    throw new GoneException('더이상 사용되지 않는 엔드포인트');
+
+    /*return this.worshipSessionService.getSessionById(
+      churchId,
+      worshipId,
+      sessionId,
+    );*/
   }
 }

--- a/backend/src/worship/decorator/worship-target-group-ids.decorator.ts
+++ b/backend/src/worship/decorator/worship-target-group-ids.decorator.ts
@@ -1,0 +1,10 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { CustomRequest } from '../../common/custom-request';
+
+export const WorshipTargetGroupIds = createParamDecorator(
+  (_, ctx: ExecutionContext) => {
+    const req: CustomRequest = ctx.switchToHttp().getRequest();
+
+    return req.worshipTargetGroupIds;
+  },
+);

--- a/backend/src/worship/dto/request/worship-session/get-worship-session-stats.dto.ts
+++ b/backend/src/worship/dto/request/worship-session/get-worship-session-stats.dto.ts
@@ -1,0 +1,9 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNumber, IsOptional } from 'class-validator';
+
+export class GetWorshipSessionStatsDto {
+  @ApiPropertyOptional({ description: '조회할 그룹' })
+  @IsOptional()
+  @IsNumber()
+  groupId?: number;
+}

--- a/backend/src/worship/dto/request/worship-session/get-worship-session.dto.ts
+++ b/backend/src/worship/dto/request/worship-session/get-worship-session.dto.ts
@@ -1,0 +1,11 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDateString, IsOptional } from 'class-validator';
+import { IsYYYYMMDD } from '../../../../common/decorator/validator/is-yyyy-mm-dd.validator';
+
+export class GetWorshipSessionDto {
+  @ApiPropertyOptional({ description: '예배 세션 날짜(yyyy-MM-dd)' })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('sessionDate')
+  sessionDate?: string;
+}

--- a/backend/src/worship/entity/worship-session.entity.ts
+++ b/backend/src/worship/entity/worship-session.entity.ts
@@ -30,9 +30,9 @@ export class WorshipSessionModel extends BaseModel {
   description: string;
 
   @Column({ nullable: true })
-  inChargeId: number;
+  inChargeId: number | null;
 
-  @ManyToOne(() => MemberModel)
+  @ManyToOne(() => MemberModel, { nullable: true })
   @JoinColumn({ name: 'inChargeId' })
-  inCharge: MemberModel;
+  inCharge: MemberModel | null;
 }

--- a/backend/src/worship/service/worship-session.service.ts
+++ b/backend/src/worship/service/worship-session.service.ts
@@ -40,8 +40,16 @@ import {
   IManagerDomainService,
 } from '../../manager/manager-domain/service/interface/manager-domain.service.interface';
 import { fromZonedTime, toZonedTime } from 'date-fns-tz';
-import { startOfDay, subDays } from 'date-fns';
+import { getDay } from 'date-fns';
 import { TIME_ZONE } from '../../common/const/time-zone.const';
+import { GetWorshipSessionDto } from '../dto/request/worship-session/get-worship-session.dto';
+import { GetWorshipSessionStatsDto } from '../dto/request/worship-session/get-worship-session-stats.dto';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import {
+  IGROUPS_DOMAIN_SERVICE,
+  IGroupsDomainService,
+} from '../../management/groups/groups-domain/interface/groups-domain.service.interface';
+import { getRecentSessionDate } from '../utils/worship-utils';
 
 @Injectable()
 export class WorshipSessionService {
@@ -59,15 +67,18 @@ export class WorshipSessionService {
     private readonly worshipEnrollmentDomainService: IWorshipEnrollmentDomainService,
     @Inject(IWORSHIP_ATTENDANCE_DOMAIN_SERVICE)
     private readonly worshipAttendanceDomainService: IWorshipAttendanceDomainService,
+
+    @Inject(IGROUPS_DOMAIN_SERVICE)
+    private readonly groupsDomainService: IGroupsDomainService,
   ) {}
 
   async getWorshipSessions(
-    churchId: number,
+    church: ChurchModel,
     worshipId: number,
     dto: GetWorshipSessionsDto,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
+    /*const church =
+      await this.churchesDomainService.findChurchModelById(churchId);*/
     const worship = await this.worshipDomainService.findWorshipModelById(
       church,
       worshipId,
@@ -86,93 +97,23 @@ export class WorshipSessionService {
   }
 
   /**
-   * 가장 최근의 예배 세션 조회 or 생성
-   * @param timeZone
-   * @param churchId
-   * @param worshipId
-   * @param qr
-   */
-  async getOrPostRecentSession(
-    timeZone: TIME_ZONE,
-    churchId: number,
-    worshipId: number,
-    qr: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const worship = await this.worshipDomainService.findWorshipModelById(
-      church,
-      worshipId,
-      qr,
-    );
-
-    const recentSessionDate: Date = this.getRecentSessionDate(
-      worship,
-      timeZone,
-    );
-
-    const recentSession =
-      await this.worshipSessionDomainService.findOrCreateRecentWorshipSession(
-        worship,
-        recentSessionDate,
-        qr,
-      );
-
-    if (recentSession.isCreated) {
-      const enrollments =
-        await this.worshipEnrollmentDomainService.findAllEnrollments(
-          worship,
-          qr,
-        );
-
-      await this.worshipAttendanceDomainService.refreshAttendances(
-        recentSession,
-        enrollments,
-        qr,
-      );
-    }
-
-    const responseSession =
-      await this.worshipSessionDomainService.findWorshipSessionById(
-        worship,
-        recentSession.id,
-        qr,
-      );
-
-    return new GetWorshipSessionResponseDto(responseSession);
-  }
-
-  /**
    * 예배 세션 수동 생성
-   * @param churchId
+   * @param church
    * @param worshipId
-   * @param sessionDate
+   * @param dto
    * @param qr
    */
-  async getOrPostWorshipSessionByDate(
-    churchId: number,
+  async getOrPostWorshipSession(
+    //churchId: number,
+    church: ChurchModel,
     worshipId: number,
-    sessionDate: Date,
+    dto: GetWorshipSessionDto,
     qr: QueryRunner,
   ) {
-    if (!sessionDate) {
-      throw new BadRequestException('조회할 날짜를 입력해주세요.');
-    }
-
-    // 미래 날짜 불가능
-    if (sessionDate.getTime() > Date.now() - 1) {
-      throw new BadRequestException(
-        WorshipSessionException.INVALID_SESSION_DATE,
-      );
-    }
-
-    const church = await this.churchesDomainService.findChurchModelById(
+    /*const church = await this.churchesDomainService.findChurchModelById(
       churchId,
       qr,
-    );
+    );*/
 
     const worship = await this.worshipDomainService.findWorshipModelById(
       church,
@@ -180,14 +121,28 @@ export class WorshipSessionService {
       qr,
     );
 
-    const zonedSessionDate = toZonedTime(sessionDate, TIME_ZONE.SEOUL);
+    let sessionDate: Date;
 
-    if (zonedSessionDate.getDay() !== worship.worshipDay) {
-      throw new ConflictException(WorshipSessionException.INVALID_SESSION_DAY);
+    if (!dto.sessionDate) {
+      sessionDate = getRecentSessionDate(worship, TIME_ZONE.SEOUL);
+    } else {
+      sessionDate = fromZonedTime(dto.sessionDate, TIME_ZONE.SEOUL);
+
+      if (sessionDate.getTime() > Date.now()) {
+        throw new BadRequestException(
+          WorshipSessionException.INVALID_SESSION_DATE,
+        );
+      }
+
+      if (getDay(dto.sessionDate) !== worship.worshipDay) {
+        throw new ConflictException(
+          WorshipSessionException.INVALID_SESSION_DAY,
+        );
+      }
     }
 
     const session =
-      await this.worshipSessionDomainService.findOrCreateWorshipSessionByDate(
+      await this.worshipSessionDomainService.findOrCreateWorshipSession(
         worship,
         sessionDate,
         qr,
@@ -206,70 +161,65 @@ export class WorshipSessionService {
         enrollments,
         qr,
       );
+
+      session.inChargeId = null;
+      session.inCharge = null;
     }
 
-    const responseSession =
-      await this.worshipSessionDomainService.findWorshipSessionById(
-        worship,
-        session.id,
-        qr,
-      );
-
-    return new PostWorshipSessionResponseDto(responseSession);
+    return new PostWorshipSessionResponseDto(session);
   }
 
-  async postWorshipSessionManual(
-    churchId: number,
-    worshipId: number,
-    dto: CreateWorshipSessionDto,
+  async getWorshipSessionStatistics(
+    church: ChurchModel,
+    worship: WorshipModel,
+    sessionId: number,
+    defaultWorshipTargetGroupIds: number[] | undefined,
+    dto: GetWorshipSessionStatsDto,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-    const worship = await this.worshipDomainService.findWorshipModelById(
-      church,
-      worshipId,
-    );
-
-    const zonedSessionDate = toZonedTime(dto.sessionDateUtc, TIME_ZONE.SEOUL);
-
-    if (zonedSessionDate.getDay() !== worship.worshipDay) {
-      throw new ConflictException(WorshipSessionException.INVALID_SESSION_DAY);
-    }
-
-    const inCharge = dto.inChargeId
-      ? await this.managerDomainService.findManagerByMemberId(
-          church,
-          dto.inChargeId,
-        )
-      : null;
-
-    const newSession =
-      await this.worshipSessionDomainService.createWorshipSession(
-        worship,
-        inCharge,
-        dto,
-      );
-
-    return new PostWorshipSessionResponseDto(newSession);
-  }
-
-  /*async getSessionById(churchId: number, worshipId: number, sessionId: number) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
-    const worship = await this.worshipDomainService.findWorshipModelById(
-      church,
-      worshipId,
-    );
-
     const session =
-      await this.worshipSessionDomainService.findWorshipSessionById(
+      await this.worshipSessionDomainService.findWorshipSessionModelById(
         worship,
         sessionId,
       );
 
-    return new GetWorshipSessionResponseDto(session);
-  }*/
+    const requestGroupIds = await this.getRequestGroupIds(
+      church,
+      defaultWorshipTargetGroupIds,
+      dto.groupId,
+    );
+
+    const stats =
+      await this.worshipAttendanceDomainService.getAttendanceStatsBySession(
+        session,
+        requestGroupIds,
+      );
+
+    return {
+      totalCount: stats.presentCount + stats.absentCount + stats.unknownCount,
+      presentCount: stats.presentCount,
+      absentCount: stats.absentCount,
+      unknownCount: stats.unknownCount,
+    };
+  }
+
+  private async getRequestGroupIds(
+    church: ChurchModel,
+    defaultWorshipTargetGroupIds: number[] | undefined,
+    groupId?: number,
+  ) {
+    // 조회 대상 groupId 가 있는 경우
+    if (groupId) {
+      return (
+        await this.groupsDomainService.findGroupAndDescendantsByIds(church, [
+          groupId,
+        ])
+      ).map((group) => group.id);
+    } else {
+      // 조회 대상 groupId 가 없을 경우
+      // 기본 예배 대상 그룹
+      return defaultWorshipTargetGroupIds;
+    }
+  }
 
   /**
    * 예배 세션 수정
@@ -366,28 +316,107 @@ export class WorshipSessionService {
     return new DeleteWorshipSessionResponseDto(
       new Date(),
       targetWorshipSession.id,
-      //targetWorshipSession.title,
       true,
     );
   }
 
-  private getRecentSessionDate(worship: WorshipModel, timeZone: TIME_ZONE) {
-    const serverToday = new Date(); // UTC 로 현재 시간
-
-    const nowInKorea = toZonedTime(serverToday, timeZone); // 현재 한국 시간
-    const todayDay = nowInKorea.getDay(); // 한국 요일
-
-    // 오늘이 예배일보다 이후(=같거나 이후)면 오늘 기준
-    // 예) 오늘 화요일(2), 예배일 일요일(0) → 지난 일요일
-    //     오늘 일요일(0), 예배일 일요일(0) → 오늘
-    const daysToSubtract = (todayDay - worship.worshipDay + 7) % 7;
-
-    // 예배 날짜의 00시 00분 (한국 기준)
-    const recentWorshipDateInKorea = startOfDay(
-      subDays(nowInKorea, daysToSubtract),
+  /**
+   * @deprecated
+   * @param churchId
+   * @param worshipId
+   * @param dto
+   */
+  async postWorshipSessionManual(
+    churchId: number,
+    worshipId: number,
+    dto: CreateWorshipSessionDto,
+  ) {
+    const church =
+      await this.churchesDomainService.findChurchModelById(churchId);
+    const worship = await this.worshipDomainService.findWorshipModelById(
+      church,
+      worshipId,
     );
 
-    // 한국 시간 기준 예배일을 UTC Date 객체로 변환 (-9시간)
-    return fromZonedTime(recentWorshipDateInKorea, timeZone);
+    const zonedSessionDate = toZonedTime(dto.sessionDateUtc, TIME_ZONE.SEOUL);
+
+    if (zonedSessionDate.getDay() !== worship.worshipDay) {
+      throw new ConflictException(WorshipSessionException.INVALID_SESSION_DAY);
+    }
+
+    const inCharge = dto.inChargeId
+      ? await this.managerDomainService.findManagerByMemberId(
+          church,
+          dto.inChargeId,
+        )
+      : null;
+
+    const newSession =
+      await this.worshipSessionDomainService.createWorshipSession(
+        worship,
+        inCharge,
+        dto,
+      );
+
+    return new PostWorshipSessionResponseDto(newSession);
+  }
+
+  /**
+   * 가장 최근의 예배 세션 조회 or 생성
+   * @deprecated
+   * @param churchId
+   * @param worshipId
+   * @param qr
+   */
+  async getOrPostRecentSession(
+    churchId: number,
+    worshipId: number,
+    qr: QueryRunner,
+  ) {
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      qr,
+    );
+
+    const worship = await this.worshipDomainService.findWorshipModelById(
+      church,
+      worshipId,
+      qr,
+    );
+
+    const recentSessionDate: Date = getRecentSessionDate(
+      worship,
+      TIME_ZONE.SEOUL,
+    );
+
+    const recentSession =
+      await this.worshipSessionDomainService.findOrCreateWorshipSession(
+        worship,
+        recentSessionDate,
+        qr,
+      );
+
+    if (recentSession.isCreated) {
+      const enrollments =
+        await this.worshipEnrollmentDomainService.findAllEnrollments(
+          worship,
+          qr,
+        );
+
+      await this.worshipAttendanceDomainService.refreshAttendances(
+        recentSession,
+        enrollments,
+        qr,
+      );
+    }
+
+    const responseSession =
+      await this.worshipSessionDomainService.findWorshipSessionById(
+        worship,
+        recentSession.id,
+        qr,
+      );
+
+    return new GetWorshipSessionResponseDto(responseSession);
   }
 }

--- a/backend/src/worship/service/worship.service.ts
+++ b/backend/src/worship/service/worship.service.ts
@@ -1,8 +1,4 @@
-import {
-  Inject,
-  Injectable,
-  InternalServerErrorException,
-} from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
@@ -88,12 +84,11 @@ export class WorshipService {
     );
   }
 
-  async findWorshipById(churchId: number, worshipId: number, qr?: QueryRunner) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
+  async findWorshipById(
+    church: ChurchModel,
+    worshipId: number,
+    qr?: QueryRunner,
+  ) {
     const worship = await this.worshipDomainService.findWorshipById(
       church,
       worshipId,
@@ -155,15 +150,15 @@ export class WorshipService {
   }
 
   async patchWorshipById(
-    churchId: number,
+    church: ChurchModel,
     worshipId: number,
     dto: UpdateWorshipDto,
     qr: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
+    /*const church = await this.churchesDomainService.findChurchModelById(
       churchId,
       qr,
-    );
+    );*/
 
     const targetWorship = await this.worshipDomainService.findWorshipModelById(
       church,
@@ -200,12 +195,12 @@ export class WorshipService {
   }
 
   async deleteWorshipById(
-    churchId: number,
+    //churchId: number,
+    church: ChurchModel,
     worshipId: number,
     qr: QueryRunner,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
+    //const church = await this.churchesDomainService.findChurchModelById(churchId);
 
     const targetWorship = await this.worshipDomainService.findWorshipModelById(
       church,
@@ -325,7 +320,7 @@ export class WorshipService {
     return { worshipCount };
   }
 
-  private async getDefaultGroupIds(church: ChurchModel, worship: WorshipModel) {
+  /*private async getDefaultGroupIds(church: ChurchModel, worship: WorshipModel) {
     if (!worship.worshipTargetGroups) {
       throw new InternalServerErrorException('WorshipTargetGroup Join Error');
     }
@@ -344,25 +339,17 @@ export class WorshipService {
         rootTargetGroupIds,
       )
     ).map((group) => group.id);
-
-    //return new Set(defaultTargetGroupIds);
-  }
+  }*/
 
   async getWorshipStatistics(
     church: ChurchModel,
-    worshipId: number,
+    worship: WorshipModel,
+    defaultWorshipTargetGroupIds: number[] | undefined,
     groupId?: number,
   ) {
-    const worship = await this.worshipDomainService.findWorshipModelById(
-      church,
-      worshipId,
-      undefined,
-      { worshipTargetGroups: true },
-    );
-
     const requestGroupIds = await this.getRequestGroupIds(
       church,
-      worship,
+      defaultWorshipTargetGroupIds,
       groupId,
     );
 
@@ -388,7 +375,7 @@ export class WorshipService {
     );
 
     return new GetWorshipStatsResponseDto(
-      worshipId,
+      worship.id,
       totalSessions,
       {
         overall: Math.round(overallRate * 100) / 100,
@@ -426,7 +413,7 @@ export class WorshipService {
 
   private async getRequestGroupIds(
     church: ChurchModel,
-    worship: WorshipModel,
+    defaultTargetGroupIds: number[] | undefined,
     groupId?: number,
   ) {
     // 조회 대상 groupId 가 있는 경우
@@ -439,7 +426,8 @@ export class WorshipService {
     } else {
       // 조회 대상 groupId 가 없을 경우
       // 예배 대상 그룹
-      return await this.getDefaultGroupIds(church, worship);
+      return defaultTargetGroupIds;
+      //await this.getDefaultGroupIds(church, worship);
 
       /*return defaultTargetGroupIds
         ? Array.from(defaultTargetGroupIds)

--- a/backend/src/worship/swagger/worship-session.swagger.ts
+++ b/backend/src/worship/swagger/worship-session.swagger.ts
@@ -1,16 +1,18 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation } from '@nestjs/swagger';
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
 
 export const ApiGetSessions = () =>
   applyDecorators(
     ApiOperation({
       summary: '예배 세션 목록 조회',
     }),
+    ApiParam({ name: 'churchId' }),
   );
 
 export const ApiGetOrPostRecentSession = () =>
   applyDecorators(
     ApiOperation({
+      deprecated: true,
       summary: '가장 최근 예배 세션 조회 or 생성',
       description:
         '<h2>가장 최근 예배 세션을 조회 또는 생성합니다.</h2>' +
@@ -20,18 +22,31 @@ export const ApiGetOrPostRecentSession = () =>
 
 export const ApiGetOrPostSessionByDate = () =>
   applyDecorators(
+    ApiParam({ name: 'churchId' }),
     ApiOperation({
-      summary: '특정 날짜의 예배 세션 조회 or 생성',
+      summary: '예배 세션 조회 or 생성',
       description:
-        '<h2>특정 날짜의 예배 세션을 조회 또는 생성합니다.</h2>' +
+        '<h2>예배 세션을 조회 또는 생성합니다.</h2>' +
+        '<p>쿼리 파라미터가 없을 경우 최근 예배 세션을 조회/생성합니다.</p>' +
+        '<p>쿼리 파라미터로 날짜를 지정하는 경우 해당 날짜의 세션을 조회/생성합니다.</p>' +
         '<p>요일이 잘못된 경우 또는 미래의 날짜를 지정한 경우 BadRequestException</p>' +
         '<p>세션을 생성하는 경우 그 하위 Attendance 도 생성됩니다. </p>',
     }),
   );
 
+export const ApiGetWorshipSessionStatistics = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '예배 세션의 출석 통계',
+    }),
+    ApiParam({ name: 'churchId' }),
+    ApiParam({ name: 'worshipId' }),
+  );
+
 export const ApiPostSessionManual = () =>
   applyDecorators(
     ApiOperation({
+      deprecated: true,
       summary: '예배 세션 수동 생성',
       description:
         '<h2>예배 세션을 수동으로 생성합니다.</h2>' +

--- a/backend/src/worship/swagger/worship.swagger.ts
+++ b/backend/src/worship/swagger/worship.swagger.ts
@@ -1,0 +1,58 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
+
+export const ApiGetWorships = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({ summary: '예배 목록 조회' }),
+  );
+
+export const ApiPostWorship = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({
+      summary: '예배 생성',
+    }),
+  );
+
+export const ApiRefreshWorshipCount = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({
+      summary: '교회 예배 수 새로고침',
+    }),
+  );
+
+export const ApiGetWorshipById = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({
+      summary: '예배 단건 조회',
+    }),
+  );
+
+export const ApiPatchWorship = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({
+      summary: '예배 수정',
+    }),
+  );
+
+export const ApiDeleteWorship = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({
+      summary: '예배 삭제',
+      description: '하위 enrollment, session, attendance 삭제',
+    }),
+  );
+
+export const ApiGetWorshipStatistics = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiParam({ name: 'worshipId' }),
+    ApiOperation({
+      summary: '예배 출석률 통계',
+    }),
+  );

--- a/backend/src/worship/utils/worship-utils.ts
+++ b/backend/src/worship/utils/worship-utils.ts
@@ -1,0 +1,25 @@
+import { WorshipModel } from '../entity/worship.entity';
+import { TIME_ZONE } from '../../common/const/time-zone.const';
+import { fromZonedTime, toZonedTime } from 'date-fns-tz';
+import { getDay, startOfDay, subDays } from 'date-fns';
+
+export function getRecentSessionDate(
+  worship: WorshipModel,
+  timeZone: TIME_ZONE,
+) {
+  const nowKst = toZonedTime(new Date(), timeZone);
+  const currentDayOfWeek = getDay(nowKst);
+
+  const worshipDay = worship.worshipDay;
+  let daysToLastWorship = currentDayOfWeek - worshipDay;
+
+  if (daysToLastWorship < 0) {
+    daysToLastWorship += 7;
+  } else if (daysToLastWorship === 0) {
+    daysToLastWorship = 0;
+  }
+
+  const lastWorshipDateKst = subDays(startOfDay(nowKst), daysToLastWorship);
+
+  return fromZonedTime(lastWorshipDateKst, timeZone);
+}

--- a/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
@@ -66,6 +66,16 @@ export interface IWorshipAttendanceDomainService {
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 
+  getAttendanceStatsBySession(
+    worshipSession: WorshipSessionModel,
+    requestGroupIds: number[] | undefined,
+    qr?: QueryRunner,
+  ): Promise<{
+    presentCount: number;
+    absentCount: number;
+    unknownCount: number;
+  }>;
+
   getAttendanceStatsByWorship(
     worship: WorshipModel,
     requestGroupIds: number[] | undefined,

--- a/backend/src/worship/worship-domain/interface/worship-session-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-session-domain.service.interface.ts
@@ -25,17 +25,17 @@ export interface IWorshipSessionDomainService {
     qr?: QueryRunner,
   ): Promise<WorshipSessionModel>;
 
-  findOrCreateWorshipSessionByDate(
+  findOrCreateWorshipSession(
     worship: WorshipModel,
     sessionDate: Date,
     qr: QueryRunner,
   ): Promise<WorshipSessionModel & { isCreated: boolean }>;
 
-  findOrCreateRecentWorshipSession(
+  /*findOrCreateRecentWorshipSession(
     worship: WorshipModel,
     sessionDate: Date,
     qr: QueryRunner,
-  ): Promise<WorshipSessionModel & { isCreated: boolean }>;
+  ): Promise<WorshipSessionModel & { isCreated: boolean }>;*/
 
   findWorshipSessionById(
     worship: WorshipModel,

--- a/backend/src/worship/worship-domain/service/worship-session-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-session-domain.service.ts
@@ -28,8 +28,8 @@ import { MemberException } from '../../../members/exception/member.exception';
 import { ChurchUserRole } from '../../../user/const/user-role.enum';
 import { TaskException } from '../../../task/const/exception-message/task.exception';
 import {
+  MemberSimpleSelect,
   MemberSummarizedRelation,
-  MemberSummarizedSelect,
 } from '../../../members/const/member-find-options.const';
 
 @Injectable()
@@ -106,7 +106,7 @@ export class WorshipSessionDomainService
     return true;
   }
 
-  async findOrCreateWorshipSessionByDate(
+  async findOrCreateWorshipSession(
     worship: WorshipModel,
     sessionDate: Date,
     qr: QueryRunner,
@@ -122,6 +122,12 @@ export class WorshipSessionDomainService
         worshipId: worship.id,
         sessionDate,
       },
+      relations: {
+        inCharge: MemberSummarizedRelation,
+      },
+      select: {
+        inCharge: MemberSimpleSelect,
+      },
     });
 
     if (existSession) {
@@ -136,7 +142,7 @@ export class WorshipSessionDomainService
     return { ...createdSession, isCreated: true };
   }
 
-  async findOrCreateRecentWorshipSession(
+  /*async findOrCreateRecentWorshipSession(
     worship: WorshipModel,
     sessionDate: Date,
     qr: QueryRunner,
@@ -160,7 +166,7 @@ export class WorshipSessionDomainService
     });
 
     return { ...createdSession, isCreated: true };
-  }
+  }*/
 
   private assertValidInChargeMember(inChargeMember: ChurchUserModel | null) {
     if (!inChargeMember) {
@@ -223,7 +229,7 @@ export class WorshipSessionDomainService
         inCharge: MemberSummarizedRelation,
       },
       select: {
-        inCharge: MemberSummarizedSelect,
+        inCharge: MemberSimpleSelect,
       },
     });
 
@@ -264,9 +270,6 @@ export class WorshipSessionDomainService
     qr: QueryRunner,
   ) {
     const repository = this.getRepository(qr);
-
-    /*dto.sessionDate &&
-      (await this.assertValidNewSession(worship, dto.sessionDate, repository));*/
 
     this.assertValidInChargeMember(inCharge);
 


### PR DESCRIPTION
## 주요 내용
예배 세션별 출석률 통계 조회 기능을 추가하고, 세션 생성/조회 엔드포인트를 통합했습니다.

## 세부 내용
- GET `/churches/{churchId}/worships/{worshipId}/sessions/{sessionId}/statistics` 엔드포인트 추가
 - groupId 쿼리 파라미터로 특정 그룹 필터링 지원 (하위 그룹 포함)
 - 세션 정보와 통계를 분리하여 독립적 조회 가능

- POST `/churches/{churchId}/worships/{worshipId}/sessions` 엔드포인트로 세션 관리 통합
 - sessionDate 파라미터 없음: 가장 최근 예배일 세션 생성/조회
 - sessionDate 파라미터 있음: 해당 날짜 세션 생성/조회
 - 기존 분리된 최근/특정날짜 엔드포인트를 하나로 통합

- 불필요한 엔드포인트 제거
 - sessionId로 단건 조회 엔드포인트 삭제
 - 세션 수동 생성 엔드포인트 삭제

## 변경사항
- WorshipSessionController에 통계 조회 메소드 추가
- 세션 생성/조회 엔드포인트 통합 및 로직 개선
- 예배 대상 그룹 조회 최적화: Guard에서 조회한 데이터를 Request 객체에 저장하여 서비스 레이어에서 재사용
- 중복 조회 제거로 성능 개선