### PR TITLE
feat: 예배 출석부 알림 기능 추가 (전날 오전 10시 발송)

### DIFF
--- a/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
+++ b/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
@@ -137,4 +137,9 @@ export interface IChurchesDomainService {
     expiredChurches: ChurchModel[],
     qr: QueryRunner,
   ): Promise<DeleteResult>;
+
+  findWorshipNotificationTargets(
+    targetChurchIds: number[],
+    qr?: QueryRunner,
+  ): Promise<ChurchModel[]>;
 }

--- a/backend/src/churches/churches-domain/service/churhes-domain.service.ts
+++ b/backend/src/churches/churches-domain/service/churhes-domain.service.ts
@@ -564,4 +564,20 @@ export class ChurchesDomainService implements IChurchesDomainService {
 
     return result;
   }
+
+  async findWorshipNotificationTargets(
+    targetChurchIds: number[],
+    qr?: QueryRunner,
+  ): Promise<ChurchModel[]> {
+    const repository = this.getChurchRepository();
+
+    return repository.find({
+      where: {
+        id: In(targetChurchIds),
+      },
+      select: {
+        id: true,
+      },
+    });
+  }
 }

--- a/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
+++ b/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
@@ -100,6 +100,11 @@ export interface IManagerDomainService {
     qr?: QueryRunner,
   ): Promise<ChurchUserModel[]>;
 
+  findAllManagerIdsBulk(
+    churchIds: number[],
+    qr?: QueryRunner,
+  ): Promise<ChurchUserModel[]>;
+
   /**
    * receiver 로 지정된 교인의 권한 확인용
    * @param church

--- a/backend/src/manager/manager-domain/service/manager-domain.service.ts
+++ b/backend/src/manager/manager-domain/service/manager-domain.service.ts
@@ -253,6 +253,7 @@ export class ManagerDomainService implements IManagerDomainService {
         churchId: church.id,
         memberId,
         role: ChurchUserManagers,
+        leftAt: IsNull(),
       },
       relations: {
         member: MemberSummarizedRelation,
@@ -273,6 +274,7 @@ export class ManagerDomainService implements IManagerDomainService {
       where: {
         churchId: church.id,
         role: ChurchUserRole.OWNER,
+        leftAt: IsNull(),
       },
     });
   }
@@ -288,6 +290,8 @@ export class ManagerDomainService implements IManagerDomainService {
       where: {
         churchId: church.id,
         permissionTemplateId: permissionTemplate.id,
+        role: ChurchUserManagers,
+        leftAt: IsNull(),
       },
       select: {
         id: true,
@@ -305,9 +309,29 @@ export class ManagerDomainService implements IManagerDomainService {
       where: {
         churchId: church.id,
         role: ChurchUserManagers,
+        leftAt: IsNull(),
       },
       select: {
         id: true,
+      },
+    });
+  }
+
+  findAllManagerIdsBulk(
+    churchIds: number[],
+    qr?: QueryRunner,
+  ): Promise<ChurchUserModel[]> {
+    const repository = this.getRepository(qr);
+
+    return repository.find({
+      where: {
+        churchId: In(churchIds),
+        role: ChurchUserManagers,
+        leftAt: IsNull(),
+      },
+      select: {
+        id: true,
+        churchId: true,
       },
     });
   }
@@ -324,6 +348,7 @@ export class ManagerDomainService implements IManagerDomainService {
         churchId: church.id,
         memberId: In(memberIds),
         role: ChurchUserManagers,
+        leftAt: IsNull(),
       },
       relations: {
         member: MemberSummarizedRelation,
@@ -346,6 +371,7 @@ export class ManagerDomainService implements IManagerDomainService {
         churchId: church.id,
         memberId: In(memberIds),
         role: ChurchUserManagers,
+        leftAt: IsNull(),
       },
       relations: {
         member: MemberSummarizedRelation,

--- a/backend/src/notification/const/notification-domain.enum.ts
+++ b/backend/src/notification/const/notification-domain.enum.ts
@@ -6,5 +6,5 @@ export enum NotificationDomain {
   MANAGER = 'manager',
   PERMISSION = 'permission',
   CHURCH_INFO = 'churchInfo',
-  WORSHIP_ATTENDANCE = 'worshipAttendance',
+  WORSHIP = 'worship',
 }

--- a/backend/src/notification/const/notification-event.enum.ts
+++ b/backend/src/notification/const/notification-event.enum.ts
@@ -39,4 +39,6 @@ export enum NotificationEvent {
   CHURCH_UPDATED = 'church.updated',
   MANAGER_PERMISSION_UPDATED = 'manager.permission.updated',
   PERMISSION_TEMPLATE_UPDATED = 'permission.template.updated',
+
+  WORSHIP_SESSION_CREATED = 'worship.session.created',
 }

--- a/backend/src/notification/controller/notification.controller.ts
+++ b/backend/src/notification/controller/notification.controller.ts
@@ -21,6 +21,7 @@ import {
   ApiPatchCheckAllRead,
   ApiPatchCheckRead,
 } from '../swagger/notification.swagger';
+import { ApiOperation } from '@nestjs/swagger';
 
 @Controller()
 export class NotificationController {
@@ -47,6 +48,15 @@ export class NotificationController {
   @UseGuards(AccessTokenGuard, ChurchUserGuard)
   createDummyNotification(@RequestChurchUser() churchUser: ChurchUserModel) {
     return this.notificationService.createDummyNotification(churchUser);
+  }
+
+  @ApiOperation({ description: '생성되는 sourceInfo 는 랜덤한 값' })
+  @Post('test-worship')
+  @UseGuards(AccessTokenGuard, ChurchUserGuard)
+  createDummyWorshipNotification(
+    @RequestChurchUser() churchUser: ChurchUserModel,
+  ) {
+    return this.notificationService.createDummyWorshipNotification(churchUser);
   }
 
   @ApiPatchCheckAllRead()

--- a/backend/src/notification/notification-domain/interface/notification-domain.service.interface.ts
+++ b/backend/src/notification/notification-domain/interface/notification-domain.service.interface.ts
@@ -37,9 +37,7 @@ export interface INotificationDomainService {
     qr?: QueryRunner,
   ): Promise<NotificationModel>;
 
-  createNotifications(
-    event: NotificationEventDto,
-  ): Promise<NotificationModel[]>;
+  createNotifications(event: NotificationEventDto): Promise<any[]>;
 
   checkRead(
     notification: NotificationModel,

--- a/backend/src/notification/notification-event.dto.ts
+++ b/backend/src/notification/notification-event.dto.ts
@@ -37,6 +37,12 @@ export class NotificationSourceChurch extends NotificationSource {
   }
 }
 
+export class NotificationSourceWorship extends NotificationSource {
+  constructor(domain: NotificationDomain, id: number) {
+    super(domain, id);
+  }
+}
+
 export class NotificationSourceManager extends NotificationSource {
   constructor(domain: NotificationDomain, id: number) {
     super(domain, id);

--- a/backend/src/worship/service/worship-notification.service.ts
+++ b/backend/src/worship/service/worship-notification.service.ts
@@ -1,0 +1,133 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import {
+  IWORSHIP_DOMAIN_SERVICE,
+  IWorshipDomainService,
+} from '../worship-domain/interface/worship-domain.service.interface';
+import { TIME_ZONE } from '../../common/const/time-zone.const';
+import { toZonedTime } from 'date-fns-tz';
+import { addDays, startOfDay } from 'date-fns';
+import { WorshipModel } from '../entity/worship.entity';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import {
+  IMANAGER_DOMAIN_SERVICE,
+  IManagerDomainService,
+} from '../../manager/manager-domain/service/interface/manager-domain.service.interface';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { NotificationEvent } from '../../notification/const/notification-event.enum';
+import {
+  NotificationEventDto,
+  NotificationSourceWorship,
+} from '../../notification/notification-event.dto';
+import { NotificationDomain } from '../../notification/const/notification-domain.enum';
+import { NotificationAction } from '../../notification/const/notification-action.enum';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+
+@Injectable()
+export class WorshipNotificationService {
+  constructor(
+    private readonly eventEmitter: EventEmitter2,
+
+    @Inject(IMANAGER_DOMAIN_SERVICE)
+    private readonly managerDomainService: IManagerDomainService,
+    @Inject(IWORSHIP_DOMAIN_SERVICE)
+    private readonly worshipDomainService: IWorshipDomainService,
+  ) {}
+
+  private logger = new Logger('WorshipNotificationService');
+
+  @Cron(CronExpression.EVERY_DAY_AT_10AM, { timeZone: TIME_ZONE.SEOUL })
+  async notifyWorshipSessionCreated() {
+    // 생성해야할 예배의 진행 요일
+    const kstToday = toZonedTime(new Date(), TIME_ZONE.SEOUL);
+    const serviceDate = startOfDay(addDays(kstToday, 1)); // 진행 날짜
+    const targetWorshipDay = serviceDate.getDay(); // 진행 요일
+
+    let cursor = 0;
+    const bulkSize = 50;
+
+    const actorName = '';
+
+    while (true) {
+      const targetWorships =
+        await this.worshipDomainService.findBulkWorshipByDay(
+          targetWorshipDay,
+          bulkSize,
+          cursor,
+        );
+
+      if (targetWorships.length === 0) break;
+
+      const worshipChurchMap = this.convertMap(targetWorships);
+
+      // 교회/매니저 일괄 조회
+      const churchIds = Array.from(worshipChurchMap.keys());
+      const managersMap = await this.fetchManagersMap(churchIds);
+
+      for (const churchId of churchIds) {
+        const worships = worshipChurchMap.get(churchId) ?? [];
+        const managers = managersMap.get(churchId) ?? [];
+        if (managers.length === 0) continue;
+
+        for (const worship of worships) {
+          // 알림 생성
+          this.eventEmitter.emit(
+            NotificationEvent.WORSHIP_SESSION_CREATED,
+            new NotificationEventDto(
+              actorName,
+              NotificationDomain.WORSHIP,
+              NotificationAction.CREATED,
+              worship.title,
+              new NotificationSourceWorship(
+                NotificationDomain.WORSHIP,
+                worship.id,
+              ),
+              managers,
+              [],
+            ),
+          );
+        }
+      }
+
+      if (targetWorships.length < bulkSize) {
+        break;
+      } else {
+        cursor = targetWorships[targetWorships.length - 1].id;
+      }
+
+      this.logger.log('예배 생성 알림 생성 완료');
+    }
+  }
+
+  private async fetchManagersMap(churchIds: number[]) {
+    const managers =
+      await this.managerDomainService.findAllManagerIdsBulk(churchIds);
+
+    const map = new Map<number, ChurchUserModel[]>();
+    for (const manager of managers) {
+      const seen = map.get(manager.churchId);
+
+      if (seen) {
+        map.get(manager.churchId)!.push(manager);
+      } else {
+        map.set(manager.churchId, [manager]);
+      }
+    }
+    return map;
+  }
+
+  private convertMap(targetWorships: WorshipModel[]) {
+    const worshipChurchMap = new Map<number, WorshipModel[]>();
+
+    for (const worship of targetWorships) {
+      const seen = worshipChurchMap.get(worship.churchId);
+
+      if (seen) {
+        worshipChurchMap.get(worship.churchId)!.push(worship);
+      } else {
+        worshipChurchMap.set(worship.churchId, [worship]);
+      }
+    }
+
+    return worshipChurchMap;
+  }
+}

--- a/backend/src/worship/service/worship-session.service.ts
+++ b/backend/src/worship/service/worship-session.service.ts
@@ -158,11 +158,6 @@ export class WorshipSessionService {
     dto: GetWorshipSessionDto,
     qr: QueryRunner,
   ) {
-    /*const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );*/
-
     const worship = await this.worshipDomainService.findWorshipModelById(
       church,
       worshipId,

--- a/backend/src/worship/worship-domain/interface/worship-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-domain.service.interface.ts
@@ -58,4 +58,10 @@ export interface IWorshipDomainService {
     member: MemberModel,
     targetGroupIds: number[] | undefined,
   ): Promise<WorshipModel[]>;
+
+  findBulkWorshipByDay(
+    targetWorshipDay: number,
+    bulkSize: number,
+    cursor: number,
+  ): Promise<WorshipModel[]>;
 }

--- a/backend/src/worship/worship-domain/service/worship-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-domain.service.ts
@@ -10,6 +10,7 @@ import { WorshipModel } from '../../entity/worship.entity';
 import {
   FindOptionsOrder,
   FindOptionsRelations,
+  MoreThan,
   QueryRunner,
   Repository,
   UpdateResult,
@@ -262,5 +263,29 @@ export class WorshipDomainService implements IWorshipDomainService {
     }
 
     return query.getMany();
+  }
+
+  findBulkWorshipByDay(
+    targetWorshipDay: number,
+    bulkSize: number,
+    cursor: number,
+  ): Promise<WorshipModel[]> {
+    const repository = this.getRepository();
+
+    return repository.find({
+      where: {
+        worshipDay: targetWorshipDay,
+        id: cursor > 0 ? MoreThan(cursor) : undefined,
+      },
+      select: {
+        id: true,
+        churchId: true,
+        title: true,
+      },
+      order: {
+        id: 'ASC',
+      },
+      take: bulkSize,
+    });
   }
 }

--- a/backend/src/worship/worship.module.ts
+++ b/backend/src/worship/worship.module.ts
@@ -13,6 +13,7 @@ import { WorshipDomainModule } from './worship-domain/worship-domain.module';
 import { GroupsDomainModule } from '../management/groups/groups-domain/groups-domain.module';
 import { MembersDomainModule } from '../members/member-domain/members-domain.module';
 import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
+import { WorshipNotificationService } from './service/worship-notification.service';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.mo
     WorshipAttendanceService,
     WorshipEnrollmentService,
     WorshipSessionService,
+    WorshipNotificationService,
   ],
 })
 export class WorshipModule {}


### PR DESCRIPTION
## 주요 내용
- 다음날 진행될 예배에 대해 **전날 오전 10:00(KST)**에 출석부 생성 알림 발송
- NotificationEventDto를 사용해 **예배 제목, 서비스 날짜(YYYY-MM-DD), 소스 정보**를 포함하여 알림 이벤트 발행

## 세부 내용
### WorshipNotificationService
- `sendPreWorshipRosterNotice()` 메소드 구현
  - 전날 기준으로 **다음날 진행 요일(Worship.dayOfWeek)과 일치하는 예배** 조회
  - 교회별 **관리자 수신자 목록** 조회 후 알림 이벤트 생성/발행

### Scheduler
- `WorshipNotificationScheduler` 추가
  - `@Cron('0 10 * * *', { timeZone: 'Asia/Seoul' })`로 **매일 오전 10시(KST)** 실행
  - 실행 시 `notifyWorshipSessionCreated()` 호출

### NotificationEvent
- `NotificationEvent.WORSHIP_SESSION_CREATED` 이벤트 사용
- `NotificationEventDto`에 **title(예배명), serviceDate, source(worshipId 등)** 포함