### PR TITLE
feat: 업무(Task) 관련 알림 생성 기능 추가

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -80,6 +80,8 @@ import { OrderModel } from './order/entity/order.entity';
 import { PaymentMethodModel } from './payment-method/entity/payment-method.entity';
 import { PaymentMethodModule } from './payment-method/payment-method.module';
 import { OrderModule } from './order/order.module';
+import { NotificationModule } from './notification/notification.module';
+import { NotificationModel } from './notification/entity/notification.entity';
 
 //import { EducationTermReportModel } from './report/education-report/entity/education-term-report.entity';
 
@@ -155,6 +157,8 @@ import { OrderModule } from './order/order.module';
           // 유저 관련 엔티티
           TempUserModel,
           UserModel,
+          // 알림 엔티티
+          NotificationModel,
           // 교회 관련 엔티티
           ChurchModel,
           // 교회 가입 엔티티
@@ -224,6 +228,7 @@ import { OrderModule } from './order/order.module';
     DummyDataModule,
     AuthModule,
     MyPageModule,
+    NotificationModule,
     ReportModule,
     UserModule,
     PaymentMethodModule,

--- a/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
+++ b/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
@@ -72,6 +72,12 @@ export interface IManagerDomainService {
     relationOptions?: FindOptionsRelations<ChurchUserModel>,
   ): Promise<ChurchUserModel>;
 
+  findManagersForNotification(
+    church: ChurchModel,
+    memberIds: number[],
+    qr?: QueryRunner,
+  ): Promise<ChurchUserModel[]>;
+
   /**
    * receiver 로 지정된 교인의 권한 확인용
    * @param church

--- a/backend/src/manager/manager-domain/service/manager-domain.service.ts
+++ b/backend/src/manager/manager-domain/service/manager-domain.service.ts
@@ -35,6 +35,7 @@ import {
   ManagersFindOptionsSelect,
 } from '../../const/manager-find-options.const';
 import {
+  MemberSimpleSelect,
   MemberSummarizedRelation,
   MemberSummarizedSelect,
 } from '../../../members/const/member-find-options.const';
@@ -230,6 +231,28 @@ export class ManagerDomainService implements IManagerDomainService {
     }
 
     return churchUser;
+  }
+
+  async findManagersForNotification(
+    church: ChurchModel,
+    memberIds: number[],
+    qr?: QueryRunner,
+  ): Promise<ChurchUserModel[]> {
+    const repository = this.getRepository(qr);
+
+    return repository.find({
+      where: {
+        churchId: church.id,
+        memberId: In(memberIds),
+        role: ChurchUserManagers,
+      },
+      relations: {
+        member: MemberSummarizedRelation,
+      },
+      select: {
+        member: MemberSimpleSelect,
+      },
+    });
   }
 
   async findManagersByMemberIds(

--- a/backend/src/notification/const/notification-action.enum.ts
+++ b/backend/src/notification/const/notification-action.enum.ts
@@ -1,0 +1,16 @@
+export enum NotificationAction {
+  CREATED = 'created',
+  UPDATED = 'updated',
+  STATUS_UPDATED = 'statusUpdated',
+  DELETED = 'deleted',
+
+  IN_CHARGE_ADDED = 'inChargedAdded',
+  IN_CHARGE_REMOVED = 'inChargedRemoved',
+  IN_CHARGE_CHANGED = 'inChargeChanged',
+
+  REPORT_ADDED = 'reportAdded',
+  REPORT_REMOVED = 'reportRemoved',
+
+  MANAGER_UPDATED = 'managerUpdated',
+  CHURCH_INFO_UPDATED = 'churchInfoUpdated',
+}

--- a/backend/src/notification/const/notification-domain.enum.ts
+++ b/backend/src/notification/const/notification-domain.enum.ts
@@ -1,0 +1,9 @@
+export enum NotificationDomain {
+  TASK = 'task',
+  VISITATION = 'visitation',
+  EDUCATION_TERM = 'educationTerm',
+  EDUCATION_SESSION = 'educationSession',
+  WORSHIP_ATTENDANCE = 'worshipAttendance',
+  PERMISSION = 'permission',
+  CHURCH_INFO = 'churchInfo',
+}

--- a/backend/src/notification/const/notification-event.enum.ts
+++ b/backend/src/notification/const/notification-event.enum.ts
@@ -1,0 +1,10 @@
+export enum NotificationEvent {
+  TASK_IN_CHARGE_ADDED = 'task.inCharge.added',
+  TASK_IN_CHARGE_CHANGED = 'task.inCharge.changed',
+  TASK_IN_CHARGE_REMOVED = 'task.inCharge.removed',
+  TASK_REPORT_ADDED = 'task.report.added',
+  TASK_REPORT_REMOVED = 'task.report.removed',
+  TASK_STATUS_UPDATED = 'task.status.updated',
+  TASK_META_UPDATED = 'task.meta.updated',
+  TASK_DELETED = 'task.deleted',
+}

--- a/backend/src/notification/const/notification-order.enum.ts
+++ b/backend/src/notification/const/notification-order.enum.ts
@@ -1,0 +1,3 @@
+export enum NotificationOrder {
+  CREATED_AT = 'createdAt',
+}

--- a/backend/src/notification/controller/notification.controller.ts
+++ b/backend/src/notification/controller/notification.controller.ts
@@ -1,0 +1,73 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { ChurchUserGuard } from '../../church-user/guard/church-user.guard';
+import { RequestChurchUser } from '../../common/decorator/request-church-user.decorator';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { NotificationService } from '../service/notification.service';
+import { GetNotificationsDto } from '../dto/request/get-notifications.dto';
+import {
+  ApiGetNotifications,
+  ApiGetUnreadCount,
+  ApiPatchCheckAllRead,
+  ApiPatchCheckRead,
+} from '../swagger/notification.swagger';
+
+@Controller()
+export class NotificationController {
+  constructor(private readonly notificationService: NotificationService) {}
+
+  @ApiGetNotifications()
+  @Get()
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
+  getNotifications(
+    @RequestChurchUser() churchUser: ChurchUserModel,
+    @Query() dto: GetNotificationsDto,
+  ) {
+    return this.notificationService.getNotifications(churchUser, dto);
+  }
+
+  @ApiGetUnreadCount()
+  @Get('unread')
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
+  getUnreadCount(@RequestChurchUser() churchUser: ChurchUserModel) {
+    return this.notificationService.getUnreadCount(churchUser);
+  }
+
+  @Post('test')
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
+  createDummyNotification(@RequestChurchUser() churchUser: ChurchUserModel) {
+    return this.notificationService.createDummyNotification(churchUser);
+  }
+
+  @ApiPatchCheckAllRead()
+  @Patch('read-all')
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
+  checkReadAll(@RequestChurchUser() churchUser: ChurchUserModel) {
+    return this.notificationService.checkReadAll(churchUser);
+  }
+
+  @ApiPatchCheckRead()
+  @Patch(':notificationId/read')
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
+  checkRead(
+    @RequestChurchUser() churchUser: ChurchUserModel,
+    @Param('notificationId', ParseIntPipe) notificationId: number,
+  ) {
+    return this.notificationService.checkRead(churchUser, notificationId);
+  }
+
+  @Delete('test-cleanup')
+  testCleanUp() {
+    return this.notificationService.cleanUp();
+  }
+}

--- a/backend/src/notification/dto/request/get-notifications.dto.ts
+++ b/backend/src/notification/dto/request/get-notifications.dto.ts
@@ -1,0 +1,15 @@
+import { BaseCursorPaginationRequestDto } from '../../../common/dto/request/base-cursor-pagination-request.dto';
+import { NotificationOrder } from '../../const/notification-order.enum';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+
+export class GetNotificationsDto extends BaseCursorPaginationRequestDto<NotificationOrder> {
+  @ApiPropertyOptional({
+    description: '정렬 기준',
+    enum: NotificationOrder,
+    default: NotificationOrder.CREATED_AT,
+  })
+  @IsOptional()
+  @IsEnum(NotificationOrder)
+  sortBy: NotificationOrder = NotificationOrder.CREATED_AT;
+}

--- a/backend/src/notification/dto/response/get-notification-list-response.dto.ts
+++ b/backend/src/notification/dto/response/get-notification-list-response.dto.ts
@@ -1,0 +1,13 @@
+import { BaseCursorPaginationResponseDto } from '../../../common/dto/base-cursor-pagination-response.dto';
+import { NotificationModel } from '../../entity/notification.entity';
+
+export class GetNotificationListResponseDto extends BaseCursorPaginationResponseDto<NotificationModel> {
+  constructor(
+    data: NotificationModel[],
+    count: number,
+    nextCursor: string | undefined,
+    hasMore: boolean,
+  ) {
+    super(data, count, nextCursor, hasMore);
+  }
+}

--- a/backend/src/notification/dto/response/get-unread-count-response.dto.ts
+++ b/backend/src/notification/dto/response/get-unread-count-response.dto.ts
@@ -1,0 +1,7 @@
+import { BaseGetResponseDto } from '../../../common/dto/reponse/base-get-response.dto';
+
+export class GetUnreadCountResponseDto extends BaseGetResponseDto<number> {
+  constructor(data: number) {
+    super(data);
+  }
+}

--- a/backend/src/notification/entity/notification.entity.ts
+++ b/backend/src/notification/entity/notification.entity.ts
@@ -1,0 +1,44 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseModel } from '../../common/entity/base.entity';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { NotificationDomain } from '../const/notification-domain.enum';
+import { NotificationAction } from '../const/notification-action.enum';
+import { NotificationFields } from '../notification-event.dto';
+
+@Entity()
+@Index(['churchUserId', 'isRead', 'createdAt'])
+@Index(['churchUserId', 'createdAt'])
+@Index(['domain', 'action', 'churchUserId'])
+export class NotificationModel extends BaseModel {
+  @Index()
+  @Column()
+  churchUserId: number;
+
+  @ManyToOne(() => ChurchUserModel, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'churchUserId' })
+  churchUser: ChurchUserModel;
+
+  @Column({ default: '' })
+  actorName: string;
+
+  @Column({ nullable: true })
+  domain: NotificationDomain;
+
+  @Column({ nullable: true })
+  action: NotificationAction;
+
+  @Column({ default: '' })
+  domainTitle: string;
+
+  @Column({ default: false })
+  isRead: boolean;
+
+  @Column({ type: 'jsonb', nullable: true })
+  payload: NotificationFields[];
+
+  @Column({ type: 'jsonb', nullable: true })
+  sourceInfo: any | null;
+
+  @Column({ type: 'timestamptz' })
+  expiresAt: Date;
+}

--- a/backend/src/notification/notification-domain/interface/notification-domain.service.interface.ts
+++ b/backend/src/notification/notification-domain/interface/notification-domain.service.interface.ts
@@ -1,0 +1,55 @@
+import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
+import {
+  DeleteResult,
+  FindOptionsRelations,
+  QueryRunner,
+  UpdateResult,
+} from 'typeorm';
+import { NotificationModel } from '../../entity/notification.entity';
+import { GetNotificationsDto } from '../../dto/request/get-notifications.dto';
+import { DomainCursorPaginationResultDto } from '../../../common/dto/domain-cursor-pagination-result.dto';
+import { NotificationEventDto } from '../../notification-event.dto';
+
+export const INOTIFICATION_DOMAIN_SERVICE = Symbol(
+  'INOTIFICATION_DOMAIN_SERVICE',
+);
+
+export interface INotificationDomainService {
+  findNotificationList(
+    churchUser: ChurchUserModel,
+    dto: GetNotificationsDto,
+  ): Promise<DomainCursorPaginationResultDto<NotificationModel>>;
+
+  findNotificationModelById(
+    churchUser: ChurchUserModel,
+    notificationId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<NotificationModel>,
+  ): Promise<NotificationModel>;
+
+  countUnreadNotifications(
+    churchUser: ChurchUserModel,
+    qr?: QueryRunner,
+  ): Promise<number>;
+
+  createDummyNotification(
+    churchUser: ChurchUserModel,
+    qr?: QueryRunner,
+  ): Promise<NotificationModel>;
+
+  createNotifications(
+    event: NotificationEventDto,
+  ): Promise<NotificationModel[]>;
+
+  checkRead(
+    notification: NotificationModel,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  checkReadAll(
+    churchUser: ChurchUserModel,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult>;
+
+  cleanUp(): Promise<DeleteResult>;
+}

--- a/backend/src/notification/notification-domain/notification-domain.module.ts
+++ b/backend/src/notification/notification-domain/notification-domain.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { NotificationModel } from '../entity/notification.entity';
+import { INOTIFICATION_DOMAIN_SERVICE } from './interface/notification-domain.service.interface';
+import { NotificationDomainService } from './service/notification-domain.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([NotificationModel])],
+  providers: [
+    {
+      provide: INOTIFICATION_DOMAIN_SERVICE,
+      useClass: NotificationDomainService,
+    },
+  ],
+  exports: [INOTIFICATION_DOMAIN_SERVICE],
+})
+export class NotificationDomainModule {}

--- a/backend/src/notification/notification-domain/service/notification-domain.service.ts
+++ b/backend/src/notification/notification-domain/service/notification-domain.service.ts
@@ -1,0 +1,229 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { INotificationDomainService } from '../interface/notification-domain.service.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { NotificationModel } from '../../entity/notification.entity';
+import {
+  FindOptionsRelations,
+  LessThanOrEqual,
+  QueryRunner,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
+import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
+import { addWeeks, subMonths } from 'date-fns';
+import { GetNotificationsDto } from '../../dto/request/get-notifications.dto';
+import { DomainCursorPaginationResultDto } from '../../../common/dto/domain-cursor-pagination-result.dto';
+import {
+  NotificationEventDto,
+  NotificationField,
+  NotificationFields,
+} from '../../notification-event.dto';
+
+@Injectable()
+export class NotificationDomainService implements INotificationDomainService {
+  constructor(
+    @InjectRepository(NotificationModel)
+    private readonly repository: Repository<NotificationModel>,
+  ) {}
+
+  private getRepository(qr?: QueryRunner) {
+    return qr ? qr.manager.getRepository(NotificationModel) : this.repository;
+  }
+
+  async findNotificationList(
+    churchUser: ChurchUserModel,
+    dto: GetNotificationsDto,
+  ): Promise<DomainCursorPaginationResultDto<NotificationModel>> {
+    const repository = this.getRepository();
+
+    const query = repository
+      .createQueryBuilder('notification')
+      .leftJoin('notification.churchUser', 'churchUser')
+      .where('churchUser.id = :churchUserId', { churchUserId: churchUser.id })
+      .orderBy('notification.isRead', 'ASC')
+      .addOrderBy('notification.id', 'DESC');
+
+    if (dto.cursor) {
+      const decodedCursor = this.decodeCursor(dto.cursor);
+
+      const { id, value } = decodedCursor;
+
+      query.andWhere(
+        `(notification.isRead = :value AND notification.id < :notificationId) OR (notification.isRead = true AND :value = false)`,
+        {
+          value,
+          notificationId: id,
+        },
+      );
+    }
+
+    const items = await query.limit(dto.limit + 1).getMany();
+
+    const hasMore = items.length > dto.limit;
+    if (hasMore) {
+      items.pop();
+    }
+
+    const nextCursor =
+      hasMore && items.length > 0
+        ? this.encodeCursor(items[items.length - 1])
+        : undefined;
+
+    return { items, nextCursor, hasMore };
+  }
+
+  private encodeCursor(notification: NotificationModel) {
+    const cursorData = {
+      id: notification.id,
+      value: notification.isRead,
+    };
+
+    return Buffer.from(JSON.stringify(cursorData)).toString('base64');
+  }
+
+  private decodeCursor(cursor: string) {
+    try {
+      const decoded = Buffer.from(cursor, 'base64').toString('utf-8');
+      return JSON.parse(decoded);
+    } catch {
+      return null;
+    }
+  }
+
+  async findNotificationModelById(
+    churchUser: ChurchUserModel,
+    notificationId: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<NotificationModel>,
+  ): Promise<NotificationModel> {
+    const repository = this.getRepository(qr);
+
+    const noti = await repository.findOne({
+      where: {
+        id: notificationId,
+        churchUserId: churchUser.id,
+      },
+      relations: relationOptions,
+    });
+
+    if (!noti) {
+      throw new NotFoundException('해당 알림을 찾을 수 없습니다.');
+    }
+
+    return noti;
+  }
+
+  countUnreadNotifications(
+    churchUser: ChurchUserModel,
+    qr?: QueryRunner,
+  ): Promise<number> {
+    const repository = this.getRepository(qr);
+
+    return repository.count({
+      where: {
+        churchUserId: churchUser.id,
+        isRead: false,
+      },
+    });
+  }
+
+  createDummyNotification(
+    churchUser: ChurchUserModel,
+    qr?: QueryRunner,
+  ): Promise<NotificationModel> {
+    const repository = this.getRepository(qr);
+
+    const now = new Date();
+
+    return repository.save({
+      churchUserId: churchUser.id,
+      payload: [
+        new NotificationFields(
+          NotificationField.TITLE,
+          '테스트 제목',
+          '제목 수정',
+        ),
+      ],
+
+      expiresAt: addWeeks(now, 2),
+    });
+  }
+
+  private uniqBy<T>(arr: T[], key: keyof T): T[] {
+    const seen = new Set<any>();
+
+    return arr.filter((item) => {
+      const val = item[key];
+      if (seen.has(val)) return false;
+      seen.add(val);
+      return true;
+    });
+  }
+
+  createNotifications(
+    event: NotificationEventDto,
+  ): Promise<NotificationModel[]> {
+    const repository = this.getRepository();
+
+    const receivers = event.notificationReceivers;
+
+    const uniqueReceivers = this.uniqBy(receivers, 'id');
+
+    const now = new Date();
+
+    const notifications = repository.create(
+      uniqueReceivers.map((receiver) => ({
+        churchUserId: receiver.id,
+        actorName: event.actorName,
+        domain: event.domain,
+        action: event.action,
+        domainTitle: event.title,
+        payload: event.fields,
+        sourceInfo: event.source,
+        expiresAt: addWeeks(now, 2),
+      })),
+    );
+
+    return repository.save(notifications, { chunk: 10 });
+  }
+
+  async checkRead(notification: NotificationModel, qr?: QueryRunner) {
+    const repository = this.getRepository(qr);
+
+    return repository.update(
+      {
+        id: notification.id,
+      },
+      {
+        isRead: true,
+      },
+    );
+  }
+
+  checkReadAll(
+    churchUser: ChurchUserModel,
+    qr?: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getRepository(qr);
+
+    return repository.update(
+      {
+        churchUserId: churchUser.id,
+        isRead: false,
+      },
+      {
+        isRead: true,
+      },
+    );
+  }
+
+  async cleanUp() {
+    const repository = this.getRepository();
+
+    const expireDate = subMonths(new Date(), 1);
+
+    return repository.delete({
+      createdAt: LessThanOrEqual(expireDate),
+    });
+  }
+}

--- a/backend/src/notification/notification-event.dto.ts
+++ b/backend/src/notification/notification-event.dto.ts
@@ -1,0 +1,73 @@
+import { NotificationDomain } from './const/notification-domain.enum';
+import { NotificationAction } from './const/notification-action.enum';
+import { ChurchUserModel } from '../church-user/entity/church-user.entity';
+
+export enum NotificationField {
+  STATUS = 'status',
+  IN_CHARGE = 'inCharge',
+  START_DATE = 'startDate',
+  END_DATE = 'endDate',
+  TITLE = 'title',
+}
+
+export class NotificationFields {
+  fields: NotificationField | string;
+  previous: any;
+  current: any;
+
+  constructor(fields: NotificationField | string, previous: any, current: any) {
+    this.fields = fields;
+    this.previous = previous;
+    this.current = current;
+  }
+}
+
+export abstract class NotificationSource {
+  id: number;
+  domain: NotificationDomain;
+
+  protected constructor(domain: NotificationDomain, id: number) {
+    this.id = id;
+    this.domain = domain;
+  }
+}
+
+export class NotificationSourceTask extends NotificationSource {
+  constructor(domain: NotificationDomain, id: number) {
+    super(domain, id);
+  }
+}
+
+export class NotificationEventDto {
+  actorName: string;
+
+  domain: NotificationDomain;
+
+  action: NotificationAction;
+
+  title: string;
+
+  source: NotificationSource | null;
+
+  notificationReceivers: ChurchUserModel[];
+
+  fields: NotificationFields[];
+
+  constructor(
+    actorName: string,
+    domain: NotificationDomain,
+    action: NotificationAction,
+    title: string,
+    source: NotificationSource | null,
+    notificationReceivers: ChurchUserModel[],
+    fields: NotificationFields[],
+  ) {
+    this.actorName = actorName;
+    this.domain = domain;
+    this.action = action;
+    this.title = title;
+    this.source = source;
+    this.notificationReceivers = notificationReceivers;
+    this.fields = fields;
+  }
+}

--- a/backend/src/notification/notification.module.ts
+++ b/backend/src/notification/notification.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { RouterModule } from '@nestjs/core';
+import { NotificationController } from './controller/notification.controller';
+import { UserDomainModule } from '../user/user-domain/user-domain.module';
+import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
+import { ChurchUserDomainModule } from '../church-user/church-user-domain/church-user-domain.module';
+import { NotificationDomainModule } from './notification-domain/notification-domain.module';
+import { NotificationService } from './service/notification.service';
+
+@Module({
+  imports: [
+    RouterModule.register([
+      { path: 'me/notification', module: NotificationModule },
+    ]),
+    UserDomainModule,
+    ChurchesDomainModule,
+    ChurchUserDomainModule,
+    NotificationDomainModule,
+  ],
+  controllers: [NotificationController],
+  providers: [NotificationService],
+})
+export class NotificationModule {}

--- a/backend/src/notification/service/notification.service.ts
+++ b/backend/src/notification/service/notification.service.ts
@@ -1,0 +1,142 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  INOTIFICATION_DOMAIN_SERVICE,
+  INotificationDomainService,
+} from '../notification-domain/interface/notification-domain.service.interface';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { GetUnreadCountResponseDto } from '../dto/response/get-unread-count-response.dto';
+import { GetNotificationsDto } from '../dto/request/get-notifications.dto';
+import { GetNotificationListResponseDto } from '../dto/response/get-notification-list-response.dto';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { OnEvent } from '@nestjs/event-emitter';
+import { NotificationEvent } from '../const/notification-event.enum';
+import { NotificationEventDto } from '../notification-event.dto';
+
+@Injectable()
+export class NotificationService {
+  constructor(
+    @Inject(INOTIFICATION_DOMAIN_SERVICE)
+    private readonly notificationDomainService: INotificationDomainService,
+  ) {}
+
+  async getNotifications(
+    churchUser: ChurchUserModel,
+    dto: GetNotificationsDto,
+  ) {
+    const result = await this.notificationDomainService.findNotificationList(
+      churchUser,
+      dto,
+    );
+
+    return new GetNotificationListResponseDto(
+      result.items,
+      result.items.length,
+      result.nextCursor,
+      result.hasMore,
+    );
+  }
+
+  async createDummyNotification(churchUser: ChurchUserModel) {
+    return this.notificationDomainService.createDummyNotification(churchUser);
+  }
+
+  async getUnreadCount(churchUser: ChurchUserModel) {
+    const unreadCount =
+      await this.notificationDomainService.countUnreadNotifications(churchUser);
+
+    return new GetUnreadCountResponseDto(unreadCount);
+  }
+
+  async checkReadAll(churchUser: ChurchUserModel) {
+    await this.notificationDomainService.checkReadAll(churchUser);
+
+    return {
+      success: true,
+      timestamp: new Date(),
+    };
+  }
+
+  async checkRead(churchUser: ChurchUserModel, notificationId: number) {
+    const targetNotification =
+      await this.notificationDomainService.findNotificationModelById(
+        churchUser,
+        notificationId,
+      );
+
+    await this.notificationDomainService.checkRead(targetNotification);
+
+    return {
+      success: true,
+      timestamp: new Date(),
+    };
+  }
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT, { timeZone: 'Asia/Seoul' })
+  async cleanUp() {
+    await this.notificationDomainService.cleanUp();
+  }
+
+  @OnEvent(NotificationEvent.TASK_IN_CHARGE_ADDED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleTaskInChargeAdded(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.TASK_IN_CHARGE_REMOVED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleTaskInChargeRemoved(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.TASK_IN_CHARGE_CHANGED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleTaskInChargeChanged(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.TASK_REPORT_ADDED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleTaskReportAdded(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.TASK_REPORT_REMOVED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleTaskReportRemoved(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.TASK_STATUS_UPDATED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleTaskStatusChanged(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.TASK_META_UPDATED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleTaskMetaUpdated(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.TASK_DELETED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleTaskDeleted(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+}

--- a/backend/src/notification/swagger/notification.swagger.ts
+++ b/backend/src/notification/swagger/notification.swagger.ts
@@ -1,0 +1,34 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+export const ApiGetNotifications = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '알림 조회',
+      description:
+        '<h2>알림을 조회합니다.</h2>' +
+        '<p>정렬 조건: 1.읽지 않음 2.최신순</p>' +
+        '<p>정렬 방향, 정렬 기준 설정이 적용되지 않습니다.</p>',
+    }),
+  );
+
+export const ApiGetUnreadCount = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '읽지 않은 알림 수 조회',
+    }),
+  );
+
+export const ApiPatchCheckAllRead = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '모두 읽음 처리',
+    }),
+  );
+
+export const ApiPatchCheckRead = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '해당 알림 읽음 처리',
+    }),
+  );

--- a/backend/src/order/order-domain/service/order-domain.service.ts
+++ b/backend/src/order/order-domain/service/order-domain.service.ts
@@ -47,7 +47,6 @@ export class OrderDomainService implements IOrderDomainService {
     }
 
     const items = await query.limit(dto.limit + 1).getMany();
-    console.log(query.getQuery());
 
     const hasMore = items.length > dto.limit;
     if (hasMore) {
@@ -121,7 +120,7 @@ export class OrderDomainService implements IOrderDomainService {
     return result;
   }
 
-  private applySort(
+  /*private applySort(
     query: SelectQueryBuilder<OrderModel>,
     sortBy: OrderSortColumn,
     sortDirection: 'ASC' | 'DESC',
@@ -135,7 +134,7 @@ export class OrderDomainService implements IOrderDomainService {
     }
 
     query.addOrderBy('order.id', sortDirection);
-  }
+  }*/
 
   private getSortColumnPath(sortBy: OrderSortColumn) {
     switch (sortBy) {

--- a/backend/src/permission/guard/church-manager.guard.ts
+++ b/backend/src/permission/guard/church-manager.guard.ts
@@ -42,8 +42,6 @@ export class ChurchManagerGuard implements CanActivate {
       { subscription: true },
     );
 
-    console.log(church);
-
     req.requestManager =
       await this.managerDomainService.findManagerForPermissionCheck(
         church,

--- a/backend/src/task/controller/task.controller.ts
+++ b/backend/src/task/controller/task.controller.ts
@@ -104,10 +104,17 @@ export class TaskController {
   patchTask(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('taskId', ParseIntPipe) taskId: number,
+    @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: UpdateTaskDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.taskService.patchTask(churchId, taskId, dto, qr);
+    return this.taskService.patchTask(
+      requestManager,
+      churchId,
+      taskId,
+      dto,
+      qr,
+    );
   }
 
   @ApiDeleteTask()
@@ -117,9 +124,10 @@ export class TaskController {
   deleteTask(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('taskId', ParseIntPipe) taskId: number,
+    @RequestManager() requestManager: ChurchUserModel,
     @QueryRunner() qr: QR,
   ) {
-    return this.taskService.deleteTask(churchId, taskId, qr);
+    return this.taskService.deleteTask(requestManager, churchId, taskId, qr);
   }
 
   @ApiAddReportReceivers()
@@ -129,10 +137,17 @@ export class TaskController {
   addReportReceivers(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('taskId', ParseIntPipe) taskId: number,
+    @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: AddTaskReportReceiverDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.taskService.addTaskReportReceivers(churchId, taskId, dto, qr);
+    return this.taskService.addTaskReportReceivers(
+      churchId,
+      taskId,
+      requestManager,
+      dto,
+      qr,
+    );
   }
 
   @ApiDeleteReportReceiver()
@@ -142,12 +157,14 @@ export class TaskController {
   deleteReportReceivers(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('taskId', ParseIntPipe) taskId: number,
+    @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: DeleteTaskReportReceiverDto,
     @QueryRunner() qr: QR,
   ) {
     return this.taskService.deleteTaskReportReceivers(
       churchId,
       taskId,
+      requestManager,
       dto,
       qr,
     );

--- a/backend/src/task/dto/request/create-task.dto.ts
+++ b/backend/src/task/dto/request/create-task.dto.ts
@@ -50,10 +50,9 @@ export class CreateTaskDto extends PickType(TaskModel, [
   @ApiProperty({
     description: '업무 상태 (예약 / 진행중 / 완료 / 지연)',
     enum: TaskStatus,
-    default: TaskStatus.RESERVE,
   })
   @IsEnum(TaskStatus)
-  override status: TaskStatus = TaskStatus.RESERVE;
+  override status: TaskStatus;
 
   @ApiProperty({
     description: '업무 시작 일자 (yyyy-MM-ddTHH:MM:SS)',

--- a/backend/src/task/entity/task.entity.ts
+++ b/backend/src/task/entity/task.entity.ts
@@ -32,7 +32,6 @@ export class TaskModel extends BaseModel {
   title: string;
 
   @Column({
-    enum: TaskStatus,
     default: TaskStatus.RESERVE,
   })
   status: TaskStatus;

--- a/backend/src/task/service/task-notification.service.ts
+++ b/backend/src/task/service/task-notification.service.ts
@@ -1,0 +1,326 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { TaskModel } from '../entity/task.entity';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { UpdateTaskDto } from '../dto/request/update-task.dto';
+import { QueryRunner } from 'typeorm';
+import {
+  NotificationEventDto,
+  NotificationField,
+  NotificationFields,
+  NotificationSourceTask,
+} from '../../notification/notification-event.dto';
+import { NotificationEvent } from '../../notification/const/notification-event.enum';
+import { NotificationDomain } from '../../notification/const/notification-domain.enum';
+import { NotificationAction } from '../../notification/const/notification-action.enum';
+import {
+  IMANAGER_DOMAIN_SERVICE,
+  IManagerDomainService,
+} from '../../manager/manager-domain/service/interface/manager-domain.service.interface';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+@Injectable()
+export class TaskNotificationService {
+  constructor(
+    private readonly eventEmitter: EventEmitter2,
+
+    @Inject(IMANAGER_DOMAIN_SERVICE)
+    private readonly managerDomainService: IManagerDomainService,
+  ) {}
+
+  private async getReportReceivers(
+    church: ChurchModel,
+    task: TaskModel,
+    qr: QueryRunner,
+  ) {
+    // 보고대상자
+    const reportReceiverIds = task.reports.map((report) => report.receiverId);
+
+    return this.managerDomainService.findManagersForNotification(
+      church,
+      reportReceiverIds,
+      qr,
+    );
+  }
+
+  notifyPost(
+    newTask: TaskModel,
+    creatorManager: ChurchUserModel,
+    inCharge: ChurchUserModel,
+  ) {
+    this.eventEmitter.emit(
+      'task.inCharge.added',
+      new NotificationEventDto(
+        creatorManager.member.name ? creatorManager.member.name : '',
+        NotificationDomain.TASK,
+        NotificationAction.IN_CHARGE_ADDED,
+        newTask.title,
+        new NotificationSourceTask(NotificationDomain.TASK, newTask.id),
+        [inCharge],
+        [],
+      ),
+    );
+  }
+
+  notifyReportAdded(
+    task: TaskModel,
+    requestManager: ChurchUserModel,
+    newReceivers: ChurchUserModel[],
+  ) {
+    this.eventEmitter.emit(
+      NotificationEvent.TASK_REPORT_ADDED,
+      new NotificationEventDto(
+        requestManager.member.name ? requestManager.member.name : '',
+        NotificationDomain.TASK,
+        NotificationAction.REPORT_ADDED,
+        task.title,
+        new NotificationSourceTask(NotificationDomain.TASK, task.id),
+        newReceivers,
+        [],
+      ),
+    );
+  }
+
+  notifyReportRemoved(
+    task: TaskModel,
+    requestManager: ChurchUserModel,
+    removedReportReceivers: ChurchUserModel[],
+  ) {
+    const actorName = requestManager.member.name
+      ? requestManager.member.name
+      : '';
+
+    this.eventEmitter.emit(
+      NotificationEvent.TASK_REPORT_REMOVED,
+      new NotificationEventDto(
+        actorName,
+        NotificationDomain.TASK,
+        NotificationAction.REPORT_REMOVED,
+        task.title,
+        new NotificationSourceTask(NotificationDomain.TASK, task.id),
+        removedReportReceivers,
+        [],
+      ),
+    );
+  }
+
+  async notifyUpdate(
+    church: ChurchModel,
+    targetTask: TaskModel,
+    newInChargeMember: ChurchUserModel | null,
+    requestManager: ChurchUserModel,
+    dto: UpdateTaskDto,
+    qr: QueryRunner,
+  ) {
+    // 담당자 (새 담당자 or 기존 담당자)
+    const inCharge = dto.inChargeId
+      ? newInChargeMember
+      : await this.managerDomainService.findManagerByMemberId(
+          church,
+          targetTask.inChargeId,
+          qr,
+        );
+
+    // 보고 대상자
+    const reportReceivers = await this.getReportReceivers(
+      church,
+      targetTask,
+      qr,
+    );
+
+    // 요청자 이름
+    const actorName = requestManager.member.name
+      ? requestManager.member.name
+      : '';
+    const notificationTitle = dto.title ? dto.title : targetTask.title;
+    const notificationSource = new NotificationSourceTask(
+      NotificationDomain.TASK,
+      targetTask.id,
+    );
+
+    // 변경 요청자가 알림 대상자에 있을 경우 제외
+    const notificationTarget = (
+      inCharge ? [...reportReceivers, inCharge] : reportReceivers
+    ).filter((target) => target.id !== requestManager.id);
+
+    const notificationFields: NotificationFields[] = [];
+
+    // 변경 사항 알림 (담당자, 내용 제외)
+    for (const key of Object.keys(dto)) {
+      if (
+        key === 'inChargeId' ||
+        key === 'content' ||
+        key === 'utcStartDate' ||
+        key === 'utcEndDate'
+      ) {
+        continue;
+      }
+      // 상태 변경일 경우 별도 알림
+      if (key === 'status' && dto.status !== targetTask.status) {
+        this.eventEmitter.emit(
+          NotificationEvent.TASK_STATUS_UPDATED,
+          new NotificationEventDto(
+            actorName,
+            NotificationDomain.TASK,
+            NotificationAction.STATUS_UPDATED,
+            notificationTitle,
+            notificationSource,
+            notificationTarget,
+            [
+              new NotificationFields(
+                NotificationField.STATUS,
+                targetTask.status,
+                dto.status,
+              ),
+            ],
+          ),
+        );
+      } else if (dto[key] !== targetTask[key]) {
+        if (key === 'startDate') {
+          const fieldUpdated = new NotificationFields(
+            key,
+            targetTask[key],
+            dto.utcStartDate,
+          );
+
+          notificationFields.push(fieldUpdated);
+        } else if (key === 'endDate') {
+          const fieldUpdated = new NotificationFields(
+            key,
+            targetTask[key],
+            dto.utcEndDate,
+          );
+
+          notificationFields.push(fieldUpdated);
+        } else {
+          const fieldUpdated = new NotificationFields(
+            key,
+            targetTask[key],
+            dto[key],
+          );
+
+          notificationFields.push(fieldUpdated);
+        }
+      }
+    }
+
+    notificationFields.length > 0 &&
+      this.eventEmitter.emit(
+        NotificationEvent.TASK_META_UPDATED,
+        new NotificationEventDto(
+          actorName,
+          NotificationDomain.TASK,
+          NotificationAction.UPDATED,
+          notificationTitle,
+          notificationSource,
+          notificationTarget,
+          notificationFields,
+        ),
+      );
+
+    // 담당자 변경 알림
+    if (dto.inChargeId && newInChargeMember) {
+      const previousInCharge =
+        await this.managerDomainService.findManagerByMemberId(
+          church,
+          targetTask.inChargeId,
+          qr,
+        );
+
+      // 이전 담당자 제외 알림
+      if (previousInCharge.id !== requestManager.id) {
+        this.eventEmitter.emit(
+          NotificationEvent.TASK_IN_CHARGE_REMOVED,
+          new NotificationEventDto(
+            actorName,
+            NotificationDomain.TASK,
+            NotificationAction.IN_CHARGE_REMOVED,
+            notificationTitle,
+            notificationSource,
+            [previousInCharge],
+            [],
+          ),
+        );
+      }
+
+      // 새로운 담당자 지정 알림
+      if (newInChargeMember.id !== requestManager.id) {
+        this.eventEmitter.emit(
+          NotificationEvent.TASK_IN_CHARGE_ADDED,
+          new NotificationEventDto(
+            actorName,
+            NotificationDomain.TASK,
+            NotificationAction.IN_CHARGE_ADDED,
+            notificationTitle,
+            notificationSource,
+            [newInChargeMember],
+            [],
+          ),
+        );
+      }
+
+      const inChargeNotificationTargets = reportReceivers.filter(
+        (target) => target.id !== requestManager.id,
+      );
+
+      // 담당자 변경 알림
+      this.eventEmitter.emit(
+        NotificationEvent.TASK_IN_CHARGE_CHANGED,
+        new NotificationEventDto(
+          actorName,
+          NotificationDomain.TASK,
+          NotificationAction.IN_CHARGE_CHANGED,
+          notificationTitle,
+          notificationSource,
+          inChargeNotificationTargets,
+          [
+            new NotificationFields(
+              NotificationField.IN_CHARGE,
+              previousInCharge.member.name,
+              newInChargeMember?.member.name,
+            ),
+          ],
+        ),
+      );
+    }
+  }
+
+  async notifyDelete(
+    church: ChurchModel,
+    targetTask: TaskModel,
+    requestManager: ChurchUserModel,
+    qr: QueryRunner,
+  ) {
+    // 요청자 이름
+    const actorName = requestManager.member.name
+      ? requestManager.member.name
+      : '';
+
+    const receiverIds = targetTask.reports.map((report) => report.receiverId);
+
+    const notificationReceiverIds = [
+      targetTask.inChargeId,
+      ...receiverIds,
+    ].filter((id) => id);
+
+    const notificationReceivers =
+      await this.managerDomainService.findManagersForNotification(
+        church,
+        notificationReceiverIds,
+        qr,
+      );
+
+    this.eventEmitter.emit(
+      NotificationEvent.TASK_DELETED,
+      new NotificationEventDto(
+        actorName,
+        NotificationDomain.TASK,
+        NotificationAction.DELETED,
+        targetTask.title,
+        null,
+        notificationReceivers,
+        [],
+      ),
+    );
+  }
+}

--- a/backend/src/task/task.module.ts
+++ b/backend/src/task/task.module.ts
@@ -7,6 +7,7 @@ import { TaskService } from './service/task.service';
 import { TaskDomainModule } from './task-domain/task-domain.module';
 import { TaskReportDomainModule } from '../report/task-report/task-report-domain/task-report-domain.module';
 import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
+import { TaskNotificationService } from './service/task-notification.service';
 
 @Module({
   imports: [
@@ -21,6 +22,6 @@ import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.mo
     TaskReportDomainModule,
   ],
   controllers: [TaskController],
-  providers: [TaskService],
+  providers: [TaskService, TaskNotificationService],
 })
 export class TaskModule {}


### PR DESCRIPTION
## 주요 내용
- **업무(Task) 도메인 알림 처리 로직**을 구현하여 생성, 수정, 담당자 변경, 삭제 시 관련자들에게 알림 자동 발송
- 알림 정보는 NotificationModel에 저장되며, 2주 뒤 만료 처리되도록 `expiresAt` 컬럼 적용

## 세부 내용
### 알림 발생 조건 및 대상
- **업무 생성 시**
  - 알림 대상: 업무 담당자, 보고대상자
- **업무 내용 수정 시**
  - 알림 대상: 업무 담당자, 보고대상자
  - 알림 필드: 제목(title), 시작일(startDate), 종료일(endDate), 상태(status)
- **담당자 변경 시**
  - 알림 대상: 기존 담당자, 신규 담당자, 보고대상자
- **업무 삭제 시**
  - 알림 대상: 업무 담당자, 보고대상자

### NotificationModel 컬럼
- `createdAt`: 알림 생성일
- `updatedAt`: 알림 읽음 처리일
- `actorName`: 알림을 발생시킨 관리자 이름
- `domain`: 알림 도메인 (예: task)
- `action`: 발생한 동작 종류 (created, updated, assignee_changed, deleted 등)
- `domainTitle`: 알림 대상의 제목(업무명)
- `isRead`: 확인 여부
- `payload`: 변경 사항 상세 JSON 예시: `[{"fields":"title","previous":"수정전","current":"수정후"}]`
- `sourceInfo`: 리소스 정보 JSON (위계 포함) 예시: `{"domain":"task","id":19}` 또는 교육 세션의 경우 `{"domain":"education_session","educationId":3,"educationTermId":42,"id":19}`
- `expiresAt`: 알림 만료 예정일 (생성일로부터 2주 후)

### 목적
- 업무 생성·변경·삭제 시 관련자들이 즉시 알림을 받아 협업 효율성을 높이고 정보 누락을 방지
- 알림 데이터 모델 정규화 및 만료 처리 정책을 통해 장기 데이터 축적 방지