### PR TITLE
feat: 결제 수단 관리 도메인 추가 및 결제 로직 분리

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -77,6 +77,8 @@ import { SubscriptionModule } from './subscription/subscription.module';
 import { DummyDataModule } from './dummy-data/dummy-data.module';
 import { ScheduleModule } from '@nestjs/schedule';
 import { OrderModel } from './subscription/entity/order.entity';
+import { PaymentMethodModel } from './payment-method/entity/payment-method.entity';
+import { PaymentMethodModule } from './payment-method/payment-method.module';
 
 //import { EducationTermReportModel } from './report/education-report/entity/education-term-report.entity';
 
@@ -148,6 +150,7 @@ import { OrderModel } from './subscription/entity/order.entity';
           // 구독 관련
           SubscriptionModel,
           OrderModel,
+          PaymentMethodModel,
           // 유저 관련 엔티티
           TempUserModel,
           UserModel,
@@ -222,6 +225,7 @@ import { OrderModel } from './subscription/entity/order.entity';
     MyPageModule,
     ReportModule,
     UserModule,
+    PaymentMethodModule,
     SubscriptionModule,
     ChurchesModule,
     ChurchJoinModule,

--- a/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
+++ b/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
@@ -75,9 +75,9 @@ export interface IChurchesDomainService {
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 
-  getChurchManagerIds(churchId: number, qr?: QueryRunner): Promise<number[]>;
+  //getChurchManagerIds(churchId: number, qr?: QueryRunner): Promise<number[]>;
 
-  getChurchOwnerIds(churchId: number, qr?: QueryRunner): Promise<number[]>;
+  //getChurchOwnerIds(churchId: number, qr?: QueryRunner): Promise<number[]>;
 
   updateChurchJoinCode(
     church: ChurchModel,

--- a/backend/src/churches/churches-domain/service/churhes-domain.service.ts
+++ b/backend/src/churches/churches-domain/service/churhes-domain.service.ts
@@ -18,7 +18,6 @@ import {
 import { ChurchModel, ManagementCountType } from '../../entity/church.entity';
 import { UpdateChurchDto } from '../../dto/update-church.dto';
 import { InjectRepository } from '@nestjs/typeorm';
-import { ChurchUserRole } from '../../../user/const/user-role.enum';
 import { RequestLimitValidationType } from '../../../request-info/types/request-limit-validation-result';
 import { ChurchException } from '../../const/exception/church.exception';
 import { UserModel } from '../../../user/entity/user.entity';
@@ -125,7 +124,7 @@ export class ChurchesDomainService implements IChurchesDomainService {
         joinCode: null,
         subscriptionId: null,
         deletedAt: new Date(),
-        //ownerUserId: null,
+        ownerUserId: null,
       },
     );
 
@@ -360,7 +359,7 @@ export class ChurchesDomainService implements IChurchesDomainService {
     return result;
   }
 
-  async getChurchOwnerIds(
+  /*async getChurchOwnerIds(
     churchId: number,
     qr?: QueryRunner,
   ): Promise<number[]> {
@@ -377,9 +376,9 @@ export class ChurchesDomainService implements IChurchesDomainService {
     }
 
     return [church.ownerUserId];
-  }
+  }*/
 
-  async getChurchManagerIds(
+  /*async getChurchManagerIds(
     churchId: number,
     qr?: QueryRunner,
   ): Promise<number[]> {
@@ -405,7 +404,7 @@ export class ChurchesDomainService implements IChurchesDomainService {
           user.role === ChurchUserRole.OWNER,
       )
       .map((manager) => manager.id);
-  }
+  }*/
 
   async incrementMemberCount(
     church: ChurchModel,

--- a/backend/src/churches/controller/churches.controller.ts
+++ b/backend/src/churches/controller/churches.controller.ts
@@ -124,10 +124,12 @@ export class ChurchesController {
   @UseInterceptors(TransactionInterceptor)
   @Delete(':churchId')
   deleteChurch(
+    @User() user: UserModel,
+    @RequestChurch() church: ChurchModel,
     @Param('churchId', ParseIntPipe) churchId: number,
     @QueryRunner() qr: QR,
   ) {
-    return this.churchesService.deleteChurchById(churchId, qr);
+    return this.churchesService.deleteChurchById(church, user, qr);
   }
 
   @ApiOperation({

--- a/backend/src/churches/entity/church.entity.ts
+++ b/backend/src/churches/entity/church.entity.ts
@@ -71,11 +71,11 @@ export class ChurchModel extends BaseModel {
 
   @Index()
   @Column({ nullable: true })
-  ownerUserId: number;
+  ownerUserId: number | null;
 
-  @OneToOne(() => UserModel, (user) => user.ownedChurch)
+  @OneToOne(() => UserModel, (user) => user.ownedChurch, { nullable: true })
   @JoinColumn({ name: 'ownerUserId' })
-  ownerUser: UserModel;
+  ownerUser: UserModel | null;
 
   @OneToMany(() => ChurchUserModel, (churchUser) => churchUser.church)
   churchUsers: ChurchUserModel[];

--- a/backend/src/churches/guard/church-write.guard.ts
+++ b/backend/src/churches/guard/church-write.guard.ts
@@ -2,8 +2,9 @@ import { applyDecorators, UseGuards } from '@nestjs/common';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
 import { SubscriptionGuard } from '../../subscription/guard/subscription.guard';
 import { ChurchOwnerGuard } from '../../permission/guard/church-owner.guard';
+import { UserGuard } from '../../user/guard/user.guard';
 
 export const ChurchWriteGuard = () =>
   applyDecorators(
-    UseGuards(AccessTokenGuard, ChurchOwnerGuard, SubscriptionGuard),
+    UseGuards(AccessTokenGuard, UserGuard, ChurchOwnerGuard, SubscriptionGuard),
   );

--- a/backend/src/churches/service/churches.service.ts
+++ b/backend/src/churches/service/churches.service.ts
@@ -146,14 +146,21 @@ export class ChurchesService {
 
   // TODO 구독 상태에 따른 교회 삭제 후 처리 로직 필요
   // TODO 삭제 시 가입된 관리자들 처리 로직 필요
-  async deleteChurchById(id: number, qr: QueryRunner) {
-    const church = await this.churchesDomainService.findChurchModelById(
+  async deleteChurchById(
+    //id: number,
+    church: ChurchModel,
+    user: UserModel,
+    qr: QueryRunner,
+  ) {
+    /*const church = await this.churchesDomainService.findChurchModelById(
       id,
       qr,
       { subscription: true },
-    );
+    );*/
 
-    const subscription = church.subscription;
+    //const subscription = church.subscription;
+    const subscription =
+      await this.subscriptionDomainService.findSubscriptionByChurch(church, qr);
 
     if (
       subscription &&
@@ -167,12 +174,13 @@ export class ChurchesService {
       );
     }
 
-    const ownerUser = await this.userDomainService.findUserModelById(
+    /*const ownerUser = await this.userDomainService.findUserModelById(
       church.ownerUserId,
-    );
+    );*/
 
     await this.userDomainService.updateUser(
-      ownerUser,
+      //ownerUser,
+      user,
       { role: UserRole.NONE },
       qr,
     );
@@ -189,6 +197,10 @@ export class ChurchesService {
       churchId,
       qr,
     );
+
+    if (!church.ownerUserId) {
+      throw new ConflictException('교회 소유자 누락');
+    }
 
     const oldOwnerUser = await this.userDomainService.findUserModelById(
       church.ownerUserId,

--- a/backend/src/payment-method/controller/payment-method.controller.ts
+++ b/backend/src/payment-method/controller/payment-method.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { UserGuard } from '../../user/guard/user.guard';
+import { User } from '../../user/decorator/user.decorator';
+import { UserModel } from '../../user/entity/user.entity';
+import { PaymentMethodService } from '../service/payment-method.service';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { UpdatePaymentMethodDto } from '../dto/request/update-payment-method.dto';
+import { CreatePaymentMethodDto } from '../dto/request/create-payment-method.dto';
+import { UseTransaction } from '../../common/decorator/use-transaction.decorator';
+import { QueryRunner } from '../../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm';
+
+@ApiTags('Payment Method')
+@Controller()
+export class PaymentMethodController {
+  constructor(private readonly paymentMethodService: PaymentMethodService) {}
+
+  @ApiOperation({
+    summary: '등록된 결제 수단 조회',
+    description: '등록된 결제 수단을 조회합니다.',
+  })
+  @Get()
+  @UseGuards(AccessTokenGuard, UserGuard)
+  getPaymentMethod(@User() user: UserModel) {
+    return this.paymentMethodService.getUserPaymentMethod(user);
+  }
+
+  @ApiOperation({
+    summary: '결제 수단 등록',
+    description: '결제 수단을 등록합니다. 최대 1개 가능',
+  })
+  @Post()
+  @UseGuards(AccessTokenGuard, UserGuard)
+  @UseTransaction()
+  postPaymentMethod(
+    @User() user: UserModel,
+    @Body() dto: CreatePaymentMethodDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.paymentMethodService.postPaymentMethod(user, dto, qr);
+  }
+
+  @ApiOperation({
+    summary: '결제 수단 변경',
+    description:
+      '기존 Bill Key 를 삭제하고 새로 발급 받아 구독 정보를 업데이트',
+  })
+  @Patch()
+  @UseGuards(AccessTokenGuard, UserGuard)
+  @UseTransaction()
+  patchPaymentMethod(
+    @User() user: UserModel,
+    @Body() dto: UpdatePaymentMethodDto,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.paymentMethodService.patchPaymentMethod(user, dto, qr);
+  }
+
+  @ApiOperation({
+    summary: '결제 수단 삭제',
+    description: '등록된 결제 수단을 삭제합니다.',
+  })
+  @Delete()
+  @UseGuards(AccessTokenGuard, UserGuard)
+  @UseTransaction()
+  deletePaymentMethod(@User() user: UserModel, @QueryRunner() qr: QR) {
+    return this.paymentMethodService.deletePaymentMethod(user, qr);
+  }
+}

--- a/backend/src/payment-method/dto/enc-data.dto.ts
+++ b/backend/src/payment-method/dto/enc-data.dto.ts
@@ -1,15 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean } from 'class-validator';
-import { EncData } from './subscribe-plan.dto';
+import { IsString, Length } from 'class-validator';
 
-export class UpdatePaymentMethodDto extends EncData {
-  @ApiProperty({
-    description: '테스트 환경 여부',
-    default: true,
-  })
-  @IsBoolean()
-  isTest: boolean = true;
-  /*
+export class EncData {
   @ApiProperty({
     description: '카드번호, 숫자만 입력',
     example: '1234123412341234',
@@ -48,5 +40,5 @@ export class UpdatePaymentMethodDto extends EncData {
   })
   @IsString()
   @Length(2, 2)
-  cardPw: string;*/
+  cardPw: string;
 }

--- a/backend/src/payment-method/dto/external/expire-bill-key-response.dto.ts
+++ b/backend/src/payment-method/dto/external/expire-bill-key-response.dto.ts
@@ -1,0 +1,30 @@
+import { IsDate, IsString } from 'class-validator';
+
+export class ExpireBillKeyResponseDto {
+  @IsString()
+  public readonly resultCode: string;
+
+  @IsString()
+  public readonly resultMsg: string;
+
+  @IsString()
+  public readonly tid: string;
+
+  @IsString()
+  public readonly orderId: string;
+
+  @IsString()
+  public readonly bid: string;
+
+  @IsDate()
+  public readonly authDate: Date;
+
+  constructor() {
+    this.resultCode = '0000'; //resultCode;
+    this.resultMsg = '정상 처리되었습니다.'; //resultMsg;
+    this.tid = 'nictest00m01011104191651325596'; //tid;
+    this.orderId = Date.now().toString(); //orderId;
+    this.bid = Date.now().toString(); //bid;
+    this.authDate = new Date(); //authDate;
+  }
+}

--- a/backend/src/payment-method/dto/external/register-bill-key-response.dto.ts
+++ b/backend/src/payment-method/dto/external/register-bill-key-response.dto.ts
@@ -1,0 +1,21 @@
+export class RegisterBillKeyResponseDto {
+  public readonly ResultCode: string;
+  public readonly ResultMsg: string;
+  public readonly tid: string;
+  public readonly orderId: string;
+  public readonly bid: string;
+  public readonly authDate: string;
+  public readonly cardCode: string;
+  public readonly cardName: string;
+
+  constructor() {
+    this.ResultCode = '0000';
+    this.ResultMsg = '빌키가 정상적으로 생성되었습니다.';
+    this.tid = 'nictest00m01011104191651325596';
+    this.orderId = Date.now().toString();
+    this.bid = Date.now().toString();
+    this.authDate = new Date().toISOString();
+    this.cardCode = '06';
+    this.cardName = '[신한]';
+  }
+}

--- a/backend/src/payment-method/dto/payment-method.dto.ts
+++ b/backend/src/payment-method/dto/payment-method.dto.ts
@@ -1,0 +1,12 @@
+import { PaymentMethodModel } from '../entity/payment-method.entity';
+
+export class PaymentMethodDto {
+  public readonly priority: number;
+  public readonly cardNo: string;
+  public readonly cardName: string;
+  constructor(paymentMethod: PaymentMethodModel) {
+    this.priority = paymentMethod.priority;
+    this.cardName = paymentMethod.cardName;
+    this.cardNo = paymentMethod.cardNo;
+  }
+}

--- a/backend/src/payment-method/dto/request/create-payment-method.dto.ts
+++ b/backend/src/payment-method/dto/request/create-payment-method.dto.ts
@@ -1,0 +1,3 @@
+import { EncData } from '../enc-data.dto';
+
+export class CreatePaymentMethodDto extends EncData {}

--- a/backend/src/payment-method/dto/request/update-payment-method.dto.ts
+++ b/backend/src/payment-method/dto/request/update-payment-method.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean } from 'class-validator';
+import { EncData } from '../enc-data.dto';
+
+export class UpdatePaymentMethodDto extends EncData {
+  @ApiProperty({
+    description: '테스트 환경 여부',
+    default: true,
+  })
+  @IsBoolean()
+  isTest: boolean = true;
+}

--- a/backend/src/payment-method/dto/response/delete-payment-method-response.dto.ts
+++ b/backend/src/payment-method/dto/response/delete-payment-method-response.dto.ts
@@ -1,0 +1,7 @@
+import { BaseDeleteResponseDto } from '../../../common/dto/reponse/base-delete-response.dto';
+
+export class DeletePaymentMethodResponseDto extends BaseDeleteResponseDto {
+  constructor(timestamp: Date, id: number, success: boolean) {
+    super(timestamp, id, success);
+  }
+}

--- a/backend/src/payment-method/dto/response/get-payment-method-response.dto.ts
+++ b/backend/src/payment-method/dto/response/get-payment-method-response.dto.ts
@@ -1,0 +1,8 @@
+import { BaseGetResponseDto } from '../../../common/dto/reponse/base-get-response.dto';
+import { PaymentMethodDto } from '../payment-method.dto';
+
+export class GetPaymentMethodResponseDto extends BaseGetResponseDto<PaymentMethodDto> {
+  constructor(data: PaymentMethodDto) {
+    super(data);
+  }
+}

--- a/backend/src/payment-method/dto/response/post-payment-method-response.dto.ts
+++ b/backend/src/payment-method/dto/response/post-payment-method-response.dto.ts
@@ -1,0 +1,8 @@
+import { BasePostResponseDto } from '../../../common/dto/reponse/base-post-response.dto';
+import { PaymentMethodDto } from '../payment-method.dto';
+
+export class PostPaymentMethodResponseDto extends BasePostResponseDto<PaymentMethodDto> {
+  constructor(data: PaymentMethodDto) {
+    super(data);
+  }
+}

--- a/backend/src/payment-method/entity/payment-method.entity.ts
+++ b/backend/src/payment-method/entity/payment-method.entity.ts
@@ -1,0 +1,25 @@
+import { Column, Entity, Index, ManyToOne } from 'typeorm';
+import { BaseModel } from '../../common/entity/base.entity';
+import { UserModel } from '../../user/entity/user.entity';
+
+@Entity()
+export class PaymentMethodModel extends BaseModel {
+  @Column()
+  @Index()
+  userId: number;
+
+  @ManyToOne(() => UserModel, (user) => user.paymentMethods)
+  user: UserModel;
+
+  @Column({ default: 1 })
+  priority: number;
+
+  @Column({ comment: '카드 번호', nullable: true })
+  cardNo: string;
+
+  @Column({ comment: '카드사', nullable: true })
+  cardName: string;
+
+  @Column({ comment: '빌키', nullable: true })
+  bid: string;
+}

--- a/backend/src/payment-method/exception/payment-method.exception.ts
+++ b/backend/src/payment-method/exception/payment-method.exception.ts
@@ -1,0 +1,6 @@
+export const PaymentMethodException = {
+  NOT_FOUND: '등록된 결제 수단이 없습니다.',
+  ALREADY_EXIST: '이미 등록된 결제 수단이 있습니다.',
+  DELETE_ERROR: '결제 수단 삭제 중 에러 발생',
+  UPDATE_ERROR: '결제 수단 업데이트 도중 에러 발생',
+};

--- a/backend/src/payment-method/payment-method-domain/interface/payment-method-domain.service.interface.ts
+++ b/backend/src/payment-method/payment-method-domain/interface/payment-method-domain.service.interface.ts
@@ -1,0 +1,34 @@
+import { UserModel } from '../../../user/entity/user.entity';
+import { QueryRunner, UpdateResult } from 'typeorm';
+import { PaymentMethodModel } from '../../entity/payment-method.entity';
+import { RegisterBillKeyResponseDto } from '../../dto/external/register-bill-key-response.dto';
+
+export const IPAYMENT_METHOD_DOMAIN_SERVICE = Symbol(
+  'IPAYMENT_METHOD_DOMAIN_SERVICE',
+);
+
+export interface IPaymentMethodDomainService {
+  findUserPaymentMethod(
+    user: UserModel,
+    qr?: QueryRunner,
+  ): Promise<PaymentMethodModel>;
+
+  createPaymentMethod(
+    user: UserModel,
+    cardNo: string,
+    newBillKey: RegisterBillKeyResponseDto,
+    qr: QueryRunner | undefined,
+  ): Promise<PaymentMethodModel>;
+
+  updatePaymentMethod(
+    paymentMethod: PaymentMethodModel,
+    cardNo: string,
+    newBillKey: RegisterBillKeyResponseDto,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  deletePaymentMethod(
+    paymentMethod: PaymentMethodModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
+}

--- a/backend/src/payment-method/payment-method-domain/payment-method-domain.module.ts
+++ b/backend/src/payment-method/payment-method-domain/payment-method-domain.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PaymentMethodModel } from '../entity/payment-method.entity';
+import { IPAYMENT_METHOD_DOMAIN_SERVICE } from './interface/payment-method-domain.service.interface';
+import { PaymentMethodDomainService } from './service/payment-method-domain.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PaymentMethodModel])],
+  providers: [
+    {
+      provide: IPAYMENT_METHOD_DOMAIN_SERVICE,
+      useClass: PaymentMethodDomainService,
+    },
+  ],
+  exports: [IPAYMENT_METHOD_DOMAIN_SERVICE],
+})
+export class PaymentMethodDomainModule {}

--- a/backend/src/payment-method/payment-method-domain/service/payment-method-domain.service.ts
+++ b/backend/src/payment-method/payment-method-domain/service/payment-method-domain.service.ts
@@ -1,0 +1,116 @@
+import {
+  ConflictException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { IPaymentMethodDomainService } from '../interface/payment-method-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { PaymentMethodModel } from '../../entity/payment-method.entity';
+import { QueryRunner, Repository, UpdateResult } from 'typeorm';
+import { UserModel } from '../../../user/entity/user.entity';
+import { PaymentMethodException } from '../../exception/payment-method.exception';
+import { RegisterBillKeyResponseDto } from '../../dto/external/register-bill-key-response.dto';
+
+@Injectable()
+export class PaymentMethodDomainService implements IPaymentMethodDomainService {
+  constructor(
+    @InjectRepository(PaymentMethodModel)
+    private readonly repository: Repository<PaymentMethodModel>,
+  ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr ? qr.manager.getRepository(PaymentMethodModel) : this.repository;
+  }
+
+  async findUserPaymentMethod(
+    user: UserModel,
+    qr?: QueryRunner,
+  ): Promise<PaymentMethodModel> {
+    const repository = this.getRepository(qr);
+
+    const paymentMethod = await repository.findOne({
+      where: {
+        userId: user.id,
+      },
+    });
+
+    if (!paymentMethod) {
+      throw new NotFoundException(PaymentMethodException.NOT_FOUND);
+    }
+
+    return paymentMethod;
+  }
+
+  async createPaymentMethod(
+    user: UserModel,
+    cardNo: string,
+    newBillKey: RegisterBillKeyResponseDto,
+    qr: QueryRunner | undefined,
+  ): Promise<PaymentMethodModel> {
+    const repository = this.getRepository(qr);
+
+    const isExist = await repository.findOne({
+      where: {
+        userId: user.id,
+      },
+    });
+
+    if (isExist) {
+      throw new ConflictException(PaymentMethodException.ALREADY_EXIST);
+    }
+
+    return repository.save({
+      userId: user.id,
+      priority: 1,
+      cardNo: cardNo.slice(12),
+      cardName: newBillKey.cardName,
+      bid: newBillKey.bid,
+    });
+  }
+
+  async updatePaymentMethod(
+    paymentMethod: PaymentMethodModel,
+    cardNo: string,
+    newBillKey: RegisterBillKeyResponseDto,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    const result = await repository.update(
+      {
+        id: paymentMethod.id,
+      },
+      {
+        cardNo: cardNo.slice(12),
+        cardName: newBillKey.cardName,
+        bid: newBillKey.bid,
+      },
+    );
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        PaymentMethodException.UPDATE_ERROR,
+      );
+    }
+
+    return result;
+  }
+
+  async deletePaymentMethod(
+    paymentMethod: PaymentMethodModel,
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    const result = await repository.softDelete({ id: paymentMethod.id });
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException(
+        PaymentMethodException.DELETE_ERROR,
+      );
+    }
+
+    return result;
+  }
+}

--- a/backend/src/payment-method/payment-method.module.ts
+++ b/backend/src/payment-method/payment-method.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { PaymentMethodController } from './controller/payment-method.controller';
+import { PaymentMethodService } from './service/payment-method.service';
+import { RouterModule } from '@nestjs/core';
+import { UserDomainModule } from '../user/user-domain/user-domain.module';
+import { PaymentMethodDomainModule } from './payment-method-domain/payment-method-domain.module';
+import { PgService } from '../subscription/service/pg.service';
+
+@Module({
+  imports: [
+    RouterModule.register([{ path: 'payment', module: PaymentMethodModule }]),
+    UserDomainModule,
+    PaymentMethodDomainModule,
+  ],
+  controllers: [PaymentMethodController],
+  providers: [PaymentMethodService, PgService],
+})
+export class PaymentMethodModule {}

--- a/backend/src/payment-method/service/payment-method.service.ts
+++ b/backend/src/payment-method/service/payment-method.service.ts
@@ -1,0 +1,123 @@
+import {
+  BadGatewayException,
+  ConflictException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { UserModel } from '../../user/entity/user.entity';
+import {
+  IPAYMENT_METHOD_DOMAIN_SERVICE,
+  IPaymentMethodDomainService,
+} from '../payment-method-domain/interface/payment-method-domain.service.interface';
+import { CreatePaymentMethodDto } from '../dto/request/create-payment-method.dto';
+import { QueryRunner } from 'typeorm';
+import { UpdatePaymentMethodDto } from '../dto/request/update-payment-method.dto';
+import { PgService } from '../../subscription/service/pg.service';
+import { GetPaymentMethodResponseDto } from '../dto/response/get-payment-method-response.dto';
+import { PaymentMethodDto } from '../dto/payment-method.dto';
+import { PostPaymentMethodResponseDto } from '../dto/response/post-payment-method-response.dto';
+import { DeletePaymentMethodResponseDto } from '../dto/response/delete-payment-method-response.dto';
+import { PaymentMethodException } from '../exception/payment-method.exception';
+
+@Injectable()
+export class PaymentMethodService {
+  constructor(
+    private readonly pgService: PgService,
+
+    @Inject(IPAYMENT_METHOD_DOMAIN_SERVICE)
+    private readonly paymentMethodDomainService: IPaymentMethodDomainService,
+  ) {}
+
+  async getUserPaymentMethod(user: UserModel) {
+    const paymentMethod =
+      await this.paymentMethodDomainService.findUserPaymentMethod(user);
+
+    return new GetPaymentMethodResponseDto(new PaymentMethodDto(paymentMethod));
+  }
+
+  async postPaymentMethod(
+    user: UserModel,
+    dto: CreatePaymentMethodDto,
+    qr: QueryRunner,
+  ) {
+    // 빌키 발급
+    const newBillKey = await this.pgService.registerBillKey(dto, true);
+
+    try {
+      const newPaymentMethod =
+        await this.paymentMethodDomainService.createPaymentMethod(
+          user,
+          dto.cardNo,
+          newBillKey,
+          qr,
+        );
+
+      return new PostPaymentMethodResponseDto(
+        new PaymentMethodDto(newPaymentMethod),
+      );
+    } catch (error) {
+      // 결제 수단 저장 실패 시 빌키 삭제
+      await this.pgService.expireBillKey(newBillKey.bid);
+
+      if (error instanceof ConflictException) {
+        throw error;
+      }
+
+      throw new InternalServerErrorException('결제 수단 등록 에러 발생');
+    }
+  }
+
+  async patchPaymentMethod(
+    user: UserModel,
+    dto: UpdatePaymentMethodDto,
+    qr: QueryRunner,
+  ) {
+    const paymentMethod =
+      await this.paymentMethodDomainService.findUserPaymentMethod(user, qr);
+
+    const newBillKey = await this.pgService.registerBillKey(dto, true);
+
+    try {
+      await this.paymentMethodDomainService.updatePaymentMethod(
+        paymentMethod,
+        dto.cardNo,
+        newBillKey,
+        qr,
+      );
+
+      // 기존 빌키 삭제
+      await this.pgService.expireBillKey(paymentMethod.bid);
+    } catch {
+      // 새로 생성된 빌키 삭제
+      await this.pgService.expireBillKey(newBillKey.bid);
+
+      throw new InternalServerErrorException(
+        PaymentMethodException.UPDATE_ERROR,
+      );
+    }
+  }
+
+  async deletePaymentMethod(user: UserModel, qr: QueryRunner) {
+    const paymentMethod =
+      await this.paymentMethodDomainService.findUserPaymentMethod(user, qr);
+
+    await this.paymentMethodDomainService.deletePaymentMethod(
+      paymentMethod,
+      qr,
+    );
+
+    try {
+      // 빌키 삭제
+      await this.pgService.expireBillKey(paymentMethod.bid);
+    } catch {
+      throw new BadGatewayException(PaymentMethodException.DELETE_ERROR);
+    }
+
+    return new DeletePaymentMethodResponseDto(
+      new Date(),
+      paymentMethod.id,
+      true,
+    );
+  }
+}

--- a/backend/src/subscription/controller/subscription.controller.ts
+++ b/backend/src/subscription/controller/subscription.controller.ts
@@ -16,7 +16,6 @@ import { SubscribePlanDto } from '../dto/request/subscribe-plan.dto';
 import { UserGuard } from '../../user/guard/user.guard';
 import { User } from '../../user/decorator/user.decorator';
 import { UserModel } from '../../user/entity/user.entity';
-import { UpdatePaymentMethodDto } from '../dto/request/update-payment-method.dto';
 import { SubscriptionCronService } from '../service/subscription-cron.service';
 import { UseTransaction } from '../../common/decorator/use-transaction.decorator';
 
@@ -52,8 +51,7 @@ export class SubscriptionController {
     summary: '구독 신청',
     description:
       '<p>구독을 생성합니다.</p>' +
-      '<p>라프텔의 경우 CANCELED 일 때 새롭게 신청 불가능, 기존 구독을 복구만 가능 (플랜 변경도 불가능)</p>' +
-      '<p>계정의 구독이 CANCELED 일 때 어떻게 해야 함?? Exception(거부) or 생성하고 기존 교회에 연결?</p>' +
+      '<p>CANCELED 일 때 새롭게 신청 불가능, 기존 구독을 복구만 가능 (플랜 변경도 불가능)</p>' +
       '<p>기존 소유한 교회가 있을 경우 해당 교회와 연결합니다.</p>',
   })
   @Post('subscribe')
@@ -87,22 +85,6 @@ export class SubscriptionController {
   @UseGuards(AccessTokenGuard, UserGuard)
   retryPurchase(@User() user: UserModel, @QueryRunner() qr: QR) {
     return this.subscriptionService.retryPurchase(user, qr);
-  }
-
-  @ApiOperation({
-    summary: '결제 수단 변경',
-    description:
-      '기존 Bill Key 를 삭제하고 새로 발급 받아 구독 정보를 업데이트',
-  })
-  @Patch('payment-method')
-  @UseGuards(AccessTokenGuard, UserGuard)
-  @UseTransaction()
-  updatePaymentMethod(
-    @User() user: UserModel,
-    @Body() dto: UpdatePaymentMethodDto,
-    @QueryRunner() qr: QR,
-  ) {
-    return this.subscriptionService.updatePaymentMethod(user, dto, qr);
   }
 
   @ApiOperation({ summary: '구독 플랜 업그레이드 (미구현)' })

--- a/backend/src/subscription/dto/request/subscribe-plan.dto.ts
+++ b/backend/src/subscription/dto/request/subscribe-plan.dto.ts
@@ -1,57 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { SubscriptionPlan } from '../../const/subscription-plan.enum';
-import {
-  IsBoolean,
-  IsEnum,
-  IsString,
-  Length,
-  ValidateNested,
-} from 'class-validator';
+import { IsBoolean, IsEnum } from 'class-validator';
 import { IsAvailablePlan } from '../../decorator/is-available-plan.decorator';
 import { BillingCycle } from '../../const/billing-cycle.enum';
-import { Type } from 'class-transformer';
-
-export class EncData {
-  @ApiProperty({
-    description: '카드번호, 숫자만 입력',
-    example: '1234123412341234',
-  })
-  @IsString()
-  @Length(16, 16)
-  cardNo: string;
-
-  @ApiProperty({
-    description: '유효기간(년, YY)',
-    example: '25',
-  })
-  @IsString()
-  @Length(2, 2)
-  expYear: string;
-
-  @ApiProperty({
-    description: '유효기간(월, MM)',
-    example: '09',
-  })
-  @IsString()
-  @Length(2, 2)
-  expMonth: string;
-
-  @ApiProperty({
-    description: '생년월일(YYMMDD) or 사업자번호(10자리)',
-    example: '000101',
-  })
-  @IsString()
-  @Length(6, 10)
-  idNo: string;
-
-  @ApiProperty({
-    description: '카드 비밀번호 앞 2자리',
-    example: '00',
-  })
-  @IsString()
-  @Length(2, 2)
-  cardPw: string;
-}
 
 export class SubscribePlanDto {
   @ApiProperty({ description: '테스트용', default: true, example: true })
@@ -73,9 +24,4 @@ export class SubscribePlanDto {
   })
   @IsEnum(BillingCycle)
   billingCycle: BillingCycle;
-
-  @ApiProperty()
-  @Type(() => EncData)
-  @ValidateNested()
-  encData: EncData;
 }

--- a/backend/src/subscription/entity/subscription.entity.ts
+++ b/backend/src/subscription/entity/subscription.entity.ts
@@ -12,7 +12,6 @@ import { SubscriptionPlan } from '../const/subscription-plan.enum';
 import { SubscriptionStatus } from '../const/subscription-status.enum';
 import { BillingCycle } from '../const/billing-cycle.enum';
 import { ChurchModel } from '../../churches/entity/church.entity';
-import { Exclude } from 'class-transformer';
 
 @Entity()
 export class SubscriptionModel extends BaseModel {
@@ -69,19 +68,9 @@ export class SubscriptionModel extends BaseModel {
   @Column()
   maxMembers: number;
 
-  @Column({ type: 'varchar', comment: '정기 결제 빌키', nullable: true })
-  @Exclude({ toPlainOnly: true })
-  bid: string | null;
-
   @Column({ type: 'timestamptz', nullable: true })
   canceledAt: Date | null;
 
   @Column({ nullable: true })
   cancellationReason: string;
-
-  @Column({ nullable: true })
-  paymentMethodId: string; // PG사 결제수단 ID
-
-  @Column({ nullable: true })
-  customerId: string; // PG사 고객 ID
 }

--- a/backend/src/subscription/guard/subscription.guard.ts
+++ b/backend/src/subscription/guard/subscription.guard.ts
@@ -55,7 +55,7 @@ export class SubscriptionGuard implements CanActivate {
         throw new ForbiddenException(SubscriptionException.EXPIRE_FREE_TRIAL);
       }
     } else {
-      if (subscription.currentPeriodEnd < now) {
+      if (subscription.currentPeriodEnd < now || !subscription.paymentSuccess) {
         throw new ForbiddenException(SubscriptionException.EXPIRE_SUBSCRIPTION);
       }
     }

--- a/backend/src/subscription/service/pg.service.ts
+++ b/backend/src/subscription/service/pg.service.ts
@@ -1,6 +1,10 @@
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { EncData } from '../dto/request/subscribe-plan.dto';
+import { EncData } from '../../payment-method/dto/enc-data.dto';
+import { RegisterBillKeyResponseDto } from '../../payment-method/dto/external/register-bill-key-response.dto';
+import { ExpireBillKeyResponseDto } from '../../payment-method/dto/external/expire-bill-key-response.dto';
+import { PaymentMethodModel } from '../../payment-method/entity/payment-method.entity';
+import { SubscriptionModel } from '../entity/subscription.entity';
 
 @Injectable()
 export class PgService {
@@ -12,13 +16,31 @@ export class PgService {
       .join('&');
 
     if (isTest) {
-      return Date.now().toString();
+      return new RegisterBillKeyResponseDto();
     }
 
     throw new InternalServerErrorException('아직 PG API 연결 안함');
   }
 
   async expireBillKey(billKey: string) {
-    return 'expired';
+    return new ExpireBillKeyResponseDto();
+  }
+
+  async pay(paymentMethod: PaymentMethodModel, plan: SubscriptionModel) {
+    const dto = {
+      orderId: Date.now(),
+      amount: plan.amount,
+      goodsName: plan.currentPlan,
+      cardQuota: 0,
+      useShopInterest: false,
+    };
+
+    // 결제 후 resultCode 가 0000 이 아니라면 BadGate
+
+    return {
+      paidAt: new Date(),
+      amount: plan.amount,
+      goodsName: plan.currentPlan,
+    };
   }
 }

--- a/backend/src/subscription/service/test-subscription.service.ts
+++ b/backend/src/subscription/service/test-subscription.service.ts
@@ -31,6 +31,10 @@ export class TestSubscriptionService {
     ).filter((church) => church.ownerUserId && !church.subscription);
 
     for (const church of churches) {
+      if (!church.ownerUserId) {
+        continue;
+      }
+
       const owner = await this.userDomainService.findUserModelById(
         church.ownerUserId,
       );

--- a/backend/src/subscription/subscription-domain/interface/subscription-domain.service.interface.ts
+++ b/backend/src/subscription/subscription-domain/interface/subscription-domain.service.interface.ts
@@ -30,7 +30,10 @@ export interface ISubscriptionDomainService {
     qr: QueryRunner,
   ): Promise<SubscriptionModel>;
 
-  findSubscriptionByChurch(church: ChurchModel): Promise<SubscriptionModel>;
+  findSubscriptionByChurch(
+    church: ChurchModel,
+    qr?: QueryRunner,
+  ): Promise<SubscriptionModel>;
 
   findSubscriptionByUser(
     user: UserModel,
@@ -47,7 +50,6 @@ export interface ISubscriptionDomainService {
   subscribePlan(
     user: UserModel,
     dto: SubscribePlanDto,
-    billKey: string,
     qr?: QueryRunner,
   ): Promise<SubscriptionModel>;
 
@@ -63,11 +65,11 @@ export interface ISubscriptionDomainService {
     qr?: QueryRunner,
   ): Promise<UpdateResult>;
 
-  updateBillKey(
+  /*updateBillKey(
     subscription: SubscriptionModel,
     newBid: string,
     qr: QueryRunner,
-  ): Promise<UpdateResult>;
+  ): Promise<UpdateResult>;*/
 
   updateSubscriptionStatus(
     subscription: SubscriptionModel,

--- a/backend/src/subscription/subscription.module.ts
+++ b/backend/src/subscription/subscription.module.ts
@@ -9,6 +9,7 @@ import { TestSubscriptionService } from './service/test-subscription.service';
 import { TestSubscriptionController } from './controller/test-subscription.controller';
 import { PgService } from './service/pg.service';
 import { SubscriptionCronService } from './service/subscription-cron.service';
+import { PaymentMethodDomainModule } from '../payment-method/payment-method-domain/payment-method-domain.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { SubscriptionCronService } from './service/subscription-cron.service';
     UserDomainModule,
     ChurchesDomainModule,
     SubscriptionDomainModule,
+    PaymentMethodDomainModule,
   ],
   controllers: [TestSubscriptionController, SubscriptionController],
   providers: [

--- a/backend/src/user/entity/user.entity.ts
+++ b/backend/src/user/entity/user.entity.ts
@@ -6,6 +6,7 @@ import { ChurchJoinModel } from '../../church-join/entity/church-join.entity';
 import { Exclude } from 'class-transformer';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { SubscriptionModel } from '../../subscription/entity/subscription.entity';
+import { PaymentMethodModel } from '../../payment-method/entity/payment-method.entity';
 
 @Entity()
 export class UserModel extends BaseModel {
@@ -47,6 +48,9 @@ export class UserModel extends BaseModel {
   // 구독 이력
   @OneToMany(() => SubscriptionModel, (subscription) => subscription.user)
   subscriptions: SubscriptionModel[];
+
+  @OneToMany(() => PaymentMethodModel, (paymentMethod) => paymentMethod.user)
+  paymentMethods: PaymentMethodModel[];
 
   @OneToMany(() => ChurchUserModel, (churchUser) => churchUser.user)
   churchUser: ChurchUserModel[];


### PR DESCRIPTION
## 주요 내용
PaymentMethod 도메인을 추가하여 결제 수단을 독립적으로 관리하고 구독과 분리

## 세부 내용

### PaymentMethod 도메인 추가
- GET /payment - 등록된 결제 수단 조회
- POST /payment - 결제 수단 등록 (사용자당 1개 제한)
- PATCH /payment - 결제 수단 변경
- DELETE /payment - 결제 수단 삭제

### 결제 구조 개선
- SubscriptionModel의 bid(Bill Key) 제거
- PaymentMethodModel로 결제 수단 독립 관리
- Subscription과 PaymentMethod 간 relation 제거 (느슨한 결합)

### 결제 프로세스 변경
- 결제 시 사용자의 PaymentMethod 조회
- SubscriptionModel로 청구 금액 계산
- PaymentMethod로 실제 결제 요청
- 구독 신청, 정기 결제, 수동 결제 모두 동일한 프로세스