### PR TITLE
feat: 예배 통계 API 개선 및 세션 출석 체크 상태 조회 기능 추가

### DIFF
--- a/backend/src/worship/controller/worship-session.controller.ts
+++ b/backend/src/worship/controller/worship-session.controller.ts
@@ -12,7 +12,7 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { WorshipSessionService } from '../service/worship-session.service';
 import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
@@ -47,6 +47,7 @@ import { ChurchModel } from '../../churches/entity/church.entity';
 import { RequestWorship } from '../decorator/request-worship.decorator';
 import { WorshipModel } from '../entity/worship.entity';
 import { PermissionScopeGroups } from '../decorator/permission-scope-groups.decorator';
+import { GetWorshipSessionCheckStatusDto } from '../dto/request/worship-session/get-worship-session-check-status.dto';
 
 @ApiTags('Worships:Sessions')
 @Controller(':worshipId/sessions')
@@ -83,6 +84,36 @@ export class WorshipSessionController {
       worshipId,
       dto,
       qr,
+    );
+  }
+
+  @ApiOperation({ summary: '예배 세션의 출석체크 완료 여부' })
+  @Get('check-status')
+  @UseGuards(
+    AccessTokenGuard,
+    createDomainGuard(
+      DomainType.WORSHIP,
+      DomainName.WORSHIP,
+      DomainAction.READ,
+    ),
+    WorshipGroupFilterGuard,
+    WorshipReadScopeGuard,
+  )
+  getSessionCheckStatus(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @Query() dto: GetWorshipSessionCheckStatusDto,
+    @RequestChurch() church: ChurchModel,
+    @RequestWorship() worship: WorshipModel,
+    @WorshipTargetGroupIds() defaultTargetGroupIds?: number[],
+    @PermissionScopeGroups() permissionScopeGroupIds?: number[],
+  ) {
+    return this.worshipSessionService.getSessionCheckStatus(
+      church,
+      worship,
+      defaultTargetGroupIds,
+      permissionScopeGroupIds,
+      dto,
     );
   }
 

--- a/backend/src/worship/controller/worship.controller.ts
+++ b/backend/src/worship/controller/worship.controller.ts
@@ -150,7 +150,7 @@ export class WorshipController {
       worship,
       defaultTargetGroupIds,
       permissionScopeGroupIds,
-      dto.groupId,
+      dto,
     );
   }
 }

--- a/backend/src/worship/dto/request/worship-session/get-worship-session-check-status.dto.ts
+++ b/backend/src/worship/dto/request/worship-session/get-worship-session-check-status.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
+import { IsDateString, IsNumber } from 'class-validator';
+import { IsYYYYMMDD } from '../../../../common/decorator/validator/is-yyyy-mm-dd.validator';
+
+export class GetWorshipSessionCheckStatusDto {
+  @ApiProperty({
+    description: '교인 그룹',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsNumber()
+  groupId: number;
+
+  @ApiProperty({
+    description: '불러올 예배 세션 시작 날짜 (YYYY-MM-DD)',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('fromSessionDate')
+  from: string;
+
+  @ApiProperty({
+    description: '불러올 예배 세션 마지막 날짜 (YYYY-MM-DD)',
+    required: false,
+  })
+  @IsOptionalNotNull()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('toSessionDate')
+  to: string;
+}

--- a/backend/src/worship/dto/request/worship/get-worship-stats.dto.ts
+++ b/backend/src/worship/dto/request/worship/get-worship-stats.dto.ts
@@ -1,7 +1,24 @@
-import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsNumber, IsOptional } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDateString, IsNumber, IsOptional } from 'class-validator';
+import { IsYYYYMMDD } from '../../../../common/decorator/validator/is-yyyy-mm-dd.validator';
+import { IsAfterDate } from '../../../../common/decorator/validator/is-after-date.decorator';
 
 export class GetWorshipStatsDto {
+  @ApiProperty({ description: '출석률 집계 시작' })
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('from')
+  from: string;
+
+  utcFrom: Date;
+
+  @ApiProperty({ description: '출석률 집계 끝' })
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('to')
+  @IsAfterDate('from')
+  to: string;
+
+  utcTo: Date;
+
   @ApiPropertyOptional({ description: '조회할 그룹' })
   @IsOptional()
   @IsNumber()

--- a/backend/src/worship/dto/response/worship/get-worship-stats-response.dto.ts
+++ b/backend/src/worship/dto/response/worship/get-worship-stats-response.dto.ts
@@ -1,17 +1,19 @@
 export class GetWorshipStatsResponseDto {
   constructor(
     public readonly worshipId: number,
-    public readonly totalSessions: number,
+    //public readonly totalSessions: number,
+    public readonly attendanceCheckRate: number,
     public readonly attendanceRate: {
       overall: number;
-      last4Weeks: number;
-      last12Weeks: number;
+      period: number;
+      //last4Weeks: number;
+      //last12Weeks: number;
     },
-    public readonly trend: {
-      longTerm: number;
-      shortTerm: number;
-      overall: number;
-    },
+    // public readonly trend: {
+    //   longTerm: number;
+    //   shortTerm: number;
+    //   overall: number;
+    // },
     public readonly timestamp: Date = new Date(),
   ) {}
 }

--- a/backend/src/worship/entity/worship-attendance.entity.ts
+++ b/backend/src/worship/entity/worship-attendance.entity.ts
@@ -10,7 +10,7 @@ export class WorshipAttendanceModel extends BaseModel {
   @Column()
   worshipSessionId: number;
 
-  @ManyToOne(() => WorshipSessionModel)
+  @ManyToOne(() => WorshipSessionModel, (session) => session.worshipAttendances)
   @JoinColumn({ name: 'worshipSessionId' })
   worshipSession: WorshipSessionModel;
 

--- a/backend/src/worship/entity/worship-session.entity.ts
+++ b/backend/src/worship/entity/worship-session.entity.ts
@@ -1,7 +1,15 @@
-import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+} from 'typeorm';
 import { BaseModel } from '../../common/entity/base.entity';
 import { WorshipModel } from './worship.entity';
 import { MemberModel } from '../../members/entity/member.entity';
+import { WorshipAttendanceModel } from './worship-attendance.entity';
 
 @Entity()
 export class WorshipSessionModel extends BaseModel {
@@ -35,4 +43,10 @@ export class WorshipSessionModel extends BaseModel {
   @ManyToOne(() => MemberModel, { nullable: true })
   @JoinColumn({ name: 'inChargeId' })
   inCharge: MemberModel | null;
+
+  @OneToMany(
+    () => WorshipAttendanceModel,
+    (attendance) => attendance.worshipSession,
+  )
+  worshipAttendances: WorshipAttendanceModel[];
 }

--- a/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
@@ -87,15 +87,17 @@ export interface IWorshipAttendanceDomainService {
     unknownCount: number;
   }>;
 
-  getAttendanceStatsByWorship(
+  getOverallAttendanceStats(
     worship: WorshipModel,
     requestGroupIds: number[] | undefined,
-  ): Promise<number>;
+  ): Promise<{ overallRate: number; attendanceCheckRate: number }>;
 
-  getMovingAverageAttendance(
+  getAttendanceStatsByPeriod(
     worship: WorshipModel,
     requestGroupIds: number[] | undefined,
-  ): Promise<{ last4Weeks: number; last12Weeks: number }>;
+    from: Date,
+    to: Date | undefined,
+  ): Promise<{ rate: number; attendanceCheckRate: number }>;
 
   getStatisticsByMemberAndPeriod(
     member: MemberModel,

--- a/backend/src/worship/worship-domain/interface/worship-session-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-session-domain.service.interface.ts
@@ -68,4 +68,11 @@ export interface IWorshipSessionDomainService {
   ): Promise<number[]>;
 
   countByWorship(worship: WorshipModel): Promise<number>;
+
+  findSessionCheckStatus(
+    worship: WorshipModel,
+    intersectionGroupIds: number[] | undefined,
+    from: Date,
+    to: Date,
+  ): Promise<any>;
 }


### PR DESCRIPTION
## 주요 내용
예배 통계 응답을 단순화하고, 세션별 출석 체크 완료 여부를 조회하는 기능을 추가했습니다.

## 세부 내용
- GET `/churches/{churchId}/worships/{worshipId}/statistics` 응답 변경
 - 이동평균 및 트렌드 분석 제거
 - 전체 기간 출석률과 지정 기간 출석률로 단순화
 - attendanceCheckRate 추가 (출석 체크 완료율)

- GET `/churches/{churchId}/worships/{worshipId}/sessions/check-status` 엔드포인트 추가
 - 기간 내 세션들의 출석 체크 완료 여부 조회
 - groupId로 특정 그룹 필터링 가능
 - from/to 미입력 시 최근 예배일 기준 14주 자동 설정
 - 14주 초과 조회 방지 validation
 - unknown 상태가 하나도 없으면 completeAttendanceCheck: true

## 변경사항
- WorshipService의 통계 계산 로직 간소화
- WorshipSessionDomainService에 세션 체크 상태 조회 메소드 추가
- 14주 기간 제한 validation 추가
- 한국 시간 기준 날짜 처리 유지