### PR TITLE
feat: EducationSession 알림 기능 추가 및 수신자 중복 조회 개선

### DIFF
--- a/backend/src/educations/education-session/controller/education-sessions.controller.ts
+++ b/backend/src/educations/education-session/controller/education-sessions.controller.ts
@@ -33,6 +33,8 @@ import { ChurchUserModel } from '../../../church-user/entity/church-user.entity'
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 import { AddEducationSessionReportDto } from '../../../report/education-report/dto/session/request/add-education-session-report.dto';
 import { DeleteEducationSessionReportDto } from '../../../report/education-report/dto/session/request/delete-education-session-report.dto';
+import { RequestChurch } from '../../../permission/decorator/permission-church.decorator';
+import { ChurchModel } from '../../../churches/entity/church.entity';
 
 @ApiTags('Educations:Sessions')
 @Controller('educations/:educationId/terms/:educationTermId/sessions')
@@ -61,19 +63,19 @@ export class EducationSessionsController {
   @ApiPostEducationSessions()
   @EducationWriteGuard()
   @Post()
-  //@UseGuards(AccessTokenGuard, ChurchManagerGuard)
   @UseInterceptors(TransactionInterceptor)
   postEducationSession(
-    @RequestManager() manager: ChurchUserModel,
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('educationId', ParseIntPipe) educationId: number,
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: CreateEducationSessionDto,
     @QueryRunner() qr: QR,
   ) {
     return this.educationSessionsService.createEducationSession(
-      manager,
-      churchId,
+      church,
+      requestManager,
       educationId,
       educationTermId,
       dto,
@@ -107,11 +109,14 @@ export class EducationSessionsController {
     @Param('educationId', ParseIntPipe) educationId: number,
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
     @Param('educationSessionId', ParseIntPipe) educationSessionId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: UpdateEducationSessionDto,
     @QueryRunner() qr: QR,
   ) {
     return this.educationSessionsService.updateEducationSession(
-      churchId,
+      church,
+      requestManager,
       educationId,
       educationTermId,
       educationSessionId,
@@ -129,10 +134,13 @@ export class EducationSessionsController {
     @Param('educationId', ParseIntPipe) educationId: number,
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
     @Param('educationSessionId', ParseIntPipe) educationSessionId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @QueryRunner() qr: QR,
   ) {
     return this.educationSessionsService.deleteEducationSessions(
-      churchId,
+      church,
+      requestManager,
       educationId,
       educationTermId,
       educationSessionId,
@@ -149,11 +157,14 @@ export class EducationSessionsController {
     @Param('educationId', ParseIntPipe) educationId: number,
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
     @Param('educationSessionId', ParseIntPipe) educationSessionId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: AddEducationSessionReportDto,
     @QueryRunner() qr: QR,
   ) {
     return this.educationSessionsService.addReportReceivers(
-      churchId,
+      church,
+      requestManager,
       educationId,
       educationTermId,
       educationSessionId,
@@ -171,11 +182,14 @@ export class EducationSessionsController {
     @Param('educationId', ParseIntPipe) educationId: number,
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
     @Param('educationSessionId', ParseIntPipe) educationSessionId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: DeleteEducationSessionReportDto,
     @QueryRunner() qr: QR,
   ) {
     return this.educationSessionsService.deleteEducationSessionReportReceivers(
-      churchId,
+      church,
+      requestManager,
       educationId,
       educationTermId,
       educationSessionId,

--- a/backend/src/educations/education-session/dto/request/create-education-session.dto.ts
+++ b/backend/src/educations/education-session/dto/request/create-education-session.dto.ts
@@ -6,7 +6,6 @@ import {
   IsDateString,
   IsNotEmpty,
   IsNumber,
-  IsOptional,
   IsString,
   MaxLength,
   Min,
@@ -60,7 +59,7 @@ export class CreateEducationSessionDto extends PickType(EducationSessionModel, [
     description: '담당자 교인 ID',
     required: false,
   })
-  @IsOptional()
+  //@IsOptional()
   @IsNumber()
   @Min(1)
   override inChargeId: number;

--- a/backend/src/educations/education-session/entity/education-session.entity.ts
+++ b/backend/src/educations/education-session/entity/education-session.entity.ts
@@ -1,4 +1,11 @@
-import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+} from 'typeorm';
 import { EducationTermModel } from '../../education-term/entity/education-term.entity';
 import { SessionAttendanceModel } from '../../session-attendance/entity/session-attendance.entity';
 import { EducationSessionStatus } from '../const/education-session-status.enum';
@@ -48,6 +55,7 @@ export class EducationSessionModel extends BaseModel {
   })
   status: EducationSessionStatus;
 
+  @Index()
   @Column({ nullable: true, comment: '회차 담당자 교인 ID' })
   inChargeId: number | null;
 
@@ -55,6 +63,7 @@ export class EducationSessionModel extends BaseModel {
     nullable: true,
     onDelete: 'SET NULL',
   })
+  @JoinColumn({ name: 'inChargeId' })
   inCharge: MemberModel;
 
   @OneToMany(

--- a/backend/src/educations/educations.module.ts
+++ b/backend/src/educations/educations.module.ts
@@ -16,6 +16,7 @@ import { MembersDomainModule } from '../members/member-domain/members-domain.mod
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
 import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
 import { EducationReportDomainModule } from '../report/education-report/education-report-domain/education-report-domain.module';
+import { EducationSessionNotificationService } from './education-session/service/education-session-notification.service';
 
 @Module({
   imports: [
@@ -48,6 +49,8 @@ import { EducationReportDomainModule } from '../report/education-report/educatio
     EducationEnrollmentService,
     EducationTermService,
     SessionAttendanceService,
+    // 알림
+    EducationSessionNotificationService,
   ],
   exports: [],
 })

--- a/backend/src/notification/const/notification-event.enum.ts
+++ b/backend/src/notification/const/notification-event.enum.ts
@@ -5,7 +5,7 @@ export enum NotificationEvent {
   TASK_REPORT_ADDED = 'task.report.added',
   TASK_REPORT_REMOVED = 'task.report.removed',
   TASK_STATUS_UPDATED = 'task.status.updated',
-  TASK_META_UPDATED = 'task.meta.updated',
+  TASK_DATA_UPDATED = 'task.data.updated',
   TASK_DELETED = 'task.deleted',
 
   VISITATION_IN_CHARGE_ADDED = 'visitation.inCharge.added',
@@ -13,7 +13,16 @@ export enum NotificationEvent {
   VISITATION_IN_CHARGE_CHANGED = 'visitation.inCharge.changed',
   VISITATION_REPORT_ADDED = 'visitation.report.added',
   VISITATION_REPORT_REMOVED = 'visitation.report.removed',
-  VISITATION_DELETED = 'visitation.deleted',
   VISITATION_STATUS_UPDATED = 'visitation.status.updated',
-  VISITATION_META_UPDATED = 'visitation.meta.updated',
+  VISITATION_DATA_UPDATED = 'visitation.data.updated',
+  VISITATION_DELETED = 'visitation.deleted',
+
+  EDUCATION_SESSION_IN_CHARGE_ADDED = 'education.session.inCharge.added',
+  EDUCATION_SESSION_IN_CHARGE_REMOVED = 'education.session.inCharge.removed',
+  EDUCATION_SESSION_IN_CHARGE_CHANGED = 'education.session.inCharge.changed',
+  EDUCATION_SESSION_REPORT_ADDED = 'education.session.report.added',
+  EDUCATION_SESSION_REPORT_REMOVED = 'education.session.report.removed',
+  EDUCATION_SESSION_STATUS_UPDATED = 'education.session.status.updated',
+  EDUCATION_SESSION_DATA_UPDATED = 'education.session.meta.updated',
+  EDUCATION_SESSION_DELETED = 'education.session.deleted',
 }

--- a/backend/src/notification/notification-domain/service/notification-domain.service.ts
+++ b/backend/src/notification/notification-domain/service/notification-domain.service.ts
@@ -169,6 +169,8 @@ export class NotificationDomainService implements INotificationDomainService {
 
     const uniqueReceivers = this.uniqBy(receivers, 'id');
 
+    //console.log(uniqueReceivers);
+
     const now = new Date();
 
     const notifications = repository.create(

--- a/backend/src/notification/notification-event.dto.ts
+++ b/backend/src/notification/notification-event.dto.ts
@@ -44,6 +44,17 @@ export class NotificationSourceVisitation extends NotificationSource {
   }
 }
 
+export class NotificationSourceEducationSession extends NotificationSource {
+  constructor(
+    domain: NotificationDomain,
+    public readonly educationId: number,
+    public readonly educationTermId: number,
+    id: number,
+  ) {
+    super(domain, id);
+  }
+}
+
 export class NotificationEventDto {
   actorName: string;
 

--- a/backend/src/notification/service/notification.service.ts
+++ b/backend/src/notification/service/notification.service.ts
@@ -128,7 +128,7 @@ export class NotificationService {
     await this.notificationDomainService.createNotifications(event);
   }
 
-  @OnEvent(NotificationEvent.TASK_META_UPDATED, {
+  @OnEvent(NotificationEvent.TASK_DATA_UPDATED, {
     async: true,
     suppressErrors: true,
   })
@@ -151,12 +151,19 @@ export class NotificationService {
   async handleVisitationInChargeAdded(event: NotificationEventDto) {
     await this.notificationDomainService.createNotifications(event);
   }
-  @OnEvent(NotificationEvent.VISITATION_IN_CHARGE_CHANGED)
+
+  @OnEvent(NotificationEvent.VISITATION_IN_CHARGE_CHANGED, {
+    async: true,
+    suppressErrors: true,
+  })
   async handleVisitationInChargeChanged(event: NotificationEventDto) {
     await this.notificationDomainService.createNotifications(event);
   }
 
-  @OnEvent(NotificationEvent.VISITATION_IN_CHARGE_REMOVED)
+  @OnEvent(NotificationEvent.VISITATION_IN_CHARGE_REMOVED, {
+    async: true,
+    suppressErrors: true,
+  })
   async handleVisitationInChargeRemoved(event: NotificationEventDto) {
     await this.notificationDomainService.createNotifications(event);
   }
@@ -185,16 +192,83 @@ export class NotificationService {
     await this.notificationDomainService.createNotifications(event);
   }
 
-  @OnEvent(NotificationEvent.VISITATION_STATUS_UPDATED, {})
-  async handleVisitationStatusStatusChanged(event: NotificationEventDto) {
+  @OnEvent(NotificationEvent.VISITATION_STATUS_UPDATED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleVisitationStatusChanged(event: NotificationEventDto) {
     await this.notificationDomainService.createNotifications(event);
   }
 
-  @OnEvent(NotificationEvent.VISITATION_META_UPDATED, {
+  @OnEvent(NotificationEvent.VISITATION_DATA_UPDATED, {
     async: true,
     suppressErrors: true,
   })
   async handleVisitationMetaUpdated(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.EDUCATION_SESSION_IN_CHARGE_ADDED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleEducationSessionInChargeAdded(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.EDUCATION_SESSION_IN_CHARGE_REMOVED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleEducationSessionInChargeRemoved(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.EDUCATION_SESSION_IN_CHARGE_CHANGED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleEducationSessionInChargeChanged(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.EDUCATION_SESSION_REPORT_ADDED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleEducationSessionReportAdded(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.EDUCATION_SESSION_REPORT_REMOVED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleEducationSessionReportRemoved(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.EDUCATION_SESSION_STATUS_UPDATED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleEducationSessionStatusUpdated(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.EDUCATION_SESSION_DATA_UPDATED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleEducationSessionDataUpdated(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.EDUCATION_SESSION_DELETED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleEducationSessionDeleted(event: NotificationEventDto) {
     await this.notificationDomainService.createNotifications(event);
   }
 }

--- a/backend/src/task/controller/task.controller.ts
+++ b/backend/src/task/controller/task.controller.ts
@@ -104,17 +104,12 @@ export class TaskController {
   patchTask(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('taskId', ParseIntPipe) taskId: number,
+    @RequestChurch() church: ChurchModel,
     @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: UpdateTaskDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.taskService.patchTask(
-      requestManager,
-      churchId,
-      taskId,
-      dto,
-      qr,
-    );
+    return this.taskService.patchTask(requestManager, church, taskId, dto, qr);
   }
 
   @ApiDeleteTask()


### PR DESCRIPTION
## 주요 내용
- EducationSession 도메인에 대한 알림 기능 추가
- 알림 수신자 중복 조회로 인한 잘못된 알림 발송 문제 개선

## 세부 내용
### EducationSession 알림
- 생성, 수정, 삭제, 담당자/보고대상자 변경 시 알림 발송 기능 추가
- NotificationModel에 `domain = educationSession` 으로 저장

### 수신자 조회 개선
- **기존 문제**: 담당자 수정과 내용 수정이 동시에 발생할 경우, 담당자에서 제외된 사람도 수정 알림을 함께 수신
- **개선 내용**: 제외된 담당자는 `inChargeRemoved` 알림만 수신하고, 수정 알림은 받지 않도록 로직 수정