### PR TITLE
feat: 구독 관리 기능 구현 (신청, 재시도, 결제수단 변경, 취소, 만료)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -76,6 +76,7 @@ import { SubscriptionModel } from './subscription/entity/subscription.entity';
 import { SubscriptionModule } from './subscription/subscription.module';
 import { DummyDataModule } from './dummy-data/dummy-data.module';
 import { ScheduleModule } from '@nestjs/schedule';
+import { OrderModel } from './subscription/entity/order.entity';
 
 //import { EducationTermReportModel } from './report/education-report/entity/education-term-report.entity';
 
@@ -146,6 +147,7 @@ import { ScheduleModule } from '@nestjs/schedule';
         entities: [
           // 구독 관련
           SubscriptionModel,
+          OrderModel,
           // 유저 관련 엔티티
           TempUserModel,
           UserModel,

--- a/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
+++ b/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
@@ -31,11 +31,18 @@ export interface IChurchesDomainService {
     relationOptions?: FindOptionsRelations<ChurchModel>,
   ): Promise<ChurchModel>;
 
+  findChurchModelByOwner(
+    ownerUser: UserModel,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<ChurchModel>,
+  ): Promise<ChurchModel>;
+
   isExistChurch(id: number, qr?: QueryRunner): Promise<boolean>;
 
   createChurch(
     dto: CreateChurchDto,
     ownerUser: UserModel,
+    subscription: SubscriptionModel,
     qr?: QueryRunner,
   ): Promise<ChurchModel>;
 

--- a/backend/src/churches/controller/churches.controller.ts
+++ b/backend/src/churches/controller/churches.controller.ts
@@ -37,6 +37,9 @@ import { TrialChurchesService } from '../service/trial-churches.service';
 import { ChurchOwnerGuard } from '../../permission/guard/church-owner.guard';
 import { RequestChurch } from '../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../entity/church.entity';
+import { UserGuard } from '../../user/guard/user.guard';
+import { User } from '../../user/decorator/user.decorator';
+import { UserModel } from '../../user/entity/user.entity';
 
 @Controller('churches')
 export class ChurchesController {
@@ -55,14 +58,15 @@ export class ChurchesController {
   // 교회 생성
   @ApiPostChurch()
   @Post()
-  @UseGuards(AccessTokenGuard)
+  @UseGuards(AccessTokenGuard, UserGuard)
   @UseInterceptors(TransactionInterceptor)
   postChurch(
-    @Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
+    //@Token(AuthType.ACCESS) accessPayload: JwtAccessPayload,
+    @User() user: UserModel,
     @Body() dto: CreateChurchDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.churchesService.createChurch(accessPayload, dto, qr);
+    return this.churchesService.createChurch(user, dto, qr);
   }
 
   @ApiOperation({
@@ -117,9 +121,13 @@ export class ChurchesController {
   // 교회 삭제
   @ApiDeleteChurch()
   @ChurchWriteGuard()
+  @UseInterceptors(TransactionInterceptor)
   @Delete(':churchId')
-  deleteChurch(@Param('churchId', ParseIntPipe) churchId: number) {
-    return this.churchesService.deleteChurchById(churchId);
+  deleteChurch(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.churchesService.deleteChurchById(churchId, qr);
   }
 
   @ApiOperation({

--- a/backend/src/churches/service/trial-churches.service.ts
+++ b/backend/src/churches/service/trial-churches.service.ts
@@ -55,6 +55,7 @@ import {
   IMEMBERS_DOMAIN_SERVICE,
   IMembersDomainService,
 } from '../../members/member-domain/interface/members-domain.service.interface';
+import { SubscriptionStatus } from '../../subscription/const/subscription-status.enum';
 
 @Injectable()
 export class TrialChurchesService {
@@ -110,7 +111,11 @@ export class TrialChurchesService {
     );
 
     // 무료 체험 활성화
-    await this.subscriptionDomainService.activateSubscription(subscription, qr);
+    await this.subscriptionDomainService.updateSubscriptionStatus(
+      subscription,
+      SubscriptionStatus.ACTIVE,
+      qr,
+    );
 
     const ownerMember = await this.membersDomainService.createMember(
       newTrialChurch,
@@ -191,10 +196,15 @@ export class TrialChurchesService {
     await this.userDomainService.updateUser(user, { role: UserRole.NONE }, qr);
 
     const subscription =
-      await this.subscriptionDomainService.findActivatedSubscription(user, qr);
+      await this.subscriptionDomainService.findSubscriptionModelByStatus(
+        user,
+        SubscriptionStatus.ACTIVE,
+        qr,
+      );
 
-    await this.subscriptionDomainService.deactivateSubscription(
+    await this.subscriptionDomainService.updateSubscriptionStatus(
       subscription,
+      SubscriptionStatus.PENDING,
       qr,
     );
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -31,7 +31,7 @@ async function bootstrap() {
     new XssSanitizerPipe(),
   );
 
-  //app.useGlobalFilters(new TypeOrmExceptionFilter());
+  app.useGlobalFilters(new TypeOrmExceptionFilter());
 
   app.useGlobalGuards(new GetHandlerGuard());
 

--- a/backend/src/permission/guard/church-manager.guard.ts
+++ b/backend/src/permission/guard/church-manager.guard.ts
@@ -42,6 +42,8 @@ export class ChurchManagerGuard implements CanActivate {
       { subscription: true },
     );
 
+    console.log(church);
+
     req.requestManager =
       await this.managerDomainService.findManagerForPermissionCheck(
         church,

--- a/backend/src/subscription/const/plan-amount.enum.ts
+++ b/backend/src/subscription/const/plan-amount.enum.ts
@@ -1,7 +1,9 @@
-export enum PlanAmount {
-  FREE_TRIAL = 0,
-  BASIC = 49_000,
-  STANDARD = 79_000,
-  PLUS = 129_000,
-  PREMIUM = 199_000,
-}
+import { SubscriptionPlan } from './subscription-plan.enum';
+
+export const PlanAmount = {
+  [SubscriptionPlan.FREE_TRIAL]: 0,
+  [SubscriptionPlan.BASIC]: 49_000,
+  [SubscriptionPlan.STANDARD]: 79_000,
+  [SubscriptionPlan.PLUS]: 129_000,
+  [SubscriptionPlan.PREMIUM]: 199_000,
+};

--- a/backend/src/subscription/const/plan-member-size.enum.ts
+++ b/backend/src/subscription/const/plan-member-size.enum.ts
@@ -1,7 +1,9 @@
-export enum PlanMemberSize {
-  FREE_TRIAL = 50,
-  BASIC = 300,
-  STANDARD = 500,
-  PLUS = 1000,
-  PREMIUM = 3000,
-}
+import { SubscriptionPlan } from './subscription-plan.enum';
+
+export const PlanMemberSize = {
+  [SubscriptionPlan.FREE_TRIAL]: 50,
+  [SubscriptionPlan.BASIC]: 300,
+  [SubscriptionPlan.STANDARD]: 500,
+  [SubscriptionPlan.PLUS]: 1000,
+  [SubscriptionPlan.PREMIUM]: 3000,
+};

--- a/backend/src/subscription/const/subscription-status.enum.ts
+++ b/backend/src/subscription/const/subscription-status.enum.ts
@@ -1,7 +1,15 @@
 export enum SubscriptionStatus {
-  PENDING = 'pending', // 구독 생성, 교회 미생성
+  PENDING = 'pending', // 구독 생성, 교회 미생성, 교회 생성 가능
   ACTIVE = 'active', // 구독 생성, 교회 생성
-  CANCELED = 'canceled', // 구독 즉시 취소 (환불)
-  EXPIRED = 'expired', // 구독 만료
-  FAILED = 'failed', // 정기 결제 실패
+  CANCELED = 'canceled', // 구독 취소 상태, 다음 정기 결제에서 제외, currentPeriodEnd 도달 전까지는 ACTIVE 와 동일한 규칙, 이후 EXPIRED
+  FAILED = 'failed', // 정기 결제 실패, currentPeriodEnd 도달 전까지는 ACTIVE 와 동일한 규칙, 이후 EXPIRED, 재시도하여 성공하면 ACTIVE
+  EXPIRED = 'expired', // 구독 만료, isCurrent 가 항상 false
 }
+
+export const SubscriptionStatusName = {
+  [SubscriptionStatus.PENDING]: '대기',
+  [SubscriptionStatus.ACTIVE]: '활성',
+  [SubscriptionStatus.CANCELED]: '취소',
+  [SubscriptionStatus.FAILED]: '정기 결제 실패',
+  [SubscriptionStatus.EXPIRED]: '종료',
+};

--- a/backend/src/subscription/controller/subscription.controller.ts
+++ b/backend/src/subscription/controller/subscription.controller.ts
@@ -18,19 +18,30 @@ import { SubscribePlanDto } from '../dto/request/subscribe-plan.dto';
 import { UserGuard } from '../../user/guard/user.guard';
 import { User } from '../../user/decorator/user.decorator';
 import { UserModel } from '../../user/entity/user.entity';
+import { UpdatePaymentMethodDto } from '../dto/request/update-payment-method.dto';
+import { SubscriptionCronService } from '../service/subscription-cron.service';
 
 @Controller()
 export class SubscriptionController {
-  constructor(private readonly subscriptionService: SubscriptionService) {}
+  constructor(
+    private readonly subscriptionService: SubscriptionService,
+    private readonly subscriptionCronService: SubscriptionCronService,
+  ) {}
 
-  @ApiOperation({ summary: '정기 결제 중인 구독 조회' })
+  @ApiOperation({
+    summary: '정기 결제 중인 구독 조회',
+    description: '현재 구독 (EXPIRED 제외)',
+  })
   @Get('current')
   @UseGuards(AccessTokenGuard, UserGuard)
   getSubscription(@User() user: UserModel) {
     return this.subscriptionService.getCurrentSubscription(user);
   }
 
-  @ApiOperation({ summary: '무료 체험 신청' })
+  @ApiOperation({
+    summary: '무료 체험 신청',
+    description: '체험 이력이 없고, 교회에 가입되지 않은 계정만 가능',
+  })
   @Post('trial')
   @UseGuards(AccessTokenGuard, UserGuard)
   @UseInterceptors(TransactionInterceptor)
@@ -38,37 +49,90 @@ export class SubscriptionController {
     return this.subscriptionService.startFreeTrial(user, qr);
   }
 
-  @ApiOperation({ summary: '구독 신청' })
+  @ApiOperation({
+    summary: '구독 신청',
+    description:
+      '<p>구독을 생성합니다.</p>' +
+      '<p>계정의 구독이 CANCELED 일 때 어떻게 해야 함?? Exception(거부) or 생성하고 기존 교회에 연결?</p>' +
+      '<p>기존 소유한 교회가 있을 경우 해당 교회와 연결합니다.</p>',
+  })
   @Post('subscribe')
+  @UseInterceptors(TransactionInterceptor)
   @UseGuards(AccessTokenGuard, UserGuard)
-  subscribePlan(@User() user: UserModel, @Body() dto: SubscribePlanDto) {
-    return this.subscriptionService.subscribePlan(user, dto);
+  subscribePlan(
+    @User() user: UserModel,
+    @Body() dto: SubscribePlanDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.subscriptionService.subscribePlan(user, dto, qr);
   }
 
-  @ApiOperation({ summary: '구독 플랜 업그레이드' })
+  @ApiOperation({
+    summary: '결제 수동 재시도',
+    description: '현재 구독의 status 가 FAILED 일떄만 사용 가능합니다.',
+  })
+  @UseInterceptors(TransactionInterceptor)
+  @Post('retry')
+  @UseGuards(AccessTokenGuard, UserGuard)
+  retryPurchase(@User() user: UserModel, @QueryRunner() qr: QR) {
+    return this.subscriptionService.retryPurchase(user, qr);
+  }
+
+  @ApiOperation({
+    summary: '결제 수단 변경',
+    description:
+      '기존 Bill Key 를 삭제하고 새로 발급 받아 구독 정보를 업데이트',
+  })
+  @Patch('payment-method')
+  @UseGuards(AccessTokenGuard, UserGuard)
+  @UseInterceptors(TransactionInterceptor)
+  updatePaymentMethod(
+    @User() user: UserModel,
+    @Body() dto: UpdatePaymentMethodDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.subscriptionService.updatePaymentMethod(user, dto, qr);
+  }
+
+  @ApiOperation({ summary: '구독 플랜 업그레이드 (미구현)' })
   @Patch('upgrade')
   @UseGuards(AccessTokenGuard, UserGuard)
   upgradePlan(@User() user: UserModel) {}
 
-  @ApiOperation({ summary: '구독 플랜 다운그레이드' })
+  @ApiOperation({ summary: '구독 플랜 다운그레이드 (미구현)' })
   @Patch('downgrade')
   @UseGuards(AccessTokenGuard, UserGuard)
   downgradePlan(@User() user: UserModel) {}
 
-  @ApiOperation({ summary: '구독 플랜 취소' })
+  @ApiOperation({
+    summary: '구독 플랜 취소',
+    description:
+      '<p>구독 취소합니다. 남은 기간동안 ACTIVE 와 동일한 권리를 갖습니다.</p>',
+  })
   @Delete('cancel')
+  @UseInterceptors(TransactionInterceptor)
   @UseGuards(AccessTokenGuard, UserGuard)
-  cancelPlan(@User() user: UserModel) {}
+  cancelPlan(@User() user: UserModel, @QueryRunner() qr: QR) {
+    return this.subscriptionService.cancelSubscription(user, qr);
+  }
 
-  @ApiOperation({ summary: '구독 즉시 만료' })
+  @ApiOperation({
+    summary: '구독 즉시 만료 (개발용)',
+    description:
+      '<p>취소된 구독의 만료 날짜를 현재로 수정 후 status 를 EXPIRED 로 변경합니다.</p>' +
+      '<p>만료된 상황을 테스트하기 위한 엔드포인트입니다.</p>',
+  })
   @Delete('expire')
+  @UseInterceptors(TransactionInterceptor)
   @UseGuards(AccessTokenGuard, UserGuard)
-  expirePlan(@User() user: UserModel) {}
+  expirePlan(@User() user: UserModel, @QueryRunner() qr: QR) {
+    return this.subscriptionService.expireSubscription(user, qr);
+  }
 
   @ApiOperation({ summary: '만료된 무료 체험 데이터 삭제' })
   @Delete('cleanup/manual/expired-trials')
   @UseInterceptors(TransactionInterceptor)
   cleanupExpiredTrials(@QueryRunner() qr: QR) {
-    return this.subscriptionService.cleanupExpiredTrialsManual(qr);
+    return this.subscriptionCronService.cleanupExpiredTrialsManual(qr);
   }
 }

--- a/backend/src/subscription/dto/request/update-payment-method.dto.ts
+++ b/backend/src/subscription/dto/request/update-payment-method.dto.ts
@@ -1,0 +1,52 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean } from 'class-validator';
+import { EncData } from './subscribe-plan.dto';
+
+export class UpdatePaymentMethodDto extends EncData {
+  @ApiProperty({
+    description: '테스트 환경 여부',
+    default: true,
+  })
+  @IsBoolean()
+  isTest: boolean = true;
+  /*
+  @ApiProperty({
+    description: '카드번호, 숫자만 입력',
+    example: '1234123412341234',
+  })
+  @IsString()
+  @Length(16, 16)
+  cardNo: string;
+
+  @ApiProperty({
+    description: '유효기간(년, YY)',
+    example: '25',
+  })
+  @IsString()
+  @Length(2, 2)
+  expYear: string;
+
+  @ApiProperty({
+    description: '유효기간(월, MM)',
+    example: '09',
+  })
+  @IsString()
+  @Length(2, 2)
+  expMonth: string;
+
+  @ApiProperty({
+    description: '생년월일(YYMMDD) or 사업자번호(10자리)',
+    example: '000101',
+  })
+  @IsString()
+  @Length(6, 10)
+  idNo: string;
+
+  @ApiProperty({
+    description: '카드 비밀번호 앞 2자리',
+    example: '00',
+  })
+  @IsString()
+  @Length(2, 2)
+  cardPw: string;*/
+}

--- a/backend/src/subscription/entity/order.entity.ts
+++ b/backend/src/subscription/entity/order.entity.ts
@@ -1,0 +1,5 @@
+import { BaseModel } from '../../common/entity/base.entity';
+import { Entity } from 'typeorm';
+
+@Entity()
+export class OrderModel extends BaseModel {}

--- a/backend/src/subscription/entity/subscription.entity.ts
+++ b/backend/src/subscription/entity/subscription.entity.ts
@@ -12,6 +12,7 @@ import { SubscriptionPlan } from '../const/subscription-plan.enum';
 import { SubscriptionStatus } from '../const/subscription-status.enum';
 import { BillingCycle } from '../const/billing-cycle.enum';
 import { ChurchModel } from '../../churches/entity/church.entity';
+import { Exclude } from 'class-transformer';
 
 @Entity()
 export class SubscriptionModel extends BaseModel {
@@ -21,9 +22,6 @@ export class SubscriptionModel extends BaseModel {
   })
   church: ChurchModel | null;
 
-  @Column({ default: true })
-  isCurrent: boolean;
-
   @Index()
   @Column({ nullable: true })
   userId: number | null;
@@ -31,6 +29,9 @@ export class SubscriptionModel extends BaseModel {
   @ManyToOne(() => UserModel, { onDelete: 'SET NULL', nullable: true })
   @JoinColumn({ name: 'userId' })
   user: UserModel | null;
+
+  @Column({ default: true })
+  isCurrent: boolean;
 
   @Column()
   currentPlan: SubscriptionPlan;
@@ -66,6 +67,7 @@ export class SubscriptionModel extends BaseModel {
   maxMembers: number;
 
   @Column({ type: 'varchar', comment: '정기 결제 빌키', nullable: true })
+  @Exclude({ toPlainOnly: true })
   bid: string | null;
 
   @Column({ type: 'timestamptz', nullable: true })

--- a/backend/src/subscription/exception/order.exception.ts
+++ b/backend/src/subscription/exception/order.exception.ts
@@ -1,0 +1,3 @@
+export const OrderException = {
+  FAIL_PAYMENT: '결제에 실패했습니다. 잠시후 다시 시도해주세요.',
+};

--- a/backend/src/subscription/exception/subscription.exception.ts
+++ b/backend/src/subscription/exception/subscription.exception.ts
@@ -1,14 +1,22 @@
+import {
+  SubscriptionStatus,
+  SubscriptionStatusName,
+} from '../const/subscription-status.enum';
+
 export const SubscriptionException = {
   INACTIVE_SUBSCRIPTION: '구독이 활성 상태가 아닙니다.',
+
+  NOT_FOUND: (status?: SubscriptionStatus) =>
+    `${status ? SubscriptionStatusName[status] + ' 상태의 ' : ''}구독 정보를 찾을 수 없습니다.`,
 
   EXPIRE_FREE_TRIAL: '무료 체험 기간이 만료되었습니다.',
   EXPIRE_SUBSCRIPTION: '구독 기간이 만료되었습니다. 구독을 갱신해주세요.',
 
+  BILL_KEY_UPDATE_ERROR: '결제 수단 업데이트 도중 에러 발생',
+
   FAIL_LOAD_SUBSCRIPTION: '구독 정보 누락',
   EXPIRE_SUBSCRIPTION_ERROR: '구독 만료 처리 중 에러 발생',
   UNAVAILABLE_PLAN: '신청할 수 없는 구독 플랜입니다.',
-  ACTIVE_NOT_FOUND: '활성 상태 구독 정보를 찾을 수 없습니다.',
-  NOT_FOUND: '구독 정보를 찾을 수 없습니다.',
   ALREADY_EXIST: '현재 진행 중인 구독이 존재합니다.',
   FAIL_CANCEL_SUBSCRIPTION: '구독 취소 실패. 잠시후 다시 시도해주세요.',
 

--- a/backend/src/subscription/guard/subscription.guard.ts
+++ b/backend/src/subscription/guard/subscription.guard.ts
@@ -11,7 +11,6 @@ import {
 } from '../../churches/churches-domain/interface/churches-domain.service.interface';
 import { CustomRequest } from '../../common/custom-request';
 import { SubscriptionException } from '../exception/subscription.exception';
-import { SubscriptionStatus } from '../const/subscription-status.enum';
 
 @Injectable()
 export class SubscriptionGuard implements CanActivate {
@@ -46,9 +45,9 @@ export class SubscriptionGuard implements CanActivate {
       );
     }
 
-    if (subscription.status !== SubscriptionStatus.ACTIVE) {
+    /*if (subscription.status !== SubscriptionStatus.ACTIVE) {
       throw new ForbiddenException(SubscriptionException.INACTIVE_SUBSCRIPTION);
-    }
+    }*/
     const now = new Date();
 
     if (church.isFreeTrial) {

--- a/backend/src/subscription/service/order.service.ts
+++ b/backend/src/subscription/service/order.service.ts
@@ -1,0 +1,13 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  IORDER_DOMAIN_SERVICE,
+  IOrderDomainService,
+} from '../subscription-domain/interface/order-domain.service.interface';
+
+@Injectable()
+export class OrderService {
+  constructor(
+    @Inject(IORDER_DOMAIN_SERVICE)
+    private readonly orderService: IOrderDomainService,
+  ) {}
+}

--- a/backend/src/subscription/service/pg.service.ts
+++ b/backend/src/subscription/service/pg.service.ts
@@ -12,9 +12,13 @@ export class PgService {
       .join('&');
 
     if (isTest) {
-      return '23DSFHFD381294';
+      return Date.now().toString();
     }
 
     throw new InternalServerErrorException('아직 PG API 연결 안함');
+  }
+
+  async expireBillKey(billKey: string) {
+    return 'expired';
   }
 }

--- a/backend/src/subscription/service/subscription-cron.service.ts
+++ b/backend/src/subscription/service/subscription-cron.service.ts
@@ -1,0 +1,70 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DataSource, QueryRunner } from 'typeorm';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import {
+  ISUBSCRIPTION_DOMAIN_SERVICE,
+  ISubscriptionDomainService,
+} from '../subscription-domain/interface/subscription-domain.service.interface';
+import {
+  IUSER_DOMAIN_SERVICE,
+  IUserDomainService,
+} from '../../user/user-domain/interface/user-domain.service.interface';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+
+@Injectable()
+export class SubscriptionCronService {
+  constructor(
+    private readonly dataSource: DataSource,
+
+    @Inject(IUSER_DOMAIN_SERVICE)
+    private readonly userDomainService: IUserDomainService,
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(ISUBSCRIPTION_DOMAIN_SERVICE)
+    private readonly subscriptionDomainService: ISubscriptionDomainService,
+  ) {}
+
+  async cleanupExpiredTrialsManual(qr: QueryRunner) {
+    const expiredTrials =
+      await this.subscriptionDomainService.findExpiredTrials(qr);
+
+    const expiredUserIds = expiredTrials
+      .filter((trial) => trial.userId)
+      .map((trial) => trial.userId) as number[];
+
+    await this.userDomainService.expireTrials(expiredUserIds, qr);
+
+    const expiredChurches = expiredTrials
+      .filter((trial) => trial.church)
+      .map((trial) => trial.church) as ChurchModel[];
+
+    await this.churchesDomainService.cleanupExpiredTrials(expiredChurches, qr);
+
+    await this.subscriptionDomainService.expireTrialSubscriptions(
+      expiredTrials,
+      qr,
+    );
+
+    return { expiredCount: expiredTrials.length, timestamp: new Date() };
+  }
+
+  //@Cron()
+  async cleanupExpiredTrialsAuto() {
+    const qr = this.dataSource.createQueryRunner();
+    await qr.connect();
+    await qr.startTransaction();
+
+    try {
+      await this.cleanupExpiredTrialsManual(qr);
+
+      await qr.commitTransaction();
+    } catch {
+      await qr.rollbackTransaction();
+    } finally {
+      await qr.release();
+    }
+  }
+}

--- a/backend/src/subscription/subscription-domain/interface/order-domain.service.interface.ts
+++ b/backend/src/subscription/subscription-domain/interface/order-domain.service.interface.ts
@@ -1,0 +1,3 @@
+export const IORDER_DOMAIN_SERVICE = Symbol('IORDER_DOMAIN_SERVICE');
+
+export interface IOrderDomainService {}

--- a/backend/src/subscription/subscription-domain/interface/subscription-domain.service.interface.ts
+++ b/backend/src/subscription/subscription-domain/interface/subscription-domain.service.interface.ts
@@ -12,50 +12,30 @@ export const ISUBSCRIPTION_DOMAIN_SERVICE = Symbol(
 export interface ISubscriptionDomainService {
   createFreeTrial(user: UserModel, qr: QueryRunner): Promise<SubscriptionModel>;
 
-  findSubscriptionByStatus(
+  findSubscriptionModelByStatus(
     user: UserModel,
     status: SubscriptionStatus,
     qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<SubscriptionModel>,
   ): Promise<SubscriptionModel>;
 
-  findTrialSubscription(
+  findAbleToCreateChurchSubscription(
+    ownerUser: UserModel,
+    qr: QueryRunner,
+  ): Promise<SubscriptionModel>;
+
+  findSubscriptionByChurch(church: ChurchModel): Promise<SubscriptionModel>;
+
+  findSubscriptionByUser(
     user: UserModel,
     qr?: QueryRunner,
   ): Promise<SubscriptionModel>;
 
-  findPendingSubscription(
-    user: UserModel,
-    qr?: QueryRunner,
-  ): Promise<SubscriptionModel>;
-
-  activateSubscription(
+  updateSubscriptionStatus(
     subscription: SubscriptionModel,
-    qr: QueryRunner,
-  ): Promise<UpdateResult>;
-
-  findActivatedSubscription(
-    user: UserModel,
+    status: SubscriptionStatus,
     qr?: QueryRunner,
-  ): Promise<SubscriptionModel>;
-
-  deactivateSubscription(
-    subscription: SubscriptionModel,
-    qr: QueryRunner,
   ): Promise<UpdateResult>;
-
-  findCurrentSubscription(church: ChurchModel): Promise<SubscriptionModel>;
-
-  findExpiredTrials(qr: QueryRunner): Promise<SubscriptionModel[]>;
-
-  expireTrialSubscriptions(
-    expiredTrials: SubscriptionModel[],
-    qr: QueryRunner,
-  ): Promise<UpdateResult>;
-
-  findCurrentUserSubscription(
-    user: UserModel,
-    qr?: QueryRunner,
-  ): Promise<SubscriptionModel>;
 
   findSubscriptionModelById(
     user: UserModel,
@@ -68,5 +48,37 @@ export interface ISubscriptionDomainService {
     user: UserModel,
     dto: SubscribePlanDto,
     billKey: string,
+    qr?: QueryRunner,
   ): Promise<SubscriptionModel>;
+
+  updateBillKey(
+    subscription: SubscriptionModel,
+    newBid: string,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  cancelSubscription(
+    subscription: SubscriptionModel,
+    canceledDate: Date,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  expireSubscriptionForTest(
+    subscription: SubscriptionModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  // ---------- 무료 체험 관련 ----------
+
+  findTrialSubscription(
+    user: UserModel,
+    qr?: QueryRunner,
+  ): Promise<SubscriptionModel>;
+
+  findExpiredTrials(qr: QueryRunner): Promise<SubscriptionModel[]>;
+
+  expireTrialSubscriptions(
+    expiredTrials: SubscriptionModel[],
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
 }

--- a/backend/src/subscription/subscription-domain/service/order-domain.service.ts
+++ b/backend/src/subscription/subscription-domain/service/order-domain.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { IOrderDomainService } from '../interface/order-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { OrderModel } from '../../entity/order.entity';
+import { QueryRunner, Repository } from 'typeorm';
+
+@Injectable()
+export class OrderDomainService implements IOrderDomainService {
+  constructor(
+    @InjectRepository(OrderModel)
+    private readonly repository: Repository<OrderModel>,
+  ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr ? qr.manager.getRepository(OrderModel) : this.repository;
+  }
+
+  createOrder() {}
+}

--- a/backend/src/subscription/subscription-domain/subscription-domain.module.ts
+++ b/backend/src/subscription/subscription-domain/subscription-domain.module.ts
@@ -5,19 +5,30 @@ import { ISUBSCRIPTION_DOMAIN_SERVICE } from './interface/subscription-domain.se
 import { SubscriptionDomainService } from './service/subscription-domain.service';
 import { ITEST_SUBSCRIPTION_DOMAIN_SERVICE } from './interface/test-subscription-domain.service.interface';
 import { TestSubscriptionDomainService } from './service/test-subscription-domain.service';
+import { IORDER_DOMAIN_SERVICE } from './interface/order-domain.service.interface';
+import { OrderDomainService } from './service/order-domain.service';
+import { OrderModel } from '../entity/order.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([SubscriptionModel])],
+  imports: [TypeOrmModule.forFeature([SubscriptionModel, OrderModel])],
   providers: [
     {
       provide: ISUBSCRIPTION_DOMAIN_SERVICE,
       useClass: SubscriptionDomainService,
     },
     {
+      provide: IORDER_DOMAIN_SERVICE,
+      useClass: OrderDomainService,
+    },
+    {
       provide: ITEST_SUBSCRIPTION_DOMAIN_SERVICE,
       useClass: TestSubscriptionDomainService,
     },
   ],
-  exports: [ISUBSCRIPTION_DOMAIN_SERVICE, ITEST_SUBSCRIPTION_DOMAIN_SERVICE],
+  exports: [
+    ISUBSCRIPTION_DOMAIN_SERVICE,
+    IORDER_DOMAIN_SERVICE,
+    ITEST_SUBSCRIPTION_DOMAIN_SERVICE,
+  ],
 })
 export class SubscriptionDomainModule {}

--- a/backend/src/subscription/subscription.module.ts
+++ b/backend/src/subscription/subscription.module.ts
@@ -8,6 +8,7 @@ import { ChurchesDomainModule } from '../churches/churches-domain/churches-domai
 import { TestSubscriptionService } from './service/test-subscription.service';
 import { TestSubscriptionController } from './controller/test-subscription.controller';
 import { PgService } from './service/pg.service';
+import { SubscriptionCronService } from './service/subscription-cron.service';
 
 @Module({
   imports: [
@@ -17,6 +18,11 @@ import { PgService } from './service/pg.service';
     SubscriptionDomainModule,
   ],
   controllers: [TestSubscriptionController, SubscriptionController],
-  providers: [SubscriptionService, PgService, TestSubscriptionService],
+  providers: [
+    SubscriptionService,
+    SubscriptionCronService,
+    PgService,
+    TestSubscriptionService,
+  ],
 })
 export class SubscriptionModule {}


### PR DESCRIPTION
## 주요 내용
구독 신청, 결제 재시도, 결제 수단 변경, 구독 취소 및 개발용 만료 기능 구현

## 세부 내용

### 구독 신청 (POST /subscribe/subscribe)
- 구독 정보 생성 및 첫 결제 시도
- 기존 교회가 있는 경우 (만료된 구독 재활성화):
 - 교회와 자동 연결, status → ACTIVE
 - 교인 수가 새 플랜 제한 초과 시 ConflictException
- 교회가 없는 경우:
 - status → PENDING
 - 교회 생성 가능 상태

### 결제 재시도 (POST /subscribe/retry)
- FAILED 상태의 구독만 재시도 가능
- 성공 시:
 - 교회 있음 → ACTIVE
 - 교회 없음 → PENDING

### 결제 수단 변경 (PATCH /subscribe/payment-method)
- 정기 결제용 카드 정보 변경
- 다음 자동 결제부터 새 카드로 청구

### 구독 취소 (DELETE /subscribe/cancel)
- status → CANCELLED
- 자동 결제 정보 삭제
- currentPeriodEnd까지 서비스 이용 가능

### 구독 강제 만료 (DELETE /subscribe/expire)
- 개발/테스트 전용 엔드포인트
- CANCELLED 상태 구독의 currentPeriodEnd → 현재 시각
- isCurrent → false
- 만료 상태 테스트용