### PR TITLE
feat: 회원 탈퇴(본인 계정) 엔드포인트 추가

### DIFF
--- a/backend/src/church-join/church-join-domain/service/church-join-requests-domain.service.ts
+++ b/backend/src/church-join/church-join-domain/service/church-join-requests-domain.service.ts
@@ -70,8 +70,6 @@ export class ChurchJoinRequestsDomainService
       user,
       status: ChurchJoinRequestStatusEnum.PENDING,
     });
-
-    //return this.findMyChurchJoinRequestById(user, newRequest.id, qr);
   }
 
   private parseCreatedAt(dto: GetJoinRequestDto) {

--- a/backend/src/church-join/service/church-join.service.ts
+++ b/backend/src/church-join/service/church-join.service.ts
@@ -66,7 +66,7 @@ export class ChurchJoinService {
     qr: QueryRunner,
   ) {
     const userId = accessPayload.id;
-    const user = await this.userDomainService.findUserModelById(userId);
+    const user = await this.userDomainService.findUserModelById(userId, qr);
 
     /**
      * ChurchUserModel 조회로 소속된 교회가 있는지 확인

--- a/backend/src/church-user/church-user-domain/service/church-user-domain.service.ts
+++ b/backend/src/church-user/church-user-domain/service/church-user-domain.service.ts
@@ -151,7 +151,7 @@ export class ChurchUserDomainService implements IChurchUserDomainService {
     });
 
     if (!churchUser) {
-      throw new NotFoundException();
+      throw new NotFoundException(ChurchUserException.NOT_FOUND);
     }
 
     return churchUser;

--- a/backend/src/churches/const/exception/church.exception.ts
+++ b/backend/src/churches/const/exception/church.exception.ts
@@ -6,7 +6,7 @@ export const ChurchException = {
   NOT_FOUND: '해당 교회를 찾을 수 없습니다.',
   ALREADY_EXIST_JOIN_CODE: '이미 존재하는 교회 가입 코드입니다.',
   INVALID_CHURCH_CODE: '교회 코드는 영문자와 숫자만 사용할 수 있습니다.',
-  SAME_MAIN_ADMIN: '동일한 교회 최고 관리자입니다.',
+  SAME_OWNER: '동일한 교회 최고 관리자입니다.',
   INVALID_NEW_OWNER:
     '관리자 권한의 교인에게만 교회 소유자 권한을 넘길 수 있습니다.',
   NOT_FOUND_TRIAL_CHURCH: '무료 체험 중인 교회를 찾을 수 없습니다.',

--- a/backend/src/churches/service/churches.service.ts
+++ b/backend/src/churches/service/churches.service.ts
@@ -203,10 +203,11 @@ export class ChurchesService {
       throw new ConflictException('교회 소유자 누락');
     }
 
-    const oldOwnerUser = await this.userDomainService.findUserModelById(
-      church.ownerUserId,
-      qr,
-    );
+    const oldOwnerUser =
+      await this.userDomainService.findUserWithChurchUserById(
+        church.ownerUserId,
+        qr,
+      );
 
     const oldOwnerChurchUser =
       await this.churchUserDomainService.findChurchUserByUser(
@@ -222,13 +223,14 @@ export class ChurchesService {
         qr,
       );
 
-    const newOwnerUser = await this.userDomainService.findUserModelById(
-      newOwnerChurchUser.userId,
-      qr,
-    );
+    const newOwnerUser =
+      await this.userDomainService.findUserWithChurchUserById(
+        newOwnerChurchUser.userId,
+        qr,
+      );
 
     if (oldOwnerChurchUser.userId === newOwnerChurchUser.userId) {
-      throw new BadRequestException(ChurchException.SAME_MAIN_ADMIN);
+      throw new BadRequestException(ChurchException.SAME_OWNER);
     }
 
     if (newOwnerChurchUser.role !== ChurchUserRole.MANAGER) {

--- a/backend/src/churches/service/trial-churches.service.ts
+++ b/backend/src/churches/service/trial-churches.service.ts
@@ -92,7 +92,10 @@ export class TrialChurchesService {
   ) {}
 
   async startTrialChurch(userId: number, qr: QueryRunner) {
-    const user = await this.userDomainService.findUserModelById(userId, qr);
+    const user = await this.userDomainService.findUserWithChurchUserById(
+      userId,
+      qr,
+    );
 
     if (user.role !== UserRole.NONE) {
       throw new ConflictException(
@@ -162,7 +165,10 @@ export class TrialChurchesService {
   }
 
   async endTrialChurch(userId: number, qr: QueryRunner) {
-    const user = await this.userDomainService.findUserModelById(userId, qr);
+    const user = await this.userDomainService.findUserWithChurchUserById(
+      userId,
+      qr,
+    );
 
     if (user.role !== UserRole.OWNER) {
       throw new ConflictException('운영 중인 교회가 없습니다.');

--- a/backend/src/mobile-verification/exception/mobile-verification.exception.ts
+++ b/backend/src/mobile-verification/exception/mobile-verification.exception.ts
@@ -4,4 +4,6 @@ export const MobileVerificationException = {
   NOT_FOUND: '문자 인증 요청 내역을 찾을 수 없습니다.',
   EXCEED_MAX_VERIFICATION_ATTEMPTS: '인증 번호 확인 횟수를 초과했습니다.',
   ALREADY_VERIFIED: '인증 완료된 번호입니다.',
+  EXPIRED_CODE: '유효 시간을 초과했습니다.',
+  WRONG_CODE: '인증 번호가 일치하지 않습니다.',
 };

--- a/backend/src/mobile-verification/mobile-verification-domain/service/mobile-verification-domain.service.ts
+++ b/backend/src/mobile-verification/mobile-verification-domain/service/mobile-verification-domain.service.ts
@@ -101,7 +101,7 @@ export class MobileVerificationDomainService
     }
 
     if (verification.expiresAt < new Date()) {
-      throw new ConflictException('유효 시간 초과');
+      throw new ConflictException(MobileVerificationException.EXPIRED_CODE);
     }
 
     if (verification.attemptCount >= 5) {
@@ -134,7 +134,7 @@ export class MobileVerificationDomainService
         },
       );
 
-      throw new ConflictException('인증 번호가 일치하지 않습니다.');
+      throw new ConflictException(MobileVerificationException.WRONG_CODE);
     }
   }
 

--- a/backend/src/user/const/swagger/user.swagger.ts
+++ b/backend/src/user/const/swagger/user.swagger.ts
@@ -15,6 +15,13 @@ export const ApiPatchUser = () =>
     }),
   );
 
+export const ApiDeleteUser = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '회원 탈퇴',
+    }),
+  );
+
 export const ApiGetMyJoinRequest = () =>
   applyDecorators(
     ApiOperation({

--- a/backend/src/user/controller/user.controller.ts
+++ b/backend/src/user/controller/user.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Patch, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { UserService } from '../service/user.service';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
@@ -7,6 +15,7 @@ import { AuthType } from '../../auth/const/enum/auth-type.enum';
 import { JwtAccessPayload } from '../../auth/type/jwt';
 import {
   ApiCancelMyJoinRequest,
+  ApiDeleteUser,
   ApiGetMyJoinRequest,
   ApiGetMyPendingJoinRequest,
   ApiGetUser,
@@ -39,6 +48,14 @@ export class UserController {
   @UseGuards(AccessTokenGuard, UserGuard)
   patchUser(@User() user: UserModel, @Body() dto: UpdateUserInfoDto) {
     return this.userService.updateUserInfo(user, dto);
+  }
+
+  @ApiDeleteUser()
+  @Delete()
+  @UseGuards(AccessTokenGuard, UserGuard)
+  @UseTransaction()
+  deleteUser(@User() user: UserModel, @QueryRunner() qr: QR) {
+    return this.userService.deleteUser(user, qr);
   }
 
   @ApiOperation({ summary: '번호 수정을 위한 인증 요청' })

--- a/backend/src/user/guard/user.guard.ts
+++ b/backend/src/user/guard/user.guard.ts
@@ -22,7 +22,7 @@ export class UserGuard implements CanActivate {
 
     const userId = req.tokenPayload.id;
 
-    req.user = await this.userDomainService.findUserModelById(userId);
+    req.user = await this.userDomainService.findUserWithChurchUserById(userId);
 
     return true;
   }

--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -42,11 +42,14 @@ export class UserService {
   ) {}
 
   async getUserById(id: number) {
-    return this.userDomainService.findUserModelById(id);
+    return this.userDomainService.findUserWithChurchUserById(id);
   }
 
   async getMyJoinRequest(userId: number, qr?: QueryRunner) {
-    const user = await this.userDomainService.findUserModelById(userId, qr);
+    const user = await this.userDomainService.findUserWithChurchUserById(
+      userId,
+      qr,
+    );
 
     return this.churchJoinRequestsDomainService.findMyChurchJoinRequest(
       user,
@@ -57,7 +60,9 @@ export class UserService {
   async updateUserInfo(user: UserModel, dto: UpdateUserInfoDto) {
     await this.userDomainService.updateUserInfo(user, dto);
 
-    const updatedUser = await this.userDomainService.findUserModelById(user.id);
+    const updatedUser = await this.userDomainService.findUserWithChurchUserById(
+      user.id,
+    );
 
     return new PatchUserResponseDto(updatedUser);
   }
@@ -108,7 +113,7 @@ export class UserService {
       qr,
     );
 
-    const updatedUser = await this.userDomainService.findUserModelById(
+    const updatedUser = await this.userDomainService.findUserWithChurchUserById(
       user.id,
       qr,
     );
@@ -117,7 +122,10 @@ export class UserService {
   }
 
   async cancelMyJoinRequest(userId: number, qr?: QueryRunner) {
-    const user = await this.userDomainService.findUserModelById(userId, qr);
+    const user = await this.userDomainService.findUserWithChurchUserById(
+      userId,
+      qr,
+    );
 
     const joinRequest =
       await this.churchJoinRequestsDomainService.findMyPendingChurchJoinRequest(
@@ -139,7 +147,8 @@ export class UserService {
   }
 
   async getMyPendingJoinRequest(userId: number) {
-    const user = await this.userDomainService.findUserModelById(userId);
+    const user =
+      await this.userDomainService.findUserWithChurchUserById(userId);
 
     return this.churchJoinRequestsDomainService.findMyPendingChurchJoinRequest(
       user,
@@ -156,6 +165,15 @@ export class UserService {
       { role: UserRole.NONE },
       qr,
     );
+
+    return {
+      success: true,
+      timestamp: new Date(),
+    };
+  }
+
+  async deleteUser(user: UserModel, qr: QueryRunner) {
+    await this.userDomainService.deleteUser(user, qr);
 
     return {
       success: true,

--- a/backend/src/user/user-domain/interface/user-domain.service.interface.ts
+++ b/backend/src/user/user-domain/interface/user-domain.service.interface.ts
@@ -1,4 +1,4 @@
-import { QueryRunner, UpdateResult } from 'typeorm';
+import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { UserModel } from '../../entity/user.entity';
 import { CreateUserDto } from '../../dto/create-user.dto';
 import { ChurchModel } from '../../../churches/entity/church.entity';
@@ -10,7 +10,13 @@ export const IUSER_DOMAIN_SERVICE = Symbol('IUserDomainService');
 export interface IUserDomainService {
   findUserById(userId: number, qr?: QueryRunner): Promise<UserModel>;
 
-  findUserModelById(id: number, qr?: QueryRunner): Promise<UserModel>;
+  findUserWithChurchUserById(id: number, qr?: QueryRunner): Promise<UserModel>;
+
+  findUserModelById(
+    id: number,
+    qr?: QueryRunner,
+    relationOptions?: FindOptionsRelations<UserModel>,
+  ): Promise<UserModel>;
 
   findUserModelByOAuth(
     provider: string,
@@ -60,4 +66,6 @@ export interface IUserDomainService {
     expiredUserIds: number[],
     qr: QueryRunner,
   ): Promise<UpdateResult>;
+
+  deleteUser(user: UserModel, qr: QueryRunner): Promise<UpdateResult>;
 }


### PR DESCRIPTION
## 주요 내용
- 로그인 사용자가 자신의 계정을 탈퇴할 수 있는 API 추가
- 엔드포인트: `DELETE /users`

## 세부 내용
### API
- `UsersController`에 `DELETE /users` 추가 (본인 계정 대상)
- 인증 필요(JWT)

### 도메인/서비스
- 사용자 계정 탈퇴 처리 로직 추가(비활성화/삭제 처리)
- 연관 데이터 정리(예: 교회 가입 정보 등)는 정책에 따라 후속 커밋에서 단계적으로 반영 예정