### PR TITLE
feat: 통계 조회 권한 범위 적용 및 출석 정보 커서 페이지네이션 추가

### DIFF
--- a/backend/src/worship/const/worship-attendance-order.enum.ts
+++ b/backend/src/worship/const/worship-attendance-order.enum.ts
@@ -1,4 +1,4 @@
-export enum WorshipAttendanceOrderEnum {
+export enum WorshipAttendanceOrder {
   //CREATED_AT = 'createdAt',
   ID = 'id',
   UPDATED_AT = 'updatedAt',

--- a/backend/src/worship/const/worship-attendance-sort-column.enum.ts
+++ b/backend/src/worship/const/worship-attendance-sort-column.enum.ts
@@ -1,0 +1,5 @@
+export enum WorshipAttendanceSortColumn {
+  ATTENDANCE_STATUS = 'attendanceStatus',
+  NAME = 'name',
+  GROUP_NAME = 'groupName',
+}

--- a/backend/src/worship/controller/worship-attendance.controller.ts
+++ b/backend/src/worship/controller/worship-attendance.controller.ts
@@ -32,6 +32,9 @@ import { RequestChurch } from '../../permission/decorator/permission-church.deco
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { RequestWorship } from '../decorator/request-worship.decorator';
 import { WorshipModel } from '../entity/worship.entity';
+import { ApiGetWorshipAttendance } from '../swagger/worship-attendance.swagger';
+import { GetWorshipAttendanceListDto } from '../dto/request/worship-attendance/get-worship-attendance-list.dto';
+import { WorshipTargetGroupIds } from '../decorator/worship-target-group-ids.decorator';
 
 @ApiTags('Worships:Attendance')
 @Controller(':worshipId/sessions/:sessionId/attendances')
@@ -40,6 +43,7 @@ export class WorshipAttendanceController {
     private readonly worshipAttendanceService: WorshipAttendanceService,
   ) {}
 
+  @ApiGetWorshipAttendance()
   @Get()
   @UseGuards(
     AccessTokenGuard,
@@ -59,13 +63,46 @@ export class WorshipAttendanceController {
     @Query() dto: GetWorshipAttendancesDto,
     @RequestChurch() church: ChurchModel,
     @RequestWorship() worship: WorshipModel,
-    @PermissionScopeGroups() permissionScopeGroupIds?: number[],
+    @WorshipTargetGroupIds() defaultTargetGroupIds: number[] | undefined,
+    @PermissionScopeGroups() permissionScopeGroupIds: number[],
   ) {
     return this.worshipAttendanceService.getAttendances(
       church,
       worship,
       sessionId,
       dto,
+      defaultTargetGroupIds,
+      permissionScopeGroupIds,
+    );
+  }
+
+  @Get('v2')
+  @UseGuards(
+    AccessTokenGuard,
+    createDomainGuard(
+      DomainType.WORSHIP,
+      DomainName.WORSHIP,
+      DomainAction.READ,
+    ),
+    WorshipGroupFilterGuard,
+    WorshipReadScopeGuard,
+  )
+  getAttendanceList(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @Param('sessionId', ParseIntPipe) sessionId: number,
+    @Query() query: GetWorshipAttendanceListDto,
+    @RequestChurch() church: ChurchModel,
+    @RequestWorship() worship: WorshipModel,
+    @WorshipTargetGroupIds() defaultTargetGroupIds: number[] | undefined,
+    @PermissionScopeGroups() permissionScopeGroupIds: number[] | undefined,
+  ) {
+    return this.worshipAttendanceService.getAttendancesV2(
+      church,
+      worship,
+      sessionId,
+      query,
+      defaultTargetGroupIds,
       permissionScopeGroupIds,
     );
   }

--- a/backend/src/worship/controller/worship-session.controller.ts
+++ b/backend/src/worship/controller/worship-session.controller.ts
@@ -46,6 +46,7 @@ import { RequestChurch } from '../../permission/decorator/permission-church.deco
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { RequestWorship } from '../decorator/request-worship.decorator';
 import { WorshipModel } from '../entity/worship.entity';
+import { PermissionScopeGroups } from '../decorator/permission-scope-groups.decorator';
 
 @ApiTags('Worships:Sessions')
 @Controller(':worshipId/sessions')
@@ -102,6 +103,7 @@ export class WorshipSessionController {
     @RequestWorship() worship: WorshipModel,
     @Param('sessionId', ParseIntPipe) sessionId: number,
     @WorshipTargetGroupIds() defaultWorshipTargetGroupIds: number[] | undefined,
+    @PermissionScopeGroups() permissionScopeGroupIds: number[] | undefined,
     @Query() dto: GetWorshipSessionStatsDto,
   ) {
     return this.worshipSessionService.getWorshipSessionStatistics(
@@ -109,6 +111,7 @@ export class WorshipSessionController {
       worship,
       sessionId,
       defaultWorshipTargetGroupIds,
+      permissionScopeGroupIds,
       dto,
     );
   }

--- a/backend/src/worship/controller/worship.controller.ts
+++ b/backend/src/worship/controller/worship.controller.ts
@@ -44,6 +44,7 @@ import {
   ApiPostWorship,
   ApiRefreshWorshipCount,
 } from '../swagger/worship.swagger';
+import { PermissionScopeGroups } from '../decorator/permission-scope-groups.decorator';
 
 @ApiTags('Worships')
 @Controller()
@@ -141,12 +142,14 @@ export class WorshipController {
     @RequestChurch() church: ChurchModel,
     @RequestWorship() worship: WorshipModel,
     @WorshipTargetGroupIds() defaultTargetGroupIds: number[] | undefined,
+    @PermissionScopeGroups() permissionScopeGroupIds: number[] | undefined,
     @Query() dto: GetWorshipStatsDto,
   ) {
     return this.worshipService.getWorshipStatistics(
       church,
       worship,
       defaultTargetGroupIds,
+      permissionScopeGroupIds,
       dto.groupId,
     );
   }

--- a/backend/src/worship/dto/request/worship-attendance/get-worship-attendance-list.dto.ts
+++ b/backend/src/worship/dto/request/worship-attendance/get-worship-attendance-list.dto.ts
@@ -1,0 +1,24 @@
+import { BaseCursorPaginationRequestDto } from '../../../../common/dto/request/base-cursor-pagination-request.dto';
+import { WorshipAttendanceSortColumn } from '../../../const/worship-attendance-sort-column.enum';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsNumber, IsOptional, Min } from 'class-validator';
+
+export class GetWorshipAttendanceListDto extends BaseCursorPaginationRequestDto<WorshipAttendanceSortColumn> {
+  @ApiPropertyOptional({
+    enum: WorshipAttendanceSortColumn,
+    description: '정렬 기준 컬럼',
+    default: WorshipAttendanceSortColumn.NAME,
+  })
+  @IsOptional()
+  @IsEnum(WorshipAttendanceSortColumn)
+  sortBy: WorshipAttendanceSortColumn = WorshipAttendanceSortColumn.NAME;
+
+  @ApiPropertyOptional({
+    description: '조회할 그룹 ID',
+    minimum: 1,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  groupId?: number;
+}

--- a/backend/src/worship/dto/request/worship-attendance/get-worship-attendances.dto.ts
+++ b/backend/src/worship/dto/request/worship-attendance/get-worship-attendances.dto.ts
@@ -1,19 +1,19 @@
 import { BaseOffsetPaginationRequestDto } from '../../../../common/dto/request/base-offset-pagination-request.dto';
-import { WorshipAttendanceOrderEnum } from '../../../const/worship-attendance-order.enum';
+import { WorshipAttendanceOrder } from '../../../const/worship-attendance-order.enum';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsNumber, Min } from 'class-validator';
 import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
 
-export class GetWorshipAttendancesDto extends BaseOffsetPaginationRequestDto<WorshipAttendanceOrderEnum> {
+export class GetWorshipAttendancesDto extends BaseOffsetPaginationRequestDto<WorshipAttendanceOrder> {
   @ApiProperty({
     description: '정렬 조건',
-    enum: WorshipAttendanceOrderEnum,
-    default: WorshipAttendanceOrderEnum.ID,
+    enum: WorshipAttendanceOrder,
+    default: WorshipAttendanceOrder.ID,
     required: false,
   })
   @IsOptionalNotNull()
-  @IsEnum(WorshipAttendanceOrderEnum)
-  order: WorshipAttendanceOrderEnum = WorshipAttendanceOrderEnum.ID;
+  @IsEnum(WorshipAttendanceOrder)
+  order: WorshipAttendanceOrder = WorshipAttendanceOrder.ID;
 
   @ApiProperty({
     description: '교인 그룹 ID',

--- a/backend/src/worship/dto/response/worship-attendance/worship-attendance-list-response.dto.ts
+++ b/backend/src/worship/dto/response/worship-attendance/worship-attendance-list-response.dto.ts
@@ -1,0 +1,13 @@
+import { WorshipAttendanceModel } from '../../../entity/worship-attendance.entity';
+import { BaseCursorPaginationResponseDto } from '../../../../common/dto/base-cursor-pagination-response.dto';
+
+export class WorshipAttendanceListResponseDto extends BaseCursorPaginationResponseDto<WorshipAttendanceModel> {
+  constructor(
+    data: WorshipAttendanceModel[],
+    count: number,
+    nextCursor: string | undefined,
+    hasMore: boolean,
+  ) {
+    super(data, count, nextCursor, hasMore);
+  }
+}

--- a/backend/src/worship/service/worship-session.service.ts
+++ b/backend/src/worship/service/worship-session.service.ts
@@ -49,7 +49,10 @@ import {
   IGROUPS_DOMAIN_SERVICE,
   IGroupsDomainService,
 } from '../../management/groups/groups-domain/interface/groups-domain.service.interface';
-import { getRecentSessionDate } from '../utils/worship-utils';
+import {
+  getIntersectionGroupIds,
+  getRecentSessionDate,
+} from '../utils/worship-utils';
 
 @Injectable()
 export class WorshipSessionService {
@@ -174,6 +177,7 @@ export class WorshipSessionService {
     worship: WorshipModel,
     sessionId: number,
     defaultWorshipTargetGroupIds: number[] | undefined,
+    permissionScopeGroupIds: number[] | undefined,
     dto: GetWorshipSessionStatsDto,
   ) {
     const session =
@@ -188,10 +192,17 @@ export class WorshipSessionService {
       dto.groupId,
     );
 
+    const intersectionGroupIds = getIntersectionGroupIds(
+      //defaultWorshipTargetGroupIds,
+      requestGroupIds,
+      permissionScopeGroupIds,
+    );
+
     const stats =
       await this.worshipAttendanceDomainService.getAttendanceStatsBySession(
         session,
-        requestGroupIds,
+        //requestGroupIds,
+        intersectionGroupIds,
       );
 
     return {

--- a/backend/src/worship/service/worship.service.ts
+++ b/backend/src/worship/service/worship.service.ts
@@ -46,6 +46,7 @@ import {
   IWorshipAttendanceDomainService,
 } from '../worship-domain/interface/worship-attendance-domain.service.interface';
 import { GetWorshipStatsResponseDto } from '../dto/response/worship/get-worship-stats-response.dto';
+import { getIntersectionGroupIds } from '../utils/worship-utils';
 
 @Injectable()
 export class WorshipService {
@@ -345,6 +346,7 @@ export class WorshipService {
     church: ChurchModel,
     worship: WorshipModel,
     defaultWorshipTargetGroupIds: number[] | undefined,
+    permissionScopeGroupIds: number[] | undefined,
     groupId?: number,
   ) {
     const requestGroupIds = await this.getRequestGroupIds(
@@ -353,18 +355,26 @@ export class WorshipService {
       groupId,
     );
 
+    const intersectionGroupIds = getIntersectionGroupIds(
+      //defaultWorshipTargetGroupIds,
+      requestGroupIds,
+      permissionScopeGroupIds,
+    );
+
     const [totalSessions, overallRate, movingAverages] = await Promise.all([
       // Session Count
       this.worshipSessionDomainService.countByWorship(worship),
       // 전체 출석률
       this.worshipAttendanceDomainService.getAttendanceStatsByWorship(
         worship,
-        requestGroupIds,
+        //requestGroupIds,
+        intersectionGroupIds,
       ),
       // 이동평균
       this.worshipAttendanceDomainService.getMovingAverageAttendance(
         worship,
-        requestGroupIds,
+        //requestGroupIds,
+        intersectionGroupIds,
       ),
     ]);
 

--- a/backend/src/worship/swagger/worship-attendance.swagger.ts
+++ b/backend/src/worship/swagger/worship-attendance.swagger.ts
@@ -1,0 +1,9 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+export const ApiGetWorshipAttendance = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '예배 세션의 출석 정보 조회',
+    }),
+  );

--- a/backend/src/worship/utils/worship-utils.ts
+++ b/backend/src/worship/utils/worship-utils.ts
@@ -23,3 +23,27 @@ export function getRecentSessionDate(
 
   return fromZonedTime(lastWorshipDateKst, timeZone);
 }
+
+export function getIntersectionGroupIds(
+  defaultWorshipTargetGroupIds: number[] | undefined,
+  permissionScopeGroupIds: number[] | undefined,
+) {
+  if (!defaultWorshipTargetGroupIds) {
+    // 요청 그룹이 없고, 예배 대상이 전체인 경우
+    // 요청자의 권한 범위 전체 --> number[] | undefined
+    return permissionScopeGroupIds;
+  }
+
+  // 요청 그룹이 특정된 경우 (요청 그룹이 있거나, 예배 대상이 있는 경우)
+  if (!permissionScopeGroupIds) {
+    // 요청자의 권한 범위가 전체인 경우
+    // 특정 예배 대상 그룹
+    return defaultWorshipTargetGroupIds;
+  }
+
+  const targetGroupIdSet = new Set(defaultWorshipTargetGroupIds);
+
+  return permissionScopeGroupIds.filter((scopeGroupId) =>
+    targetGroupIdSet.has(scopeGroupId),
+  );
+}

--- a/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
@@ -6,12 +6,21 @@ import { WorshipAttendanceModel } from '../../entity/worship-attendance.entity';
 import { WorshipEnrollmentModel } from '../../entity/worship-enrollment.entity';
 import { UpdateWorshipAttendanceDto } from '../../dto/request/worship-attendance/update-worship-attendance.dto';
 import { WorshipModel } from '../../entity/worship.entity';
+import { GetWorshipAttendanceListDto } from '../../dto/request/worship-attendance/get-worship-attendance-list.dto';
+import { DomainCursorPaginationResultDto } from '../../../common/dto/domain-cursor-pagination-result.dto';
 
 export const IWORSHIP_ATTENDANCE_DOMAIN_SERVICE = Symbol(
   'IWORSHIP_ATTENDANCE_DOMAIN_SERVICE',
 );
 
 export interface IWorshipAttendanceDomainService {
+  findAttendanceList(
+    session: WorshipSessionModel,
+    dto: GetWorshipAttendanceListDto,
+    groupIds: number[] | undefined,
+    qr?: QueryRunner,
+  ): Promise<DomainCursorPaginationResultDto<WorshipAttendanceModel>>;
+
   findAttendances(
     session: WorshipSessionModel,
     dto: GetWorshipAttendancesDto,


### PR DESCRIPTION
## 주요 내용
통계 조회 시 관리자 권한 범위를 자동 적용하고, 출석 정보 조회에 커서 기반 페이지네이션을 추가했습니다.

## 세부 내용
- 예배/세션 통계 조회 권한 범위 자동 적용
 - groupId 미지정 시 요청자의 권한 범위 내 통계만 반환
 - 기존: 예배 대상 그룹 전체 통계 (권한 무관)
 - 변경: 관리자가 관리 가능한 그룹 범위로 자동 제한

- GET `/churches/{churchId}/worships/{worshipId}/sessions/{sessionId}/attendances/v2` 엔드포인트 추가
 - 커서 기반 페이지네이션으로 대용량 출석 데이터 효율적 조회
 - 쿼리 파라미터:
   - limit: 조회할 데이터 수
   - cursor: 페이지네이션 커서
   - sortDirection: 'ASC' | 'DESC'
   - sortBy: 'attendanceStatus' | 'groupName' | 'name'
   - groupId: 특정 그룹 필터링 (선택)

## 변경사항
- WorshipService, WorshipSessionService에 권한 범위 체크 로직 추가
- WorshipAttendanceController에 v2 엔드포인트 구현
- 커서 기반 페이지네이션을 위한 쿼리 빌더 구현
- 기존 offset 기반 페이지네이션과 병행 운영