### PR TITLE
fix: 교인 수정 시 이름/전화번호 필수 입력 문제 해결 및 관리자 추방 기능 추가

### DIFF
--- a/backend/src/church-user/church-user-domain/service/church-user-domain.service.ts
+++ b/backend/src/church-user/church-user-domain/service/church-user-domain.service.ts
@@ -131,6 +131,23 @@ export class ChurchUserDomainService implements IChurchUserDomainService {
     return churchUser;
   }
 
+  async isLinkedWithMember(
+    church: ChurchModel,
+    member: MemberModel,
+    qr?: QueryRunner,
+  ): Promise<boolean> {
+    const repository = this.getChurchUserRepository(qr);
+
+    const churchUser = await repository.findOne({
+      where: {
+        churchId: church.id,
+        memberId: member.id,
+      },
+    });
+
+    return !!churchUser;
+  }
+
   async findChurchUserByUserId(
     userId: number,
     qr?: QueryRunner,

--- a/backend/src/church-user/church-user-domain/service/interface/church-user-domain.service.interface.ts
+++ b/backend/src/church-user/church-user-domain/service/interface/church-user-domain.service.interface.ts
@@ -51,14 +51,17 @@ export interface IChurchUserDomainService {
     qr?: QueryRunner,
   ): Promise<ChurchUserModel>;
 
+  isLinkedWithMember(
+    church: ChurchModel,
+    member: MemberModel,
+    qr?: QueryRunner,
+  ): Promise<boolean>;
+
   findChurchUserByUser(
     church: ChurchModel,
     user: UserModel,
     qr?: QueryRunner,
   ): Promise<ChurchUserModel>;
-
-  //linkMember(): Promise<UpdateResult>;
-  //unlinkMember(): Promise<UpdateResult>;
 
   updateLinkedMember(
     targetChurchUser: ChurchUserModel,

--- a/backend/src/church-user/controller/church-user.controller.ts
+++ b/backend/src/church-user/controller/church-user.controller.ts
@@ -3,6 +3,7 @@ import {
   Body,
   Controller,
   Get,
+  GoneException,
   Param,
   ParseIntPipe,
   Patch,
@@ -17,6 +18,9 @@ import { ChurchUserWriteGuard } from '../guard/church-user-write.guard';
 import { RequestChurch } from '../../permission/decorator/permission-church.decorator';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { LinkMemberDto } from '../dto/request/link-member.dto';
+import { UseTransaction } from '../../common/decorator/use-transaction.decorator';
+import { QueryRunner } from '../../common/decorator/query-runner.decorator';
+import { QueryRunner as QR } from 'typeorm';
 
 @ApiTags('Churches:Church-Users')
 @Controller('church-users')
@@ -48,6 +52,35 @@ export class ChurchUserController {
   }
 
   @ApiOperation({
+    summary: '계정 - 교인 연결 수정',
+  })
+  @Patch(':churchUserId/change-member')
+  @ChurchUserWriteGuard()
+  changeMember(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
+    @Body() dto: LinkMemberDto,
+    @RequestChurch() church: ChurchModel,
+  ) {
+    return this.churchUserService.changeMemberLink(church, churchUserId, dto);
+  }
+
+  @ApiOperation({
+    summary: '교회 계정 가입 취소',
+  })
+  @Patch(':churchUserId/leave-church')
+  @UseTransaction()
+  @ChurchUserWriteGuard()
+  leaveChurch(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @Param('churchUserId', ParseIntPipe) churchUserId: number,
+    @RequestChurch() church: ChurchModel,
+    @QueryRunner() qr: QR,
+  ) {
+    return this.churchUserService.leaveChurchUser(church, churchUserId, qr);
+  }
+
+  @ApiOperation({
     deprecated: true,
     summary: '교회 가입 교인의 role 변경',
     description:
@@ -68,6 +101,7 @@ export class ChurchUserController {
   }
 
   @ApiOperation({
+    deprecated: true,
     summary: '계정 - 교인 정보 연결',
   })
   @ChurchUserWriteGuard()
@@ -78,10 +112,12 @@ export class ChurchUserController {
     @Body() dto: LinkMemberDto,
     @RequestChurch() church: ChurchModel,
   ) {
-    return this.churchUserService.changeMemberLink(church, churchUserId, dto);
+    throw new GoneException('다른 엔드포인트로 대체 됨.');
+    //return this.churchUserService.changeMemberLink(church, churchUserId, dto);
   }
 
   @ApiOperation({
+    deprecated: true,
     summary: '계정 - 교인 정보 연결 해제',
   })
   @Patch(':churchUserId/unlink-member')
@@ -91,32 +127,7 @@ export class ChurchUserController {
     @Param('churchUserId', ParseIntPipe) churchUserId: number,
     @RequestChurch() church: ChurchModel,
   ) {
-    return this.churchUserService.unLinkMember(church, churchUserId);
-  }
-
-  @ApiOperation({
-    summary: '계정 - 교인 연결 수정',
-  })
-  @Patch(':churchUserId/change-member')
-  @ChurchUserWriteGuard()
-  changeMember(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('churchUserId', ParseIntPipe) churchUserId: number,
-    @Body() dto: LinkMemberDto,
-    @RequestChurch() church: ChurchModel,
-  ) {
-    return this.churchUserService.changeMemberLink(church, churchUserId, dto);
-  }
-
-  @ApiOperation({
-    summary: '교회 계정 가입 취소',
-  })
-  @Patch(':churchUserId/leave-church')
-  @ChurchUserWriteGuard()
-  leaveChurch(
-    @Param('churchId', ParseIntPipe) churchId: number,
-    @Param('churchUserId', ParseIntPipe) churchUserId: number,
-  ) {
-    return '개발 전';
+    throw new GoneException('다른 엔드포인트로 대체 됨.');
+    //return this.churchUserService.unLinkMember(church, churchUserId);
   }
 }

--- a/backend/src/church-user/service/church-user.service.ts
+++ b/backend/src/church-user/service/church-user.service.ts
@@ -23,6 +23,7 @@ import { PatchChurchUserResponseDto } from '../dto/response/patch-church-user-re
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { LinkMemberDto } from '../dto/request/link-member.dto';
 import { MemberException } from '../../members/exception/member.exception';
+import { UserRole } from '../../user/const/user-role.enum';
 
 @Injectable()
 export class ChurchUserService {
@@ -131,6 +132,35 @@ export class ChurchUserService {
       );
 
     return new PatchChurchUserResponseDto(updatedChurchUser);
+  }
+
+  async leaveChurchUser(
+    church: ChurchModel,
+    churchUserId: number,
+    qr?: QueryRunner,
+  ) {
+    const targetChurchUser =
+      await this.churchUserDomainService.findChurchUserById(
+        church,
+        churchUserId,
+        qr,
+      );
+    const user = await this.userDomainService.findUserById(
+      targetChurchUser.userId,
+      qr,
+    );
+
+    await this.churchUserDomainService.leaveChurch(targetChurchUser, qr);
+    await this.userDomainService.updateUserRole(
+      user,
+      { role: UserRole.NONE },
+      qr,
+    );
+
+    return {
+      success: true,
+      timestamp: new Date(),
+    };
   }
 
   /*async patchChurchUserRole(

--- a/backend/src/members/dto/request/create-member.dto.ts
+++ b/backend/src/members/dto/request/create-member.dto.ts
@@ -215,7 +215,7 @@ export class CreateMemberDto {
   @ApiProperty({
     name: 'marriage',
     description: '결혼',
-    example: '미혼',
+    example: Marriage.SINGLE,
     enum: Marriage,
     required: false,
   })
@@ -252,7 +252,7 @@ export class CreateMemberDto {
   })
   @IsEnum(Baptism)
   @IsOptional()
-  baptism?: Baptism = Baptism.NONE;
+  baptism?: Baptism;
 
   /*@ApiProperty({
     name: 'previousChurch',

--- a/backend/src/members/dto/request/update-member.dto.ts
+++ b/backend/src/members/dto/request/update-member.dto.ts
@@ -1,9 +1,11 @@
-import { OmitType } from '@nestjs/swagger';
+import { OmitType, PartialType } from '@nestjs/swagger';
 import { CreateMemberDto } from './create-member.dto';
 
-export class UpdateMemberDto extends OmitType(CreateMemberDto, [
-  //'name',
-  //'mobilePhone',
-  'familyMemberId',
-  'relation',
-]) {}
+export class UpdateMemberDto extends PartialType(
+  OmitType(CreateMemberDto, [
+    //'name',
+    //'mobilePhone',
+    'familyMemberId',
+    'relation',
+  ]),
+) {}

--- a/backend/src/members/entity/member.entity.ts
+++ b/backend/src/members/entity/member.entity.ts
@@ -139,7 +139,6 @@ export class MemberModel extends BaseModel {
 
   @Index()
   @Column({
-    enum: Baptism,
     default: Baptism.NONE,
     comment: '신급',
   })

--- a/backend/src/members/exception/member.exception.ts
+++ b/backend/src/members/exception/member.exception.ts
@@ -9,6 +9,7 @@ export const MemberException = {
   ALREADY_LINKED: '해당 교인은 이미 다른 계정과 연결되어 있습니다.',
   LINK_ERROR: '계정 연결 중 에러 발생',
   NOT_LINKED_MEMBER: '계정 연동이 되어있지 않은 교인입니다.',
+  CANNOT_DELETE_LINKED_MEMBER: '계정과 연결된 교인은 삭제할 수 없습니다.',
 
   SAME_ROLE: '이미 동일한 권한입니다.',
 

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -575,6 +575,20 @@ export class MembersDomainService implements IMembersDomainService {
 
     const membersRepository = this.getMembersRepository(qr);
 
+    const partialEntity = {};
+
+    for (const [key, value] of Object.entries(dto)) {
+      if (key === 'registeredAt' && dto.utcRegisteredAt) {
+        partialEntity[key] = dto.utcRegisteredAt;
+      } else if (key === 'birth' && dto.utcBirth) {
+        partialEntity[key] = dto.utcBirth;
+        partialEntity['birthdayMMDD'] = dto.utcBirth.toISOString().slice(5, 10);
+      } else if (key === 'utcBirth' || key === 'utcRegisteredAt') {
+      } else {
+        partialEntity[key] = value;
+      }
+    }
+
     const result = await membersRepository.update(
       {
         id: member.id,
@@ -582,12 +596,7 @@ export class MembersDomainService implements IMembersDomainService {
         deletedAt: IsNull(),
       },
       {
-        ...dto,
-        registeredAt: dto.utcRegisteredAt,
-        birth: dto.utcBirth,
-        birthdayMMDD: dto.utcBirth
-          ? dto.utcBirth.toISOString().slice(5, 10)
-          : undefined,
+        ...partialEntity,
       },
     );
 

--- a/backend/src/members/members.module.ts
+++ b/backend/src/members/members.module.ts
@@ -13,6 +13,7 @@ import { IMEMBER_FILTER_SERVICE } from './service/interface/member-filter.servic
 import { MemberFilterService } from './service/member-filter.service';
 import { WorshipDomainModule } from '../worship/worship-domain/worship-domain.module';
 import { MinistryHistoryDomainModule } from '../member-history/ministry-history/ministry-history-domain/ministry-history-domain.module';
+import { ChurchUserDomainModule } from '../church-user/church-user-domain/church-user-domain.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { MinistryHistoryDomainModule } from '../member-history/ministry-history/
       { path: 'churches/:churchId', module: MembersModule },
     ]),
     ChurchesDomainModule,
+    ChurchUserDomainModule,
     ManagerDomainModule,
     MembersDomainModule,
     FamilyRelationDomainModule,


### PR DESCRIPTION
## 주요 내용
- 교인 수정 시 이름, 전화번호를 수정하지 않아도 강제로 값을 넣어야 하는 문제 해결
- 교인 생일 수정 실패 문제 해결
- 계정과 연결된 교인의 삭제를 제한하는 제약 추가
- 관리자 추방 기능 추가
- 계정-교인 연결 관리 방식 단순화

## 세부 내용
### 교인(Member) 관련
- **수정 로직**
  - 이름/전화번호를 수정하지 않을 경우에도 필수 입력 요구가 발생하던 문제를 해결
  - 생일 수정 시 발생하던 오류 해결
- **삭제 로직**
  - 계정과 연결된 교인은 삭제 불가하도록 제약 추가

### 관리자 관련
- **추방 기능**
  - 관리자가 다른 관리자를 추방할 수 있는 기능 추가
  - 엔드포인트: `PATCH /churches/{churchId}/church-users/{churchUserId}/leave-church`

### 계정-교인 연결 관리
- 수동으로 계정과 교인의 연결을 끊거나 다시 맺는 기능 제거
- 계정과 교인 연결은 항상 유지되며, 연결된 교인만 수정 가능하도록 구조 단순화