### PR TITLE
feat: 심방(Visitation) 생성/보고대상자 추가·삭제/삭제 알림 기능 추가

### DIFF
--- a/backend/src/notification/const/notification-event.enum.ts
+++ b/backend/src/notification/const/notification-event.enum.ts
@@ -7,4 +7,9 @@ export enum NotificationEvent {
   TASK_STATUS_UPDATED = 'task.status.updated',
   TASK_META_UPDATED = 'task.meta.updated',
   TASK_DELETED = 'task.deleted',
+
+  VISITATION_IN_CHARGE_ADDED = 'visitation.inCharge.added',
+  VISITATION_REPORT_ADDED = 'visitation.report.added',
+  VISITATION_REPORT_REMOVED = 'visitation.report.removed',
+  VISITATION_DELETED = 'visitation.deleted',
 }

--- a/backend/src/notification/notification-event.dto.ts
+++ b/backend/src/notification/notification-event.dto.ts
@@ -38,6 +38,12 @@ export class NotificationSourceTask extends NotificationSource {
   }
 }
 
+export class NotificationSourceVisitation extends NotificationSource {
+  constructor(domain: NotificationDomain, id: number) {
+    super(domain, id);
+  }
+}
+
 export class NotificationEventDto {
   actorName: string;
 

--- a/backend/src/notification/service/notification.service.ts
+++ b/backend/src/notification/service/notification.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import {
   INOTIFICATION_DOMAIN_SERVICE,
   INotificationDomainService,
@@ -18,6 +18,8 @@ export class NotificationService {
     @Inject(INOTIFICATION_DOMAIN_SERVICE)
     private readonly notificationDomainService: INotificationDomainService,
   ) {}
+
+  private readonly logger = new Logger(NotificationService.name);
 
   async getNotifications(
     churchUser: ChurchUserModel,
@@ -73,7 +75,9 @@ export class NotificationService {
 
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT, { timeZone: 'Asia/Seoul' })
   async cleanUp() {
-    await this.notificationDomainService.cleanUp();
+    const result = await this.notificationDomainService.cleanUp();
+
+    this.logger.log(`${result.affected} 개 알림 삭제`);
   }
 
   @OnEvent(NotificationEvent.TASK_IN_CHARGE_ADDED, {
@@ -137,6 +141,38 @@ export class NotificationService {
     suppressErrors: true,
   })
   async handleTaskDeleted(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.VISITATION_IN_CHARGE_ADDED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleVisitationInChargeAdded(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.VISITATION_REPORT_ADDED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleVisitationReportAdded(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.VISITATION_REPORT_REMOVED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleVisitationReportRemoved(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.VISITATION_DELETED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleVisitationDeleted(event: NotificationEventDto) {
     await this.notificationDomainService.createNotifications(event);
   }
 }

--- a/backend/src/task/service/task-notification.service.ts
+++ b/backend/src/task/service/task-notification.service.ts
@@ -49,7 +49,7 @@ export class TaskNotificationService {
     inCharge: ChurchUserModel,
   ) {
     this.eventEmitter.emit(
-      'task.inCharge.added',
+      NotificationEvent.TASK_IN_CHARGE_ADDED,
       new NotificationEventDto(
         creatorManager.member.name ? creatorManager.member.name : '',
         NotificationDomain.TASK,

--- a/backend/src/task/service/task.service.ts
+++ b/backend/src/task/service/task.service.ts
@@ -256,7 +256,7 @@ export class TaskService {
     // 업무 보고 삭제
     await this.taskReportDomainService.deleteTaskReportCascade(targetTask, qr);
 
-    this.taskNotificationService.notifyDelete(
+    await this.taskNotificationService.notifyDelete(
       church,
       targetTask,
       requestManager,

--- a/backend/src/visitation/controller/visitation.controller.ts
+++ b/backend/src/visitation/controller/visitation.controller.ts
@@ -115,9 +115,16 @@ export class VisitationController {
   deleteVisiting(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('visitationId', ParseIntPipe) visitationId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @QueryRunner() qr: QR,
   ) {
-    return this.visitationService.deleteVisitation(churchId, visitationId, qr);
+    return this.visitationService.deleteVisitation(
+      church,
+      requestManager,
+      visitationId,
+      qr,
+    );
   }
 
   @ApiOperation({
@@ -129,11 +136,14 @@ export class VisitationController {
   addReportReceivers(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('visitationId', ParseIntPipe) visitationId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: AddReceiverDto,
     @QueryRunner() qr: QR,
   ) {
     return this.visitationService.addReportReceivers(
-      churchId,
+      church,
+      requestManager,
       visitationId,
       dto.receiverIds,
       qr,
@@ -149,11 +159,14 @@ export class VisitationController {
   removeReportReceivers(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('visitationId', ParseIntPipe) visitationId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: DeleteReceiverDto,
     @QueryRunner() qr: QR,
   ) {
     return this.visitationService.deleteReportReceivers(
-      churchId,
+      church,
+      requestManager,
       visitationId,
       dto.receiverIds,
       qr,

--- a/backend/src/visitation/dto/request/create-visitation.dto.ts
+++ b/backend/src/visitation/dto/request/create-visitation.dto.ts
@@ -61,17 +61,15 @@ export class CreateVisitationDto {
   })
   @IsDateString({ strict: true })
   @IsDateTime('startDate')
-  //@IsDate()
-  startDate: string; //Date;
+  startDate: string;
 
   @ApiProperty({
     description: '심방 종료 날짜 (yyyy-MM-ddTHH:mm:ss)',
   })
-  //@IsDate()
   @IsDateString({ strict: true })
   @IsDateTime('endDate')
   @IsAfterDate('startDate')
-  endDate: string; //Date;
+  endDate: string;
 
   @ApiProperty({
     description: '심방 대상자 교인 ID 배열',
@@ -91,12 +89,8 @@ export class CreateVisitationDto {
   })
   @ValidateNested({ each: true })
   @Type(() => VisitationDetailDto)
-  @ArrayMaxSize(
-    1 /*30, {
-    message: VisitationException.EXCEED_VISITATION_MEMBER,
-  }*/,
-  )
-  //@VisitationDetailValidator()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(1)
   visitationDetails: VisitationDetailDto[];
 
   @ApiProperty({

--- a/backend/src/visitation/service/visitation-notification.service.ts
+++ b/backend/src/visitation/service/visitation-notification.service.ts
@@ -1,0 +1,156 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import {
+  IMANAGER_DOMAIN_SERVICE,
+  IManagerDomainService,
+} from '../../manager/manager-domain/service/interface/manager-domain.service.interface';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { VisitationMetaModel } from '../entity/visitation-meta.entity';
+import { QueryRunner } from 'typeorm';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { NotificationEvent } from '../../notification/const/notification-event.enum';
+import {
+  NotificationEventDto,
+  NotificationSourceVisitation,
+} from '../../notification/notification-event.dto';
+import { NotificationDomain } from '../../notification/const/notification-domain.enum';
+import { NotificationAction } from '../../notification/const/notification-action.enum';
+
+@Injectable()
+export class VisitationNotificationService {
+  constructor(
+    private readonly eventEmitter: EventEmitter2,
+    @Inject(IMANAGER_DOMAIN_SERVICE)
+    private readonly managerDomainService: IManagerDomainService,
+  ) {}
+
+  private async getReportReceivers(
+    church: ChurchModel,
+    visitation: VisitationMetaModel,
+    qr: QueryRunner,
+  ) {
+    const reportReceiverIds = visitation.reports.map((r) => r.receiverId);
+
+    return this.managerDomainService.findManagersForNotification(
+      church,
+      reportReceiverIds,
+      qr,
+    );
+  }
+
+  notifyPost(
+    newVisitation: VisitationMetaModel,
+    creatorManager: ChurchUserModel,
+    inCharge: ChurchUserModel,
+  ) {
+    const actorName = creatorManager.member.name
+      ? creatorManager.member.name
+      : '';
+
+    this.eventEmitter.emit(
+      NotificationEvent.VISITATION_IN_CHARGE_ADDED,
+      new NotificationEventDto(
+        actorName,
+        NotificationDomain.VISITATION,
+        NotificationAction.IN_CHARGE_ADDED,
+        newVisitation.title,
+        new NotificationSourceVisitation(
+          NotificationDomain.VISITATION,
+          newVisitation.id,
+        ),
+        [inCharge],
+        [],
+      ),
+    );
+  }
+
+  notifyReportAdded(
+    visitation: VisitationMetaModel,
+    requestManager: ChurchUserModel,
+    newReceivers: ChurchUserModel[],
+  ) {
+    const actorName = requestManager.member.name
+      ? requestManager.member.name
+      : '';
+
+    this.eventEmitter.emit(
+      NotificationEvent.VISITATION_REPORT_ADDED,
+      new NotificationEventDto(
+        actorName,
+        NotificationDomain.VISITATION,
+        NotificationAction.REPORT_ADDED,
+        visitation.title,
+        new NotificationSourceVisitation(
+          NotificationDomain.VISITATION,
+          visitation.id,
+        ),
+        newReceivers,
+        [],
+      ),
+    );
+  }
+
+  notifyReportRemoved(
+    visitation: VisitationMetaModel,
+    requestManager: ChurchUserModel,
+    removedReportReceivers: ChurchUserModel[],
+  ) {
+    const actorName = requestManager.member.name
+      ? requestManager.member.name
+      : '';
+
+    this.eventEmitter.emit(
+      NotificationEvent.VISITATION_REPORT_REMOVED,
+      new NotificationEventDto(
+        actorName,
+        NotificationDomain.VISITATION,
+        NotificationAction.REPORT_REMOVED,
+        visitation.title,
+        new NotificationSourceVisitation(
+          NotificationDomain.VISITATION,
+          visitation.id,
+        ),
+        removedReportReceivers,
+        [],
+      ),
+    );
+  }
+
+  async notifyDelete(
+    church: ChurchModel,
+    targetVisitation: VisitationMetaModel,
+    requestManager: ChurchUserModel,
+    qr: QueryRunner,
+  ) {
+    const actorName = requestManager.member.name
+      ? requestManager.member.name
+      : '';
+
+    const receiverIds = targetVisitation.reports.map((r) => r.receiverId);
+
+    const notificationReceiverIds = [
+      targetVisitation.inChargeId,
+      ...receiverIds,
+    ].filter((id) => id !== null);
+
+    const notificationReceivers =
+      await this.managerDomainService.findManagersForNotification(
+        church,
+        notificationReceiverIds,
+        qr,
+      );
+
+    this.eventEmitter.emit(
+      NotificationEvent.VISITATION_DELETED,
+      new NotificationEventDto(
+        actorName,
+        NotificationDomain.VISITATION,
+        NotificationAction.DELETED,
+        targetVisitation.title,
+        null,
+        notificationReceivers,
+        [],
+      ),
+    );
+  }
+}

--- a/backend/src/visitation/visitation.module.ts
+++ b/backend/src/visitation/visitation.module.ts
@@ -9,6 +9,7 @@ import { VisitationReportDomainModule } from '../report/visitation-report/visita
 import { VisitationDetailController } from './controller/visitation-detail.controller';
 import { VisitationDetailService } from './service/visitation-detail.service';
 import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
+import { VisitationNotificationService } from './service/visitation-notification.service';
 
 @Module({
   imports: [
@@ -23,6 +24,10 @@ import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.mo
     VisitationReportDomainModule,
   ],
   controllers: [VisitationController, VisitationDetailController],
-  providers: [VisitationService, VisitationDetailService],
+  providers: [
+    VisitationService,
+    VisitationDetailService,
+    VisitationNotificationService,
+  ],
 })
 export class VisitationModule {}


### PR DESCRIPTION
## 주요 내용
- 심방 생성, 보고대상자 추가·삭제, 심방 삭제 시 관련자에게 알림 발송
- 업무(Task)와 동일한 알림 처리 원칙 적용(수신자 중복 제거, 발신자 제외, TTL 적용)

## 세부 내용
### 알림 액션·대상
- **심방 생성** → `NotificationAction.CREATED`
  - 대상: 담당자(inCharge), 보고대상자(report receivers)
- **보고대상자 추가** → `NotificationAction.REPORT_ADDED`
  - 대상: 추가된 보고대상자(본인)
- **보고대상자 삭제** → `NotificationAction.REPORT_REMOVED`
  - 대상: 삭제된 보고대상자(본인)
- **심방 삭제** → `NotificationAction.DELETED`
  - 대상: 담당자(inCharge), 보고대상자(report receivers)

### NotificationModel 활용(공통)
- `domain`: `visitation`
- `action`: `created` | `reportAdded` | `reportRemoved` | `deleted`
- `domainTitle`: 심방 제목
- `actorName`: 알림 발생 관리자 이름
- `isRead`: 기본 `false`
- `payload`: 변경 항목 JSON(필요 시)
- `sourceInfo`: `{"domain":"visitation","id":<visitationId>}` (위계 도메인 확장 예정)
- `expiresAt`: 생성일로부터 2주 후 자동 만료