### PR TITLE
feat: 관리자 권한/권한 유형 변경 알림 기능 추가 및 권한 유형 설명 필드 도입

### DIFF
--- a/backend/src/church-user/exception/church-user.exception.ts
+++ b/backend/src/church-user/exception/church-user.exception.ts
@@ -4,4 +4,5 @@ export const ChurchUserException = {
   UPDATE_ERROR: '교회 가입 정보 업데이트 도중 에러 발생',
   DELETE_ERROR: '교회 가입 정보 삭제 도중 에러 발생',
   ALREADY_EXIST: '이미 존재하는 데이터입니다.',
+  NOT_LINKED: '교인 정보가 연동되어 있지 않은 계정입니다.',
 };

--- a/backend/src/manager/controller/manager.controller.ts
+++ b/backend/src/manager/controller/manager.controller.ts
@@ -18,6 +18,10 @@ import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { UpdatePermissionScopeDto } from '../dto/request/update-permission-scope.dto';
 import { ManagerReadGuard } from '../guard/manager-read.guard';
 import { ManagerWriteGuard } from '../guard/manager-write.guard';
+import { RequestChurch } from '../../permission/decorator/request-church.decorator';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { RequestManager } from '../../permission/decorator/request-manager.decorator';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 
 @ApiTags('Churches:Managers')
 @Controller('managers')
@@ -29,9 +33,10 @@ export class ManagerController {
   @ManagerReadGuard()
   getManagers(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Query() dto: GetManagersDto,
   ) {
-    return this.managerService.getManagers(churchId, dto);
+    return this.managerService.getManagers(church, dto);
   }
 
   @ApiOperation({ summary: '관리자 단건 조회' })
@@ -40,8 +45,9 @@ export class ManagerController {
   getManagerById(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('churchUserId', ParseIntPipe) churchUserId: number,
+    @RequestChurch() church: ChurchModel,
   ) {
-    return this.managerService.getManagerById(churchId, churchUserId);
+    return this.managerService.getManagerById(church, churchUserId);
   }
 
   @ApiOperation({ summary: '관리자 활성 상태 온오프' })
@@ -51,10 +57,13 @@ export class ManagerController {
   toggleManagerPermissionActive(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('churchUserId', ParseIntPipe) churchUserId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @QueryRunner() qr: QR,
   ) {
     return this.managerService.togglePermissionActive(
-      churchId,
+      church,
+      requestManager,
       churchUserId,
       qr,
     );
@@ -67,11 +76,14 @@ export class ManagerController {
   assignPermissionTemplate(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('churchUserId', ParseIntPipe) churchUserId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: AssignPermissionTemplateDto,
     @QueryRunner() qr: QR,
   ) {
     return this.managerService.assignPermissionTemplate(
-      churchId,
+      church,
+      requestManager,
       churchUserId,
       dto,
       qr,
@@ -85,10 +97,13 @@ export class ManagerController {
   unassignPermissionTemplate(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('churchUserId', ParseIntPipe) churchUserId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @QueryRunner() qr: QR,
   ) {
     return this.managerService.unassignPermissionTemplate(
-      churchId,
+      church,
+      requestManager,
       churchUserId,
       qr,
     );
@@ -101,11 +116,14 @@ export class ManagerController {
   patchPermissionScope(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('churchUserId', ParseIntPipe) churchUserId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: UpdatePermissionScopeDto,
     @QueryRunner() qr: QR,
   ) {
     return this.managerService.patchPermissionScope(
-      churchId,
+      church,
+      requestManager,
       churchUserId,
       dto,
       qr,

--- a/backend/src/manager/exception/manager.exception.ts
+++ b/backend/src/manager/exception/manager.exception.ts
@@ -4,6 +4,8 @@ export const ManagerException = {
 
   CANNOT_CHANGE_ACTIVITY:
     '관리자 권한의 교인만 활성 상태를 변경할 수 있습니다.',
+  IN_ACTIVE: '권한이 비활성 상태입니다.',
+  NOT_LINKED: '이 계정은 교인 데이터와 연결되지 않아 활동할 수 없습니다.',
 
   MISSING_MEMBER_DATA: (domain: string = '') =>
     `교인 데이터와 연결이 끊겼습니다. (에러 발생 위치: ${domain})`,

--- a/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
+++ b/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
@@ -84,6 +84,17 @@ export interface IManagerDomainService {
     qr?: QueryRunner,
   ): Promise<ChurchUserModel | null>;
 
+  findOwnerForNotification(
+    church: ChurchModel,
+    qr?: QueryRunner,
+  ): Promise<ChurchUserModel | null>;
+
+  findManagersByPermissionTemplateForNotification(
+    church: ChurchModel,
+    permissionTemplate: PermissionTemplateModel,
+    qr?: QueryRunner,
+  ): Promise<ChurchUserModel[]>;
+
   findAllManagerIds(
     church: ChurchModel,
     qr?: QueryRunner,

--- a/backend/src/manager/manager-domain/service/manager-domain.service.ts
+++ b/backend/src/manager/manager-domain/service/manager-domain.service.ts
@@ -230,6 +230,14 @@ export class ManagerDomainService implements IManagerDomainService {
       throw new ForbiddenException(ManagerException.FORBIDDEN);
     }
 
+    if (!churchUser.isPermissionActive) {
+      throw new ForbiddenException(ManagerException.IN_ACTIVE);
+    }
+
+    if (!churchUser.member) {
+      throw new ForbiddenException(ManagerException.NOT_LINKED);
+    }
+
     return churchUser;
   }
 
@@ -251,6 +259,38 @@ export class ManagerDomainService implements IManagerDomainService {
       },
       select: {
         member: MemberSimpleSelect,
+      },
+    });
+  }
+
+  findOwnerForNotification(
+    church: ChurchModel,
+    qr?: QueryRunner,
+  ): Promise<ChurchUserModel | null> {
+    const repository = this.getRepository(qr);
+
+    return repository.findOne({
+      where: {
+        churchId: church.id,
+        role: ChurchUserRole.OWNER,
+      },
+    });
+  }
+
+  findManagersByPermissionTemplateForNotification(
+    church: ChurchModel,
+    permissionTemplate: PermissionTemplateModel,
+    qr?: QueryRunner,
+  ): Promise<ChurchUserModel[]> {
+    const repository = this.getRepository(qr);
+
+    return repository.find({
+      where: {
+        churchId: church.id,
+        permissionTemplateId: permissionTemplate.id,
+      },
+      select: {
+        id: true,
       },
     });
   }

--- a/backend/src/manager/manager.module.ts
+++ b/backend/src/manager/manager.module.ts
@@ -7,6 +7,7 @@ import { ChurchesDomainModule } from '../churches/churches-domain/churches-domai
 import { PermissionDomainModule } from '../permission/permission-domain/permission-domain.module';
 import { UserDomainModule } from '../user/user-domain/user-domain.module';
 import { GroupsDomainModule } from '../management/groups/groups-domain/groups-domain.module';
+import { ManagerNotificationService } from './service/manager-notification.service';
 
 @Module({
   imports: [
@@ -20,6 +21,6 @@ import { GroupsDomainModule } from '../management/groups/groups-domain/groups-do
     GroupsDomainModule,
   ],
   controllers: [ManagerController],
-  providers: [ManagerService],
+  providers: [ManagerService, ManagerNotificationService],
 })
 export class ManagerModule {}

--- a/backend/src/manager/service/manager-notification.service.ts
+++ b/backend/src/manager/service/manager-notification.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { NotificationEvent } from '../../notification/const/notification-event.enum';
+import {
+  NotificationEventDto,
+  NotificationSourceManager,
+} from '../../notification/notification-event.dto';
+import { NotificationAction } from '../../notification/const/notification-action.enum';
+import { NotificationDomain } from '../../notification/const/notification-domain.enum';
+
+@Injectable()
+export class ManagerNotificationService {
+  constructor(private readonly eventEmitter: EventEmitter2) {}
+
+  notifyPermissionUpdated(
+    requestManager: ChurchUserModel,
+    targetManager: ChurchUserModel,
+    ownerManager: ChurchUserModel | null,
+  ) {
+    const actorName = requestManager.member.name;
+
+    // 당사자에게 알림
+    requestManager.id !== targetManager.id &&
+      this.eventEmitter.emit(
+        NotificationEvent.MANAGER_PERMISSION_UPDATED,
+        new NotificationEventDto(
+          actorName,
+          NotificationDomain.MANAGER,
+          NotificationAction.UPDATED,
+          '',
+          null,
+          [targetManager],
+          [],
+        ),
+      );
+
+    // 소유자에게 알림
+    ownerManager &&
+      ownerManager.id !== requestManager.id &&
+      this.eventEmitter.emit(
+        NotificationEvent.MANAGER_PERMISSION_UPDATED,
+        new NotificationEventDto(
+          actorName,
+          NotificationDomain.MANAGER,
+          NotificationAction.UPDATED,
+          targetManager.member.name,
+          new NotificationSourceManager(
+            NotificationDomain.MANAGER,
+            targetManager.id,
+          ),
+          [ownerManager],
+          [],
+        ),
+      );
+  }
+}

--- a/backend/src/manager/service/manager.service.ts
+++ b/backend/src/manager/service/manager.service.ts
@@ -1,9 +1,5 @@
 import { ConflictException, Inject, Injectable } from '@nestjs/common';
 import { GetManagersDto } from '../dto/request/get-managers.dto';
-import {
-  ICHURCHES_DOMAIN_SERVICE,
-  IChurchesDomainService,
-} from '../../churches/churches-domain/interface/churches-domain.service.interface';
 import { QueryRunner } from 'typeorm';
 import { ManagerPaginationResponseDto } from '../dto/response/manager-pagination-response.dto';
 import { PatchManagerResponseDto } from '../dto/response/patch-manager-response.dto';
@@ -31,12 +27,14 @@ import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { ChurchUserRole } from '../../user/const/user-role.enum';
 import { PermissionScopeException } from '../../permission/exception/permission-scope.exception';
+import { ManagerNotificationService } from './manager-notification.service';
+import { ChurchUserException } from '../../church-user/exception/church-user.exception';
 
 @Injectable()
 export class ManagerService {
   constructor(
-    @Inject(ICHURCHES_DOMAIN_SERVICE)
-    private readonly churchesDomainService: IChurchesDomainService,
+    private readonly managerNotificationService: ManagerNotificationService,
+
     @Inject(IMANAGER_DOMAIN_SERVICE)
     private readonly managerDomainService: IManagerDomainService,
     @Inject(IPERMISSION_DOMAIN_SERVICE)
@@ -47,10 +45,7 @@ export class ManagerService {
     private readonly groupsDomainService: IGroupsDomainService,
   ) {}
 
-  async getManagers(churchId: number, dto: GetManagersDto) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
+  async getManagers(church: ChurchModel, dto: GetManagersDto) {
     const { data, totalCount } = await this.managerDomainService.findManagers(
       church,
       dto,
@@ -66,20 +61,21 @@ export class ManagerService {
   }
 
   async togglePermissionActive(
-    churchId: number,
+    church: ChurchModel,
+    requestManager: ChurchUserModel,
     churchUserId: number,
     qr: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
     const targetManager = await this.managerDomainService.findManagerModelById(
       church,
       churchUserId,
       qr,
+      { member: true },
     );
+
+    if (!targetManager.member) {
+      throw new ConflictException(ChurchUserException.NOT_LINKED);
+    }
 
     await this.managerDomainService.updatePermissionActive(
       targetManager,
@@ -93,13 +89,21 @@ export class ManagerService {
       qr,
     );
 
+    const owner = await this.managerDomainService.findOwnerForNotification(
+      church,
+      qr,
+    );
+
+    this.managerNotificationService.notifyPermissionUpdated(
+      requestManager,
+      targetManager,
+      owner,
+    );
+
     return new PatchManagerResponseDto(updatedManager);
   }
 
-  async getManagerById(churchId: number, churchUserId: number) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
+  async getManagerById(church: ChurchModel, churchUserId: number) {
     const manager = await this.managerDomainService.findManagerById(
       church,
       churchUserId,
@@ -109,16 +113,12 @@ export class ManagerService {
   }
 
   async assignPermissionTemplate(
-    churchId: number,
+    church: ChurchModel,
+    requestManager: ChurchUserModel,
     churchUserId: number,
     dto: AssignPermissionTemplateDto,
     qr: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
     const permissionTemplate =
       await this.permissionDomainService.findPermissionTemplateModelById(
         church,
@@ -130,7 +130,7 @@ export class ManagerService {
       church,
       churchUserId,
       qr,
-      { permissionTemplate: true },
+      { member: true, permissionTemplate: true },
     );
 
     // 기존 권한 유형이 있는 경우 memberCount 감소
@@ -152,6 +152,18 @@ export class ManagerService {
       qr,
     );
 
+    const owner = await this.managerDomainService.findOwnerForNotification(
+      church,
+      qr,
+    );
+
+    manager.permissionTemplateId !== dto.permissionTemplateId &&
+      this.managerNotificationService.notifyPermissionUpdated(
+        requestManager,
+        manager,
+        owner,
+      );
+
     const updatedManager = await this.managerDomainService.findManagerById(
       church,
       churchUserId,
@@ -162,20 +174,16 @@ export class ManagerService {
   }
 
   async unassignPermissionTemplate(
-    churchId: number,
+    church: ChurchModel,
+    requestManager: ChurchUserModel,
     churchUserId: number,
     qr: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
     const manager = await this.managerDomainService.findManagerModelById(
       church,
       churchUserId,
       qr,
-      { permissionTemplate: true },
+      { member: true, permissionTemplate: true },
     );
 
     await this.managerDomainService.unassignPermissionTemplate(manager, qr);
@@ -185,6 +193,17 @@ export class ManagerService {
         manager.permissionTemplate,
         qr,
       ));
+
+    const owner = await this.managerDomainService.findOwnerForNotification(
+      church,
+      qr,
+    );
+
+    this.managerNotificationService.notifyPermissionUpdated(
+      requestManager,
+      manager,
+      owner,
+    );
 
     const updatedManager = await this.managerDomainService.findManagerById(
       church,
@@ -276,14 +295,12 @@ export class ManagerService {
   }
 
   async patchPermissionScope(
-    churchId: number,
+    church: ChurchModel,
+    requestManager: ChurchUserModel,
     churchUserId: number,
     dto: UpdatePermissionScopeDto,
     qr: QueryRunner,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
     const manager = await this.managerDomainService.findManagerById(
       church,
       churchUserId,
@@ -300,9 +317,20 @@ export class ManagerService {
         qr,
       );
 
+    const owner = await this.managerDomainService.findOwnerForNotification(
+      church,
+      qr,
+    );
+
     // 전체 그룹 범위 지정
     if (dto.isAllGroups) {
       await this.handleAllGroupScope(manager, existingScope, qr);
+
+      this.managerNotificationService.notifyPermissionUpdated(
+        requestManager,
+        manager,
+        owner,
+      );
 
       return this.managerDomainService.findManagerById(
         church,
@@ -316,6 +344,12 @@ export class ManagerService {
         existingScope,
         dto,
         qr,
+      );
+
+      this.managerNotificationService.notifyPermissionUpdated(
+        requestManager,
+        manager,
+        owner,
       );
 
       return this.managerDomainService.findManagerById(

--- a/backend/src/notification/const/notification-domain.enum.ts
+++ b/backend/src/notification/const/notification-domain.enum.ts
@@ -3,6 +3,7 @@ export enum NotificationDomain {
   VISITATION = 'visitation',
   EDUCATION_TERM = 'educationTerm',
   EDUCATION_SESSION = 'educationSession',
+  MANAGER = 'manager',
   PERMISSION = 'permission',
   CHURCH_INFO = 'churchInfo',
   WORSHIP_ATTENDANCE = 'worshipAttendance',

--- a/backend/src/notification/const/notification-event.enum.ts
+++ b/backend/src/notification/const/notification-event.enum.ts
@@ -37,4 +37,6 @@ export enum NotificationEvent {
   EDUCATION_TERM_ENROLLMENT_UPDATED = 'education.term.enrollment.updated',
 
   CHURCH_UPDATED = 'church.updated',
+  MANAGER_PERMISSION_UPDATED = 'manager.permission.updated',
+  PERMISSION_TEMPLATE_UPDATED = 'permission.template.updated',
 }

--- a/backend/src/notification/notification-event.dto.ts
+++ b/backend/src/notification/notification-event.dto.ts
@@ -37,6 +37,18 @@ export class NotificationSourceChurch extends NotificationSource {
   }
 }
 
+export class NotificationSourceManager extends NotificationSource {
+  constructor(domain: NotificationDomain, id: number) {
+    super(domain, id);
+  }
+}
+
+export class NotificationSourcePermissionTemplate extends NotificationSource {
+  constructor(domain: NotificationDomain, id: number) {
+    super(domain, id);
+  }
+}
+
 export class NotificationSourceTask extends NotificationSource {
   constructor(domain: NotificationDomain, id: number) {
     super(domain, id);

--- a/backend/src/notification/service/notification.service.ts
+++ b/backend/src/notification/service/notification.service.ts
@@ -347,4 +347,20 @@ export class NotificationService {
   async handleChurchUpdated(event: NotificationEventDto) {
     await this.notificationDomainService.createNotifications(event);
   }
+
+  @OnEvent(NotificationEvent.MANAGER_PERMISSION_UPDATED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handleManagerPermissionUpdated(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
+
+  @OnEvent(NotificationEvent.PERMISSION_TEMPLATE_UPDATED, {
+    async: true,
+    suppressErrors: true,
+  })
+  async handlePermissionTemplateUpdated(event: NotificationEventDto) {
+    await this.notificationDomainService.createNotifications(event);
+  }
 }

--- a/backend/src/permission/controller/permission.controller.ts
+++ b/backend/src/permission/controller/permission.controller.ts
@@ -36,6 +36,10 @@ import { PermissionReadGuard } from '../guard/permission-read.guard';
 import { PermissionWriteGuard } from '../guard/permission-write.guard';
 import { ChurchManagerGuard } from '../guard/church-manager.guard';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
+import { RequestChurch } from '../decorator/request-church.decorator';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { RequestManager } from '../decorator/request-manager.decorator';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 
 @ApiTags('Churches:Permissions')
 @Controller('permissions')
@@ -58,9 +62,10 @@ export class PermissionController {
   @PermissionReadGuard()
   getPermissionTemplates(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Query() dto: GetPermissionTemplateDto,
   ) {
-    return this.permissionService.getPermissionTemplates(churchId, dto);
+    return this.permissionService.getPermissionTemplates(church, dto);
   }
 
   @ApiPostPermissionTemplates()
@@ -68,9 +73,10 @@ export class PermissionController {
   @PermissionWriteGuard()
   postPermissionTemplates(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Body() dto: CreatePermissionTemplateDto,
   ) {
-    return this.permissionService.postPermissionTemplates(churchId, dto);
+    return this.permissionService.postPermissionTemplates(church, dto);
   }
 
   @ApiPostSamplePermissionTemplates()
@@ -79,9 +85,10 @@ export class PermissionController {
   @UseInterceptors(TransactionInterceptor)
   postSamplePermissionTemplates(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @QueryRunner() qr: QR,
   ) {
-    return this.permissionService.postSamplePermissionTemplates(churchId, qr);
+    return this.permissionService.postSamplePermissionTemplates(church, qr);
   }
 
   @ApiGetPermissionTemplateById()
@@ -89,12 +96,10 @@ export class PermissionController {
   @PermissionReadGuard()
   getPermissionTemplateById(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Param('templateId', ParseIntPipe) templateId: number,
   ) {
-    return this.permissionService.getPermissionTemplateById(
-      churchId,
-      templateId,
-    );
+    return this.permissionService.getPermissionTemplateById(church, templateId);
   }
 
   @ApiGetManagersByPermissionTemplate()
@@ -102,11 +107,12 @@ export class PermissionController {
   @PermissionReadGuard()
   getManagersByPermissionTemplate(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Param('templateId', ParseIntPipe) templateId: number,
     @Query() dto: GetManagersByPermissionTemplateDto,
   ) {
     return this.permissionService.getManagersByPermissionTemplate(
-      churchId,
+      church,
       templateId,
       dto,
     );
@@ -117,11 +123,14 @@ export class PermissionController {
   @PermissionWriteGuard()
   patchPermissionTemplate(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Param('templateId', ParseIntPipe) templateId: number,
     @Body() dto: UpdatePermissionTemplateDto,
+    @RequestManager() requestManager: ChurchUserModel,
   ) {
     return this.permissionService.patchPermissionTemplate(
-      churchId,
+      church,
+      requestManager,
       templateId,
       dto,
     );
@@ -132,11 +141,9 @@ export class PermissionController {
   @PermissionWriteGuard()
   deletePermissionTemplate(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Param('templateId', ParseIntPipe) templateId: number,
   ) {
-    return this.permissionService.deletePermissionTemplate(
-      churchId,
-      templateId,
-    );
+    return this.permissionService.deletePermissionTemplate(church, templateId);
   }
 }

--- a/backend/src/permission/dto/template/request/create-permission-template.dto.ts
+++ b/backend/src/permission/dto/template/request/create-permission-template.dto.ts
@@ -9,7 +9,10 @@ import {
   IsString,
   Length,
 } from 'class-validator';
-import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import {
+  IsBasicText,
+  IsNoSpecialChar,
+} from '../../../../common/decorator/validator/is-no-special-char.validator';
 import { RemoveSpaces } from '../../../../common/decorator/transformer/remove-spaces';
 import { Transform } from 'class-transformer';
 import {
@@ -18,10 +21,12 @@ import {
   MIN_PERMISSION_TEMPLATE_TITLE_LENGTH,
   MIN_PERMISSION_UNIT_COUNT,
 } from '../../../constraints/permission.constraints';
+import { SanitizeDto } from '../../../../common/decorator/sanitize-target.decorator';
 
+@SanitizeDto()
 export class CreatePermissionTemplateDto extends PickType(
   PermissionTemplateModel,
-  ['title'],
+  ['title', 'description'],
 ) {
   @ApiProperty({
     description: '권한 유형 이름',
@@ -35,6 +40,12 @@ export class CreatePermissionTemplateDto extends PickType(
     MAX_PERMISSION_TEMPLATE_TITLE_LENGTH,
   )
   override title: string;
+
+  @ApiProperty({ description: '권한 유형 설명' })
+  @IsString()
+  @IsBasicText('description')
+  @Length(0, 50)
+  override description: string;
 
   @ApiProperty({
     description: '권한 단위 ID 배열',

--- a/backend/src/permission/dto/template/request/update-permission-template.dto.ts
+++ b/backend/src/permission/dto/template/request/update-permission-template.dto.ts
@@ -9,7 +9,10 @@ import {
   IsString,
   Length,
 } from 'class-validator';
-import { IsNoSpecialChar } from '../../../../common/decorator/validator/is-no-special-char.validator';
+import {
+  IsBasicText,
+  IsNoSpecialChar,
+} from '../../../../common/decorator/validator/is-no-special-char.validator';
 import { RemoveSpaces } from '../../../../common/decorator/transformer/remove-spaces';
 import { Transform } from 'class-transformer';
 import {
@@ -20,7 +23,7 @@ import {
 } from '../../../constraints/permission.constraints';
 
 export class UpdatePermissionTemplateDto extends PartialType(
-  PickType(PermissionTemplateModel, ['title']),
+  PickType(PermissionTemplateModel, ['title', 'description']),
 ) {
   @ApiProperty({
     description: '권한 유형 이름',
@@ -35,6 +38,13 @@ export class UpdatePermissionTemplateDto extends PartialType(
     MAX_PERMISSION_TEMPLATE_TITLE_LENGTH,
   )
   override title?: string;
+
+  @ApiProperty({ description: '권한 유형 설명' })
+  @IsOptionalNotNull()
+  @IsString()
+  @IsBasicText('description')
+  @Length(0, 50)
+  override description?: string;
 
   @ApiProperty({
     description: '권한 단위 ID 배열',

--- a/backend/src/permission/entity/permission-template.entity.ts
+++ b/backend/src/permission/entity/permission-template.entity.ts
@@ -24,6 +24,9 @@ export class PermissionTemplateModel extends BaseModel {
   @Column()
   title: string;
 
+  @Column({ default: '' })
+  description: string;
+
   @Column({ default: 0 })
   memberCount: number;
 

--- a/backend/src/permission/permission-domain/service/permission-domain.service.ts
+++ b/backend/src/permission/permission-domain/service/permission-domain.service.ts
@@ -238,35 +238,20 @@ export class PermissionDomainService implements IPermissionDomainService {
 
     if (dto.title) {
       await this.assertValidTemplateTitle(church, dto.title, qr);
-      template.title = dto.title;
-    }
-
-    if (units) {
-      template.permissionUnits = units;
     }
 
     const templateRepository = this.getTemplateRepository(qr);
 
-    await templateRepository.save(template);
+    const update = templateRepository.create({
+      ...template,
+      title: dto.title,
+      permissionUnits: units,
+      description: dto.description,
+    });
+
+    await templateRepository.save(update);
 
     return;
-
-    /*const result = await templateRepository.update(
-      {
-        churchId: church.id,
-        id: template.id,
-      },
-      {
-        title: dto.title,
-        permissionUnits: units,
-      },
-    );
-
-    if (result.affected === 0) {
-      throw new InternalServerErrorException(PermissionException.UPDATE_ERROR);
-    }
-
-    return result;*/
   }
 
   async deletePermissionTemplate(

--- a/backend/src/permission/permission.module.ts
+++ b/backend/src/permission/permission.module.ts
@@ -5,6 +5,7 @@ import { PermissionService } from './service/permission.service';
 import { PermissionDomainModule } from './permission-domain/permission-domain.module';
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
 import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
+import { PermissionNotificationService } from './service/permission-notification.service';
 
 @Module({
   imports: [
@@ -16,7 +17,6 @@ import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.mo
     PermissionDomainModule,
   ],
   controllers: [PermissionController],
-  providers: [PermissionService],
-  exports: [],
+  providers: [PermissionService, PermissionNotificationService],
 })
 export class PermissionModule {}

--- a/backend/src/permission/service/permission-notification.service.ts
+++ b/backend/src/permission/service/permission-notification.service.ts
@@ -1,0 +1,108 @@
+import { Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { NotificationEvent } from '../../notification/const/notification-event.enum';
+import {
+  NotificationEventDto,
+  NotificationFields,
+  NotificationSourcePermissionTemplate,
+} from '../../notification/notification-event.dto';
+import { NotificationDomain } from '../../notification/const/notification-domain.enum';
+import { NotificationAction } from '../../notification/const/notification-action.enum';
+import { PermissionTemplateModel } from '../entity/permission-template.entity';
+import { UpdatePermissionTemplateDto } from '../dto/template/request/update-permission-template.dto';
+
+@Injectable()
+export class PermissionNotificationService {
+  constructor(private readonly eventEmitter: EventEmitter2) {}
+
+  isDifferent(a: number[], b: number[]) {
+    if (a.length !== b.length) {
+      return true;
+    }
+
+    const sortedA = [...a].sort((x, y) => x - y);
+    const sortedB = [...b].sort((x, y) => x - y);
+
+    return !sortedA.every((val, idx) => val === sortedB[idx]);
+  }
+
+  notifyPermissionTemplateUpdated(
+    requestManager: ChurchUserModel,
+    notificationTargets: ChurchUserModel[],
+    owner: ChurchUserModel | null,
+    permissionTemplate: PermissionTemplateModel,
+    dto: UpdatePermissionTemplateDto,
+  ) {
+    const actorName = requestManager.member.name;
+
+    const notificationReceivers = notificationTargets.filter(
+      (t) => t.id !== requestManager.id,
+    );
+
+    const notificationFields: NotificationFields[] = [];
+
+    // 제목 변경 시
+    if (dto.title && dto.title !== permissionTemplate.title) {
+      notificationFields.push(
+        new NotificationFields('title', permissionTemplate.title, dto.title),
+      );
+    }
+    // 설명 변경
+    if (dto.description && dto.description !== permissionTemplate.description) {
+      notificationFields.push(
+        new NotificationFields(
+          'description',
+          permissionTemplate.description,
+          dto.description,
+        ),
+      );
+    }
+    // 권한 유닛 변경
+    if (dto.unitIds) {
+      const unitIds = permissionTemplate.permissionUnits.map((u) => u.id);
+      if (this.isDifferent(unitIds, dto.unitIds)) {
+        notificationFields.push(
+          new NotificationFields('permissionUnits', null, null),
+        );
+      }
+    }
+
+    // 변경 사항 없음 --> 알림 X
+    if (notificationFields.length === 0) {
+      return;
+    }
+
+    notificationReceivers.length > 0 &&
+      this.eventEmitter.emit(
+        NotificationEvent.PERMISSION_TEMPLATE_UPDATED,
+        new NotificationEventDto(
+          actorName,
+          NotificationDomain.PERMISSION,
+          NotificationAction.UPDATED,
+          '',
+          null,
+          notificationReceivers,
+          notificationFields,
+        ),
+      );
+
+    owner &&
+      owner.id !== requestManager.id &&
+      this.eventEmitter.emit(
+        NotificationEvent.PERMISSION_TEMPLATE_UPDATED,
+        new NotificationEventDto(
+          actorName,
+          NotificationDomain.PERMISSION,
+          NotificationAction.UPDATED,
+          permissionTemplate.title,
+          new NotificationSourcePermissionTemplate(
+            NotificationDomain.PERMISSION,
+            permissionTemplate.id,
+          ),
+          [owner],
+          notificationFields,
+        ),
+      );
+  }
+}

--- a/backend/src/permission/service/permission.service.ts
+++ b/backend/src/permission/service/permission.service.ts
@@ -5,10 +5,6 @@ import {
 } from '../permission-domain/service/interface/permission-domain.service.interface';
 import { DomainType } from '../const/domain-type.enum';
 import { GetPermissionTemplateDto } from '../dto/template/request/get-permission-template.dto';
-import {
-  ICHURCHES_DOMAIN_SERVICE,
-  IChurchesDomainService,
-} from '../../churches/churches-domain/interface/churches-domain.service.interface';
 import { PermissionTemplatePaginationResponseDto } from '../dto/template/response/permission-template-pagination-response.dto';
 import { CreatePermissionTemplateDto } from '../dto/template/request/create-permission-template.dto';
 import { PostPermissionTemplateResponseDto } from '../dto/template/response/post-permission-template-response.dto';
@@ -24,12 +20,15 @@ import {
 } from '../../manager/manager-domain/service/interface/manager-domain.service.interface';
 import { MemberPaginationResponseDto } from '../../members/dto/response/member-pagination-response.dto';
 import { GetManagersByPermissionTemplateDto } from '../dto/template/request/get-managers-by-permission-template.dto';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { PermissionNotificationService } from './permission-notification.service';
 
 @Injectable()
 export class PermissionService {
   constructor(
-    @Inject(ICHURCHES_DOMAIN_SERVICE)
-    private readonly churchesDomainService: IChurchesDomainService,
+    private readonly permissionNotificationService: PermissionNotificationService,
+
     @Inject(IMANAGER_DOMAIN_SERVICE)
     private readonly managerDomainService: IManagerDomainService,
 
@@ -45,12 +44,9 @@ export class PermissionService {
   }
 
   async getPermissionTemplates(
-    churchId: number,
+    church: ChurchModel,
     dto: GetPermissionTemplateDto,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
     const { data, totalCount } =
       await this.permissionDomainService.findPermissionTemplates(church, dto);
 
@@ -64,22 +60,16 @@ export class PermissionService {
   }
 
   async postPermissionTemplates(
-    churchId: number,
+    church: ChurchModel,
     dto: CreatePermissionTemplateDto,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
     const newTemplate =
       await this.permissionDomainService.createPermissionTemplate(church, dto);
 
     return new PostPermissionTemplateResponseDto(newTemplate);
   }
 
-  async getPermissionTemplateById(churchId: number, templateId: number) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
+  async getPermissionTemplateById(church: ChurchModel, templateId: number) {
     const template =
       await this.permissionDomainService.findPermissionTemplateById(
         church,
@@ -90,21 +80,38 @@ export class PermissionService {
   }
 
   async patchPermissionTemplate(
-    churchId: number,
+    church: ChurchModel,
+    requestManager: ChurchUserModel,
     templateId: number,
     dto: UpdatePermissionTemplateDto,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
     const targetTemplate =
       await this.permissionDomainService.findPermissionTemplateModelById(
         church,
         templateId,
+        undefined,
+        { permissionUnits: true },
       );
 
     await this.permissionDomainService.updatePermissionTemplate(
       church,
+      targetTemplate,
+      dto,
+    );
+
+    const owner =
+      await this.managerDomainService.findOwnerForNotification(church);
+
+    const notificationTargets =
+      await this.managerDomainService.findManagersByPermissionTemplateForNotification(
+        church,
+        targetTemplate,
+      );
+
+    this.permissionNotificationService.notifyPermissionTemplateUpdated(
+      requestManager,
+      notificationTargets,
+      owner,
       targetTemplate,
       dto,
     );
@@ -118,10 +125,7 @@ export class PermissionService {
     return new PatchPermissionTemplateResponseDto(updatedTemplate);
   }
 
-  async deletePermissionTemplate(churchId: number, templateId: number) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
+  async deletePermissionTemplate(church: ChurchModel, templateId: number) {
     const targetTemplate =
       await this.permissionDomainService.findPermissionTemplateModelById(
         church,
@@ -138,12 +142,7 @@ export class PermissionService {
     );
   }
 
-  async postSamplePermissionTemplates(churchId: number, qr: QueryRunner) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
+  async postSamplePermissionTemplates(church: ChurchModel, qr: QueryRunner) {
     const educationUnits =
       await this.permissionDomainService.findPermissionUnits(
         DomainType.EDUCATION,
@@ -151,6 +150,7 @@ export class PermissionService {
 
     const educationManager: CreatePermissionTemplateDto = {
       title: '교육 관리자(샘플)',
+      description: '교회의 교육을 열람/작성합니다.',
       unitIds: educationUnits.map((unit) => unit.id),
     };
 
@@ -161,6 +161,7 @@ export class PermissionService {
 
     const visitationManager: CreatePermissionTemplateDto = {
       title: '심방 관리자(샘플)',
+      description: '교인의 심방을 열람/작성합니다.',
       unitIds: visitationUnits.map((unit) => unit.id),
     };
 
@@ -181,12 +182,10 @@ export class PermissionService {
   }
 
   async getManagersByPermissionTemplate(
-    churchId: number,
+    church: ChurchModel,
     templateId: number,
     dto: GetManagersByPermissionTemplateDto,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
     const permissionTemplate =
       await this.permissionDomainService.findPermissionTemplateModelById(
         church,


### PR DESCRIPTION
## 주요 내용
- 관리자 권한 변경 시 알림 발송 기능 추가
- 권한 유형(permission template) 변경 시 알림 발송 기능 추가
- 권한 유형에 설명(description) 필드 추가

## 세부 내용
### 관리자 권한 변경 알림
- 알림 발생 조건
  1. 권한 활성 여부 변경
  2. 권한 유형 변경/해제
  3. 권한 범위 변경
- 알림 대상
  - 해당 관리자
    - domain: `NotificationDomain.MANAGER` = `"manager"`
    - action: `NotificationAction.UPDATED` = `"updated"`
    - payload, sourceInfo: 없음
  - 교회 Owner 사용자
    - domain: `NotificationDomain.MANAGER` = `"manager"`
    - action: `NotificationAction.UPDATED` = `"updated"`
    - domainTitle: 해당 관리자의 이름
    - payload: 없음
    - sourceInfo: `{"domain":"manager","id":<ChurchUserId>}`

### 권한 유형(PermissionTemplate) 변경 알림
- 알림 발생 조건
  1. 제목(title) 변경
  2. 설명(description) 변경
  3. 권한 유닛(permissionUnits) 변경
- 알림 대상: 해당 권한 유형을 부여받은 관리자 + 교회 Owner 사용자
- 알림 데이터
  - domain: `NotificationDomain.PERMISSION` = `"permission"`
  - action: `NotificationAction.UPDATED` = `"updated"`
  - domainTitle: 권한 유형 이름
  - payload:
    - title/description 변경 시 → `{ field, previous, current }`
    - permissionUnits 변경 시 → `{ field:"permissionUnits", previous:null, current:null }`
  - sourceInfo: `{"domain":"permission","id":<PermissionTemplateId>}`

### 권한 유형 설명(description) 필드
- 최대 50자
- 일부 특수문자 허용
- 생성/수정 시 작성 가능