### PR TITLE
feat: 교인별 예배 조회 및 출석률 통계 API 구현

### DIFF
--- a/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
+++ b/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
@@ -64,7 +64,7 @@ export interface IGroupsDomainService {
     church: ChurchModel,
     groupId: number,
     qr?: QueryRunner,
-  ): Promise<GroupModelWithParentGroups>;
+  ): Promise<ParentGroup[]>;
 
   createGroup(
     church: ChurchModel,

--- a/backend/src/management/groups/groups-domain/service/groups-domain.service.ts
+++ b/backend/src/management/groups/groups-domain/service/groups-domain.service.ts
@@ -7,7 +7,6 @@ import {
 } from '@nestjs/common';
 import {
   ChildGroup,
-  GroupModelWithParentGroups,
   IGroupsDomainService,
   ParentGroup,
 } from '../interface/groups-domain.service.interface';
@@ -263,13 +262,25 @@ export class GroupsDomainService implements IGroupsDomainService {
     church: ChurchModel,
     groupId: number,
     qr?: QueryRunner,
-  ): Promise<GroupModelWithParentGroups> {
+  ): Promise<ParentGroup[]> {
     const group = await this.findGroupById(church, groupId, qr);
 
-    return {
-      ...group,
-      parentGroups: await this.findParentGroups(church, group, qr),
-    };
+    const parentGroups = await this.findParentGroups(church, group, qr);
+
+    const lastParentGroup =
+      parentGroups.length > 0
+        ? parentGroups[parentGroups.length - 1]
+        : undefined;
+
+    return [
+      ...parentGroups,
+      {
+        id: group.id,
+        name: group.name,
+        parentGroupId: group.parentGroupId,
+        depth: lastParentGroup ? lastParentGroup.depth + 1 : 1,
+      },
+    ];
   }
 
   async findParentGroups(

--- a/backend/src/members/controller/members.controller.ts
+++ b/backend/src/members/controller/members.controller.ts
@@ -12,7 +12,7 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { MembersService } from '../service/members.service';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CreateMemberDto } from '../dto/request/create-member.dto';
 import { QueryRunner as QR } from 'typeorm';
 import { UpdateMemberDto } from '../dto/request/update-member.dto';
@@ -33,6 +33,10 @@ import { ChurchManagerGuard } from '../../permission/guard/church-manager.guard'
 import { GetMemberListDto } from '../dto/list/get-member-list.dto';
 import { MemberDisplayColumn } from '../const/enum/list/display-column.enum';
 import { GetSimpleMemberListDto } from '../dto/list/get-simple-member-list.dto';
+import { GetMemberWorshipStatisticsDto } from '../dto/request/worship/get-member-worship-statistics.dto';
+import { endOfYear, startOfYear } from 'date-fns';
+import { fromZonedTime } from 'date-fns-tz';
+import { TIME_ZONE } from '../../common/const/time-zone.const';
 
 @ApiTags('Churches:Members')
 @Controller('members')
@@ -135,6 +139,42 @@ export class MembersController {
     @QueryRunner() qr: QR,
   ) {
     return this.membersService.softDeleteMember(church, targetMember, qr);
-    //return this.membersService.softDeleteMember(churchId, memberId, qr);
   }
+
+  @ApiOperation({ summary: '대상 예배 조회' })
+  @Get(':memberId/worship/available')
+  @MemberReadGuard()
+  getMemberAvailableWorship(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @RequestChurch() church: ChurchModel,
+  ) {
+    return this.membersService.getAvailableWorship(church, memberId);
+  }
+
+  @ApiOperation({ summary: '예배 출석률 조회' })
+  @Get(':memberId/worship/statistics')
+  @MemberReadGuard()
+  getMemberWorshipStatistics(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @RequestChurch() church: ChurchModel,
+    @Query() dto: GetMemberWorshipStatisticsDto,
+  ) {
+    dto.utcFrom = dto.from
+      ? fromZonedTime(dto.from, TIME_ZONE.SEOUL)
+      : fromZonedTime(startOfYear(new Date()), TIME_ZONE.SEOUL);
+    dto.utcTo = dto.to
+      ? fromZonedTime(dto.to, TIME_ZONE.SEOUL)
+      : fromZonedTime(endOfYear(new Date()), TIME_ZONE.SEOUL);
+
+    return this.membersService.getMemberWorshipStatistics(
+      church,
+      memberId,
+      dto,
+    );
+  }
+
+  @Get(':memberId/worship/recent')
+  getMemberWorshipRecentAttendance() {}
 }

--- a/backend/src/members/dto/request/worship/get-member-worship-statistics.dto.ts
+++ b/backend/src/members/dto/request/worship/get-member-worship-statistics.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDateString, IsNumber, IsOptional } from 'class-validator';
+import { IsYYYYMMDD } from '../../../../common/decorator/validator/is-yyyy-mm-dd.validator';
+import { IsAfterDate } from '../../../../common/decorator/validator/is-after-date.decorator';
+
+export class GetMemberWorshipStatisticsDto {
+  @ApiProperty({ description: '예배 ID' })
+  @IsNumber()
+  worshipId: number;
+
+  @ApiPropertyOptional({
+    description: '날짜 범위 시작 (yyyy-MM-dd)',
+    example: '2025-01-01',
+  })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('from')
+  from: string;
+
+  utcFrom: Date;
+
+  @ApiPropertyOptional({
+    description: '날짜 범위 끝 (yyyy-MM-dd)',
+    example: '2025-12-31',
+  })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('to')
+  @IsAfterDate('from')
+  to: string;
+
+  utcTo: Date;
+}

--- a/backend/src/members/dto/response/worship/get-available-worship-response.dto.ts
+++ b/backend/src/members/dto/response/worship/get-available-worship-response.dto.ts
@@ -1,0 +1,10 @@
+import { BaseGetResponseDto } from '../../../../common/dto/reponse/base-get-response.dto';
+import { WorshipModel } from '../../../../worship/entity/worship.entity';
+
+export class GetAvailableWorshipResponseDto extends BaseGetResponseDto<
+  WorshipModel[]
+> {
+  constructor(data: WorshipModel[]) {
+    super(data);
+  }
+}

--- a/backend/src/members/dto/response/worship/get-member-worship-statistics-response.dto.ts
+++ b/backend/src/members/dto/response/worship/get-member-worship-statistics-response.dto.ts
@@ -1,0 +1,7 @@
+import { BaseGetResponseDto } from '../../../../common/dto/reponse/base-get-response.dto';
+
+export class GetMemberWorshipStatisticsResponseDto extends BaseGetResponseDto<any> {
+  constructor(data: any) {
+    super(data);
+  }
+}

--- a/backend/src/worship/const/worship-enrollment-order.enum.ts
+++ b/backend/src/worship/const/worship-enrollment-order.enum.ts
@@ -1,7 +1,7 @@
 export enum WorshipEnrollmentOrderEnum {
   //CREATED_AT = 'createdAt',
-  ID = 'id',
-  UPDATED_AT = 'updatedAt',
+  //ID = 'id',
+  //UPDATED_AT = 'updatedAt',
   NAME = 'name',
   GROUP_NAME = 'groupName',
   ATTENDANCE_RATE = 'attendanceRate',

--- a/backend/src/worship/dto/request/worship-enrollment/get-worship-enrollments.dto.ts
+++ b/backend/src/worship/dto/request/worship-enrollment/get-worship-enrollments.dto.ts
@@ -11,11 +11,11 @@ export class GetWorshipEnrollmentsDto extends BaseOffsetPaginationRequestDto<Wor
   @ApiProperty({
     description: '정렬 조건',
     enum: WorshipEnrollmentOrderEnum,
-    default: WorshipEnrollmentOrderEnum.ID,
+    default: WorshipEnrollmentOrderEnum.NAME,
     required: false,
   })
   @IsEnum(WorshipEnrollmentOrderEnum)
-  order: WorshipEnrollmentOrderEnum = WorshipEnrollmentOrderEnum.ID;
+  order: WorshipEnrollmentOrderEnum = WorshipEnrollmentOrderEnum.NAME;
 
   @ApiProperty({
     description: '교인 그룹',

--- a/backend/src/worship/entity/worship.entity.ts
+++ b/backend/src/worship/entity/worship.entity.ts
@@ -9,6 +9,7 @@ import {
 import { BaseModel } from '../../common/entity/base.entity';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { WorshipTargetGroupModel } from './worship-target-group.entity';
+import { WorshipEnrollmentModel } from './worship-enrollment.entity';
 
 @Entity()
 export class WorshipModel extends BaseModel {
@@ -37,4 +38,10 @@ export class WorshipModel extends BaseModel {
     (worshipTargetGroup) => worshipTargetGroup.worship,
   )
   worshipTargetGroups: WorshipTargetGroupModel[];
+
+  @OneToMany(
+    () => WorshipEnrollmentModel,
+    (worshipEnrollment) => worshipEnrollment.worship,
+  )
+  worshipEnrollments: WorshipEnrollmentModel[];
 }

--- a/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
@@ -8,6 +8,7 @@ import { UpdateWorshipAttendanceDto } from '../../dto/request/worship-attendance
 import { WorshipModel } from '../../entity/worship.entity';
 import { GetWorshipAttendanceListDto } from '../../dto/request/worship-attendance/get-worship-attendance-list.dto';
 import { DomainCursorPaginationResultDto } from '../../../common/dto/domain-cursor-pagination-result.dto';
+import { MemberModel } from '../../../members/entity/member.entity';
 
 export const IWORSHIP_ATTENDANCE_DOMAIN_SERVICE = Symbol(
   'IWORSHIP_ATTENDANCE_DOMAIN_SERVICE',
@@ -94,4 +95,11 @@ export interface IWorshipAttendanceDomainService {
     worship: WorshipModel,
     requestGroupIds: number[] | undefined,
   ): Promise<{ last4Weeks: number; last12Weeks: number }>;
+
+  getStatisticsByMemberAndPeriod(
+    member: MemberModel,
+    worship: WorshipModel,
+    utcFrom: Date,
+    utcTo: Date,
+  ): any;
 }

--- a/backend/src/worship/worship-domain/interface/worship-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-domain.service.interface.ts
@@ -5,6 +5,7 @@ import { WorshipDomainPaginationResultDto } from '../dto/worship-domain-paginati
 import { WorshipModel } from '../../entity/worship.entity';
 import { CreateWorshipDto } from '../../dto/request/worship/create-worship.dto';
 import { UpdateWorshipDto } from '../../dto/request/worship/update-worship.dto';
+import { MemberModel } from '../../../members/entity/member.entity';
 
 export const IWORSHIP_DOMAIN_SERVICE = Symbol('IWORSHIP_DOMAIN_SERVICE');
 
@@ -52,4 +53,9 @@ export interface IWorshipDomainService {
   ): Promise<UpdateResult>;
 
   countAllWorships(church: ChurchModel, qr: QueryRunner): Promise<number>;
+
+  findAvailableWorships(
+    member: MemberModel,
+    targetGroupIds: number[] | undefined,
+  ): Promise<WorshipModel[]>;
 }

--- a/backend/src/worship/worship-domain/interface/worship-enrollment-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-enrollment-domain.service.interface.ts
@@ -3,7 +3,6 @@ import { QueryRunner, UpdateResult } from 'typeorm';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { WorshipEnrollmentModel } from '../../entity/worship-enrollment.entity';
 import { GetWorshipEnrollmentsDto } from '../../dto/request/worship-enrollment/get-worship-enrollments.dto';
-import { WorshipEnrollmentDomainPaginationResultDto } from '../dto/worship-enrollment-domain-pagination-result.dto';
 import { GetLowWorshipAttendanceMembersDto } from '../../../home/dto/request/get-low-worship-attendance-members.dto';
 
 export const IWORSHIP_ENROLLMENT_DOMAIN_SERVICE = Symbol(
@@ -11,12 +10,12 @@ export const IWORSHIP_ENROLLMENT_DOMAIN_SERVICE = Symbol(
 );
 
 export interface IWorshipEnrollmentDomainService {
-  findEnrollments(
+  /*findEnrollments(
     worship: WorshipModel,
     dto: GetWorshipEnrollmentsDto,
     groupIds?: number[],
     qr?: QueryRunner,
-  ): Promise<WorshipEnrollmentDomainPaginationResultDto>;
+  ): Promise<WorshipEnrollmentDomainPaginationResultDto>;*/
 
   findEnrollmentsByQueryBuilder(
     worship: WorshipModel,


### PR DESCRIPTION
## 주요 내용
교인이 참여 가능한 예배 목록 조회와 예배별 출석률 통계 API를 구현했습니다.

## 세부 내용
- GET `/churches/{churchId}/members/{memberId}/worship/available` 엔드포인트 추가
 - 교인이 등록되고 대상 그룹에 포함된 예배 목록 조회
 - 그룹 없는 교인은 전체 대상 예배만 조회
 - 예배 요일순 정렬

- GET `/churches/{churchId}/members/{memberId}/worship/statistics` 엔드포인트 추가
 - 특정 예배의 기간별 출석률 통계 제공
 - from/to 날짜 파라미터 (미입력 시 현재 연도)
 - 출석률 계산: PRESENT / (PRESENT + ABSENT)
 - Unknown 상태는 출석률 계산에서 제외

## 변경사항
- MemberWorshipController 생성
- WorshipDomainService에 대상 예배 필터링 메소드 추가
- WorshipAttendanceDomainService에 기간별 통계 집계 쿼리 추가
- 한국 시간대 기준 날짜 처리 (date-fns-tz 활용)