### PR TITLE
feat: EducationTerm 알림 기능 추가

### DIFF
--- a/backend/src/educations/education-enrollment/controller/education-enrollments.controller.ts
+++ b/backend/src/educations/education-enrollment/controller/education-enrollments.controller.ts
@@ -21,6 +21,10 @@ import { EducationWriteGuard } from '../../guard/education-write.guard';
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 import { GetNotEnrolledMembersDto } from '../dto/request/get-not-enrolled-members.dto';
+import { RequestChurch } from '../../../permission/decorator/permission-church.decorator';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { RequestManager } from '../../../permission/decorator/permission-manager.decorator';
+import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 
 @ApiTags('Educations:Enrollments')
 @Controller('educations/:educationId/terms/:educationTermId/enrollments')
@@ -52,11 +56,15 @@ export class EducationEnrollmentsController {
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('educationId', ParseIntPipe) educationId: number,
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
-    @Body() dto: CreateEducationEnrollmentDto,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
+    @Body()
+    dto: CreateEducationEnrollmentDto,
     @QueryRunner() qr: QR,
   ) {
     return this.educationEnrollmentsService.createEducationEnrollment(
-      churchId,
+      requestManager,
+      church,
       educationId,
       educationTermId,
       dto,
@@ -108,10 +116,13 @@ export class EducationEnrollmentsController {
     @Param('educationId', ParseIntPipe) educationId: number,
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
     @Param('educationEnrollmentId', ParseIntPipe) educationEnrollmentId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @QueryRunner() qr: QR,
   ) {
     return this.educationEnrollmentsService.deleteEducationEnrollment(
-      churchId,
+      requestManager,
+      church,
       educationId,
       educationTermId,
       educationEnrollmentId,

--- a/backend/src/educations/education-enrollment/service/member-education-event-handler.service.ts
+++ b/backend/src/educations/education-enrollment/service/member-education-event-handler.service.ts
@@ -7,6 +7,10 @@ import {
   IEducationEnrollmentsDomainService,
 } from '../../education-domain/interface/education-enrollment-domain.service.interface';
 import { MemberDeletedEvent } from '../../../members/events/member.event';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../../churches/churches-domain/interface/churches-domain.service.interface';
 
 @Injectable()
 export class MemberEducationEventHandler {
@@ -15,6 +19,8 @@ export class MemberEducationEventHandler {
     private readonly eventEmitter: EventEmitter2,
     private readonly dataSource: DataSource,
 
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
     @Inject(IEDUCATION_ENROLLMENT_DOMAIN_SERVICE)
     private readonly educationEnrollmentDomainService: IEducationEnrollmentsDomainService,
   ) {}
@@ -42,10 +48,16 @@ export class MemberEducationEventHandler {
           qr,
         );
 
+      const church = await this.churchesDomainService.findChurchModelById(
+        churchId,
+        qr,
+      );
+
       await Promise.all(
         enrollments.map((enrollment) =>
           this.educationEnrollmentService.deleteEducationEnrollment(
-            churchId,
+            undefined,
+            church,
             enrollment.educationTerm.educationId,
             enrollment.educationTermId,
             enrollment.id,

--- a/backend/src/educations/education-term/controller/education-terms.controller.ts
+++ b/backend/src/educations/education-term/controller/education-terms.controller.ts
@@ -101,11 +101,14 @@ export class EducationTermsController {
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('educationId', ParseIntPipe) educationId: number,
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: UpdateEducationTermDto,
     @QueryRunner() qr: QR,
   ) {
     return this.educationTermService.updateEducationTerm(
-      churchId,
+      requestManager,
+      church,
       educationId,
       educationTermId,
       dto,
@@ -121,10 +124,13 @@ export class EducationTermsController {
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('educationId', ParseIntPipe) educationId: number,
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @QueryRunner() qr: QR,
   ) {
     return this.educationTermService.deleteEducationTerm(
-      churchId,
+      requestManager,
+      church,
       educationId,
       educationTermId,
       qr,
@@ -151,15 +157,19 @@ export class EducationTermsController {
 
   @Patch(':educationTermId/add-receivers')
   @UseInterceptors(TransactionInterceptor)
+  @EducationWriteGuard()
   addReportReceivers(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('educationId', ParseIntPipe) educationId: number,
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: AddEducationTermReportDto,
     @QueryRunner() qr: QR,
   ) {
     return this.educationTermService.addReportReceivers(
-      churchId,
+      requestManager,
+      church,
       educationId,
       educationTermId,
       dto,
@@ -169,15 +179,19 @@ export class EducationTermsController {
 
   @Patch(':educationTermId/delete-receivers')
   @UseInterceptors(TransactionInterceptor)
+  @EducationWriteGuard()
   deleteReportReceivers(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('educationId', ParseIntPipe) educationId: number,
     @Param('educationTermId', ParseIntPipe) educationTermId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: DeleteEducationTermReportDto,
     @QueryRunner() qr: QR,
   ) {
     return this.educationTermService.deleteEducationTermReportReceivers(
-      churchId,
+      requestManager,
+      church,
       educationId,
       educationTermId,
       dto,

--- a/backend/src/educations/education-term/dto/request/create-education-term.dto.ts
+++ b/backend/src/educations/education-term/dto/request/create-education-term.dto.ts
@@ -3,22 +3,16 @@ import { EducationTermModel } from '../../entity/education-term.entity';
 import {
   ArrayUnique,
   IsArray,
-  IsDate,
   IsDateString,
   IsNumber,
-  IsOptional,
   IsString,
   MaxLength,
   Min,
 } from 'class-validator';
 import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
 import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
-import { PlainTextMaxLength } from '../../../../common/decorator/validator/plain-text-max-length.validator';
 import { IsAfterDate } from '../../../../common/decorator/validator/is-after-date.decorator';
-import {
-  IsBasicText,
-  IsNoSpecialChar,
-} from '../../../../common/decorator/validator/is-no-special-char.validator';
+import { IsBasicText } from '../../../../common/decorator/validator/is-no-special-char.validator';
 import { EducationTermConstraints } from '../../const/education-term.constraints';
 import { IsYYYYMMDD } from '../../../../common/decorator/validator/is-yyyy-mm-dd.validator';
 
@@ -68,11 +62,11 @@ export class CreateEducationTermDto extends PickType(EducationTermModel, [
   @ApiProperty({
     description: '교육 진행자 ID',
     minimum: 1,
-    required: false,
+    //required: false,
   })
   @IsNumber()
   @Min(1)
-  @IsOptional()
+  //@IsOptional()
   override inChargeId: number;
 
   @ApiProperty({

--- a/backend/src/educations/education-term/dto/request/update-education-term.dto.ts
+++ b/backend/src/educations/education-term/dto/request/update-education-term.dto.ts
@@ -38,15 +38,6 @@ export class UpdateEducationTermDto {
   @IsBasicText('장소')
   location: string;
 
-  /*@ApiProperty({
-    description: '내용',
-    required: false,
-  })
-  @IsOptionalNotNull()
-  @IsString()
-  @PlainTextMaxLength(500)
-  content?: string;*/
-
   @ApiProperty({
     description: '교육 진행 상태',
     enum: EducationTermStatus,

--- a/backend/src/educations/education-term/service/education-term-notification.service.ts
+++ b/backend/src/educations/education-term/service/education-term-notification.service.ts
@@ -1,0 +1,351 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { EducationTermModel } from '../entity/education-term.entity';
+import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
+import { NotificationEvent } from '../../../notification/const/notification-event.enum';
+import {
+  NotificationEventDto,
+  NotificationField,
+  NotificationFields,
+  NotificationSourceEducationTerm,
+} from '../../../notification/notification-event.dto';
+import { NotificationDomain } from '../../../notification/const/notification-domain.enum';
+import { NotificationAction } from '../../../notification/const/notification-action.enum';
+import { EducationTermStatus } from '../const/education-term-status.enum';
+import { UpdateEducationTermDto } from '../dto/request/update-education-term.dto';
+import {
+  IMANAGER_DOMAIN_SERVICE,
+  IManagerDomainService,
+} from '../../../manager/manager-domain/service/interface/manager-domain.service.interface';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+
+@Injectable()
+export class EducationTermNotificationService {
+  constructor(
+    private readonly eventEmitter: EventEmitter2,
+    @Inject(IMANAGER_DOMAIN_SERVICE)
+    private readonly managerDomainService: IManagerDomainService,
+  ) {}
+
+  notifyPost(
+    newTerm: EducationTermModel,
+    creatorManager: ChurchUserModel,
+    inCharge: ChurchUserModel,
+    notificationTitle: string,
+    educationId: number,
+  ) {
+    const actorName = creatorManager.member.name;
+
+    this.eventEmitter.emit(
+      NotificationEvent.EDUCATION_TERM_IN_CHARGE_ADDED,
+      new NotificationEventDto(
+        actorName,
+        NotificationDomain.EDUCATION_TERM,
+        NotificationAction.IN_CHARGE_ADDED,
+        notificationTitle,
+        new NotificationSourceEducationTerm(
+          NotificationDomain.EDUCATION_TERM,
+          educationId,
+          newTerm.id,
+        ),
+        [inCharge],
+        [],
+      ),
+    );
+  }
+
+  notifyReportAdded(
+    term: EducationTermModel,
+    requestManager: ChurchUserModel,
+    newReceivers: ChurchUserModel[],
+    notificationTitle: string,
+    educationId: number,
+  ) {
+    const actorName = requestManager.member.name;
+
+    const notificationReceivers = newReceivers.filter(
+      (r) => r.id !== requestManager.id,
+    );
+
+    this.eventEmitter.emit(
+      NotificationEvent.EDUCATION_TERM_REPORT_ADDED,
+      new NotificationEventDto(
+        actorName,
+        NotificationDomain.EDUCATION_TERM,
+        NotificationAction.REPORT_ADDED,
+        notificationTitle,
+        new NotificationSourceEducationTerm(
+          NotificationDomain.EDUCATION_TERM,
+          educationId,
+          term.id,
+        ),
+        notificationReceivers,
+        [],
+      ),
+    );
+  }
+
+  notifyReportRemoved(
+    term: EducationTermModel,
+    requestManager: ChurchUserModel,
+    removedReportReceivers: ChurchUserModel[],
+    notificationTitle: string,
+    educationId: number,
+  ) {
+    const actorName = requestManager.member.name;
+
+    const notificationReceivers = removedReportReceivers.filter(
+      (r) => r.id !== requestManager.id,
+    );
+
+    this.eventEmitter.emit(
+      NotificationEvent.EDUCATION_TERM_REPORT_REMOVED,
+      new NotificationEventDto(
+        actorName,
+        NotificationDomain.EDUCATION_TERM,
+        NotificationAction.REPORT_REMOVED,
+        notificationTitle,
+        new NotificationSourceEducationTerm(
+          NotificationDomain.EDUCATION_TERM,
+          educationId,
+          term.id,
+        ),
+        notificationReceivers,
+        [],
+      ),
+    );
+  }
+
+  notifyStatusUpdate(
+    requestManager: ChurchUserModel,
+    notificationTargets: ChurchUserModel[],
+    notificationTitle: string,
+    notificationSource: NotificationSourceEducationTerm,
+    previousStatus: EducationTermStatus,
+    newStatus: EducationTermStatus,
+  ) {
+    const notificationReceivers = notificationTargets.filter(
+      (t) => t.id !== requestManager.id,
+    );
+
+    const actorName = requestManager.member.name;
+
+    this.eventEmitter.emit(
+      NotificationEvent.EDUCATION_TERM_STATUS_UPDATED,
+      new NotificationEventDto(
+        actorName,
+        NotificationDomain.EDUCATION_TERM,
+        NotificationAction.STATUS_UPDATED,
+        notificationTitle,
+        notificationSource,
+        notificationReceivers,
+        [
+          new NotificationFields(
+            NotificationField.STATUS,
+            previousStatus,
+            newStatus,
+          ),
+        ],
+      ),
+    );
+  }
+
+  notifyInChargeUpdate(
+    requestManager: ChurchUserModel,
+    reportReceivers: ChurchUserModel[],
+    oldInCharge: ChurchUserModel | null,
+    newInCharge: ChurchUserModel,
+    notificationTitle: string,
+    notificationSource: NotificationSourceEducationTerm,
+  ) {
+    const actorName = requestManager.member.name;
+
+    // 이전 담당자 제외 알림
+    if (oldInCharge && oldInCharge.id !== requestManager.id) {
+      this.eventEmitter.emit(
+        NotificationEvent.EDUCATION_TERM_IN_CHARGE_REMOVED,
+        new NotificationEventDto(
+          actorName,
+          NotificationDomain.EDUCATION_TERM,
+          NotificationAction.IN_CHARGE_REMOVED,
+          notificationTitle,
+          notificationSource,
+          [oldInCharge],
+          [],
+        ),
+      );
+    }
+
+    // 새 담당자 지정 알림
+    if (newInCharge.id !== requestManager.id) {
+      this.eventEmitter.emit(
+        NotificationEvent.EDUCATION_TERM_IN_CHARGE_ADDED,
+        new NotificationEventDto(
+          actorName,
+          NotificationDomain.EDUCATION_TERM,
+          NotificationAction.IN_CHARGE_ADDED,
+          notificationTitle,
+          notificationSource,
+          [newInCharge],
+          [],
+        ),
+      );
+    }
+
+    const notificationReceivers = reportReceivers.filter(
+      (r) => r.id !== requestManager.id,
+    );
+
+    notificationReceivers.length > 0 &&
+      this.eventEmitter.emit(
+        NotificationEvent.EDUCATION_TERM_IN_CHARGE_CHANGED,
+        new NotificationEventDto(
+          actorName,
+          NotificationDomain.EDUCATION_TERM,
+          NotificationAction.IN_CHARGE_CHANGED,
+          notificationTitle,
+          notificationSource,
+          notificationReceivers,
+          [
+            new NotificationFields(
+              NotificationField.IN_CHARGE,
+              oldInCharge?.member.name,
+              newInCharge.member.name,
+            ),
+          ],
+        ),
+      );
+  }
+
+  notifyDataUpdate(
+    requestManager: ChurchUserModel,
+    notificationTargets: ChurchUserModel[],
+    notificationTitle: string,
+    notificationSource: NotificationSourceEducationTerm,
+    educationTerm: EducationTermModel,
+    dto: UpdateEducationTermDto,
+  ) {
+    const actorName = requestManager.member.name;
+
+    const notificationReceivers = notificationTargets.filter(
+      (t) => t.id !== requestManager.id,
+    );
+
+    const notificationColumns = ['term', 'location', 'startDate', 'endDate'];
+
+    const notificationFields: NotificationFields[] = [];
+
+    for (const key of Object.keys(dto)) {
+      if (!notificationColumns.includes(key)) {
+        continue;
+      }
+
+      if (key === 'startDate' && dto.utcStartDate) {
+        if (dto.utcStartDate.getTime() !== educationTerm.startDate.getTime()) {
+          notificationFields.push(
+            new NotificationFields(
+              NotificationField.START_DATE,
+              educationTerm.startDate,
+              dto.utcStartDate,
+            ),
+          );
+        }
+      } else if (key === 'endDate' && dto.utcEndDate) {
+        if (dto.utcEndDate.getTime() !== educationTerm.endDate.getTime()) {
+          notificationFields.push(
+            new NotificationFields(
+              NotificationField.END_DATE,
+              educationTerm.endDate,
+              dto.utcEndDate,
+            ),
+          );
+        }
+      } else {
+        if (dto[key] !== educationTerm[key]) {
+          notificationFields.push(
+            new NotificationFields(key, educationTerm[key], dto[key]),
+          );
+        }
+      }
+    }
+
+    notificationFields.length > 0 &&
+      this.eventEmitter.emit(
+        NotificationEvent.EDUCATION_TERM_DATA_UPDATED,
+        new NotificationEventDto(
+          actorName,
+          NotificationDomain.EDUCATION_TERM,
+          NotificationAction.UPDATED,
+          notificationTitle,
+          notificationSource,
+          notificationReceivers,
+          notificationFields,
+        ),
+      );
+  }
+
+  notifyDelete(
+    notificationTitle: string,
+    requestManager: ChurchUserModel,
+    notificationTargets: ChurchUserModel[],
+  ) {
+    const actorName = requestManager.member.name;
+
+    const notificationReceivers = notificationTargets.filter(
+      (t) => t.id !== requestManager.id,
+    );
+
+    this.eventEmitter.emit(
+      NotificationEvent.EDUCATION_TERM_DELETED,
+      new NotificationEventDto(
+        actorName,
+        NotificationDomain.EDUCATION_TERM,
+        NotificationAction.DELETED,
+        notificationTitle,
+        null,
+        notificationReceivers,
+        [],
+      ),
+    );
+  }
+
+  async notifyEnrollmentUpdate(
+    church: ChurchModel,
+    requestManager: ChurchUserModel,
+    educationTerm: EducationTermModel,
+    notificationTitle: string,
+    notificationSource: NotificationSourceEducationTerm,
+  ) {
+    const [inCharge, reportReceivers] = await Promise.all([
+      educationTerm.inChargeId
+        ? this.managerDomainService.findManagerForNotification(
+            church,
+            educationTerm.inChargeId,
+          )
+        : null,
+      this.managerDomainService.findManagersForNotification(
+        church,
+        educationTerm.reports.map((r) => r.receiverId),
+      ),
+    ]);
+
+    const notificationReceivers = (
+      inCharge ? [...reportReceivers, inCharge] : reportReceivers
+    ).filter((t) => t.id !== requestManager.id);
+
+    const actorName = requestManager.member.name;
+
+    this.eventEmitter.emit(
+      NotificationEvent.EDUCATION_TERM_ENROLLMENT_UPDATED,
+      new NotificationEventDto(
+        actorName,
+        NotificationDomain.EDUCATION_TERM,
+        NotificationAction.UPDATED,
+        notificationTitle,
+        notificationSource,
+        notificationReceivers,
+        [new NotificationFields('enrollments', null, null)],
+      ),
+    );
+  }
+}

--- a/backend/src/educations/educations.module.ts
+++ b/backend/src/educations/educations.module.ts
@@ -17,6 +17,7 @@ import { ChurchesDomainModule } from '../churches/churches-domain/churches-domai
 import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
 import { EducationReportDomainModule } from '../report/education-report/education-report-domain/education-report-domain.module';
 import { EducationSessionNotificationService } from './education-session/service/education-session-notification.service';
+import { EducationTermNotificationService } from './education-term/service/education-term-notification.service';
 
 @Module({
   imports: [
@@ -51,6 +52,7 @@ import { EducationSessionNotificationService } from './education-session/service
     SessionAttendanceService,
     // 알림
     EducationSessionNotificationService,
+    EducationTermNotificationService,
   ],
   exports: [],
 })

--- a/backend/src/notification/const/notification-event.enum.ts
+++ b/backend/src/notification/const/notification-event.enum.ts
@@ -25,4 +25,14 @@ export enum NotificationEvent {
   EDUCATION_SESSION_STATUS_UPDATED = 'education.session.status.updated',
   EDUCATION_SESSION_DATA_UPDATED = 'education.session.meta.updated',
   EDUCATION_SESSION_DELETED = 'education.session.deleted',
+
+  EDUCATION_TERM_IN_CHARGE_ADDED = 'education.term.inCharge.added',
+  EDUCATION_TERM_IN_CHARGE_REMOVED = 'education.term.inCharge.removed',
+  EDUCATION_TERM_IN_CHARGE_CHANGED = 'education.term.inCharge.changed',
+  EDUCATION_TERM_REPORT_ADDED = 'education.term.report.added',
+  EDUCATION_TERM_REPORT_REMOVED = 'education.term.report.removed',
+  EDUCATION_TERM_STATUS_UPDATED = 'education.term.status.updated',
+  EDUCATION_TERM_DATA_UPDATED = 'education.term.data.updated',
+  EDUCATION_TERM_DELETED = 'education.term.deleted',
+  EDUCATION_TERM_ENROLLMENT_UPDATED = 'education.term.enrollment.updated',
 }

--- a/backend/src/notification/notification-domain/service/notification-domain.service.ts
+++ b/backend/src/notification/notification-domain/service/notification-domain.service.ts
@@ -153,6 +153,7 @@ export class NotificationDomainService implements INotificationDomainService {
     const seen = new Set<any>();
 
     return arr.filter((item) => {
+      if (item === undefined || item === null) return false;
       const val = item[key];
       if (seen.has(val)) return false;
       seen.add(val);
@@ -168,8 +169,6 @@ export class NotificationDomainService implements INotificationDomainService {
     const receivers = event.notificationReceivers;
 
     const uniqueReceivers = this.uniqBy(receivers, 'id');
-
-    //console.log(uniqueReceivers);
 
     const now = new Date();
 

--- a/backend/src/notification/notification-event.dto.ts
+++ b/backend/src/notification/notification-event.dto.ts
@@ -55,6 +55,16 @@ export class NotificationSourceEducationSession extends NotificationSource {
   }
 }
 
+export class NotificationSourceEducationTerm extends NotificationSource {
+  constructor(
+    domain: NotificationDomain,
+    public readonly educationId: number,
+    id: number,
+  ) {
+    super(domain, id);
+  }
+}
+
 export class NotificationEventDto {
   actorName: string;
 

--- a/backend/src/notification/service/notification.service.ts
+++ b/backend/src/notification/service/notification.service.ts
@@ -271,4 +271,72 @@ export class NotificationService {
   async handleEducationSessionDeleted(event: NotificationEventDto) {
     await this.notificationDomainService.createNotifications(event);
   }
+
+  @OnEvent(NotificationEvent.EDUCATION_TERM_IN_CHARGE_ADDED, {
+    async: true,
+    suppressErrors: true,
+  })
+  @OnEvent(NotificationEvent.EDUCATION_TERM_IN_CHARGE_REMOVED, {
+    async: true,
+    suppressErrors: true,
+  })
+  @OnEvent(NotificationEvent.EDUCATION_TERM_IN_CHARGE_CHANGED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleEducationTermInChargeAdded(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  /*async handleEducationTermInChargeRemoved(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }*/
+
+  /*async handleEducationTermInChargeChanged(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }*/
+
+  @OnEvent(NotificationEvent.EDUCATION_TERM_REPORT_ADDED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleEducationTermReportAdded(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.EDUCATION_TERM_REPORT_REMOVED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleEducationTermReportRemoved(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.EDUCATION_TERM_STATUS_UPDATED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleEducationTermStatusUpdated(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.EDUCATION_TERM_DATA_UPDATED, {
+    async: true,
+    suppressErrors: true,
+  })
+  @OnEvent(NotificationEvent.EDUCATION_TERM_ENROLLMENT_UPDATED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleEducationTermDataUpdated(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.EDUCATION_TERM_DELETED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleEducationTermDeleted(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
 }


### PR DESCRIPTION
## 주요 내용
- EducationTerm 도메인에 대한 알림 기능 추가
- 담당자/보고대상자 알림은 기존 Task, EducationSession, Visitation과 동일하게 처리
- 교육대상자(enrollment) 추가/제거 시 알림 발송 기능 추가

## 세부 내용
### EducationTerm 알림
- 생성, 수정, 삭제, 담당자/보고대상자 변경 시 알림 발송
- 교육대상자 변경 시 알림 발송
  - `action`: `NotificationAction.UPDATED`
  - `payload`: `{"fields":"enrollments","previous":null,"current":null}`
  - 단순히 교육대상자에 변경사항이 발생했음을 알림