### PR TITLE
feat: 무료 구독 만료 시 무료 체험 교회 자동 삭제 로직 추가

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/jwt": "^10.2.0",
         "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.4.8",
+        "@nestjs/schedule": "^6.0.0",
         "@nestjs/swagger": "^8.0.7",
         "@nestjs/typeorm": "^10.0.2",
         "class-transformer": "^0.5.1",
@@ -2013,6 +2014,19 @@
         "@nestjs/core": "^10.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.0.0.tgz",
+      "integrity": "sha512-aQySMw6tw2nhitELXd3EiRacQRgzUKD9mFcUZVOJ7jPLqIBvXOyvRWLsK9SdurGA+jjziAlMef7iB5ZEFFoQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.3.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "10.2.3",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-10.2.3.tgz",
@@ -2490,6 +2504,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -4301,6 +4321,19 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.3.0.tgz",
+      "integrity": "sha512-ciiYNLfSlF9MrDqnbMdRWFiA6oizSF7kA1osPP9lRzNu0Uu+AWog1UKy7SkckiDY2irrNjeO6qLyKnXC8oxmrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.6.0",
+        "luxon": "~3.6.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
     },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
@@ -7339,6 +7372,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.4.8",
+    "@nestjs/schedule": "^6.0.0",
     "@nestjs/swagger": "^8.0.7",
     "@nestjs/typeorm": "^10.0.2",
     "class-transformer": "^0.5.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,7 +12,6 @@ import { UserModel } from './user/entity/user.entity';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { UserModule } from './user/user.module';
 import { ChurchesModule } from './churches/churches.module';
-
 import { OfficerModel } from './management/officers/entity/officer.entity';
 import { MinistryModel } from './management/ministries/entity/ministry.entity';
 import { MinistryGroupModel } from './management/ministries/entity/ministry-group.entity';
@@ -76,6 +75,7 @@ import { EducationEnrollmentModel } from './educations/education-enrollment/enti
 import { SubscriptionModel } from './subscription/entity/subscription.entity';
 import { SubscriptionModule } from './subscription/subscription.module';
 import { DummyDataModule } from './dummy-data/dummy-data.module';
+import { ScheduleModule } from '@nestjs/schedule';
 
 //import { EducationTermReportModel } from './report/education-report/entity/education-term-report.entity';
 
@@ -214,6 +214,7 @@ import { DummyDataModule } from './dummy-data/dummy-data.module';
       }),
       inject: [ConfigService],
     }),
+    ScheduleModule.forRoot(),
     DummyDataModule,
     AuthModule,
     MyPageModule,

--- a/backend/src/calendar/entity/church-event.entity.ts
+++ b/backend/src/calendar/entity/church-event.entity.ts
@@ -8,7 +8,7 @@ export class ChurchEventModel extends BaseModel {
   @Column()
   churchId: number;
 
-  @ManyToOne(() => ChurchModel)
+  @ManyToOne(() => ChurchModel, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'churchId' })
   church: ChurchModel;
 

--- a/backend/src/church-join/entity/church-join-stat.entity.ts
+++ b/backend/src/church-join/entity/church-join-stat.entity.ts
@@ -9,7 +9,7 @@ export class ChurchJoinStatModel extends BaseModel {
   @Column()
   userId: number;
 
-  @ManyToOne(() => UserModel)
+  @ManyToOne(() => UserModel, { onDelete: 'CASCADE' })
   user: UserModel;
 
   @Index()

--- a/backend/src/church-join/entity/church-join.entity.ts
+++ b/backend/src/church-join/entity/church-join.entity.ts
@@ -10,14 +10,18 @@ export class ChurchJoinModel extends BaseModel {
   @Column()
   churchId: number;
 
-  @ManyToOne(() => ChurchModel, (church) => church.joinRequests)
+  @ManyToOne(() => ChurchModel, (church) => church.joinRequests, {
+    onDelete: 'CASCADE',
+  })
   church: ChurchModel;
 
   @Index()
   @Column()
   userId: number;
 
-  @ManyToOne(() => UserModel, (user) => user.joinRequest)
+  @ManyToOne(() => UserModel, (user) => user.joinRequest, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'userId' })
   user: UserModel;
 

--- a/backend/src/church-user/entity/church-user.entity.ts
+++ b/backend/src/church-user/entity/church-user.entity.ts
@@ -21,7 +21,7 @@ export class ChurchUserModel extends BaseModel {
   @Column()
   churchId: number;
 
-  @ManyToOne(() => ChurchModel)
+  @ManyToOne(() => ChurchModel, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'churchId' })
   church: ChurchModel;
 
@@ -29,7 +29,7 @@ export class ChurchUserModel extends BaseModel {
   @Column()
   userId: number;
 
-  @ManyToOne(() => UserModel)
+  @ManyToOne(() => UserModel, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'userId' })
   user: UserModel;
 
@@ -37,7 +37,9 @@ export class ChurchUserModel extends BaseModel {
   @Column({ nullable: true })
   memberId: number | null;
 
-  @OneToOne(() => MemberModel, (member) => member.churchUser)
+  @OneToOne(() => MemberModel, (member) => member.churchUser, {
+    onDelete: 'SET NULL',
+  })
   @JoinColumn({ name: 'memberId' })
   member: MemberModel;
 
@@ -48,7 +50,7 @@ export class ChurchUserModel extends BaseModel {
   @Column({ nullable: true })
   permissionTemplateId: number | null;
 
-  @ManyToOne(() => PermissionTemplateModel)
+  @ManyToOne(() => PermissionTemplateModel, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'permissionTemplateId' })
   permissionTemplate: PermissionTemplateModel;
 

--- a/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
+++ b/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
@@ -119,4 +119,9 @@ export interface IChurchesDomainService {
     user: UserModel,
     qr: QueryRunner,
   ): Promise<ChurchModel>;
+
+  cleanupExpiredTrials(
+    expiredChurches: ChurchModel[],
+    qr: QueryRunner,
+  ): Promise<DeleteResult>;
 }

--- a/backend/src/churches/churches-domain/service/churhes-domain.service.ts
+++ b/backend/src/churches/churches-domain/service/churhes-domain.service.ts
@@ -9,6 +9,7 @@ import { CreateChurchDto } from '../../dto/create-church.dto';
 import {
   DeleteResult,
   FindOptionsRelations,
+  In,
   QueryFailedError,
   QueryRunner,
   Repository,
@@ -484,5 +485,24 @@ export class ChurchesDomainService implements IChurchesDomainService {
     }
 
     return church;
+  }
+
+  async cleanupExpiredTrials(
+    expiredChurches: ChurchModel[],
+    qr: QueryRunner,
+  ): Promise<DeleteResult> {
+    const repository = this.getChurchRepository(qr);
+
+    const result = await repository.delete({
+      id: In(expiredChurches.map((c) => c.id)),
+    });
+
+    if (result.affected !== expiredChurches.length) {
+      throw new InternalServerErrorException(
+        ChurchException.EXPIRE_TRIAL_ERROR,
+      );
+    }
+
+    return result;
   }
 }

--- a/backend/src/churches/const/exception/church.exception.ts
+++ b/backend/src/churches/const/exception/church.exception.ts
@@ -10,6 +10,7 @@ export const ChurchException = {
   INVALID_NEW_OWNER:
     '관리자 권한의 교인에게만 교회 소유자 권한을 넘길 수 있습니다.',
   NOT_FOUND_TRIAL_CHURCH: '무료 체험 중인 교회를 찾을 수 없습니다.',
+  EXPIRE_TRIAL_ERROR: '무료 체험 만료 처리 중 에러 발생',
 };
 
 export const ChurchAuthException = {

--- a/backend/src/churches/service/trial-churches.service.ts
+++ b/backend/src/churches/service/trial-churches.service.ts
@@ -1,5 +1,5 @@
 import { ConflictException, Inject, Injectable } from '@nestjs/common';
-import { QueryRunner } from 'typeorm';
+import { DataSource, QueryRunner } from 'typeorm';
 import { ChurchUserRole, UserRole } from '../../user/const/user-role.enum';
 import { PostChurchResponseDto } from '../dto/response/post-church-response.dto';
 import { ChurchModel, ManagementCountType } from '../entity/church.entity';
@@ -59,6 +59,8 @@ import {
 @Injectable()
 export class TrialChurchesService {
   constructor(
+    private readonly dataSource: DataSource,
+
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,
     @Inject(ICHURCH_USER_DOMAIN_SERVICE)

--- a/backend/src/educations/education-enrollment/entity/education-enrollment.entity.ts
+++ b/backend/src/educations/education-enrollment/entity/education-enrollment.entity.ts
@@ -11,14 +11,18 @@ export class EducationEnrollmentModel extends BaseModel {
   @Column({ comment: '교육 대상자 ID' })
   memberId: number;
 
-  @ManyToOne(() => MemberModel, (member) => member.educationEnrollments)
+  @ManyToOne(() => MemberModel, (member) => member.educationEnrollments, {
+    onDelete: 'CASCADE',
+  })
   member: MemberModel;
 
   @Index()
   @Column({ comment: '교육 기수 ID' })
   educationTermId: number;
 
-  @ManyToOne(() => EducationTermModel, (term) => term.educationEnrollments)
+  @ManyToOne(() => EducationTermModel, (term) => term.educationEnrollments, {
+    onDelete: 'CASCADE',
+  })
   educationTerm: EducationTermModel;
 
   @Index()

--- a/backend/src/educations/education-session/entity/education-session.entity.ts
+++ b/backend/src/educations/education-session/entity/education-session.entity.ts
@@ -12,7 +12,9 @@ export class EducationSessionModel extends BaseModel {
   @Column({ comment: '교육 기수 ID' })
   educationTermId: number;
 
-  @ManyToOne(() => EducationTermModel, (term) => term.educationSessions)
+  @ManyToOne(() => EducationTermModel, (term) => term.educationSessions, {
+    onDelete: 'CASCADE',
+  })
   educationTerm: EducationTermModel;
 
   @Column({ comment: '교육 회차' })
@@ -47,9 +49,12 @@ export class EducationSessionModel extends BaseModel {
   status: EducationSessionStatus;
 
   @Column({ nullable: true, comment: '회차 담당자 교인 ID' })
-  inChargeId: number;
+  inChargeId: number | null;
 
-  @ManyToOne(() => MemberModel, (member) => member.inChargeEducationSession)
+  @ManyToOne(() => MemberModel, (member) => member.inChargeEducationSession, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
   inCharge: MemberModel;
 
   @OneToMany(
@@ -61,10 +66,10 @@ export class EducationSessionModel extends BaseModel {
   @Column({ default: 0 })
   attendancesCount: number;
 
-  @Column()
-  creatorId: number;
+  @Column({ nullable: true })
+  creatorId: number | null;
 
-  @ManyToOne(() => MemberModel)
+  @ManyToOne(() => MemberModel, { nullable: true, onDelete: 'SET NULL' })
   creator: MemberModel;
 
   @OneToMany(() => EducationReportModel, (report) => report.educationSession)

--- a/backend/src/educations/education-term/entity/education-term.entity.ts
+++ b/backend/src/educations/education-term/entity/education-term.entity.ts
@@ -11,7 +11,6 @@ import {
 import { MemberModel } from '../../../members/entity/member.entity';
 import { EducationTermStatus } from '../const/education-term-status.enum';
 import { EducationReportModel } from '../../../report/education-report/entity/education-report.entity';
-//import { EducationTermReportModel } from '../../../report/education-report/entity/education-term-report.entity';
 
 @Entity()
 export class EducationTermModel extends BaseModel {
@@ -22,13 +21,15 @@ export class EducationTermModel extends BaseModel {
   @Column({ comment: '교육 이름' })
   educationName: string;
 
-  @ManyToOne(() => EducationModel, (education) => education.educationTerms)
+  @ManyToOne(() => EducationModel, (education) => education.educationTerms, {
+    onDelete: 'CASCADE',
+  })
   education!: EducationModel;
 
   @Column({ nullable: true })
-  creatorId: number;
+  creatorId: number | null;
 
-  @ManyToOne(() => MemberModel)
+  @ManyToOne(() => MemberModel, { nullable: true, onDelete: 'SET NULL' })
   creator: MemberModel;
 
   @Column({ comment: '교육 기수' })
@@ -51,7 +52,9 @@ export class EducationTermModel extends BaseModel {
   @Column({ type: 'int', comment: '교육 진행자 ID', nullable: true })
   inChargeId!: number | null;
 
-  @ManyToOne(() => MemberModel, (member) => member.inChargeEducationTerm)
+  @ManyToOne(() => MemberModel, (member) => member.inChargeEducationTerm, {
+    onDelete: 'SET NULL',
+  })
   inCharge!: MemberModel;
 
   @OneToMany(() => EducationSessionModel, (session) => session.educationTerm)

--- a/backend/src/educations/education/entity/education.entity.ts
+++ b/backend/src/educations/education/entity/education.entity.ts
@@ -37,13 +37,15 @@ export class EducationModel extends BaseModel {
   @Column({ comment: '교회 ID' })
   churchId: number;
 
-  @ManyToOne(() => ChurchModel, (church) => church.educations)
+  @ManyToOne(() => ChurchModel, (church) => church.educations, {
+    onDelete: 'CASCADE',
+  })
   church: ChurchModel;
 
-  @Column()
-  creatorId: number;
+  @Column({ nullable: true })
+  creatorId: number | null;
 
-  @ManyToOne(() => MemberModel)
+  @ManyToOne(() => MemberModel, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'creatorId' })
   creator: MemberModel;
 

--- a/backend/src/educations/session-attendance/entity/session-attendance.entity.ts
+++ b/backend/src/educations/session-attendance/entity/session-attendance.entity.ts
@@ -13,6 +13,7 @@ export class SessionAttendanceModel extends BaseModel {
   @ManyToOne(
     () => EducationSessionModel,
     (educationSession) => educationSession.sessionAttendances,
+    { onDelete: 'CASCADE' },
   )
   educationSession: EducationSessionModel;
 
@@ -23,6 +24,7 @@ export class SessionAttendanceModel extends BaseModel {
   @ManyToOne(
     () => EducationEnrollmentModel,
     (enrollment) => enrollment.sessionAttendance,
+    { onDelete: 'CASCADE' },
   )
   educationEnrollment: EducationEnrollmentModel;
 

--- a/backend/src/family-relation/entity/family-relation.entity.ts
+++ b/backend/src/family-relation/entity/family-relation.entity.ts
@@ -8,7 +8,9 @@ export class FamilyRelationModel extends BaseModel {
   @Column()
   meId: number;
 
-  @ManyToOne(() => MemberModel, (member) => member.family)
+  @ManyToOne(() => MemberModel, (member) => member.family, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'meId' })
   me: MemberModel;
 
@@ -16,7 +18,9 @@ export class FamilyRelationModel extends BaseModel {
   @Column()
   familyMemberId: number;
 
-  @ManyToOne(() => MemberModel, (member) => member.counterFamily)
+  @ManyToOne(() => MemberModel, (member) => member.counterFamily, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'familyMemberId' })
   familyMember: MemberModel;
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -31,7 +31,7 @@ async function bootstrap() {
     new XssSanitizerPipe(),
   );
 
-  app.useGlobalFilters(new TypeOrmExceptionFilter());
+  //app.useGlobalFilters(new TypeOrmExceptionFilter());
 
   app.useGlobalGuards(new GetHandlerGuard());
 

--- a/backend/src/management/groups/entity/group.entity.ts
+++ b/backend/src/management/groups/entity/group.entity.ts
@@ -17,7 +17,9 @@ export class GroupModel extends BaseModel {
   @Column({ type: 'int', nullable: true })
   parentGroupId: number | null;
 
-  @ManyToOne(() => GroupModel, (group) => group.childGroups)
+  @ManyToOne(() => GroupModel, (group) => group.childGroups, {
+    onDelete: 'CASCADE',
+  })
   parentGroup: GroupModel;
 
   @Column('int', { array: true, default: [] })
@@ -30,7 +32,9 @@ export class GroupModel extends BaseModel {
   @Index()
   churchId: number;
 
-  @ManyToOne(() => ChurchModel, (church) => church.groups)
+  @ManyToOne(() => ChurchModel, (church) => church.groups, {
+    onDelete: 'CASCADE',
+  })
   church: ChurchModel;
 
   @Column({ default: 0 })

--- a/backend/src/management/ministries/entity/ministry-group.entity.ts
+++ b/backend/src/management/ministries/entity/ministry-group.entity.ts
@@ -30,6 +30,7 @@ export class MinistryGroupModel extends BaseModel {
   @ManyToOne(
     () => MinistryGroupModel,
     (ministryGroup) => ministryGroup.childMinistryGroups,
+    { onDelete: 'CASCADE' },
   )
   parentMinistryGroup: MinistryGroupModel;
 
@@ -46,7 +47,9 @@ export class MinistryGroupModel extends BaseModel {
   @Index()
   churchId: number;
 
-  @ManyToOne(() => ChurchModel, (church) => church.ministryGroups)
+  @ManyToOne(() => ChurchModel, (church) => church.ministryGroups, {
+    onDelete: 'CASCADE',
+  })
   church: ChurchModel;
 
   @ManyToMany(() => MemberModel, (member) => member.ministryGroups)
@@ -59,7 +62,7 @@ export class MinistryGroupModel extends BaseModel {
   @Column({ type: 'int', nullable: true })
   leaderMemberId: number | null;
 
-  @ManyToOne(() => MemberModel)
+  @ManyToOne(() => MemberModel, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'leaderMemberId' })
   leaderMember: MemberModel;
 

--- a/backend/src/management/ministries/entity/ministry.entity.ts
+++ b/backend/src/management/ministries/entity/ministry.entity.ts
@@ -28,7 +28,9 @@ export class MinistryModel extends BaseModel {
   @Column()
   churchId: number;
 
-  @ManyToOne(() => ChurchModel, (church) => church.ministries)
+  @ManyToOne(() => ChurchModel, (church) => church.ministries, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'churchId' })
   church: ChurchModel;
 
@@ -39,6 +41,7 @@ export class MinistryModel extends BaseModel {
   @ManyToOne(
     () => MinistryGroupModel,
     (ministryGroup) => ministryGroup.ministries,
+    { onDelete: 'CASCADE' },
   )
   @JoinColumn({ name: 'ministryGroupId' })
   ministryGroup: MinistryGroupModel;
@@ -50,7 +53,7 @@ export class MinistryModel extends BaseModel {
     () => MinistryHistoryModel,
     (ministryHistory) => ministryHistory.ministry,
   )
-  ministryHistory: MinistryModel[];
+  ministryHistory: MinistryHistoryModel[];
 }
 
 export const MinistryModelColumns = {

--- a/backend/src/management/officers/entity/officer.entity.ts
+++ b/backend/src/management/officers/entity/officer.entity.ts
@@ -10,7 +10,9 @@ export class OfficerModel extends BaseModel {
   @Column()
   churchId: number;
 
-  @ManyToOne(() => ChurchModel, (church) => church.officers)
+  @ManyToOne(() => ChurchModel, (church) => church.officers, {
+    onDelete: 'CASCADE',
+  })
   church: ChurchModel;
 
   @Index()

--- a/backend/src/member-history/group-history/entity/group-detail-history.entity.ts
+++ b/backend/src/member-history/group-history/entity/group-detail-history.entity.ts
@@ -10,7 +10,7 @@ export class GroupDetailHistoryModel extends BaseModel {
   @Column()
   memberId: number;
 
-  @ManyToOne(() => MemberModel)
+  @ManyToOne(() => MemberModel, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'memberId' })
   member: MemberModel;
 
@@ -18,7 +18,7 @@ export class GroupDetailHistoryModel extends BaseModel {
   @Column()
   groupHistoryId: number;
 
-  @ManyToOne(() => GroupHistoryModel)
+  @ManyToOne(() => GroupHistoryModel, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'groupHistoryId' })
   groupHistory: GroupHistoryModel;
 

--- a/backend/src/member-history/group-history/entity/group-history.entity.ts
+++ b/backend/src/member-history/group-history/entity/group-history.entity.ts
@@ -17,7 +17,9 @@ export class GroupHistoryModel extends BaseModel {
   @Column()
   memberId: number;
 
-  @ManyToOne(() => MemberModel, (member) => member.groupHistory)
+  @ManyToOne(() => MemberModel, (member) => member.groupHistory, {
+    onDelete: 'CASCADE',
+  })
   member: MemberModel;
 
   @Index()
@@ -28,7 +30,9 @@ export class GroupHistoryModel extends BaseModel {
   })
   groupId: number | null;
 
-  @ManyToOne(() => GroupModel, (group) => group.history)
+  @ManyToOne(() => GroupModel, (group) => group.history, {
+    onDelete: 'SET NULL',
+  })
   @JoinColumn({ name: 'groupId' })
   group: GroupModel | null;
 

--- a/backend/src/member-history/ministry-history/entity/child/ministry-history.entity.ts
+++ b/backend/src/member-history/ministry-history/entity/child/ministry-history.entity.ts
@@ -12,7 +12,9 @@ export class MinistryHistoryModel extends MinistryGroupDetailHistoryModel {
   })
   ministryId: number | null;
 
-  @ManyToOne(() => MinistryModel, (ministry) => ministry.ministryHistory)
+  @ManyToOne(() => MinistryModel, (ministry) => ministry.ministryHistory, {
+    onDelete: 'SET NULL',
+  })
   ministry: MinistryModel | null;
 
   @Column({ comment: '사역 종료일 시점의 사역 이름', nullable: true })

--- a/backend/src/member-history/ministry-history/entity/ministry-group-detail-history.entity.ts
+++ b/backend/src/member-history/ministry-history/entity/ministry-group-detail-history.entity.ts
@@ -17,14 +17,14 @@ export class MinistryGroupDetailHistoryModel extends BaseModel {
   @Column()
   memberId: number;
 
-  @ManyToOne(() => MemberModel)
+  @ManyToOne(() => MemberModel, { onDelete: 'CASCADE' })
   member: MemberModel;
 
   @Index()
   @Column()
   ministryGroupHistoryId: number;
 
-  @ManyToOne(() => MinistryGroupHistoryModel)
+  @ManyToOne(() => MinistryGroupHistoryModel, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'ministryGroupHistoryId' })
   ministryGroupHistory: MinistryGroupHistoryModel;
 

--- a/backend/src/member-history/ministry-history/entity/ministry-group-history.entity.ts
+++ b/backend/src/member-history/ministry-history/entity/ministry-group-history.entity.ts
@@ -17,7 +17,7 @@ export class MinistryGroupHistoryModel extends BaseModel {
   @Column()
   memberId: number;
 
-  @ManyToOne(() => MemberModel)
+  @ManyToOne(() => MemberModel, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'memberId' })
   member: MemberModel;
 
@@ -25,7 +25,7 @@ export class MinistryGroupHistoryModel extends BaseModel {
   @Column({ nullable: true })
   ministryGroupId: number | null;
 
-  @ManyToOne(() => MinistryGroupModel)
+  @ManyToOne(() => MinistryGroupModel, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'ministryGroupId' })
   ministryGroup: MinistryGroupModel | null;
 

--- a/backend/src/member-history/officer-history/entity/officer-history.entity.ts
+++ b/backend/src/member-history/officer-history/entity/officer-history.entity.ts
@@ -9,7 +9,9 @@ export class OfficerHistoryModel extends BaseModel {
   @Column({ comment: '교인 ID' })
   memberId: number;
 
-  @ManyToOne(() => MemberModel, (member) => member.officerHistory)
+  @ManyToOne(() => MemberModel, (member) => member.officerHistory, {
+    onDelete: 'CASCADE',
+  })
   member: MemberModel;
 
   @Index()
@@ -20,7 +22,9 @@ export class OfficerHistoryModel extends BaseModel {
   })
   officerId: number | null;
 
-  @ManyToOne(() => OfficerModel, (officer) => officer.history)
+  @ManyToOne(() => OfficerModel, (officer) => officer.history, {
+    onDelete: 'SET NULL',
+  })
   officer: OfficerModel | null;
 
   @Column({ comment: '직분 종료일 시점의 직분명', nullable: true })

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -43,7 +43,9 @@ export class MemberModel extends BaseModel {
   @Exclude({ toPlainOnly: true })
   churchId: number;
 
-  @ManyToOne(() => ChurchModel, (church) => church.members)
+  @ManyToOne(() => ChurchModel, (church) => church.members, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'churchId' })
   church: ChurchModel;
 
@@ -125,16 +127,15 @@ export class MemberModel extends BaseModel {
   guidedById: number | null;
 
   // 나를 인도한 사람
-  @ManyToOne(() => MemberModel, (member) => member.guiding)
+  @ManyToOne(() => MemberModel, (member) => member.guiding, {
+    onDelete: 'SET NULL',
+  })
   @JoinColumn({ name: 'guidedById' })
   guidedBy: MemberModel;
 
   // 내가 인도한 사람
   @OneToMany(() => MemberModel, (member) => member.guidedBy)
   guiding: MemberModel[];
-
-  /*@Column({ length: 30, nullable: true, comment: '이전교회 이름' })
-  previousChurch: string;*/
 
   @Index()
   @Column({
@@ -175,7 +176,9 @@ export class MemberModel extends BaseModel {
   @Exclude({ toPlainOnly: true })
   officerId: number | null;
 
-  @ManyToOne(() => OfficerModel, (officer) => officer.members)
+  @ManyToOne(() => OfficerModel, (officer) => officer.members, {
+    onDelete: 'SET NULL',
+  })
   @JoinColumn({ name: 'officerId' })
   officer: OfficerModel;
 
@@ -202,7 +205,9 @@ export class MemberModel extends BaseModel {
   @Exclude({ toPlainOnly: true })
   groupId: number | null;
 
-  @ManyToOne(() => GroupModel, (group) => group.members)
+  @ManyToOne(() => GroupModel, (group) => group.members, {
+    onDelete: 'SET NULL',
+  })
   @JoinColumn({ name: 'groupId' })
   group: GroupModel;
 
@@ -232,6 +237,7 @@ export class MemberModel extends BaseModel {
   @ManyToMany(
     () => VisitationMetaModel,
     (visitationMeta) => visitationMeta.members,
+    { onDelete: 'CASCADE' },
   )
   visitationMetas: VisitationMetaModel[];
 

--- a/backend/src/permission/entity/permission-scope.entity.ts
+++ b/backend/src/permission/entity/permission-scope.entity.ts
@@ -12,7 +12,11 @@ export class PermissionScopeModel extends BaseModel {
   @Column()
   churchUserId: number;
 
-  @ManyToOne(() => ChurchUserModel, (churchUser) => churchUser.permissionScopes)
+  @ManyToOne(
+    () => ChurchUserModel,
+    (churchUser) => churchUser.permissionScopes,
+    { onDelete: 'CASCADE' },
+  )
   @JoinColumn({ name: 'churchUserId' })
   churchUser: ChurchUserModel;
 
@@ -23,7 +27,7 @@ export class PermissionScopeModel extends BaseModel {
   @Column({ nullable: true })
   groupId: number;
 
-  @ManyToOne(() => GroupModel, { nullable: true })
+  @ManyToOne(() => GroupModel, { nullable: true, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'groupId' })
   group: GroupModel;
 }

--- a/backend/src/permission/entity/permission-template.entity.ts
+++ b/backend/src/permission/entity/permission-template.entity.ts
@@ -17,7 +17,7 @@ export class PermissionTemplateModel extends BaseModel {
   @Column()
   churchId: number;
 
-  @ManyToOne(() => ChurchModel)
+  @ManyToOne(() => ChurchModel, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'churchId' })
   church: ChurchModel;
 

--- a/backend/src/report/base-report/entity/report.entity.ts
+++ b/backend/src/report/base-report/entity/report.entity.ts
@@ -9,7 +9,7 @@ export abstract class ReportModel extends BaseModel {
   @Column()
   receiverId: number;
 
-  @ManyToOne(() => MemberModel)
+  @ManyToOne(() => MemberModel, { onDelete: 'CASCADE' })
   receiver: MemberModel;
 
   @Column({ type: 'timestamptz', default: new Date() })

--- a/backend/src/report/education-report/entity/education-report.entity.ts
+++ b/backend/src/report/education-report/entity/education-report.entity.ts
@@ -18,7 +18,7 @@ export class EducationReportModel extends ReportModel {
   @Column()
   educationId: number;
 
-  @ManyToOne(() => EducationModel)
+  @ManyToOne(() => EducationModel, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'educationId' })
   education: EducationModel;
 
@@ -26,7 +26,11 @@ export class EducationReportModel extends ReportModel {
   @Column()
   educationTermId: number;
 
-  @ManyToOne(() => EducationTermModel, (educationTerm) => educationTerm.reports)
+  @ManyToOne(
+    () => EducationTermModel,
+    (educationTerm) => educationTerm.reports,
+    { onDelete: 'CASCADE' },
+  )
   @JoinColumn({ name: 'educationTermId' })
   educationTerm: EducationTermModel;
 
@@ -36,6 +40,7 @@ export class EducationReportModel extends ReportModel {
 
   @ManyToOne(() => EducationSessionModel, (session) => session.reports, {
     nullable: true,
+    onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'educationSessionId' })
   educationSession?: EducationSessionModel;

--- a/backend/src/report/task-report/entity/task-report.entity.ts
+++ b/backend/src/report/task-report/entity/task-report.entity.ts
@@ -9,7 +9,7 @@ export class TaskReportModel extends ReportModel {
   @Column()
   taskId: number;
 
-  @ManyToOne(() => TaskModel)
+  @ManyToOne(() => TaskModel, (task) => task.reports, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'taskId' })
   task: TaskModel;
 }

--- a/backend/src/report/visitation-report/entity/visitation-report.entity.ts
+++ b/backend/src/report/visitation-report/entity/visitation-report.entity.ts
@@ -9,6 +9,8 @@ export class VisitationReportModel extends ReportModel {
   @Column()
   visitationId: number;
 
-  @ManyToOne(() => VisitationMetaModel, (visitation) => visitation.reports)
+  @ManyToOne(() => VisitationMetaModel, (visitation) => visitation.reports, {
+    onDelete: 'CASCADE',
+  })
   visitation: VisitationMetaModel;
 }

--- a/backend/src/request-info/entity/request-info.entity.ts
+++ b/backend/src/request-info/entity/request-info.entity.ts
@@ -20,7 +20,9 @@ export class RequestInfoModel extends BaseModel {
   @Exclude()
   churchId: number;
 
-  @ManyToOne(() => ChurchModel, (church) => church.requestInfos)
+  @ManyToOne(() => ChurchModel, (church) => church.requestInfos, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'churchId' })
   church: ChurchModel;
 
@@ -29,7 +31,9 @@ export class RequestInfoModel extends BaseModel {
   @Exclude()
   memberId: number;
 
-  @OneToOne(() => MemberModel, (member) => member.requestInfo)
+  @OneToOne(() => MemberModel, (member) => member.requestInfo, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'memberId' })
   member: MemberModel;
 

--- a/backend/src/subscription/const/subscription-plan.enum.ts
+++ b/backend/src/subscription/const/subscription-plan.enum.ts
@@ -2,6 +2,7 @@ export enum SubscriptionPlan {
   FREE_TRIAL = 'freeTrial',
   BASIC = 'basic',
   STANDARD = 'standard',
+  PLUS = 'plus',
   PREMIUM = 'premium',
   ENTERPRISE = 'enterprise',
 }

--- a/backend/src/subscription/controller/subscription.controller.ts
+++ b/backend/src/subscription/controller/subscription.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Post, UseGuards, UseInterceptors } from '@nestjs/common';
+import {
+  Controller,
+  Delete,
+  Post,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
 import { SubscriptionService } from '../service/subscription.service';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
 import { Token } from '../../auth/decorator/jwt.decorator';
@@ -25,5 +31,11 @@ export class SubscriptionController {
   @Post('subscribe')
   startSubscription(@Token(AuthType.ACCESS) accessToken: JwtPayload) {
     return accessToken;
+  }
+
+  @Delete('cleanup/expired-trials')
+  @UseInterceptors(TransactionInterceptor)
+  cleanupExpiredTrials(@QueryRunner() qr: QR) {
+    return this.subscriptionService.cleanupExpiredTrialsManual(qr);
   }
 }

--- a/backend/src/subscription/entity/subscription.entity.ts
+++ b/backend/src/subscription/entity/subscription.entity.ts
@@ -15,14 +15,16 @@ import { ChurchModel } from '../../churches/entity/church.entity';
 
 @Entity()
 export class SubscriptionModel extends BaseModel {
-  @OneToOne(() => ChurchModel, (church) => church.subscription)
+  @OneToOne(() => ChurchModel, (church) => church.subscription, {
+    nullable: true,
+  })
   church: ChurchModel;
 
   @Column()
   @Index()
   userId: number;
 
-  @ManyToOne(() => UserModel)
+  @ManyToOne(() => UserModel, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'userId' })
   user: UserModel;
 

--- a/backend/src/subscription/exception/subscription.exception.ts
+++ b/backend/src/subscription/exception/subscription.exception.ts
@@ -5,4 +5,5 @@ export const SubscriptionException = {
   EXPIRE_SUBSCRIPTION: '구독 기간이 만료되었습니다. 구독을 갱신해주세요.',
 
   FAIL_LOAD_SUBSCRIPTION: '구독 정보 누락',
+  EXPIRE_SUBSCRIPTION_ERROR: '구독 만료 처리 중 에러 발생',
 };

--- a/backend/src/subscription/service/subscription.service.ts
+++ b/backend/src/subscription/service/subscription.service.ts
@@ -7,16 +7,24 @@ import {
   ISUBSCRIPTION_DOMAIN_SERVICE,
   ISubscriptionDomainService,
 } from '../subscription-domain/interface/subscription-domain.service.interface';
-import { QueryRunner } from 'typeorm';
+import { DataSource, QueryRunner } from 'typeorm';
 import { UserRole } from '../../user/const/user-role.enum';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
 
 @Injectable()
 export class SubscriptionService {
   constructor(
+    private readonly dataSource: DataSource,
+
     @Inject(IUSER_DOMAIN_SERVICE)
     private readonly userDomainService: IUserDomainService,
     @Inject(ISUBSCRIPTION_DOMAIN_SERVICE)
     private readonly subscriptionDomainService: ISubscriptionDomainService,
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
   ) {}
 
   async startFreeTrial(userId: number, qr: QueryRunner) {
@@ -38,5 +46,44 @@ export class SubscriptionService {
     await this.userDomainService.startFreeTrial(user, qr);
 
     return trialSubscription;
+  }
+
+  async cleanupExpiredTrialsManual(qr: QueryRunner) {
+    const expiredTrials =
+      await this.subscriptionDomainService.findExpiredTrials(qr);
+
+    const expiredUserIds = expiredTrials.map((trial) => trial.userId);
+
+    await this.userDomainService.expireTrials(expiredUserIds, qr);
+
+    const expiredChurches = expiredTrials
+      .filter((trial) => trial.church)
+      .map((trial) => trial.church);
+
+    await this.churchesDomainService.cleanupExpiredTrials(expiredChurches, qr);
+
+    await this.subscriptionDomainService.expireTrialSubscriptions(
+      expiredTrials,
+      qr,
+    );
+
+    return { expiredCount: expiredTrials.length, timestamp: new Date() };
+  }
+
+  //@Cron('0 0 0 * * *')
+  async cleanupExpiredTrialsAuto() {
+    const qr = this.dataSource.createQueryRunner();
+    await qr.connect();
+    await qr.startTransaction();
+
+    try {
+      await this.cleanupExpiredTrialsManual(qr);
+
+      await qr.commitTransaction();
+    } catch {
+      await qr.rollbackTransaction();
+    } finally {
+      await qr.release();
+    }
   }
 }

--- a/backend/src/subscription/subscription-domain/interface/subscription-domain.service.interface.ts
+++ b/backend/src/subscription/subscription-domain/interface/subscription-domain.service.interface.ts
@@ -36,4 +36,11 @@ export interface ISubscriptionDomainService {
   ): Promise<UpdateResult>;
 
   findCurrentSubscription(church: ChurchModel): Promise<SubscriptionModel>;
+
+  findExpiredTrials(qr: QueryRunner): Promise<SubscriptionModel[]>;
+
+  expireTrialSubscriptions(
+    expiredTrials: SubscriptionModel[],
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
 }

--- a/backend/src/subscription/subscription.module.ts
+++ b/backend/src/subscription/subscription.module.ts
@@ -4,11 +4,13 @@ import { SubscriptionController } from './controller/subscription.controller';
 import { SubscriptionService } from './service/subscription.service';
 import { UserDomainModule } from '../user/user-domain/user-domain.module';
 import { SubscriptionDomainModule } from './subscription-domain/subscription-domain.module';
+import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
 
 @Module({
   imports: [
     RouterModule.register([{ path: 'subscribe', module: SubscriptionModule }]),
     UserDomainModule,
+    ChurchesDomainModule,
     SubscriptionDomainModule,
   ],
   controllers: [SubscriptionController],

--- a/backend/src/task/entity/task.entity.ts
+++ b/backend/src/task/entity/task.entity.ts
@@ -19,7 +19,9 @@ export class TaskModel extends BaseModel {
   @Column()
   churchId: number;
 
-  @ManyToOne(() => ChurchModel, (church) => church.tasks)
+  @ManyToOne(() => ChurchModel, (church) => church.tasks, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'churchId' })
   church: ChurchModel;
 
@@ -57,7 +59,9 @@ export class TaskModel extends BaseModel {
   @Column({ comment: '상위 업무 ID', nullable: true })
   parentTaskId: number | null;
 
-  @ManyToOne(() => TaskModel, (parentTask) => parentTask.subTasks)
+  @ManyToOne(() => TaskModel, (parentTask) => parentTask.subTasks, {
+    onDelete: 'CASCADE',
+  })
   parentTask: TaskModel;
 
   @Column({ default: '' })
@@ -67,15 +71,20 @@ export class TaskModel extends BaseModel {
   @Column({ comment: '담당자 ID', nullable: true })
   inChargeId: number;
 
-  @ManyToOne(() => MemberModel, (member) => member.assignedTask)
+  @ManyToOne(() => MemberModel, (member) => member.assignedTask, {
+    onDelete: 'SET NULL',
+  })
   @JoinColumn({ name: 'inChargeId' })
   inCharge: MemberModel;
 
   @Index()
-  @Column({ comment: '업무 생성자 ID' })
-  creatorId: number;
+  @Column({ comment: '업무 생성자 ID', nullable: true })
+  creatorId: number | null;
 
-  @ManyToOne(() => MemberModel, (member) => member.createdTask)
+  @ManyToOne(() => MemberModel, (member) => member.createdTask, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
   @JoinColumn({ name: 'creatorId' })
   creator: MemberModel;
 

--- a/backend/src/user/const/exception/user.exception.ts
+++ b/backend/src/user/const/exception/user.exception.ts
@@ -5,4 +5,5 @@ export const UserException = {
   CANNOT_CREATE_CHURCH: '소속된 교회가 있을 경우, 교회를 생성할 수 없습니다.',
   UPDATE_ERROR: '사용자 업데이트 도중 에러 발생',
   DELETE_ERROR: '사용자 삭제 도중 에러 발생',
+  EXPIRE_TRIAL_ERROR: '무료 체험 만료 처리 중 에러 발생',
 };

--- a/backend/src/user/user-domain/interface/user-domain.service.interface.ts
+++ b/backend/src/user/user-domain/interface/user-domain.service.interface.ts
@@ -40,4 +40,9 @@ export interface IUserDomainService {
   ): Promise<void>;
 
   startFreeTrial(user: UserModel, qr: QueryRunner): Promise<UpdateResult>;
+
+  expireTrials(
+    expiredUserIds: number[],
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
 }

--- a/backend/src/user/user-domain/service/user-domain.service.ts
+++ b/backend/src/user/user-domain/service/user-domain.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserModel } from '../../entity/user.entity';
-import { QueryRunner, Repository, UpdateResult } from 'typeorm';
+import { In, QueryRunner, Repository, UpdateResult } from 'typeorm';
 import { CreateUserDto } from '../../dto/create-user.dto';
 import { IUserDomainService } from '../interface/user-domain.service.interface';
 import { ChurchModel } from '../../../churches/entity/church.entity';
@@ -203,6 +203,24 @@ export class UserDomainService implements IUserDomainService {
 
     if (result.affected === 0) {
       throw new InternalServerErrorException(UserException.UPDATE_ERROR);
+    }
+
+    return result;
+  }
+
+  async expireTrials(
+    expiredUserIds: number[],
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getUserRepository(qr);
+
+    const result = await repository.update(
+      { id: In(expiredUserIds) },
+      { role: UserRole.NONE },
+    );
+
+    if (result.affected !== expiredUserIds.length) {
+      throw new InternalServerErrorException(UserException.EXPIRE_TRIAL_ERROR);
     }
 
     return result;

--- a/backend/src/visitation/entity/visitation-detail.entity.ts
+++ b/backend/src/visitation/entity/visitation-detail.entity.ts
@@ -11,9 +11,16 @@ export class VisitationDetailModel extends BaseModel {
   @ManyToOne(
     () => VisitationMetaModel,
     (visitingMeta) => visitingMeta.visitationDetails,
+    { onDelete: 'CASCADE' },
   )
   @JoinColumn({ name: 'visitationMetaId' })
   visitationMeta: VisitationMetaModel;
+
+  @Column({ default: '' })
+  visitationContent: string;
+
+  @Column({ default: '' })
+  visitationPray: string;
 
   /*@Index()
   @Column()
@@ -22,10 +29,4 @@ export class VisitationDetailModel extends BaseModel {
   @ManyToOne(() => MemberModel, (member) => member.visitationDetails)
   @JoinColumn({ name: 'memberId' })
   member: MemberModel;*/
-
-  @Column({ default: '' })
-  visitationContent: string;
-
-  @Column({ default: '' })
-  visitationPray: string;
 }

--- a/backend/src/visitation/entity/visitation-meta.entity.ts
+++ b/backend/src/visitation/entity/visitation-meta.entity.ts
@@ -23,7 +23,9 @@ export class VisitationMetaModel extends BaseModel {
   @Column()
   churchId: number;
 
-  @ManyToOne(() => ChurchModel, (church) => church.visitations)
+  @ManyToOne(() => ChurchModel, (church) => church.visitations, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'churchId' })
   church: ChurchModel;
 
@@ -61,21 +63,29 @@ export class VisitationMetaModel extends BaseModel {
 
   @Index()
   @Column({ comment: '심방 진행자 ID', nullable: true })
-  inChargeId: number;
+  inChargeId: number | null;
 
-  @ManyToOne(() => MemberModel, (member) => member.inChargingVisitations)
+  @ManyToOne(() => MemberModel, (member) => member.inChargingVisitations, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
   @JoinColumn({ name: 'inChargeId' })
   inCharge: MemberModel;
 
   @Index()
-  @Column({ comment: '심방 생성자 ID' })
-  creatorId: number;
+  @Column({ comment: '심방 생성자 ID', nullable: true })
+  creatorId: number | null;
 
-  @ManyToOne(() => MemberModel, (member) => member.createdVisitations)
+  @ManyToOne(() => MemberModel, (member) => member.createdVisitations, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
   @JoinColumn({ name: 'creatorId' })
   creator: MemberModel;
 
-  @ManyToMany(() => MemberModel, (member) => member.visitationMetas)
+  @ManyToMany(() => MemberModel, (member) => member.visitationMetas, {
+    onDelete: 'CASCADE',
+  })
   @JoinTable()
   members: MemberModel[];
 

--- a/backend/src/worship/controller/worship-enrollment.controller.ts
+++ b/backend/src/worship/controller/worship-enrollment.controller.ts
@@ -28,6 +28,7 @@ import { DomainName } from '../../permission/const/domain-name.enum';
 import { DomainAction } from '../../permission/const/domain-action.enum';
 import { PermissionScopeGroups } from '../decorator/permission-scope-groups.decorator';
 import { ChurchManagerGuard } from '../../permission/guard/church-manager.guard';
+import { WorshipTargetGroupIds } from '../decorator/worship-target-group-ids.decorator';
 
 @ApiTags('Worships:Enrollments')
 @Controller(':worshipId/enrollments')
@@ -56,12 +57,14 @@ export class WorshipEnrollmentController {
     @RequestChurch() church: ChurchModel,
     @RequestWorship() worship: WorshipModel,
     @PermissionScopeGroups() permissionScopeGroupIds?: number[],
+    @WorshipTargetGroupIds() defaultTargetGroupIds?: number[],
   ) {
     return this.worshipEnrollmentService.getEnrollments(
       church,
       worship,
       dto,
       permissionScopeGroupIds,
+      defaultTargetGroupIds,
     );
   }
 

--- a/backend/src/worship/entity/worship-attendance.entity.ts
+++ b/backend/src/worship/entity/worship-attendance.entity.ts
@@ -10,7 +10,11 @@ export class WorshipAttendanceModel extends BaseModel {
   @Column()
   worshipSessionId: number;
 
-  @ManyToOne(() => WorshipSessionModel, (session) => session.worshipAttendances)
+  @ManyToOne(
+    () => WorshipSessionModel,
+    (session) => session.worshipAttendances,
+    { onDelete: 'CASCADE' },
+  )
   @JoinColumn({ name: 'worshipSessionId' })
   worshipSession: WorshipSessionModel;
 
@@ -31,6 +35,7 @@ export class WorshipAttendanceModel extends BaseModel {
   @ManyToOne(
     () => WorshipEnrollmentModel,
     (enrollment) => enrollment.worshipAttendances,
+    { onDelete: 'CASCADE' },
   )
   @JoinColumn({ name: 'worshipEnrollmentId' })
   worshipEnrollment: WorshipEnrollmentModel;

--- a/backend/src/worship/entity/worship-enrollment.entity.ts
+++ b/backend/src/worship/entity/worship-enrollment.entity.ts
@@ -17,7 +17,9 @@ export class WorshipEnrollmentModel extends BaseModel {
   @Column()
   worshipId: number;
 
-  @ManyToOne(() => WorshipModel)
+  @ManyToOne(() => WorshipModel, (worship) => worship.worshipEnrollments, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'worshipId' })
   worship: WorshipModel;
 
@@ -25,7 +27,7 @@ export class WorshipEnrollmentModel extends BaseModel {
   @Column()
   memberId: number;
 
-  @ManyToOne(() => MemberModel)
+  @ManyToOne(() => MemberModel, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'memberId' })
   member: MemberModel;
 

--- a/backend/src/worship/entity/worship-session.entity.ts
+++ b/backend/src/worship/entity/worship-session.entity.ts
@@ -17,7 +17,7 @@ export class WorshipSessionModel extends BaseModel {
   @Column()
   worshipId: number;
 
-  @ManyToOne(() => WorshipModel)
+  @ManyToOne(() => WorshipModel, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'worshipId' })
   worship: WorshipModel;
 

--- a/backend/src/worship/entity/worship-target-group.entity.ts
+++ b/backend/src/worship/entity/worship-target-group.entity.ts
@@ -9,7 +9,9 @@ export class WorshipTargetGroupModel extends BaseModel {
   @Column()
   worshipId: number;
 
-  @ManyToOne(() => WorshipModel)
+  @ManyToOne(() => WorshipModel, (worship) => worship.worshipTargetGroups, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'worshipId' })
   worship: WorshipModel;
 
@@ -17,7 +19,7 @@ export class WorshipTargetGroupModel extends BaseModel {
   @Column()
   groupId: number;
 
-  @ManyToOne(() => GroupModel)
+  @ManyToOne(() => GroupModel, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'groupId' })
   group: GroupModel;
 }

--- a/backend/src/worship/entity/worship.entity.ts
+++ b/backend/src/worship/entity/worship.entity.ts
@@ -17,7 +17,9 @@ export class WorshipModel extends BaseModel {
   @Column()
   churchId: number;
 
-  @ManyToOne(() => ChurchModel)
+  @ManyToOne(() => ChurchModel, (church) => church.worships, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'churchId' })
   church: ChurchModel;
 

--- a/backend/src/worship/service/worship-enrollment.service.ts
+++ b/backend/src/worship/service/worship-enrollment.service.ts
@@ -31,6 +31,7 @@ import {
 import { WorshipEnrollmentModel } from '../entity/worship-enrollment.entity';
 import { WorshipAttendanceModel } from '../entity/worship-attendance.entity';
 import { WorshipModel } from '../entity/worship.entity';
+import { getIntersectionGroupIds } from '../utils/worship-utils';
 
 @Injectable()
 export class WorshipEnrollmentService {
@@ -52,10 +53,22 @@ export class WorshipEnrollmentService {
 
   private async getRequestGroupIds(
     church: ChurchModel,
-    dto: GetWorshipEnrollmentsDto,
-    qr?: QueryRunner,
+    defaultTargetGroupIds: number[] | undefined,
+    groupId?: number,
+    /*dto: GetWorshipEnrollmentsDto,
+    qr?: QueryRunner,*/
   ): Promise<number[] | undefined> {
-    if (!dto.groupId) {
+    if (groupId) {
+      return (
+        await this.groupsDomainService.findGroupAndDescendantsByIds(church, [
+          groupId,
+        ])
+      ).map((group) => group.id);
+    } else {
+      return defaultTargetGroupIds;
+    }
+
+    /*if (!dto.groupId) {
       return undefined;
     }
 
@@ -71,10 +84,10 @@ export class WorshipEnrollmentService {
 
     groupIds && groupIds.unshift(group.id);
 
-    return groupIds;
+    return groupIds;*/
   }
 
-  private async getDefaultGroupIds(
+  /*private async getDefaultGroupIds(
     church: ChurchModel,
     worship: WorshipModel,
     qr?: QueryRunner,
@@ -96,32 +109,32 @@ export class WorshipEnrollmentService {
     } else {
       return undefined;
     }
-  }
+  }*/
 
-  private intersection(
+  /*private intersection(
     defaultWorshipTargetGroupIds?: number[],
     permissionScopeGroupIds?: number[],
   ) {
-    /*
+    /!*
     2. 예배 범위가 전체인 경우
     --> defaultWorshipTargetGroup 이 빈 배열 []
       case 1. 권한 범위가 정해져있는 경우
       --> permissionScopeGroupIds 로 조회
       case 2. 권한 범위가 전체인 경우
       --> 그룹 조건 없이 모두 조회
-    */
+    *!/
     if (!defaultWorshipTargetGroupIds) {
       return permissionScopeGroupIds;
     }
 
-    /*
+    /!*
     3. 예배 범위가 정해진 경우
       case 1. 권한 범위가 정해져 있는 경우
       --> defaultWorshipTargetGroup 과 permissionScopeGroupIds 의 교집합으로 조회
       case 2. 권한 범위가 전체인 경우
       --> permissionScopeGroupIds 가 undefined
       --> defaultWorshipTargetGroup 으로 조회
-     */
+     *!/
     if (!permissionScopeGroupIds) {
       return defaultWorshipTargetGroupIds;
     }
@@ -131,13 +144,14 @@ export class WorshipEnrollmentService {
     return permissionScopeGroupIds.filter((scopeGroupId) =>
       targetGroupIdSet.has(scopeGroupId),
     );
-  }
+  }*/
 
   async getEnrollments(
     church: ChurchModel,
     worship: WorshipModel,
     dto: GetWorshipEnrollmentsDto,
     permissionScopeGroupIds?: number[],
+    defaultTargetGroupIds?: number[],
     qr?: QueryRunner,
   ) {
     // 조회 요청 groupId, 가드에서 검증 완료
@@ -146,9 +160,13 @@ export class WorshipEnrollmentService {
        -> 가드에서 예배 범위, 사용자의 권한 체크
        -> 그대로 보여줌
      */
-    const requestGroupIds = await this.getRequestGroupIds(church, dto, qr);
+    const requestGroupIds = await this.getRequestGroupIds(
+      church,
+      defaultTargetGroupIds,
+      dto.groupId,
+    );
 
-    const defaultWorshipTargetGroup = await this.getDefaultGroupIds(
+    /*const defaultWorshipTargetGroup = await this.getDefaultGroupIds(
       church,
       worship,
       qr,
@@ -156,7 +174,12 @@ export class WorshipEnrollmentService {
 
     const groupIds = requestGroupIds
       ? requestGroupIds
-      : this.intersection(defaultWorshipTargetGroup, permissionScopeGroupIds);
+      : this.intersection(defaultWorshipTargetGroup, permissionScopeGroupIds);*/
+
+    const groupIds = getIntersectionGroupIds(
+      requestGroupIds,
+      permissionScopeGroupIds,
+    );
 
     const { data, totalCount } =
       await this.worshipEnrollmentDomainService.findEnrollmentsByQueryBuilder(


### PR DESCRIPTION
## 주요 내용
- 무료 구독 만료 시 해당 구독과 연동된 무료 체험 교회를 삭제하는 로직 추가
- 현재는 테스트용으로 수동 기능만 적용, 추후 Cron 작업으로 매일 자정에 자동 처리 예정
- 무료 체험 교회가 물리 삭제될 때 하위 데이터도 자동 삭제되도록 **CASCADE 옵션** 적용

## 세부 내용
### Subscription
- 무료 구독 종료 시 관련 교회 식별 및 삭제 로직 구현
- 수동 트리거 기반 테스트 기능 제공

### Church
- 무료 체험 교회 삭제 시 **CASCADE 삭제**가 적용되어 하위 엔티티(회원, 그룹, 예배 등)가 함께 제거되도록 설정