### PR TITLE
feat: 홈화면 담당 일정 상태 조회 API 추가

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -134,8 +134,8 @@ import { EducationEnrollmentModel } from './educations/education-enrollment/enti
     TypeOrmModule.forRootAsync({
       useFactory: (configService: ConfigService) => ({
         type: configService.get<string>('DB_TYPE') as 'postgres',
-        url: configService.get<string>('DB_HOST') as string,
-        //host: configService.get<string>('DB_HOST'),
+        //url: configService.get<string>('DB_HOST') as string,
+        host: configService.get<string>('DB_HOST'),
         port: configService.get<number>('DB_PORT'),
         username: configService.get<string>('DB_USERNAME'),
         password: configService.get<string>('DB_PASSWORD'),
@@ -198,7 +198,7 @@ import { EducationEnrollmentModel } from './educations/education-enrollment/enti
           // 교회 일정표/이벤트
           ChurchEventModel,
         ],
-        synchronize: false,
+        synchronize: true,
       }),
       inject: [ConfigService],
     }),

--- a/backend/src/educations/education-domain/interface/education-session-domain.service.interface.ts
+++ b/backend/src/educations/education-domain/interface/education-session-domain.service.interface.ts
@@ -8,6 +8,7 @@ import { ChurchModel } from '../../../churches/entity/church.entity';
 import { GetEducationSessionForCalendarDto } from '../../../calendar/dto/request/education/get-education-session-for-calendar.dto';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
+import { MyScheduleStatusCountDto } from '../../../task/dto/my-schedule-status-count.dto';
 
 export const IEDUCATION_SESSION_DOMAIN_SERVICE = Symbol(
   'IEDUCATION_SESSION_DOMAIN_SERVICE',
@@ -92,12 +93,6 @@ export interface IEducationSessionDomainService {
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 
-  findMyEducationSessions(
-    inCharge: MemberModel,
-    from: Date,
-    to: Date,
-  ): Promise<EducationSessionModel[]>;
-
   incrementAttendancesCount(
     educationSession: EducationSessionModel,
     count: number,
@@ -109,4 +104,16 @@ export interface IEducationSessionDomainService {
     count: number,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
+
+  findMyEducationSessions(
+    inCharge: MemberModel,
+    from: Date,
+    to: Date,
+  ): Promise<EducationSessionModel[]>;
+
+  countMyEducationSessionStatus(
+    me: MemberModel,
+    from: Date,
+    to: Date,
+  ): Promise<MyScheduleStatusCountDto>;
 }

--- a/backend/src/educations/education-domain/interface/education-term-domain.service.interface.ts
+++ b/backend/src/educations/education-domain/interface/education-term-domain.service.interface.ts
@@ -12,6 +12,8 @@ import { UpdateEducationTermDto } from '../../education-term/dto/request/update-
 import { GetInProgressEducationTermDto } from '../../education-term/dto/request/get-in-progress-education-term.dto';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
+import { MemberModel } from '../../../members/entity/member.entity';
+import { MyScheduleStatusCountDto } from '../../../task/dto/my-schedule-status-count.dto';
 
 export const IEDUCATION_TERM_DOMAIN_SERVICE = Symbol(
   'IEDUCATION_TERM_DOMAIN_SERVICE',
@@ -112,4 +114,16 @@ export interface IEducationTermDomainService {
     dto: GetInProgressEducationTermDto,
     qr?: QueryRunner,
   ): Promise<EducationTermModel[]>;
+
+  findMyEducationTerms(
+    me: MemberModel,
+    from: Date,
+    to: Date,
+  ): Promise<EducationTermModel[]>;
+
+  countMyEducationTermStatus(
+    me: MemberModel,
+    from: Date,
+    to: Date,
+  ): Promise<MyScheduleStatusCountDto>;
 }

--- a/backend/src/educations/education-domain/service/education-session-domain.service.ts
+++ b/backend/src/educations/education-domain/service/education-session-domain.service.ts
@@ -15,7 +15,6 @@ import {
 import { EducationTermModel } from '../../education-term/entity/education-term.entity';
 import {
   BadRequestException,
-  ConflictException,
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
@@ -30,9 +29,11 @@ import {
   MemberSummarizedSelect,
 } from '../../../members/const/member-find-options.const';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
-import { ChurchUserRole } from '../../../user/const/user-role.enum';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { EducationSessionException } from '../../education-session/exception/education-session.exception';
+import { MyScheduleStatusCountDto } from '../../../task/dto/my-schedule-status-count.dto';
+import { session } from 'passport';
+import { EducationSessionStatus } from '../../education-session/const/education-session-status.enum';
 
 export class EducationSessionDomainService
   implements IEducationSessionDomainService
@@ -456,43 +457,6 @@ export class EducationSessionDomainService
     );
   }
 
-  findMyEducationSessions(
-    inCharge: MemberModel,
-    from: Date,
-    to: Date,
-  ): Promise<EducationSessionModel[]> {
-    const repository = this.getEducationSessionsRepository();
-
-    return repository.find({
-      where: {
-        inChargeId: inCharge.id,
-        startDate: LessThanOrEqual(to),
-        endDate: MoreThanOrEqual(from),
-      },
-      order: {
-        endDate: 'ASC',
-      },
-      relations: {
-        educationTerm: true,
-      },
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-        session: true,
-        title: true,
-        startDate: true,
-        endDate: true,
-        status: true,
-        educationTerm: {
-          id: true,
-          educationId: true,
-        },
-      },
-      take: 50,
-    });
-  }
-
   async incrementAttendancesCount(
     educationSession: EducationSessionModel,
     count: number,
@@ -535,5 +499,86 @@ export class EducationSessionDomainService
     }
 
     return result;
+  }
+
+  findMyEducationSessions(
+    inCharge: MemberModel,
+    from: Date,
+    to: Date,
+  ): Promise<EducationSessionModel[]> {
+    const repository = this.getEducationSessionsRepository();
+
+    return repository.find({
+      where: {
+        inChargeId: inCharge.id,
+        startDate: LessThanOrEqual(to),
+        endDate: MoreThanOrEqual(from),
+      },
+      order: {
+        endDate: 'ASC',
+      },
+      relations: {
+        educationTerm: true,
+      },
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        session: true,
+        title: true,
+        startDate: true,
+        endDate: true,
+        status: true,
+        educationTerm: {
+          id: true,
+          educationId: true,
+          educationName: true,
+          term: true,
+        },
+      },
+      take: 50,
+    });
+  }
+
+  async countMyEducationSessionStatus(
+    me: MemberModel,
+    from: Date,
+    to: Date,
+  ): Promise<MyScheduleStatusCountDto> {
+    const repository = this.getEducationSessionsRepository();
+
+    const query = repository
+      .createQueryBuilder('educationSession')
+      .innerJoin('educationSession.inCharge', 'inCharge', 'inCharge.id = :id', {
+        id: me.id,
+      })
+      .where(
+        'educationSession.startDate <= :to AND educationSession.endDate >= :from',
+        {
+          from,
+          to,
+        },
+      )
+      .select([
+        'SUM(CASE WHEN educationSession.status = :reserve THEN 1 ELSE 0 END) as reserve_count',
+        'SUM(CASE WHEN educationSession.status = :inProgress THEN 1 ELSE 0 END) as inprogress_count',
+        'SUM(CASE WHEN educationSession.status = :done THEN 1 ELSE 0 END) as done_count',
+        'SUM(CASE WHEN educationSession.status = :pending THEN 1 ELSE 0 END) as pending_count',
+      ])
+      .setParameters({
+        reserve: EducationSessionStatus.RESERVE,
+        inProgress: EducationSessionStatus.IN_PROGRESS,
+        done: EducationSessionStatus.DONE,
+        pending: EducationSessionStatus.PENDING,
+      });
+
+    const result = await query.getRawOne();
+
+    return new MyScheduleStatusCountDto(
+      parseInt(result.reserve_count),
+      parseInt(result.inprogress_count),
+      parseInt(result.done_count),
+      parseInt(result.pending_count),
+    );
   }
 }

--- a/backend/src/home/controller/home.controller.ts
+++ b/backend/src/home/controller/home.controller.ts
@@ -15,6 +15,7 @@ import { GetNewMemberDetailDto } from '../dto/request/get-new-member-detail.dto'
 import {
   ApiGetLowWorshipAttendanceMembers,
   ApiGetMyInChargedSchedules,
+  ApiGetMyInChargeScheduleStatus,
   ApiGetMyScheduleReports,
   ApiGetNewMemberDetail,
   ApiGetNewMemberSummary,
@@ -61,6 +62,16 @@ export class HomeController {
     }
 
     return this.homeService.getMyInChargedSchedules(pm, dto);
+  }
+
+  @ApiGetMyInChargeScheduleStatus()
+  @Get('schedules/status')
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
+  getMyInChargeScheduleStatus(
+    @Query() dto: GetMyInChargedSchedulesDto,
+    @RequestManager() requestMember: ChurchUserModel,
+  ) {
+    return this.homeService.getMyInChargeScheduleStatus(requestMember, dto);
   }
 
   @ApiGetMyScheduleReports()

--- a/backend/src/home/swagger/home.swagger.ts
+++ b/backend/src/home/swagger/home.swagger.ts
@@ -39,6 +39,12 @@ export const ApiGetMyInChargedSchedules = () =>
     }),
   );
 
+export const ApiGetMyInChargeScheduleStatus = () =>
+  applyDecorators(
+    ApiParam({ name: 'churchId' }),
+    ApiOperation({ summary: '내가 담당한 일정의 상태값 조회' }),
+  );
+
 export const ApiGetMyScheduleReports = () =>
   applyDecorators(
     ApiParam({ name: 'churchId' }),

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -13,7 +13,7 @@ async function bootstrap() {
 
   // CORS 설정
   app.enableCors({
-    origin: 'https://mokjang-pied.vercel.app',
+    origin: true,
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
     credentials: true,
   });

--- a/backend/src/task/dto/my-schedule-status-count.dto.ts
+++ b/backend/src/task/dto/my-schedule-status-count.dto.ts
@@ -1,0 +1,8 @@
+export class MyScheduleStatusCountDto {
+  constructor(
+    public readonly reserve: number,
+    public readonly inProgress: number,
+    public readonly done: number,
+    public readonly pending: number,
+  ) {}
+}

--- a/backend/src/task/task-domain/interface/task-domain.service.interface.ts
+++ b/backend/src/task/task-domain/interface/task-domain.service.interface.ts
@@ -7,6 +7,7 @@ import { TaskDomainPaginationResultDto } from '../../dto/task-domain-pagination-
 import { UpdateTaskDto } from '../../dto/request/update-task.dto';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
+import { MyScheduleStatusCountDto } from '../../dto/my-schedule-status-count.dto';
 
 export const ITASK_DOMAIN_SERVICE = Symbol('ITASK_DOMAIN_SERVICE');
 
@@ -69,4 +70,10 @@ export interface ITaskDomainService {
     from: Date,
     to: Date,
   ): Promise<TaskModel[]>;
+
+  countMyTaskStatus(
+    me: MemberModel,
+    from: Date,
+    to: Date,
+  ): Promise<MyScheduleStatusCountDto>;
 }

--- a/backend/src/visitation/const/visitation-status.enum.ts
+++ b/backend/src/visitation/const/visitation-status.enum.ts
@@ -1,5 +1,6 @@
 export enum VisitationStatus {
   RESERVE = 'reserve',
+  IN_PROGRESS = 'inProgress',
   DONE = 'done',
   PENDING = 'pending',
 }

--- a/backend/src/visitation/dto/my-visitation-status-count.dto.ts
+++ b/backend/src/visitation/dto/my-visitation-status-count.dto.ts
@@ -1,0 +1,8 @@
+export class MyVisitationStatusCountDto {
+  constructor(
+    public readonly reserve: number,
+    public readonly inProgress: number,
+    public readonly done: number,
+    public readonly pending: number,
+  ) {}
+}

--- a/backend/src/visitation/visitation-domain/interface/visitation-meta-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/interface/visitation-meta-domain.service.interface.ts
@@ -5,6 +5,7 @@ import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
 import { GetVisitationDto } from '../../dto/request/get-visitation.dto';
 import { UpdateVisitationMetaDto } from '../../dto/internal/meta/update-visitation-meta.dto';
+import { MyScheduleStatusCountDto } from '../../../task/dto/my-schedule-status-count.dto';
 
 export const IVISITATION_META_DOMAIN_SERVICE = Symbol(
   'IVISITATION_META_DOMAIN_SERVICE',
@@ -60,4 +61,10 @@ export interface IVisitationMetaDomainService {
     from: Date,
     to: Date,
   ): Promise<VisitationMetaModel[]>;
+
+  countMyVisitationStatus(
+    me: MemberModel,
+    from: Date,
+    to: Date,
+  ): Promise<MyScheduleStatusCountDto>;
 }


### PR DESCRIPTION
## 주요 내용
홈화면 위젯에서 사용자가 담당한 일정들의 상태를 집계하여 조회하는 API를 구현했습니다.

## 세부 내용
- **엔드포인트**: `GET /churches/{churchId}/home/schedules/status`
- **조회 범위 설정**:
 - `range` 파라미터로 주간(`weekly`) 또는 월간(`monthly`) 조회 지원
 - 개발 테스트용 `from`, `to` 파라미터 추가 (프로덕션에서는 `range`만 사용)
- **집계 대상**:
 - 업무(task)
 - 심방(visitation)
 - 교육 기수(educationTerm)
 - 교육 세션(educationSession)
- **상태별 카운트**: 각 일정 타입별로 `reserve`, `inProgress`, `done`, `pending` 상태 집계
- **내가 담당한 일정 조회 개선**:
 - 교육 기수(educationTerm)를 조회 대상에 추가
 - 교육 관련 응답에 `educationId`, `educationName`, `educationTerm` 정보 포함
 - 교육 기수와 세션의 통합적인 상태 관리 지원

### 응답 예시

#### 상태 집계 응답
```json
{
 "range": "monthly",
 "from": "2024-12-31T15:00:00.000Z",
 "to": "2025-12-30T14:59:59.999Z",
 "data": {
   "task": {
     "reserve": 1,
     "inProgress": 0,
     "done": 1,
     "pending": 0
   },
   "visitation": {
     "reserve": 1,
     "inProgress": 0,
     "done": 0,
     "pending": 0
   },
   "educationTerm": {
     "reserve": 4,
     "inProgress": 0,
     "done": 0,
     "pending": 0
   },
   "educationSession": {
     "reserve": 1,
     "inProgress": 0,
     "done": 0,
     "pending": 0
   }
 },
 "timestamp": "2025-08-25T11:37:19.616Z"
}
```