### PR TITLE
feat: 예배 세션 일괄 출석 처리 기능 추가

### DIFF
--- a/backend/src/worship/controller/worship-attendance.controller.ts
+++ b/backend/src/worship/controller/worship-attendance.controller.ts
@@ -20,7 +20,7 @@ import { UpdateWorshipAttendanceDto } from '../dto/request/worship-attendance/up
 import { WorshipReadGuard } from '../guard/worship-read.guard';
 import { WorshipWriteGuard } from '../guard/worship-write.guard';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
-import { WorshipReadScopeGuard } from '../guard/worship-read-scope.guard';
+import { WorshipScopeGuard } from '../guard/worship-scope.guard';
 import { WorshipGroupFilterGuard } from '../guard/worship-group-filter.guard';
 import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
 import { DomainType } from '../../permission/const/domain-type.enum';
@@ -35,6 +35,7 @@ import { WorshipModel } from '../entity/worship.entity';
 import { ApiGetWorshipAttendance } from '../swagger/worship-attendance.swagger';
 import { GetWorshipAttendanceListDto } from '../dto/request/worship-attendance/get-worship-attendance-list.dto';
 import { WorshipTargetGroupIds } from '../decorator/worship-target-group-ids.decorator';
+import { UpdateWorshipAllAttendedDto } from '../dto/request/worship-attendance/update-worship-all-attended.dto';
 
 @ApiTags('Worships:Attendance')
 @Controller(':worshipId/sessions/:sessionId/attendances')
@@ -53,7 +54,7 @@ export class WorshipAttendanceController {
       DomainAction.READ,
     ),
     WorshipGroupFilterGuard,
-    WorshipReadScopeGuard,
+    WorshipScopeGuard,
   )
   @WorshipReadGuard()
   getAttendances(
@@ -85,7 +86,7 @@ export class WorshipAttendanceController {
       DomainAction.READ,
     ),
     WorshipGroupFilterGuard,
-    WorshipReadScopeGuard,
+    WorshipScopeGuard,
   )
   getAttendanceList(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -120,6 +121,39 @@ export class WorshipAttendanceController {
       churchId,
       worshipId,
       sessionId,
+      qr,
+    );
+  }
+
+  @Patch('all-attended')
+  @UseGuards(
+    AccessTokenGuard,
+    createDomainGuard(
+      DomainType.WORSHIP,
+      DomainName.WORSHIP,
+      DomainAction.WRITE,
+    ),
+    WorshipGroupFilterGuard,
+    WorshipScopeGuard,
+  )
+  @UseInterceptors(TransactionInterceptor)
+  patchAllAttended(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('worshipId', ParseIntPipe) worshipId: number,
+    @Param('sessionId', ParseIntPipe) sessionId: number,
+    @Body() dto: UpdateWorshipAllAttendedDto,
+    @RequestChurch() church: ChurchModel,
+    @RequestWorship() worship: WorshipModel,
+    @WorshipTargetGroupIds() defaultTargetGroupIds: number[] | undefined,
+    @PermissionScopeGroups() permissionScopeGroupIds: number[] | undefined,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.worshipAttendanceService.patchAllAttended(
+      church,
+      worship,
+      sessionId,
+      defaultTargetGroupIds,
+      permissionScopeGroupIds,
       qr,
     );
   }

--- a/backend/src/worship/controller/worship-enrollment.controller.ts
+++ b/backend/src/worship/controller/worship-enrollment.controller.ts
@@ -20,7 +20,7 @@ import { RequestWorship } from '../decorator/request-worship.decorator';
 import { WorshipModel } from '../entity/worship.entity';
 import { RequestChurch } from '../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../churches/entity/church.entity';
-import { WorshipReadScopeGuard } from '../guard/worship-read-scope.guard';
+import { WorshipScopeGuard } from '../guard/worship-scope.guard';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
 import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
 import { DomainType } from '../../permission/const/domain-type.enum';
@@ -45,7 +45,7 @@ export class WorshipEnrollmentController {
       DomainAction.READ,
     ),
     WorshipGroupFilterGuard,
-    WorshipReadScopeGuard,
+    WorshipScopeGuard,
   )
   getEnrollments(
     @Param('churchId', ParseIntPipe) churchId: number,

--- a/backend/src/worship/controller/worship-session.controller.ts
+++ b/backend/src/worship/controller/worship-session.controller.ts
@@ -41,7 +41,7 @@ import { DomainType } from '../../permission/const/domain-type.enum';
 import { DomainName } from '../../permission/const/domain-name.enum';
 import { DomainAction } from '../../permission/const/domain-action.enum';
 import { WorshipGroupFilterGuard } from '../guard/worship-group-filter.guard';
-import { WorshipReadScopeGuard } from '../guard/worship-read-scope.guard';
+import { WorshipScopeGuard } from '../guard/worship-scope.guard';
 import { RequestChurch } from '../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { RequestWorship } from '../decorator/request-worship.decorator';
@@ -97,7 +97,7 @@ export class WorshipSessionController {
       DomainAction.READ,
     ),
     WorshipGroupFilterGuard,
-    WorshipReadScopeGuard,
+    WorshipScopeGuard,
   )
   getSessionCheckStatus(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -127,7 +127,7 @@ export class WorshipSessionController {
       DomainAction.READ,
     ),
     WorshipGroupFilterGuard,
-    WorshipReadScopeGuard,
+    WorshipScopeGuard,
   )
   getWorshipSessionStatistics(
     @RequestChurch() church: ChurchModel,

--- a/backend/src/worship/controller/worship.controller.ts
+++ b/backend/src/worship/controller/worship.controller.ts
@@ -31,7 +31,7 @@ import { DomainType } from '../../permission/const/domain-type.enum';
 import { DomainName } from '../../permission/const/domain-name.enum';
 import { DomainAction } from '../../permission/const/domain-action.enum';
 import { WorshipGroupFilterGuard } from '../guard/worship-group-filter.guard';
-import { WorshipReadScopeGuard } from '../guard/worship-read-scope.guard';
+import { WorshipScopeGuard } from '../guard/worship-scope.guard';
 import { RequestWorship } from '../decorator/request-worship.decorator';
 import { WorshipModel } from '../entity/worship.entity';
 import { WorshipTargetGroupIds } from '../decorator/worship-target-group-ids.decorator';
@@ -134,7 +134,7 @@ export class WorshipController {
       DomainAction.READ,
     ),
     WorshipGroupFilterGuard,
-    WorshipReadScopeGuard,
+    WorshipScopeGuard,
   )
   getWorshipStatistics(
     @Param('churchId', ParseIntPipe) churchId: number,

--- a/backend/src/worship/dto/request/worship-attendance/update-worship-all-attended.dto.ts
+++ b/backend/src/worship/dto/request/worship-attendance/update-worship-all-attended.dto.ts
@@ -1,0 +1,10 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNumber, IsOptional, Min } from 'class-validator';
+
+export class UpdateWorshipAllAttendedDto {
+  @ApiPropertyOptional({ description: '그룹 ID' })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  groupId?: number;
+}

--- a/backend/src/worship/dto/response/worship-attendance/patch-worship-all-attended-response.dto.ts
+++ b/backend/src/worship/dto/response/worship-attendance/patch-worship-all-attended-response.dto.ts
@@ -1,0 +1,7 @@
+export class PatchWorshipAllAttendedResponseDto {
+  constructor(
+    public readonly success: boolean,
+    public readonly changedCount: number,
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/worship/guard/worship-scope.guard.ts
+++ b/backend/src/worship/guard/worship-scope.guard.ts
@@ -29,7 +29,7 @@ import { CustomRequest } from '../../common/custom-request';
  * 필터링 요청한 그룹이 요청자의 권한 범위 내에 속하는지 검사
  */
 @Injectable()
-export class WorshipReadScopeGuard implements CanActivate {
+export class WorshipScopeGuard implements CanActivate {
   constructor(
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,

--- a/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
@@ -111,4 +111,21 @@ export interface IWorshipAttendanceDomainService {
     worship: WorshipModel,
     dto: GetMemberWorshipAttendancesDto,
   ): Promise<DomainCursorPaginationResultDto<WorshipAttendanceModel>>;
+
+  findUnknownAttendances(
+    session: WorshipSessionModel,
+    groupIds: number[] | undefined,
+    qr: QueryRunner,
+  ): Promise<WorshipAttendanceModel[]>;
+
+  findAbsentAttendances(
+    session: WorshipSessionModel,
+    groupIds: number[] | undefined,
+    qr: QueryRunner,
+  ): Promise<WorshipAttendanceModel[]>;
+
+  updateAllAttended(
+    updateTargetIds: number[],
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
 }

--- a/backend/src/worship/worship-domain/interface/worship-enrollment-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-enrollment-domain.service.interface.ts
@@ -4,6 +4,7 @@ import { MemberModel } from '../../../members/entity/member.entity';
 import { WorshipEnrollmentModel } from '../../entity/worship-enrollment.entity';
 import { GetWorshipEnrollmentsDto } from '../../dto/request/worship-enrollment/get-worship-enrollments.dto';
 import { GetLowWorshipAttendanceMembersDto } from '../../../home/dto/request/get-low-worship-attendance-members.dto';
+import { WorshipAttendanceModel } from '../../entity/worship-attendance.entity';
 
 export const IWORSHIP_ENROLLMENT_DOMAIN_SERVICE = Symbol(
   'IWORSHIP_ENROLLMENT_DOMAIN',
@@ -85,4 +86,14 @@ export interface IWorshipEnrollmentDomainService {
     presentCount: number,
     absentCount: number,
   ): Promise<UpdateResult>;*/
+
+  incrementPresentCounts(
+    worshipAttendanceModels: WorshipAttendanceModel[],
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  decrementAbsentCounts(
+    worshipAttendance: WorshipAttendanceModel[],
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
 }


### PR DESCRIPTION
## 주요 내용
특정 그룹의 교인들을 대상으로 일괄 출석 처리하는 기능을 구현했습니다.

## 세부 내용
- PATCH `/churches/{churchId}/worships/{worshipId}/sessions/{sessionId}/attendances/all-attended` 엔드포인트 추가
 - body: groupId (선택적)
 - groupId 없음: 예배 대상 그룹 ∩ 사용자 권한 범위
 - groupId 있음: 해당 그룹 및 하위 그룹 (예배 대상 & 권한 범위 검증)

- 출석 상태 변경 로직
 - UNKNOWN → PRESENT: presentCount++
 - ABSENT → PRESENT: presentCount++, absentCount--
 - 이미 PRESENT인 경우 제외

- 응답 형식
 - success: 처리 성공 여부
 - changedCount: 변경된 출석 기록 수
 - timestamp: 처리 시간

## 변경사항
- WorshipAttendanceController에 일괄 출석 메소드 추가
- WorshipAttendanceDomainService에 bulk update 로직 구현
- WorshipEnrollmentModel의 presentCount, absentCount 동기화 처리
- 트랜잭션으로 데이터 일관성 보장
- 권한 검증 로직 추가