### PR TITLE
fix: 담당 일정 상태 조회 시 count null 반환 문제 수정

### DIFF
--- a/backend/src/educations/education-domain/service/educaiton-term-domain.service.ts
+++ b/backend/src/educations/education-domain/service/educaiton-term-domain.service.ts
@@ -619,10 +619,10 @@ export class EducationTermDomainService implements IEducationTermDomainService {
     const result = await query.getRawOne();
 
     return new MyScheduleStatusCountDto(
-      parseInt(result.reserve_count),
-      parseInt(result.inprogress_count),
-      parseInt(result.done_count),
-      parseInt(result.pending_count),
+      parseInt(result.reserve_count) || 0,
+      parseInt(result.inprogress_count) || 0,
+      parseInt(result.done_count) || 0,
+      parseInt(result.pending_count) || 0,
     );
   }
 }

--- a/backend/src/educations/education-domain/service/education-session-domain.service.ts
+++ b/backend/src/educations/education-domain/service/education-session-domain.service.ts
@@ -575,10 +575,10 @@ export class EducationSessionDomainService
     const result = await query.getRawOne();
 
     return new MyScheduleStatusCountDto(
-      parseInt(result.reserve_count),
-      parseInt(result.inprogress_count),
-      parseInt(result.done_count),
-      parseInt(result.pending_count),
+      parseInt(result.reserve_count) || 0,
+      parseInt(result.inprogress_count) || 0,
+      parseInt(result.done_count) || 0,
+      parseInt(result.pending_count) || 0,
     );
   }
 }

--- a/backend/src/task/task-domain/service/task-domain.service.ts
+++ b/backend/src/task/task-domain/service/task-domain.service.ts
@@ -473,10 +473,10 @@ export class TaskDomainService implements ITaskDomainService {
     const result = await query.getRawOne();
 
     return new MyScheduleStatusCountDto(
-      parseInt(result.reserve_count),
-      parseInt(result.inprogress_count),
-      parseInt(result.done_count),
-      parseInt(result.pending_count),
+      parseInt(result.reserve_count) || 0,
+      parseInt(result.inprogress_count) || 0,
+      parseInt(result.done_count) || 0,
+      parseInt(result.pending_count) || 0,
     );
   }
 }

--- a/backend/src/visitation/dto/my-visitation-status-count.dto.ts
+++ b/backend/src/visitation/dto/my-visitation-status-count.dto.ts
@@ -1,8 +1,0 @@
-export class MyVisitationStatusCountDto {
-  constructor(
-    public readonly reserve: number,
-    public readonly inProgress: number,
-    public readonly done: number,
-    public readonly pending: number,
-  ) {}
-}

--- a/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
@@ -342,10 +342,10 @@ export class VisitationMetaDomainService
     const result = await query.getRawOne();
 
     return new MyScheduleStatusCountDto(
-      parseInt(result.reserve_count),
-      parseInt(result.inprogress_count),
-      parseInt(result.done_count),
-      parseInt(result.pending_count),
+      parseInt(result.reserve_count) || 0,
+      parseInt(result.inprogress_count) || 0,
+      parseInt(result.done_count) || 0,
+      parseInt(result.pending_count) || 0,
     );
   }
 }


### PR DESCRIPTION
## 주요 내용
담당한 일정의 상태값 조회 시 해당 상태의 일정이 없을 경우 count가 null로 반환되는 문제를 수정했습니다.

## 세부 내용
- **문제 상황**: 특정 상태(reserve, inProgress, done, pending)의 일정이 존재하지 않을 때 count 값이 0이 아닌 null로 반환
- **해결 방법**: 조회 결과가 없는 경우 기본값 0으로 처리하도록 로직 수정
- **영향 범위**:
 - 업무(task)
 - 심방(visitation)
 - 교육 기수(educationTerm)
 - 교육 세션(educationSession)
- **결과**: 모든 상태값이 일관되게 숫자(0 이상)로 반환되어 클라이언트 측 null 체크 불필요