### PR TITLE
feat: 담당 일정 상태값 조회 엔드포인트 옵션 추가

### DIFF
--- a/backend/src/educations/education-domain/interface/education-session-domain.service.interface.ts
+++ b/backend/src/educations/education-domain/interface/education-session-domain.service.interface.ts
@@ -9,6 +9,7 @@ import { GetEducationSessionForCalendarDto } from '../../../calendar/dto/request
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { MyScheduleStatusCountDto } from '../../../task/dto/my-schedule-status-count.dto';
+import { ScheduleStatusOption } from '../../../home/const/schedule-status-option.enum';
 
 export const IEDUCATION_SESSION_DOMAIN_SERVICE = Symbol(
   'IEDUCATION_SESSION_DOMAIN_SERVICE',
@@ -112,8 +113,10 @@ export interface IEducationSessionDomainService {
   ): Promise<EducationSessionModel[]>;
 
   countMyEducationSessionStatus(
+    church: ChurchModel,
     me: MemberModel,
     from: Date,
     to: Date,
+    option: ScheduleStatusOption,
   ): Promise<MyScheduleStatusCountDto>;
 }

--- a/backend/src/educations/education-domain/interface/education-term-domain.service.interface.ts
+++ b/backend/src/educations/education-domain/interface/education-term-domain.service.interface.ts
@@ -14,6 +14,7 @@ import { ChurchModel } from '../../../churches/entity/church.entity';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { MyScheduleStatusCountDto } from '../../../task/dto/my-schedule-status-count.dto';
+import { ScheduleStatusOption } from '../../../home/const/schedule-status-option.enum';
 
 export const IEDUCATION_TERM_DOMAIN_SERVICE = Symbol(
   'IEDUCATION_TERM_DOMAIN_SERVICE',
@@ -122,8 +123,10 @@ export interface IEducationTermDomainService {
   ): Promise<EducationTermModel[]>;
 
   countMyEducationTermStatus(
+    church: ChurchModel,
     me: MemberModel,
     from: Date,
     to: Date,
+    option: ScheduleStatusOption,
   ): Promise<MyScheduleStatusCountDto>;
 }

--- a/backend/src/home/const/schedule-status-option.enum.ts
+++ b/backend/src/home/const/schedule-status-option.enum.ts
@@ -1,0 +1,4 @@
+export enum ScheduleStatusOption {
+  CHURCH = 'church',
+  MEMBER = 'member',
+}

--- a/backend/src/home/controller/home.controller.ts
+++ b/backend/src/home/controller/home.controller.ts
@@ -15,7 +15,7 @@ import { GetNewMemberDetailDto } from '../dto/request/get-new-member-detail.dto'
 import {
   ApiGetLowWorshipAttendanceMembers,
   ApiGetMyInChargedSchedules,
-  ApiGetMyInChargeScheduleStatus,
+  ApiGetScheduleStatus,
   ApiGetMyScheduleReports,
   ApiGetNewMemberDetail,
   ApiGetNewMemberSummary,
@@ -25,6 +25,7 @@ import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { GetMyInChargedSchedulesDto } from '../dto/request/get-my-in-charged-schedules.dto';
 import { GetMyReportsDto } from '../dto/request/get-my-reports.dto';
 import { GetLowWorshipAttendanceMembersDto } from '../dto/request/get-low-worship-attendance-members.dto';
+import { GetScheduleStatusDto } from '../dto/request/get-schedule-status.dto';
 
 @Controller()
 export class HomeController {
@@ -64,14 +65,23 @@ export class HomeController {
     return this.homeService.getMyInChargedSchedules(pm, dto);
   }
 
-  @ApiGetMyInChargeScheduleStatus()
+  @ApiGetScheduleStatus()
   @Get('schedules/status')
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
-  getMyInChargeScheduleStatus(
-    @Query() dto: GetMyInChargedSchedulesDto,
+  getScheduleStatus(
+    @Query() dto: GetScheduleStatusDto,
+    @RequestChurch() requestChurch: ChurchModel,
     @RequestManager() requestMember: ChurchUserModel,
   ) {
-    return this.homeService.getMyInChargeScheduleStatus(requestMember, dto);
+    if ((dto.from && !dto.to) || (!dto.from && dto.to)) {
+      throw new BadRequestException('from, to 에러');
+    }
+
+    return this.homeService.getMyInChargeScheduleStatus(
+      requestChurch,
+      requestMember,
+      dto,
+    );
   }
 
   @ApiGetMyScheduleReports()
@@ -86,7 +96,6 @@ export class HomeController {
     }
 
     return this.homeService.getMyReports(pm, dto);
-    //return this.homeService.getMyScheduleReports(pm, dto);
   }
 
   @ApiGetLowWorshipAttendanceMembers()

--- a/backend/src/home/dto/request/get-schedule-status.dto.ts
+++ b/backend/src/home/dto/request/get-schedule-status.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { WidgetRange } from '../../const/widget-range.enum';
+import { IsDateString, IsEnum, IsOptional } from 'class-validator';
+import { IsYYYYMMDD } from '../../../common/decorator/validator/is-yyyy-mm-dd.validator';
+import { IsAfterDate } from '../../../common/decorator/validator/is-after-date.decorator';
+import { ScheduleStatusOption } from '../../const/schedule-status-option.enum';
+
+export class GetScheduleStatusDto {
+  @ApiProperty({
+    description: '검색 단위 (주간 / 월간)',
+    enum: WidgetRange,
+  })
+  @IsEnum(WidgetRange)
+  range: WidgetRange;
+
+  @ApiProperty({
+    description: '검색 범위(교회 / 개인)',
+    enum: ScheduleStatusOption,
+    default: ScheduleStatusOption.CHURCH,
+  })
+  @IsEnum(ScheduleStatusOption)
+  option: ScheduleStatusOption = ScheduleStatusOption.CHURCH;
+
+  @ApiProperty({
+    description: '검색 시작일(YYYY-MM-DD)',
+    required: false,
+  })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('from')
+  from?: string;
+
+  @ApiProperty({
+    description: '검색 종료일(YYYY-MM-DD)',
+    required: false,
+  })
+  @IsOptional()
+  @IsDateString({ strict: true })
+  @IsAfterDate('from')
+  @IsYYYYMMDD('to')
+  to?: string;
+}

--- a/backend/src/home/service/home.service.ts
+++ b/backend/src/home/service/home.service.ts
@@ -87,6 +87,7 @@ import {
   IEducationTermDomainService,
 } from '../../educations/education-domain/interface/education-term-domain.service.interface';
 import { EducationTermModel } from '../../educations/education-term/entity/education-term.entity';
+import { GetScheduleStatusDto } from '../dto/request/get-schedule-status.dto';
 
 @Injectable()
 export class HomeService {
@@ -272,8 +273,9 @@ export class HomeService {
   }
 
   async getMyInChargeScheduleStatus(
+    church: ChurchModel,
     requestMember: ChurchUserModel,
-    dto: GetMyInChargedSchedulesDto,
+    dto: GetScheduleStatusDto,
   ) {
     const me = requestMember.member;
 
@@ -290,20 +292,36 @@ export class HomeService {
     const [task, visitation, educationTerm, educationSession] =
       await Promise.all([
         // Task
-        this.taskDomainService.countMyTaskStatus(me, from, to),
-        // Visitation
-        this.visitationMetaDomainService.countMyVisitationStatus(me, from, to),
-        // Education Term
-        this.educationTermDomainService.countMyEducationTermStatus(
+        this.taskDomainService.countMyTaskStatus(
+          church,
           me,
           from,
           to,
+          dto.option,
+        ),
+        // Visitation
+        this.visitationMetaDomainService.countMyVisitationStatus(
+          church,
+          me,
+          from,
+          to,
+          dto.option,
+        ),
+        // Education Term
+        this.educationTermDomainService.countMyEducationTermStatus(
+          church,
+          me,
+          from,
+          to,
+          dto.option,
         ),
         // Education Session
         this.educationSessionDomainService.countMyEducationSessionStatus(
+          church,
           me,
           from,
           to,
+          dto.option,
         ),
       ]);
 

--- a/backend/src/home/swagger/home.swagger.ts
+++ b/backend/src/home/swagger/home.swagger.ts
@@ -39,10 +39,13 @@ export const ApiGetMyInChargedSchedules = () =>
     }),
   );
 
-export const ApiGetMyInChargeScheduleStatus = () =>
+export const ApiGetScheduleStatus = () =>
   applyDecorators(
     ApiParam({ name: 'churchId' }),
-    ApiOperation({ summary: '내가 담당한 일정의 상태값 조회' }),
+    ApiOperation({
+      summary: '일정의 상태값 조회',
+      description: '<h2>이번주/이번달 일정의 상태 통계값을 조회합니다.</h2>',
+    }),
   );
 
 export const ApiGetMyScheduleReports = () =>

--- a/backend/src/task/task-domain/interface/task-domain.service.interface.ts
+++ b/backend/src/task/task-domain/interface/task-domain.service.interface.ts
@@ -8,6 +8,7 @@ import { UpdateTaskDto } from '../../dto/request/update-task.dto';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { MyScheduleStatusCountDto } from '../../dto/my-schedule-status-count.dto';
+import { ScheduleStatusOption } from '../../../home/const/schedule-status-option.enum';
 
 export const ITASK_DOMAIN_SERVICE = Symbol('ITASK_DOMAIN_SERVICE');
 
@@ -72,8 +73,10 @@ export interface ITaskDomainService {
   ): Promise<TaskModel[]>;
 
   countMyTaskStatus(
+    church: ChurchModel,
     me: MemberModel,
     from: Date,
     to: Date,
+    option: ScheduleStatusOption,
   ): Promise<MyScheduleStatusCountDto>;
 }

--- a/backend/src/visitation/visitation-domain/interface/visitation-meta-domain.service.interface.ts
+++ b/backend/src/visitation/visitation-domain/interface/visitation-meta-domain.service.interface.ts
@@ -6,6 +6,7 @@ import { VisitationMetaModel } from '../../entity/visitation-meta.entity';
 import { GetVisitationDto } from '../../dto/request/get-visitation.dto';
 import { UpdateVisitationMetaDto } from '../../dto/internal/meta/update-visitation-meta.dto';
 import { MyScheduleStatusCountDto } from '../../../task/dto/my-schedule-status-count.dto';
+import { ScheduleStatusOption } from '../../../home/const/schedule-status-option.enum';
 
 export const IVISITATION_META_DOMAIN_SERVICE = Symbol(
   'IVISITATION_META_DOMAIN_SERVICE',
@@ -63,8 +64,10 @@ export interface IVisitationMetaDomainService {
   ): Promise<VisitationMetaModel[]>;
 
   countMyVisitationStatus(
+    church: ChurchModel,
     me: MemberModel,
     from: Date,
     to: Date,
+    option: ScheduleStatusOption,
   ): Promise<MyScheduleStatusCountDto>;
 }


### PR DESCRIPTION
## 주요 내용
담당한 일정 상태값 조회 API에 조회 범위를 선택할 수 있는 option 파라미터를 추가했습니다.

## 세부 내용
- **엔드포인트**: `GET /churches/{churchId}/home/schedules/status`
- **새로운 쿼리 파라미터 추가**:
 - `option`: 조회 범위 지정
   - `'church'`: 교회 내 모든 일정들의 상태값 조회
   - `'member'`: 요청자 본인의 일정들의 상태값 조회
- **활용 목적**:
 - 관리자는 교회 전체 일정 현황 파악 가능
 - 일반 사용자는 본인 일정만 필터링하여 조회 가능
- **기존 파라미터와 조합**: `range`(weekly/monthly)와 함께 사용하여 세밀한 조회 가능