### PR TITLE
feat: 유료 구독 신청 기능 및 UserGuard 추가

### DIFF
--- a/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
+++ b/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
@@ -47,6 +47,12 @@ export interface IChurchesDomainService {
 
   updateChurch(church: ChurchModel, dto: UpdateChurchDto): Promise<ChurchModel>;
 
+  updateSubscription(
+    church: ChurchModel,
+    subscription: SubscriptionModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
   deleteChurch(church: ChurchModel, qr?: QueryRunner): Promise<string>;
 
   deleteChurchCascade(

--- a/backend/src/churches/entity/church.entity.ts
+++ b/backend/src/churches/entity/church.entity.ts
@@ -32,7 +32,9 @@ export class ChurchModel extends BaseModel {
   @Index()
   subscriptionId: number | null;
 
-  @OneToOne(() => SubscriptionModel, { nullable: true })
+  @OneToOne(() => SubscriptionModel, (subscription) => subscription.church, {
+    nullable: true,
+  })
   @JoinColumn({ name: 'subscriptionId' })
   subscription: SubscriptionModel;
 

--- a/backend/src/common/custom-request.ts
+++ b/backend/src/common/custom-request.ts
@@ -5,6 +5,7 @@ import { ChurchUserModel } from '../church-user/entity/church-user.entity';
 import { JwtAccessPayload } from '../auth/type/jwt';
 import { MemberModel } from '../members/entity/member.entity';
 import { QueryRunner } from 'typeorm';
+import { UserModel } from '../user/entity/user.entity';
 
 export interface CustomRequest extends Request {
   queryRunner: QueryRunner;
@@ -15,6 +16,7 @@ export interface CustomRequest extends Request {
   requestManager: ChurchUserModel;
   permissionScopeGroupIds: number[];
   tokenPayload: JwtAccessPayload;
+  user: UserModel;
 
   targetMember: MemberModel;
 

--- a/backend/src/management/ministries/ministries.module.ts
+++ b/backend/src/management/ministries/ministries.module.ts
@@ -1,6 +1,4 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { MinistryModel } from './entity/ministry.entity';
 import { MinistriesController } from './controller/ministries.controller';
 import { MinistryGroupsController } from './controller/ministry-groups.controller';
 import { MinistryService } from './service/ministry.service';
@@ -24,7 +22,6 @@ import { MinistryHistoryDomainModule } from '../../member-history/ministry-histo
         module: MinistriesModule,
       },
     ]),
-    TypeOrmModule.forFeature([MinistryModel]),
     ChurchesDomainModule,
     ManagerDomainModule,
     MinistriesDomainModule,

--- a/backend/src/permission/guard/church-owner.guard.ts
+++ b/backend/src/permission/guard/church-owner.guard.ts
@@ -29,8 +29,11 @@ export class ChurchOwnerGuard implements CanActivate {
     }
 
     const churchId = parseInt(req.params.churchId);
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      req.queryRunner,
+      { subscription: true },
+    );
 
     req.church = church;
 

--- a/backend/src/subscription/const/plan-amount.enum.ts
+++ b/backend/src/subscription/const/plan-amount.enum.ts
@@ -1,0 +1,7 @@
+export enum PlanAmount {
+  FREE_TRIAL = 0,
+  BASIC = 49_000,
+  STANDARD = 79_000,
+  PLUS = 129_000,
+  PREMIUM = 199_000,
+}

--- a/backend/src/subscription/const/plan-member-size.enum.ts
+++ b/backend/src/subscription/const/plan-member-size.enum.ts
@@ -1,0 +1,7 @@
+export enum PlanMemberSize {
+  FREE_TRIAL = 50,
+  BASIC = 300,
+  STANDARD = 500,
+  PLUS = 1000,
+  PREMIUM = 3000,
+}

--- a/backend/src/subscription/const/subscription-status.enum.ts
+++ b/backend/src/subscription/const/subscription-status.enum.ts
@@ -1,6 +1,7 @@
 export enum SubscriptionStatus {
-  PENDING = 'pending',
-  ACTIVE = 'active',
-  EXPIRED = 'expired',
-  CANCELED = 'canceled',
+  PENDING = 'pending', // 구독 생성, 교회 미생성
+  ACTIVE = 'active', // 구독 생성, 교회 생성
+  CANCELED = 'canceled', // 구독 즉시 취소 (환불)
+  EXPIRED = 'expired', // 구독 만료
+  FAILED = 'failed', // 정기 결제 실패
 }

--- a/backend/src/subscription/controller/subscription.controller.ts
+++ b/backend/src/subscription/controller/subscription.controller.ts
@@ -1,39 +1,72 @@
 import {
+  Body,
   Controller,
   Delete,
+  Get,
+  Patch,
   Post,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { SubscriptionService } from '../service/subscription.service';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
-import { Token } from '../../auth/decorator/jwt.decorator';
-import { AuthType } from '../../auth/const/enum/auth-type.enum';
-import { JwtPayload } from '../../auth/type/jwt';
 import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
+import { ApiOperation } from '@nestjs/swagger';
+import { SubscribePlanDto } from '../dto/request/subscribe-plan.dto';
+import { UserGuard } from '../../user/guard/user.guard';
+import { User } from '../../user/decorator/user.decorator';
+import { UserModel } from '../../user/entity/user.entity';
 
 @Controller()
 export class SubscriptionController {
   constructor(private readonly subscriptionService: SubscriptionService) {}
 
+  @ApiOperation({ summary: '정기 결제 중인 구독 조회' })
+  @Get('current')
+  @UseGuards(AccessTokenGuard, UserGuard)
+  getSubscription(@User() user: UserModel) {
+    return this.subscriptionService.getCurrentSubscription(user);
+  }
+
+  @ApiOperation({ summary: '무료 체험 신청' })
   @Post('trial')
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, UserGuard)
   @UseInterceptors(TransactionInterceptor)
-  startFreeTrial(
-    @Token(AuthType.ACCESS) accessToken: JwtPayload,
-    @QueryRunner() qr: QR,
-  ) {
-    return this.subscriptionService.startFreeTrial(accessToken.id, qr);
+  startFreeTrial(@User() user: UserModel, @QueryRunner() qr: QR) {
+    return this.subscriptionService.startFreeTrial(user, qr);
   }
 
+  @ApiOperation({ summary: '구독 신청' })
   @Post('subscribe')
-  startSubscription(@Token(AuthType.ACCESS) accessToken: JwtPayload) {
-    return accessToken;
+  @UseGuards(AccessTokenGuard, UserGuard)
+  subscribePlan(@User() user: UserModel, @Body() dto: SubscribePlanDto) {
+    return this.subscriptionService.subscribePlan(user, dto);
   }
 
-  @Delete('cleanup/expired-trials')
+  @ApiOperation({ summary: '구독 플랜 업그레이드' })
+  @Patch('upgrade')
+  @UseGuards(AccessTokenGuard, UserGuard)
+  upgradePlan(@User() user: UserModel) {}
+
+  @ApiOperation({ summary: '구독 플랜 다운그레이드' })
+  @Patch('downgrade')
+  @UseGuards(AccessTokenGuard, UserGuard)
+  downgradePlan(@User() user: UserModel) {}
+
+  @ApiOperation({ summary: '구독 플랜 취소' })
+  @Delete('cancel')
+  @UseGuards(AccessTokenGuard, UserGuard)
+  cancelPlan(@User() user: UserModel) {}
+
+  @ApiOperation({ summary: '구독 즉시 만료' })
+  @Delete('expire')
+  @UseGuards(AccessTokenGuard, UserGuard)
+  expirePlan(@User() user: UserModel) {}
+
+  @ApiOperation({ summary: '만료된 무료 체험 데이터 삭제' })
+  @Delete('cleanup/manual/expired-trials')
   @UseInterceptors(TransactionInterceptor)
   cleanupExpiredTrials(@QueryRunner() qr: QR) {
     return this.subscriptionService.cleanupExpiredTrialsManual(qr);

--- a/backend/src/subscription/controller/test-subscription.controller.ts
+++ b/backend/src/subscription/controller/test-subscription.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Post, UseInterceptors } from '@nestjs/common';
+import { TestSubscriptionService } from '../service/test-subscription.service';
+import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
+import { QueryRunner } from '../../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm/query-runner/QueryRunner';
+import { ApiOperation } from '@nestjs/swagger';
+
+@Controller('test-subscribe')
+export class TestSubscriptionController {
+  constructor(
+    private readonly testSubscriptionService: TestSubscriptionService,
+  ) {}
+
+  @ApiOperation({
+    summary: '기존 교회들의 구독 정보 초기 생성',
+  })
+  @Post('init')
+  @UseInterceptors(TransactionInterceptor)
+  startTestSubscribe(@QueryRunner() qr: QR) {
+    return this.testSubscriptionService.initTestPlan(qr);
+  }
+}

--- a/backend/src/subscription/decorator/is-available-plan.decorator.ts
+++ b/backend/src/subscription/decorator/is-available-plan.decorator.ts
@@ -1,0 +1,30 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+} from 'class-validator';
+import { SubscriptionPlan } from '../const/subscription-plan.enum';
+import { SubscriptionException } from '../exception/subscription.exception';
+
+export function IsAvailablePlan(
+  unavailablePlans: SubscriptionPlan[],
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'isAvailablePlan',
+      target: object.constructor,
+      propertyName,
+      constraints: [unavailablePlans],
+      options: validationOptions,
+      validator: {
+        defaultMessage(): string {
+          return SubscriptionException.UNAVAILABLE_PLAN;
+        },
+        validate(value: SubscriptionPlan, args: ValidationArguments) {
+          return !args.constraints[0].includes(value);
+        },
+      },
+    });
+  };
+}

--- a/backend/src/subscription/dto/request/subscribe-plan.dto.ts
+++ b/backend/src/subscription/dto/request/subscribe-plan.dto.ts
@@ -1,0 +1,81 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SubscriptionPlan } from '../../const/subscription-plan.enum';
+import {
+  IsBoolean,
+  IsEnum,
+  IsString,
+  Length,
+  ValidateNested,
+} from 'class-validator';
+import { IsAvailablePlan } from '../../decorator/is-available-plan.decorator';
+import { BillingCycle } from '../../const/billing-cycle.enum';
+import { Type } from 'class-transformer';
+
+export class EncData {
+  @ApiProperty({
+    description: '카드번호, 숫자만 입력',
+    example: '1234123412341234',
+  })
+  @IsString()
+  @Length(16, 16)
+  cardNo: string;
+
+  @ApiProperty({
+    description: '유효기간(년, YY)',
+    example: '25',
+  })
+  @IsString()
+  @Length(2, 2)
+  expYear: string;
+
+  @ApiProperty({
+    description: '유효기간(월, MM)',
+    example: '09',
+  })
+  @IsString()
+  @Length(2, 2)
+  expMonth: string;
+
+  @ApiProperty({
+    description: '생년월일(YYMMDD) or 사업자번호(10자리)',
+    example: '000101',
+  })
+  @IsString()
+  @Length(6, 10)
+  idNo: string;
+
+  @ApiProperty({
+    description: '카드 비밀번호 앞 2자리',
+    example: '00',
+  })
+  @IsString()
+  @Length(2, 2)
+  cardPw: string;
+}
+
+export class SubscribePlanDto {
+  @ApiProperty({ description: '테스트용', default: true, example: true })
+  @IsBoolean()
+  isTest: boolean = true;
+
+  @ApiProperty({
+    description: '구독 플랜 (freeTrial, basic, standard, plus, premium)',
+    enum: SubscriptionPlan,
+    example: SubscriptionPlan.BASIC,
+  })
+  @IsAvailablePlan([SubscriptionPlan.FREE_TRIAL, SubscriptionPlan.ENTERPRISE])
+  @IsEnum(SubscriptionPlan)
+  plan: SubscriptionPlan;
+
+  @ApiProperty({
+    description: '구독 단위 (월간/연간)',
+    enum: BillingCycle,
+  })
+  @IsEnum(BillingCycle)
+  billingCycle: BillingCycle;
+
+  @ApiProperty()
+  @Type(() => EncData)
+  @ValidateNested()
+  encData: EncData;
+}

--- a/backend/src/subscription/dto/response/post-subscribe-plan-response.dto.ts
+++ b/backend/src/subscription/dto/response/post-subscribe-plan-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePostResponseDto } from '../../../common/dto/reponse/base-post-response.dto';
+import { SubscriptionModel } from '../../entity/subscription.entity';
+
+export class PostSubscribePlanResponseDto extends BasePostResponseDto<SubscriptionModel> {
+  constructor(data: SubscriptionModel) {
+    super(data);
+  }
+}

--- a/backend/src/subscription/entity/subscription.entity.ts
+++ b/backend/src/subscription/entity/subscription.entity.ts
@@ -17,16 +17,20 @@ import { ChurchModel } from '../../churches/entity/church.entity';
 export class SubscriptionModel extends BaseModel {
   @OneToOne(() => ChurchModel, (church) => church.subscription, {
     nullable: true,
+    onDelete: 'SET NULL',
   })
-  church: ChurchModel;
+  church: ChurchModel | null;
 
-  @Column()
+  @Column({ default: true })
+  isCurrent: boolean;
+
   @Index()
-  userId: number;
+  @Column({ nullable: true })
+  userId: number | null;
 
-  @ManyToOne(() => UserModel, { onDelete: 'CASCADE' })
+  @ManyToOne(() => UserModel, { onDelete: 'SET NULL', nullable: true })
   @JoinColumn({ name: 'userId' })
-  user: UserModel;
+  user: UserModel | null;
 
   @Column()
   currentPlan: SubscriptionPlan;
@@ -43,8 +47,8 @@ export class SubscriptionModel extends BaseModel {
   @Column({ nullable: true })
   billingCycle: BillingCycle;
 
-  @Column({ nullable: true })
-  nextBillingDate: Date;
+  @Column({ type: 'timestamptz', nullable: true })
+  nextBillingDate: Date | null;
 
   @Column({ nullable: true })
   amount: number;
@@ -55,21 +59,24 @@ export class SubscriptionModel extends BaseModel {
   @Column({ default: false })
   isFreeTrial: boolean;
 
-  @Column({ nullable: true })
+  @Column({ type: 'timestamptz', nullable: true })
   trialEndsAt: Date;
 
   @Column()
   maxMembers: number;
+
+  @Column({ type: 'varchar', comment: '정기 결제 빌키', nullable: true })
+  bid: string | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  canceledAt: Date;
+
+  @Column({ nullable: true })
+  cancellationReason: string;
 
   @Column({ nullable: true })
   paymentMethodId: string; // PG사 결제수단 ID
 
   @Column({ nullable: true })
   customerId: string; // PG사 고객 ID
-
-  @Column({ nullable: true })
-  canceledAt: Date;
-
-  @Column({ nullable: true })
-  cancellationReason: string;
 }

--- a/backend/src/subscription/exception/subscription.exception.ts
+++ b/backend/src/subscription/exception/subscription.exception.ts
@@ -6,4 +6,12 @@ export const SubscriptionException = {
 
   FAIL_LOAD_SUBSCRIPTION: '구독 정보 누락',
   EXPIRE_SUBSCRIPTION_ERROR: '구독 만료 처리 중 에러 발생',
+  UNAVAILABLE_PLAN: '신청할 수 없는 구독 플랜입니다.',
+  ACTIVE_NOT_FOUND: '활성 상태 구독 정보를 찾을 수 없습니다.',
+  NOT_FOUND: '구독 정보를 찾을 수 없습니다.',
+  ALREADY_EXIST: '현재 진행 중인 구독이 존재합니다.',
+  FAIL_CANCEL_SUBSCRIPTION: '구독 취소 실패. 잠시후 다시 시도해주세요.',
+
+  // 테스트 상황 에러
+  FAIL_EXPIRE_SUBSCRIPTION: '구독 강제 만료 실패',
 };

--- a/backend/src/subscription/guard/subscription.guard.ts
+++ b/backend/src/subscription/guard/subscription.guard.ts
@@ -26,9 +26,11 @@ export class SubscriptionGuard implements CanActivate {
     }
     const churchId = parseInt(req.params.churchId);
 
-    return this.churchesDomainService.findChurchModelById(churchId, undefined, {
-      subscription: true,
-    });
+    return this.churchesDomainService.findChurchModelById(
+      churchId,
+      req.queryRunner,
+      { subscription: true },
+    );
   }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {

--- a/backend/src/subscription/service/pg.service.ts
+++ b/backend/src/subscription/service/pg.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EncData } from '../dto/request/subscribe-plan.dto';
+
+@Injectable()
+export class PgService {
+  constructor(private readonly configService: ConfigService) {}
+
+  async registerBillKey(encData: EncData, isTest: boolean) {
+    const plainText = Object.entries(encData)
+      .map(([key, value]) => `${key}=${value}`)
+      .join('&');
+
+    if (isTest) {
+      return '23DSFHFD381294';
+    }
+
+    throw new InternalServerErrorException('아직 PG API 연결 안함');
+  }
+}

--- a/backend/src/subscription/service/test-subscription.service.ts
+++ b/backend/src/subscription/service/test-subscription.service.ts
@@ -1,0 +1,54 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { QueryRunner } from 'typeorm';
+import {
+  IUSER_DOMAIN_SERVICE,
+  IUserDomainService,
+} from '../../user/user-domain/interface/user-domain.service.interface';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  ITEST_SUBSCRIPTION_DOMAIN_SERVICE,
+  ITestSubscriptionDomainService,
+} from '../subscription-domain/interface/test-subscription-domain.service.interface';
+
+@Injectable()
+export class TestSubscriptionService {
+  constructor(
+    @Inject(IUSER_DOMAIN_SERVICE)
+    private readonly userDomainService: IUserDomainService,
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+
+    @Inject(ITEST_SUBSCRIPTION_DOMAIN_SERVICE)
+    private readonly testSubscriptionDomainService: ITestSubscriptionDomainService,
+  ) {}
+
+  async initTestPlan(qr: QueryRunner) {
+    const churches = (
+      await this.churchesDomainService.findAllChurches()
+    ).filter((church) => church.ownerUserId && !church.subscription);
+
+    for (const church of churches) {
+      const owner = await this.userDomainService.findUserModelById(
+        church.ownerUserId,
+      );
+
+      const subscription =
+        await this.testSubscriptionDomainService.initTestPlan(
+          church,
+          owner,
+          qr,
+        );
+
+      await this.churchesDomainService.updateSubscription(
+        church,
+        subscription,
+        qr,
+      );
+    }
+
+    return churches;
+  }
+}

--- a/backend/src/subscription/subscription-domain/interface/subscription-domain.service.interface.ts
+++ b/backend/src/subscription/subscription-domain/interface/subscription-domain.service.interface.ts
@@ -1,7 +1,9 @@
 import { UserModel } from '../../../user/entity/user.entity';
 import { SubscriptionModel } from '../../entity/subscription.entity';
-import { QueryRunner, UpdateResult } from 'typeorm';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { ChurchModel } from '../../../churches/entity/church.entity';
+import { SubscribePlanDto } from '../../dto/request/subscribe-plan.dto';
+import { SubscriptionStatus } from '../../const/subscription-status.enum';
 
 export const ISUBSCRIPTION_DOMAIN_SERVICE = Symbol(
   'ISUBSCRIPTION_DOMAIN_SERVICE',
@@ -9,6 +11,12 @@ export const ISUBSCRIPTION_DOMAIN_SERVICE = Symbol(
 
 export interface ISubscriptionDomainService {
   createFreeTrial(user: UserModel, qr: QueryRunner): Promise<SubscriptionModel>;
+
+  findSubscriptionByStatus(
+    user: UserModel,
+    status: SubscriptionStatus,
+    qr?: QueryRunner,
+  ): Promise<SubscriptionModel>;
 
   findTrialSubscription(
     user: UserModel,
@@ -43,4 +51,22 @@ export interface ISubscriptionDomainService {
     expiredTrials: SubscriptionModel[],
     qr: QueryRunner,
   ): Promise<UpdateResult>;
+
+  findCurrentUserSubscription(
+    user: UserModel,
+    qr?: QueryRunner,
+  ): Promise<SubscriptionModel>;
+
+  findSubscriptionModelById(
+    user: UserModel,
+    subscriptionId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<SubscriptionModel>,
+  ): Promise<SubscriptionModel>;
+
+  subscribePlan(
+    user: UserModel,
+    dto: SubscribePlanDto,
+    billKey: string,
+  ): Promise<SubscriptionModel>;
 }

--- a/backend/src/subscription/subscription-domain/interface/test-subscription-domain.service.interface.ts
+++ b/backend/src/subscription/subscription-domain/interface/test-subscription-domain.service.interface.ts
@@ -1,0 +1,16 @@
+import { SubscriptionModel } from '../../entity/subscription.entity';
+import { UserModel } from '../../../user/entity/user.entity';
+import { QueryRunner } from 'typeorm';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+
+export const ITEST_SUBSCRIPTION_DOMAIN_SERVICE = Symbol(
+  'ITEST_SUBSCRIPTION_DOMAIN_SERVICE',
+);
+
+export interface ITestSubscriptionDomainService {
+  initTestPlan(
+    church: ChurchModel,
+    owner: UserModel,
+    qr: QueryRunner,
+  ): Promise<SubscriptionModel>;
+}

--- a/backend/src/subscription/subscription-domain/service/test-subscription-domain.service.ts
+++ b/backend/src/subscription/subscription-domain/service/test-subscription-domain.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { ITestSubscriptionDomainService } from '../interface/test-subscription-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { SubscriptionModel } from '../../entity/subscription.entity';
+import { QueryRunner, Repository } from 'typeorm';
+import { UserModel } from '../../../user/entity/user.entity';
+import { SubscriptionPlan } from '../../const/subscription-plan.enum';
+import { SubscriptionStatus } from '../../const/subscription-status.enum';
+import { addDays, subHours } from 'date-fns';
+import { BillingCycle } from '../../const/billing-cycle.enum';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+
+@Injectable()
+export class TestSubscriptionDomainService
+  implements ITestSubscriptionDomainService
+{
+  constructor(
+    @InjectRepository(SubscriptionModel)
+    private readonly repository: Repository<SubscriptionModel>,
+  ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr ? qr.manager.getRepository(SubscriptionModel) : this.repository;
+  }
+
+  initTestPlan(
+    church: ChurchModel,
+    owner: UserModel,
+    qr: QueryRunner,
+  ): Promise<SubscriptionModel> {
+    const repository = this.getRepository(qr);
+
+    const now = new Date();
+    const endDate = addDays(new Date(), 30);
+
+    return repository.save({
+      churchId: church.id,
+      isCurrent: true,
+      userId: owner.id,
+      currentPlan: SubscriptionPlan.BASIC,
+      status: SubscriptionStatus.ACTIVE,
+      currentPeriodStart: now,
+      currentPeriodEnd: endDate,
+      billingCycle: BillingCycle.MONTHLY,
+      nextBillingDate: subHours(endDate, 2),
+      amount: 49000,
+      autoRenew: true,
+      maxMembers: 100,
+    });
+  }
+}

--- a/backend/src/subscription/subscription-domain/subscription-domain.module.ts
+++ b/backend/src/subscription/subscription-domain/subscription-domain.module.ts
@@ -3,6 +3,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { SubscriptionModel } from '../entity/subscription.entity';
 import { ISUBSCRIPTION_DOMAIN_SERVICE } from './interface/subscription-domain.service.interface';
 import { SubscriptionDomainService } from './service/subscription-domain.service';
+import { ITEST_SUBSCRIPTION_DOMAIN_SERVICE } from './interface/test-subscription-domain.service.interface';
+import { TestSubscriptionDomainService } from './service/test-subscription-domain.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([SubscriptionModel])],
@@ -11,7 +13,11 @@ import { SubscriptionDomainService } from './service/subscription-domain.service
       provide: ISUBSCRIPTION_DOMAIN_SERVICE,
       useClass: SubscriptionDomainService,
     },
+    {
+      provide: ITEST_SUBSCRIPTION_DOMAIN_SERVICE,
+      useClass: TestSubscriptionDomainService,
+    },
   ],
-  exports: [ISUBSCRIPTION_DOMAIN_SERVICE],
+  exports: [ISUBSCRIPTION_DOMAIN_SERVICE, ITEST_SUBSCRIPTION_DOMAIN_SERVICE],
 })
 export class SubscriptionDomainModule {}

--- a/backend/src/subscription/subscription.module.ts
+++ b/backend/src/subscription/subscription.module.ts
@@ -5,6 +5,9 @@ import { SubscriptionService } from './service/subscription.service';
 import { UserDomainModule } from '../user/user-domain/user-domain.module';
 import { SubscriptionDomainModule } from './subscription-domain/subscription-domain.module';
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
+import { TestSubscriptionService } from './service/test-subscription.service';
+import { TestSubscriptionController } from './controller/test-subscription.controller';
+import { PgService } from './service/pg.service';
 
 @Module({
   imports: [
@@ -13,7 +16,7 @@ import { ChurchesDomainModule } from '../churches/churches-domain/churches-domai
     ChurchesDomainModule,
     SubscriptionDomainModule,
   ],
-  controllers: [SubscriptionController],
-  providers: [SubscriptionService],
+  controllers: [TestSubscriptionController, SubscriptionController],
+  providers: [SubscriptionService, PgService, TestSubscriptionService],
 })
 export class SubscriptionModule {}

--- a/backend/src/user/decorator/user.decorator.ts
+++ b/backend/src/user/decorator/user.decorator.ts
@@ -1,0 +1,16 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { CustomRequest } from '../../common/custom-request';
+
+export const User = createParamDecorator((_, ctx: ExecutionContext) => {
+  const req: CustomRequest = ctx.switchToHttp().getRequest();
+
+  if (!req.user) {
+    throw new InternalServerErrorException('User 처리 누락');
+  }
+
+  return req.user;
+});

--- a/backend/src/user/guard/user.guard.ts
+++ b/backend/src/user/guard/user.guard.ts
@@ -1,0 +1,29 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
+import {
+  IUSER_DOMAIN_SERVICE,
+  IUserDomainService,
+} from '../user-domain/interface/user-domain.service.interface';
+import { CustomRequest } from '../../common/custom-request';
+
+@Injectable()
+export class UserGuard implements CanActivate {
+  constructor(
+    @Inject(IUSER_DOMAIN_SERVICE)
+    private readonly userDomainService: IUserDomainService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req: CustomRequest = context.switchToHttp().getRequest();
+
+    const userId = req.tokenPayload.id;
+
+    req.user = await this.userDomainService.findUserModelById(userId);
+
+    return true;
+  }
+}


### PR DESCRIPTION
## 주요 내용
유료 구독 신청 기능 구현 및 사용자 인증을 위한 UserGuard 추가

## 세부 내용

### UserGuard 추가
- 계정 정보가 필요한 엔드포인트에서 사용자 검증
- 검증된 사용자 정보를 request 객체에 저장
- 후속 Guard 및 Controller에서 사용자 정보 재사용 가능

### 구독 신청 기능 구현
- POST /subscribe/subscribe 엔드포인트 추가
- 플랜 선택 및 구독 생성 (BASIC, STANDARD, PREMIUM)
- PG 연동 전 Mock 결제 처리 구현
- 구독 상태 관리 (PENDING → ACTIVE)

### 개발용 마이그레이션 기능
- 기존 교회들을 위한 구독 정보 일괄 생성
- 구독 기능 도입 전 생성된 교회 데이터 호환성 처리
- 개발/테스트 환경 전용 기능