### PR TITLE
feat: 구독 복구 기능 추가 및 중복 구독 방지

### DIFF
--- a/backend/src/common/decorator/use-transaction.decorator.ts
+++ b/backend/src/common/decorator/use-transaction.decorator.ts
@@ -1,0 +1,5 @@
+import { applyDecorators, UseInterceptors } from '@nestjs/common';
+import { TransactionInterceptor } from '../interceptor/transaction.interceptor';
+
+export const UseTransaction = () =>
+  applyDecorators(UseInterceptors(TransactionInterceptor));

--- a/backend/src/subscription/entity/subscription.entity.ts
+++ b/backend/src/subscription/entity/subscription.entity.ts
@@ -71,7 +71,7 @@ export class SubscriptionModel extends BaseModel {
   bid: string | null;
 
   @Column({ type: 'timestamptz', nullable: true })
-  canceledAt: Date;
+  canceledAt: Date | null;
 
   @Column({ nullable: true })
   cancellationReason: string;

--- a/backend/src/subscription/exception/subscription.exception.ts
+++ b/backend/src/subscription/exception/subscription.exception.ts
@@ -19,6 +19,7 @@ export const SubscriptionException = {
   UNAVAILABLE_PLAN: '신청할 수 없는 구독 플랜입니다.',
   ALREADY_EXIST: '현재 진행 중인 구독이 존재합니다.',
   FAIL_CANCEL_SUBSCRIPTION: '구독 취소 실패. 잠시후 다시 시도해주세요.',
+  FAIL_RESTORE_SUBSCRIPTION: '구독 재활성화 실패',
 
   // 테스트 상황 에러
   FAIL_EXPIRE_SUBSCRIPTION: '구독 강제 만료 실패',

--- a/backend/src/subscription/service/subscription.service.ts
+++ b/backend/src/subscription/service/subscription.service.ts
@@ -110,6 +110,26 @@ export class SubscriptionService {
     return new PostSubscribePlanResponseDto(newPlan);
   }
 
+  async restoreSubscription(user: UserModel, qr: QueryRunner) {
+    const canceledSubscription =
+      await this.subscriptionDomainService.findSubscriptionModelByStatus(
+        user,
+        SubscriptionStatus.CANCELED,
+        qr,
+        { church: true },
+      );
+
+    const restoreStatus = canceledSubscription.church
+      ? SubscriptionStatus.ACTIVE
+      : SubscriptionStatus.PENDING;
+
+    await this.subscriptionDomainService.restoreSubscription(
+      canceledSubscription,
+      restoreStatus,
+      qr,
+    );
+  }
+
   async retryPurchase(user: UserModel, qr: QueryRunner) {
     const subscription =
       await this.subscriptionDomainService.findSubscriptionModelByStatus(

--- a/backend/src/subscription/subscription-domain/interface/subscription-domain.service.interface.ts
+++ b/backend/src/subscription/subscription-domain/interface/subscription-domain.service.interface.ts
@@ -31,12 +31,6 @@ export interface ISubscriptionDomainService {
     qr?: QueryRunner,
   ): Promise<SubscriptionModel>;
 
-  updateSubscriptionStatus(
-    subscription: SubscriptionModel,
-    status: SubscriptionStatus,
-    qr?: QueryRunner,
-  ): Promise<UpdateResult>;
-
   findSubscriptionModelById(
     user: UserModel,
     subscriptionId: number,
@@ -51,10 +45,22 @@ export interface ISubscriptionDomainService {
     qr?: QueryRunner,
   ): Promise<SubscriptionModel>;
 
+  restoreSubscription(
+    canceledSubscription: SubscriptionModel,
+    restoreStatus: SubscriptionStatus,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
   updateBillKey(
     subscription: SubscriptionModel,
     newBid: string,
     qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  updateSubscriptionStatus(
+    subscription: SubscriptionModel,
+    status: SubscriptionStatus,
+    qr?: QueryRunner,
   ): Promise<UpdateResult>;
 
   cancelSubscription(


### PR DESCRIPTION
## 주요 내용
취소된 구독 복구 기능 추가 및 CANCELLED 상태에서 신규 구독 차단

## 세부 내용

### 구독 복구 (POST /subscribe/restore)
- CANCELLED 상태 구독만 복구 가능
- 자동 결제 재활성화
- 복구 후 상태:
 - 교회 연결됨 → ACTIVE
 - 교회 없음 → PENDING

### 구독 신청 로직 개선
- CANCELLED 상태 구독이 있으면 신규 구독 차단
- 기존 구독 복구 유도 (restore 사용)
- 중복 구독 방지