### PR TITLE
refactor: 구독 결제 상태 관리 개선 - FAILED 상태 제거

### DIFF
--- a/backend/src/churches/service/churches.service.ts
+++ b/backend/src/churches/service/churches.service.ts
@@ -145,6 +145,7 @@ export class ChurchesService {
   }
 
   // TODO 구독 상태에 따른 교회 삭제 후 처리 로직 필요
+  // TODO 삭제 시 가입된 관리자들 처리 로직 필요
   async deleteChurchById(id: number, qr: QueryRunner) {
     const church = await this.churchesDomainService.findChurchModelById(
       id,
@@ -169,6 +170,7 @@ export class ChurchesService {
     const ownerUser = await this.userDomainService.findUserModelById(
       church.ownerUserId,
     );
+
     await this.userDomainService.updateUser(
       ownerUser,
       { role: UserRole.NONE },

--- a/backend/src/subscription/const/subscription-status.enum.ts
+++ b/backend/src/subscription/const/subscription-status.enum.ts
@@ -2,7 +2,7 @@ export enum SubscriptionStatus {
   PENDING = 'pending', // 구독 생성, 교회 미생성, 교회 생성 가능
   ACTIVE = 'active', // 구독 생성, 교회 생성
   CANCELED = 'canceled', // 구독 취소 상태, 다음 정기 결제에서 제외, currentPeriodEnd 도달 전까지는 ACTIVE 와 동일한 규칙, 이후 EXPIRED
-  FAILED = 'failed', // 정기 결제 실패, currentPeriodEnd 도달 전까지는 ACTIVE 와 동일한 규칙, 이후 EXPIRED, 재시도하여 성공하면 ACTIVE
+  //FAILED = 'failed', // 정기 결제 실패, currentPeriodEnd 도달 전까지는 ACTIVE 와 동일한 규칙, 이후 EXPIRED, 재시도하여 성공하면 ACTIVE
   EXPIRED = 'expired', // 구독 만료, isCurrent 가 항상 false
 }
 
@@ -10,6 +10,6 @@ export const SubscriptionStatusName = {
   [SubscriptionStatus.PENDING]: '대기',
   [SubscriptionStatus.ACTIVE]: '활성',
   [SubscriptionStatus.CANCELED]: '취소',
-  [SubscriptionStatus.FAILED]: '정기 결제 실패',
+  //[SubscriptionStatus.FAILED]: '정기 결제 실패',
   [SubscriptionStatus.EXPIRED]: '종료',
 };

--- a/backend/src/subscription/entity/subscription.entity.ts
+++ b/backend/src/subscription/entity/subscription.entity.ts
@@ -51,6 +51,9 @@ export class SubscriptionModel extends BaseModel {
   @Column({ type: 'timestamptz', nullable: true })
   nextBillingDate: Date | null;
 
+  @Column({ default: false })
+  paymentSuccess: boolean;
+
   @Column({ nullable: true })
   amount: number;
 

--- a/backend/src/subscription/exception/subscription.exception.ts
+++ b/backend/src/subscription/exception/subscription.exception.ts
@@ -5,6 +5,8 @@ import {
 
 export const SubscriptionException = {
   INACTIVE_SUBSCRIPTION: '구독이 활성 상태가 아닙니다.',
+  FAILED_NOT_FOUND: '결제 실패 상태의 구독이 없습니다.',
+  PAYMENT_SUCCESS_UPDATE_ERROR: '결제 상태 업데이트 도중 에러 발생',
 
   NOT_FOUND: (status?: SubscriptionStatus) =>
     `${status ? SubscriptionStatusName[status] + ' 상태의 ' : ''}구독 정보를 찾을 수 없습니다.`,

--- a/backend/src/subscription/service/subscription.service.ts
+++ b/backend/src/subscription/service/subscription.service.ts
@@ -132,24 +132,18 @@ export class SubscriptionService {
 
   async retryPurchase(user: UserModel, qr: QueryRunner) {
     const subscription =
-      await this.subscriptionDomainService.findSubscriptionModelByStatus(
+      await this.subscriptionDomainService.findFailedSubscriptionModel(
         user,
-        SubscriptionStatus.FAILED,
         qr,
-        { church: true },
       );
 
     try {
       // 결제 시도 | 반환값: 결제 내역
       // const order = await this.orderService.payment(subscription, user, paymentDto ...)
 
-      const status = subscription.church
-        ? SubscriptionStatus.ACTIVE
-        : SubscriptionStatus.PENDING;
-
-      await this.subscriptionDomainService.updateSubscriptionStatus(
+      await this.subscriptionDomainService.updatePaymentSuccess(
         subscription,
-        status,
+        true,
         qr,
       );
 

--- a/backend/src/subscription/subscription-domain/interface/subscription-domain.service.interface.ts
+++ b/backend/src/subscription/subscription-domain/interface/subscription-domain.service.interface.ts
@@ -19,6 +19,12 @@ export interface ISubscriptionDomainService {
     relationOptions?: FindOptionsRelations<SubscriptionModel>,
   ): Promise<SubscriptionModel>;
 
+  findFailedSubscriptionModel(
+    user: UserModel,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<SubscriptionModel>,
+  ): Promise<SubscriptionModel>;
+
   findAbleToCreateChurchSubscription(
     ownerUser: UserModel,
     qr: QueryRunner,
@@ -49,6 +55,12 @@ export interface ISubscriptionDomainService {
     canceledSubscription: SubscriptionModel,
     restoreStatus: SubscriptionStatus,
     qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  updatePaymentSuccess(
+    subscription: SubscriptionModel,
+    value: boolean,
+    qr?: QueryRunner,
   ): Promise<UpdateResult>;
 
   updateBillKey(


### PR DESCRIPTION
## 주요 내용
SubscriptionStatus에서 FAILED 제거하고 paymentSuccess 필드로 결제 상태 분리

## 세부 내용

### 구독 상태 관리 변경
- SubscriptionStatus.FAILED 제거
- paymentSuccess 컬럼 추가 (boolean)
- 구독 라이프사이클과 결제 성공 여부 분리

### 결제 실패 처리
- 자동 결제 실패 시 paymentSuccess → false
- status는 기존 상태 유지 (ACTIVE/CANCELLED)
- 결제 재시도는 paymentSuccess가 false인 구독만 가능

### 개선 효과
- 결제 재시도 후 이전 상태 복구 문제 해결
- 구독 상태와 결제 상태의 명확한 분리
- 상태 관리 로직 단순화