### PR TITLE
feat: 심방 메타 업데이트 알림 추가 및 휴대폰 번호 인증 검증 로직 수정

### DIFF
--- a/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
+++ b/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
@@ -78,6 +78,12 @@ export interface IManagerDomainService {
     qr?: QueryRunner,
   ): Promise<ChurchUserModel[]>;
 
+  findManagerForNotification(
+    church: ChurchModel,
+    memberId: number,
+    qr?: QueryRunner,
+  ): Promise<ChurchUserModel | null>;
+
   /**
    * receiver 로 지정된 교인의 권한 확인용
    * @param church

--- a/backend/src/manager/manager-domain/service/manager-domain.service.ts
+++ b/backend/src/manager/manager-domain/service/manager-domain.service.ts
@@ -233,6 +233,28 @@ export class ManagerDomainService implements IManagerDomainService {
     return churchUser;
   }
 
+  async findManagerForNotification(
+    church: ChurchModel,
+    memberId: number,
+    qr?: QueryRunner,
+  ): Promise<ChurchUserModel | null> {
+    const repository = this.getRepository(qr);
+
+    return repository.findOne({
+      where: {
+        churchId: church.id,
+        memberId,
+        role: ChurchUserManagers,
+      },
+      relations: {
+        member: MemberSummarizedRelation,
+      },
+      select: {
+        member: MemberSimpleSelect,
+      },
+    });
+  }
+
   async findManagersForNotification(
     church: ChurchModel,
     memberIds: number[],

--- a/backend/src/mobile-verification/mobile-verification-domain/service/mobile-verification-domain.service.ts
+++ b/backend/src/mobile-verification/mobile-verification-domain/service/mobile-verification-domain.service.ts
@@ -119,7 +119,7 @@ export class MobileVerificationDomainService
       await repository.update(
         { id: verification.id },
         {
-          attemptCount: () => 'attemptCount + 1',
+          attemptCount: verification.attemptCount + 1,
           isVerified: true,
         },
       );
@@ -130,7 +130,7 @@ export class MobileVerificationDomainService
       await repository.update(
         { id: verification.id },
         {
-          attemptCount: () => 'attemptCount + 1',
+          attemptCount: verification.attemptCount + 1,
         },
       );
 

--- a/backend/src/notification/const/notification-event.enum.ts
+++ b/backend/src/notification/const/notification-event.enum.ts
@@ -9,7 +9,11 @@ export enum NotificationEvent {
   TASK_DELETED = 'task.deleted',
 
   VISITATION_IN_CHARGE_ADDED = 'visitation.inCharge.added',
+  VISITATION_IN_CHARGE_REMOVED = 'visitation.inCharge.removed',
+  VISITATION_IN_CHARGE_CHANGED = 'visitation.inCharge.changed',
   VISITATION_REPORT_ADDED = 'visitation.report.added',
   VISITATION_REPORT_REMOVED = 'visitation.report.removed',
   VISITATION_DELETED = 'visitation.deleted',
+  VISITATION_STATUS_UPDATED = 'visitation.status.updated',
+  VISITATION_META_UPDATED = 'visitation.meta.updated',
 }

--- a/backend/src/notification/service/notification.service.ts
+++ b/backend/src/notification/service/notification.service.ts
@@ -151,6 +151,15 @@ export class NotificationService {
   async handleVisitationInChargeAdded(event: NotificationEventDto) {
     await this.notificationDomainService.createNotifications(event);
   }
+  @OnEvent(NotificationEvent.VISITATION_IN_CHARGE_CHANGED)
+  async handleVisitationInChargeChanged(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.VISITATION_IN_CHARGE_REMOVED)
+  async handleVisitationInChargeRemoved(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
 
   @OnEvent(NotificationEvent.VISITATION_REPORT_ADDED, {
     async: true,
@@ -173,6 +182,19 @@ export class NotificationService {
     suppressErrors: true,
   })
   async handleVisitationDeleted(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.VISITATION_STATUS_UPDATED, {})
+  async handleVisitationStatusStatusChanged(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.VISITATION_META_UPDATED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleVisitationMetaUpdated(event: NotificationEventDto) {
     await this.notificationDomainService.createNotifications(event);
   }
 }

--- a/backend/src/user/controller/user.controller.ts
+++ b/backend/src/user/controller/user.controller.ts
@@ -73,13 +73,11 @@ export class UserController {
   @ApiOperation({ summary: '인증 확인 및 번호 수정' })
   @Post('verification/verify')
   @UseGuards(AccessTokenGuard, UserGuard)
-  @UseTransaction()
   verifyMobileVerification(
     @User() user: UserModel,
     @Body() dto: VerifyUserMobilePhoneDto,
-    @QueryRunner() qr: QR,
   ) {
-    return this.userService.verifyMobilePhone(user, dto, qr);
+    return this.userService.verifyMobilePhone(user, dto);
   }
 
   @ApiGetMyJoinRequest()

--- a/backend/src/visitation/controller/visitation.controller.ts
+++ b/backend/src/visitation/controller/visitation.controller.ts
@@ -97,11 +97,14 @@ export class VisitationController {
   patchVisitationMetaData(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('visitationId', ParseIntPipe) visitationMetaDataId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: UpdateVisitationDto,
     @QueryRunner() qr: QR,
   ) {
     return this.visitationService.updateVisitationData(
-      churchId,
+      church,
+      requestManager,
       visitationMetaDataId,
       dto,
       qr,

--- a/backend/src/visitation/dto/request/update-visitation.dto.ts
+++ b/backend/src/visitation/dto/request/update-visitation.dto.ts
@@ -64,21 +64,19 @@ export class UpdateVisitationDto {
     required: false,
   })
   @IsOptionalNotNull()
-  //@IsDate()
   @IsDateString({ strict: true })
   @IsDateTime('startDate')
-  startDate?: string; //Date;
+  startDate?: string;
 
   @ApiProperty({
     description: '심방 종료 날짜 (yyyy-MM-ddTHH:mm:ss)',
     required: false,
   })
   @IsOptionalNotNull()
-  //@IsDate()
   @IsDateString({ strict: true })
   @IsDateTime('endDate')
   @IsAfterDate('startDate')
-  endDate?: string; //Date;
+  endDate?: string;
 
   @ApiProperty({
     description: '심방 대상자 교인 ID',

--- a/backend/src/visitation/service/visitation-notification.service.ts
+++ b/backend/src/visitation/service/visitation-notification.service.ts
@@ -11,10 +11,16 @@ import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { NotificationEvent } from '../../notification/const/notification-event.enum';
 import {
   NotificationEventDto,
+  NotificationField,
+  NotificationFields,
   NotificationSourceVisitation,
 } from '../../notification/notification-event.dto';
 import { NotificationDomain } from '../../notification/const/notification-domain.enum';
 import { NotificationAction } from '../../notification/const/notification-action.enum';
+import { VisitationStatus } from '../const/visitation-status.enum';
+import { UpdateVisitationDto } from '../dto/request/update-visitation.dto';
+import { fromZonedTime } from 'date-fns-tz';
+import { TIME_ZONE } from '../../common/const/time-zone.const';
 
 @Injectable()
 export class VisitationNotificationService {
@@ -114,6 +120,285 @@ export class VisitationNotificationService {
         [],
       ),
     );
+  }
+
+  async notifyStatusUpdate(
+    church: ChurchModel,
+    requestManager: ChurchUserModel,
+    targetVisitation: VisitationMetaModel,
+    newStatus: VisitationStatus,
+    qr: QueryRunner,
+  ) {
+    const reportReceivers = await this.getReportReceivers(
+      church,
+      targetVisitation,
+      qr,
+    );
+
+    const inCharge = targetVisitation.inChargeId
+      ? await this.managerDomainService.findManagerForNotification(
+          church,
+          targetVisitation.inChargeId,
+          qr,
+        )
+      : null;
+
+    const notificationTargets = (
+      inCharge ? [...reportReceivers, inCharge] : reportReceivers
+    ).filter((t) => t.id !== requestManager.id);
+
+    const actorName = requestManager.member.name
+      ? requestManager.member.name
+      : '';
+
+    this.eventEmitter.emit(
+      NotificationEvent.VISITATION_STATUS_UPDATED,
+      new NotificationEventDto(
+        actorName,
+        NotificationDomain.VISITATION,
+        NotificationAction.STATUS_UPDATED,
+        targetVisitation.title,
+        new NotificationSourceVisitation(
+          NotificationDomain.VISITATION,
+          targetVisitation.id,
+        ),
+        notificationTargets,
+        [
+          new NotificationFields(
+            NotificationField.STATUS,
+            targetVisitation.status,
+            newStatus,
+          ),
+        ],
+      ),
+    );
+  }
+
+  async notifyInChargeUpdate(
+    church: ChurchModel,
+    requestManager: ChurchUserModel,
+    targetVisitation: VisitationMetaModel,
+    newInChargeMember: ChurchUserModel,
+    qr: QueryRunner,
+  ) {
+    const actorName = requestManager.member.name
+      ? requestManager.member.name
+      : '';
+
+    const previousInCharge = targetVisitation.inChargeId
+      ? await this.managerDomainService.findManagerForNotification(
+          church,
+          targetVisitation.inChargeId,
+          qr,
+        )
+      : null;
+
+    const notificationSource = new NotificationSourceVisitation(
+      NotificationDomain.VISITATION,
+      targetVisitation.id,
+    );
+
+    // 이전 담당자 제외 알림
+    if (previousInCharge && previousInCharge.id !== requestManager.id) {
+      this.eventEmitter.emit(
+        NotificationEvent.VISITATION_IN_CHARGE_REMOVED,
+        new NotificationEventDto(
+          actorName,
+          NotificationDomain.VISITATION,
+          NotificationAction.IN_CHARGE_REMOVED,
+          targetVisitation.title,
+          notificationSource,
+          [previousInCharge],
+          [],
+        ),
+      );
+    }
+
+    // 새 담당자 지정 알림
+    if (newInChargeMember.id !== requestManager.id) {
+      this.eventEmitter.emit(
+        NotificationEvent.VISITATION_IN_CHARGE_ADDED,
+        new NotificationEventDto(
+          actorName,
+          NotificationDomain.VISITATION,
+          NotificationAction.IN_CHARGE_ADDED,
+          targetVisitation.title,
+          notificationSource,
+          [newInChargeMember],
+          [],
+        ),
+      );
+    }
+
+    const reportReceivers = (
+      await this.getReportReceivers(church, targetVisitation, qr)
+    ).filter((r) => r.id !== requestManager.id);
+
+    // 담당자 변경 알림
+    this.eventEmitter.emit(
+      NotificationEvent.VISITATION_IN_CHARGE_CHANGED,
+      new NotificationEventDto(
+        actorName,
+        NotificationDomain.VISITATION,
+        NotificationAction.IN_CHARGE_CHANGED,
+        targetVisitation.title,
+        notificationSource,
+        reportReceivers,
+        [
+          new NotificationFields(
+            NotificationField.IN_CHARGE,
+            previousInCharge?.member.name,
+            newInChargeMember.member.name,
+          ),
+        ],
+      ),
+    );
+  }
+
+  async notifyMemberUpdate(
+    church: ChurchModel,
+    targetVisitation: VisitationMetaModel,
+    requestManager: ChurchUserModel,
+    qr: QueryRunner,
+  ) {
+    const actorName = requestManager.member.name
+      ? requestManager.member.name
+      : '';
+
+    const inCharge = targetVisitation.inChargeId
+      ? await this.managerDomainService.findManagerForNotification(
+          church,
+          targetVisitation.inChargeId,
+          qr,
+        )
+      : null;
+
+    const reportReceivers = await this.getReportReceivers(
+      church,
+      targetVisitation,
+      qr,
+    );
+
+    const notificationReceivers = (
+      inCharge ? [...reportReceivers, inCharge] : reportReceivers
+    ).filter((r) => r.id !== requestManager.id);
+
+    this.eventEmitter.emit(
+      NotificationEvent.VISITATION_META_UPDATED,
+      new NotificationEventDto(
+        actorName,
+        NotificationDomain.VISITATION,
+        NotificationAction.UPDATED,
+        targetVisitation.title,
+        new NotificationSourceVisitation(
+          NotificationDomain.VISITATION,
+          targetVisitation.id,
+        ),
+        notificationReceivers,
+        [new NotificationFields('members', null, null)],
+      ),
+    );
+  }
+
+  async notifyDataUpdate(
+    church: ChurchModel,
+    targetVisitation: VisitationMetaModel,
+    requestManager: ChurchUserModel,
+    dto: UpdateVisitationDto,
+    qr: QueryRunner,
+  ) {
+    const reportReceivers = await this.getReportReceivers(
+      church,
+      targetVisitation,
+      qr,
+    );
+    const inCharge = targetVisitation.inChargeId
+      ? await this.managerDomainService.findManagerForNotification(
+          church,
+          targetVisitation.inChargeId,
+          qr,
+        )
+      : null;
+
+    // 알림 수신 대상자
+    const notificationTargets = (
+      inCharge ? [...reportReceivers, inCharge] : reportReceivers
+    ).filter((r) => r.id !== requestManager.id);
+
+    const actorName = requestManager.member.name
+      ? requestManager.member.name
+      : '';
+
+    const title = targetVisitation.title;
+    const notificationSource = new NotificationSourceVisitation(
+      NotificationDomain.VISITATION,
+      targetVisitation.id,
+    );
+
+    const notificationFields: NotificationFields[] = [];
+
+    const notificationColumns = [
+      'title',
+      'startDate',
+      'endDate',
+      'visitationMethod',
+    ];
+
+    // 업데이트 사항 체크
+    for (const key of Object.keys(dto)) {
+      if (!notificationColumns.includes(key)) {
+        continue;
+      }
+
+      // 제목 변경
+      /*if (key === 'title' && dto.title !== title) {
+        notificationFields.push(
+          new NotificationFields('title', title, dto.title),
+        );
+      } else*/ if (key === 'startDate' && dto.startDate) {
+        const utcStartDate = fromZonedTime(dto.startDate, TIME_ZONE.SEOUL);
+        if (utcStartDate !== targetVisitation.startDate) {
+          notificationFields.push(
+            new NotificationFields(
+              'startDate',
+              targetVisitation.startDate,
+              utcStartDate,
+            ),
+          );
+        }
+      } else if (key === 'endDate' && dto.endDate) {
+        const utcEndDate = fromZonedTime(dto.endDate, TIME_ZONE.SEOUL);
+        if (utcEndDate !== targetVisitation.startDate) {
+          notificationFields.push(
+            new NotificationFields(
+              'endDate',
+              targetVisitation.endDate,
+              utcEndDate,
+            ),
+          );
+        }
+      } else {
+        if (dto[key] !== targetVisitation[key]) {
+          notificationFields.push(
+            new NotificationFields(key, targetVisitation[key], dto[key]),
+          );
+        }
+      }
+    }
+
+    notificationFields.length > 0 &&
+      this.eventEmitter.emit(
+        NotificationEvent.VISITATION_META_UPDATED,
+        new NotificationEventDto(
+          actorName,
+          NotificationDomain.VISITATION,
+          NotificationAction.UPDATED,
+          title,
+          notificationSource,
+          notificationTargets,
+          notificationFields,
+        ),
+      );
   }
 
   async notifyDelete(


### PR DESCRIPTION
## 주요 내용
- 심방(Visitation) 메타데이터 변경 시 알림 발송 기능 추가
- 사용자 휴대폰 번호 변경 시 인증번호 검증 횟수가 카운트되지 않던 문제 해결

## 세부 내용
### 심방 알림
- 알림 발생 조건: 상태(status), 제목(title), 시작일(startDate), 종료일(endDate), 심방 방식(대면/비대면) 변경
- `payload` 포맷:
  - 메타 필드 변경 시 → `{ field, previous, current }` 포함
  - 심방 대상자(member) 변경 시 → `{ field: 'member', previous: null, current: null }`로 변경 여부만 알림
- NotificationAction: `UPDATED`

### 인증 검증 로직 수정
- 문제 원인: 검증 실패 시 `ConflictException` 발생으로 트랜잭션 전체 롤백 → 검증 횟수 증가 쿼리가 커밋되지 않음
- 수정 내용: `try-catch`에서 사용자 사유 검증 실패일 경우
  - **검증 횟수 증가 쿼리를 커밋** 후 에러를 다시 throw 하도록 변경
- 결과: 휴대폰 번호 검증 실패 시도 횟수가 정상적으로 카운트됨