### PR TITLE
fix: 심방 대상자 권한 범위 검증 로직 강화

### DIFF
--- a/backend/src/common/custom-request.ts
+++ b/backend/src/common/custom-request.ts
@@ -6,6 +6,7 @@ import { JwtAccessPayload } from '../auth/type/jwt';
 import { MemberModel } from '../members/entity/member.entity';
 import { QueryRunner } from 'typeorm';
 import { UserModel } from '../user/entity/user.entity';
+import { VisitationMetaModel } from '../visitation/entity/visitation-meta.entity';
 
 export interface CustomRequest extends Request {
   queryRunner: QueryRunner;
@@ -15,11 +16,12 @@ export interface CustomRequest extends Request {
   requestChurchUser: ChurchUserModel;
   requestManager: ChurchUserModel;
   requestOwner: ChurchUserModel;
-  permissionScopeGroupIds: number[];
+  permissionScopeGroupIds: number[]; // 요청자의 권한 범위 내 모든 그룹 ID
   tokenPayload: JwtAccessPayload;
   user: UserModel;
 
   targetMember: MemberModel;
+  targetVisitation: VisitationMetaModel;
 
   worshipTargetGroupIds: number[] | undefined;
 }

--- a/backend/src/members/controller/members.controller.ts
+++ b/backend/src/members/controller/members.controller.ts
@@ -44,26 +44,27 @@ import { GetMemberWorshipAttendancesDto } from '../dto/request/worship/get-membe
 export class MembersController {
   constructor(private readonly membersService: MembersService) {}
 
-  @Get()
-  //@MemberReadGuard()
+  /*@Get()
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   getMembers(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Query() dto: GetMemberDto,
     @RequestManager() pm: ChurchUserModel,
   ) {
-    return this.membersService.getMembers(churchId, pm, dto);
-  }
+    return this.membersService.getMembers(church, pm, dto);
+  }*/
 
   @Post()
   @MemberWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   postMember(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Body() dto: CreateMemberDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.membersService.createMember(churchId, dto, qr);
+    return this.membersService.createMember(church, dto, qr);
   }
 
   @Get('v2')
@@ -87,14 +88,15 @@ export class MembersController {
     return this.membersService.getMemberList(church, requestManager, query);
   }
 
-  @Get('simple')
+  /*@Get('simple')
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   getMembersSimple(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Query() dto: GetSimpleMembersDto,
   ) {
-    return this.membersService.getSimpleMembers(churchId, dto);
-  }
+    return this.membersService.getSimpleMembers(church, dto);
+  }*/
 
   @Get('simple/v2')
   @UseGuards(AccessTokenGuard, ChurchManagerGuard)
@@ -111,9 +113,10 @@ export class MembersController {
   getMemberById(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('memberId', ParseIntPipe) memberId: number,
+    @RequestChurch() church: ChurchModel,
     @RequestManager() pm: ChurchUserModel,
   ) {
-    return this.membersService.getMemberById(churchId, memberId, pm);
+    return this.membersService.getMemberById(church, memberId, pm);
   }
 
   @Patch(':memberId')
@@ -126,7 +129,6 @@ export class MembersController {
     @TargetMember() targetMember: MemberModel,
   ) {
     return this.membersService.updateMember(church, targetMember, dto);
-    //return this.membersService.updateMember(churchId, memberId, dto);
   }
 
   @Delete(':memberId')

--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -24,15 +24,6 @@ import { GetSimpleMemberListDto } from '../../dto/list/get-simple-member-list.dt
 export const IMEMBERS_DOMAIN_SERVICE = Symbol('IMEMBERS_DOMAIN_SERVICE');
 
 export interface IMembersDomainService {
-  findMembers(
-    dto: GetMemberDto,
-    whereOptions: FindOptionsWhere<MemberModel>,
-    orderOptions: FindOptionsOrder<MemberModel>,
-    relationOptions: FindOptionsRelations<MemberModel>,
-    selectOptions: FindOptionsSelect<MemberModel>,
-    qr?: QueryRunner,
-  ): Promise<{ data: MemberModel[]; totalCount: number }>;
-
   migrationBirthdayMMDD(church: ChurchModel): Promise<void>;
 
   findBirthdayMembers(
@@ -41,11 +32,10 @@ export interface IMembersDomainService {
     qr?: QueryRunner,
   ): Promise<MemberModel[]>;
 
-  findSimpleMembers(
+  getMemberListWithPagination(
     church: ChurchModel,
-    dto: GetSimpleMembersDto,
-    qr?: QueryRunner,
-  ): Promise<MemberModel[]>;
+    dto: GetMemberListDto,
+  ): Promise<DomainCursorPaginationResultDto<MemberModel>>;
 
   findSimpleMemberList(
     church: ChurchModel,
@@ -149,8 +139,18 @@ export interface IMembersDomainService {
     to: Date,
   ): Promise<MemberModel[]>;
 
-  getMemberListWithPagination(
+  /*findMembers(
+   dto: GetMemberDto,
+   whereOptions: FindOptionsWhere<MemberModel>,
+   orderOptions: FindOptionsOrder<MemberModel>,
+   relationOptions: FindOptionsRelations<MemberModel>,
+   selectOptions: FindOptionsSelect<MemberModel>,
+   qr?: QueryRunner,
+ ): Promise<{ data: MemberModel[]; totalCount: number }>;*/
+
+  /*findSimpleMembers(
     church: ChurchModel,
-    dto: GetMemberListDto,
-  ): Promise<DomainCursorPaginationResultDto<MemberModel>>;
+    dto: GetSimpleMembersDto,
+    qr?: QueryRunner,
+  ): Promise<MemberModel[]>;*/
 }

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -9,9 +9,7 @@ import { MemberModel } from '../../entity/member.entity';
 import {
   Between,
   Brackets,
-  FindOptionsOrder,
   FindOptionsRelations,
-  FindOptionsSelect,
   FindOptionsWhere,
   ILike,
   In,
@@ -24,7 +22,6 @@ import {
   WhereExpressionBuilder,
 } from 'typeorm';
 import { ChurchModel } from '../../../churches/entity/church.entity';
-import { GetMemberDto } from '../../dto/request/get-member.dto';
 import { MemberException } from '../../exception/member.exception';
 import { CreateMemberDto } from '../../dto/request/create-member.dto';
 import { UpdateMemberDto } from '../../dto/request/update-member.dto';
@@ -64,36 +61,6 @@ export class MembersDomainService implements IMembersDomainService {
 
   private getMembersRepository(qr?: QueryRunner) {
     return qr ? qr.manager.getRepository(MemberModel) : this.membersRepository;
-  }
-
-  async findMembers(
-    dto: GetMemberDto,
-    whereOptions: FindOptionsWhere<MemberModel>,
-    orderOptions: FindOptionsOrder<MemberModel>,
-    relationOptions: FindOptionsRelations<MemberModel>,
-    selectOptions: FindOptionsSelect<MemberModel>,
-    qr?: QueryRunner,
-  ) {
-    const membersRepository = this.getMembersRepository(qr);
-
-    const [totalCount, result] = await Promise.all([
-      membersRepository.count({
-        where: whereOptions,
-      }),
-      membersRepository.find({
-        where: whereOptions,
-        order: orderOptions,
-        relations: relationOptions,
-        select: selectOptions,
-        take: dto.take,
-        skip: dto.take * (dto.page - 1),
-      }),
-    ]);
-
-    return {
-      data: result,
-      totalCount,
-    };
   }
 
   async migrationBirthdayMMDD(church: ChurchModel) {
@@ -221,45 +188,6 @@ export class MembersDomainService implements IMembersDomainService {
       ],
       relations: MemberSummarizedRelation,
       select: { ...MemberSummarizedSelect, mobilePhone: true },
-    });
-  }
-
-  async findSimpleMembers(
-    church: ChurchModel,
-    dto: GetSimpleMembersDto,
-    qr?: QueryRunner,
-  ): Promise<MemberModel[]> {
-    const repository = this.getMembersRepository(qr);
-
-    const whereOptions: FindOptionsWhere<MemberModel> = {
-      churchId: church.id,
-      name: dto.name && ILike(`%${dto.name}%`),
-      mobilePhone: dto.mobilePhone && ILike(`%${dto.mobilePhone}%`),
-    };
-
-    return repository.find({
-      where: whereOptions,
-      relations: MemberSummarizedRelation,
-      order: {
-        [dto.order]: dto.orderDirection,
-        id: dto.orderDirection,
-      },
-      select: {
-        id: true,
-        name: true,
-        profileImageUrl: true,
-        registeredAt: true,
-        officer: {
-          id: true,
-          name: true,
-        },
-        group: {
-          id: true,
-          name: true,
-        },
-        groupRole: true,
-        ministryGroupRole: true,
-      },
     });
   }
 
@@ -1077,4 +1005,73 @@ export class MembersDomainService implements IMembersDomainService {
       return null;
     }
   }
+
+  /*async findMembers(
+    dto: GetMemberDto,
+    whereOptions: FindOptionsWhere<MemberModel>,
+    orderOptions: FindOptionsOrder<MemberModel>,
+    relationOptions: FindOptionsRelations<MemberModel>,
+    selectOptions: FindOptionsSelect<MemberModel>,
+    qr?: QueryRunner,
+  ) {
+    const membersRepository = this.getMembersRepository(qr);
+
+    const [totalCount, result] = await Promise.all([
+      membersRepository.count({
+        where: whereOptions,
+      }),
+      membersRepository.find({
+        where: whereOptions,
+        order: orderOptions,
+        relations: relationOptions,
+        select: selectOptions,
+        take: dto.take,
+        skip: dto.take * (dto.page - 1),
+      }),
+    ]);
+
+    return {
+      data: result,
+      totalCount,
+    };
+  }*/
+
+  /*async findSimpleMembers(
+    church: ChurchModel,
+    dto: GetSimpleMembersDto,
+    qr?: QueryRunner,
+  ): Promise<MemberModel[]> {
+    const repository = this.getMembersRepository(qr);
+
+    const whereOptions: FindOptionsWhere<MemberModel> = {
+      churchId: church.id,
+      name: dto.name && ILike(`%${dto.name}%`),
+      mobilePhone: dto.mobilePhone && ILike(`%${dto.mobilePhone}%`),
+    };
+
+    return repository.find({
+      where: whereOptions,
+      relations: MemberSummarizedRelation,
+      order: {
+        [dto.order]: dto.orderDirection,
+        id: dto.orderDirection,
+      },
+      select: {
+        id: true,
+        name: true,
+        profileImageUrl: true,
+        registeredAt: true,
+        officer: {
+          id: true,
+          name: true,
+        },
+        group: {
+          id: true,
+          name: true,
+        },
+        groupRole: true,
+        ministryGroupRole: true,
+      },
+    });
+  }*/
 }

--- a/backend/src/members/members.module.ts
+++ b/backend/src/members/members.module.ts
@@ -2,10 +2,8 @@ import { Module } from '@nestjs/common';
 import { MembersController } from './controller/members.controller';
 import { MembersService } from './service/members.service';
 import { RouterModule } from '@nestjs/core';
-import { SearchMembersService } from './service/search-members.service';
 import { ChurchesDomainModule } from '../churches/churches-domain/churches-domain.module';
 import { MembersDomainModule } from './member-domain/members-domain.module';
-import { ISEARCH_MEMBERS_SERVICE } from './service/interface/search-members.service.interface';
 import { FamilyRelationDomainModule } from '../family-relation/family-relation-domain/family-relation-domain.module';
 import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
 import { GroupsDomainModule } from '../management/groups/groups-domain/groups-domain.module';
@@ -32,10 +30,10 @@ import { ChurchUserDomainModule } from '../church-user/church-user-domain/church
   controllers: [MembersController],
   providers: [
     MembersService,
-    {
+    /*{
       provide: ISEARCH_MEMBERS_SERVICE,
       useClass: SearchMembersService,
-    },
+    },*/
     {
       provide: IMEMBER_FILTER_SERVICE,
       useClass: MemberFilterService,

--- a/backend/src/members/service/members.service.ts
+++ b/backend/src/members/service/members.service.ts
@@ -1,9 +1,8 @@
 import { ConflictException, Inject, Injectable } from '@nestjs/common';
 import { MemberModel } from '../entity/member.entity';
-import { FindOptionsOrder, FindOptionsWhere, QueryRunner } from 'typeorm';
+import { QueryRunner } from 'typeorm';
 import { CreateMemberDto } from '../dto/request/create-member.dto';
 import { UpdateMemberDto } from '../dto/request/update-member.dto';
-import { GetMemberDto } from '../dto/request/get-member.dto';
 import { DeleteMemberResponseDto } from '../dto/response/delete-member-response.dto';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MemberDeletedEvent } from '../events/member.event';
@@ -16,16 +15,9 @@ import {
   IMembersDomainService,
 } from '../member-domain/interface/members-domain.service.interface';
 import {
-  ISEARCH_MEMBERS_SERVICE,
-  ISearchMembersService,
-} from './interface/search-members.service.interface';
-import {
   IFAMILY_RELATION_DOMAIN_SERVICE,
   IFamilyRelationDomainService,
 } from '../../family-relation/family-relation-domain/service/interface/family-relation-domain.service.interface';
-import { MemberPaginationResponseDto } from '../dto/response/member-pagination-response.dto';
-import { GetSimpleMembersDto } from '../dto/request/get-simple-members.dto';
-import { SimpleMembersPaginationResponseDto } from '../dto/response/simple-members-pagination-response.dto';
 import { PostMemberResponseDto } from '../dto/response/post-member-response.dto';
 import { PatchMemberResponseDto } from '../dto/response/patch-member-response.dto';
 import { GetMemberResponseDto } from '../dto/response/get-member-response.dto';
@@ -83,8 +75,6 @@ export class MembersService {
     private readonly churchUserDomainService: IChurchUserDomainService,
     @Inject(IMEMBERS_DOMAIN_SERVICE)
     private readonly membersDomainService: IMembersDomainService,
-    @Inject(ISEARCH_MEMBERS_SERVICE)
-    private readonly searchMembersService: ISearchMembersService,
     @Inject(IFAMILY_RELATION_DOMAIN_SERVICE)
     private readonly familyDomainService: IFamilyRelationDomainService,
     @Inject(IWORSHIP_DOMAIN_SERVICE)
@@ -103,68 +93,12 @@ export class MembersService {
     private readonly groupsDomainService: IGroupsDomainService,
   ) {}
 
-  async getMembers(
-    churchId: number,
-    requestManager: ChurchUserModel,
-    dto: GetMemberDto,
-    qr?: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
-    const whereOptions: FindOptionsWhere<MemberModel> =
-      this.searchMembersService.parseWhereOption(church, dto);
-
-    const orderOptions: FindOptionsOrder<MemberModel> =
-      this.searchMembersService.parseOrderOption(dto);
-
-    const relationOptions = this.searchMembersService.parseRelationOption(dto);
-
-    const selectOptions = this.searchMembersService.parseSelectOption(dto);
-
-    const { data, totalCount } = await this.membersDomainService.findMembers(
-      dto,
-      whereOptions,
-      orderOptions,
-      relationOptions,
-      selectOptions,
-      qr,
-    );
-
-    const possibleGroupIds = await this.memberFilterService.getScopeGroupIds(
-      church,
-      requestManager,
-      qr,
-    );
-
-    const filteredMember = this.memberFilterService.filterMembers(
-      requestManager,
-      data,
-      possibleGroupIds,
-    );
-
-    return new MemberPaginationResponseDto(
-      filteredMember,
-      totalCount,
-      data.length,
-      dto.page,
-      Math.ceil(totalCount / dto.take),
-    );
-  }
-
   async getMemberById(
-    churchId: number,
+    church: ChurchModel,
     memberId: number,
     requestManager: ChurchUserModel,
     qr?: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
     const member = await this.membersDomainService.findMemberById(
       church,
       memberId,
@@ -193,12 +127,11 @@ export class MembersService {
     return new GetMemberResponseDto(filteredMember);
   }
 
-  async createMember(churchId: number, dto: CreateMemberDto, qr: QueryRunner) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
+  async createMember(
+    church: ChurchModel,
+    dto: CreateMemberDto,
+    qr: QueryRunner,
+  ) {
     // 교회의 교인 수 증가
     await this.churchesDomainService.incrementMemberCount(church, qr);
     church.memberCount++;
@@ -311,15 +244,6 @@ export class MembersService {
       targetMember.name,
       true,
     );
-  }
-
-  async getSimpleMembers(churchId: number, dto: GetSimpleMembersDto) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
-    const data = await this.membersDomainService.findSimpleMembers(church, dto);
-
-    return new SimpleMembersPaginationResponseDto(data);
   }
 
   async getSimpleMemberList(
@@ -471,4 +395,56 @@ export class MembersService {
       result.hasMore,
     );
   }
+
+  /*async getMembers(
+    church: ChurchModel,
+    requestManager: ChurchUserModel,
+    dto: GetMemberDto,
+    qr?: QueryRunner,
+  ) {
+    const whereOptions: FindOptionsWhere<MemberModel> =
+      this.searchMembersService.parseWhereOption(church, dto);
+
+    const orderOptions: FindOptionsOrder<MemberModel> =
+      this.searchMembersService.parseOrderOption(dto);
+
+    const relationOptions = this.searchMembersService.parseRelationOption(dto);
+
+    const selectOptions = this.searchMembersService.parseSelectOption(dto);
+
+    const { data, totalCount } = await this.membersDomainService.findMembers(
+      dto,
+      whereOptions,
+      orderOptions,
+      relationOptions,
+      selectOptions,
+      qr,
+    );
+
+    const possibleGroupIds = await this.memberFilterService.getScopeGroupIds(
+      church,
+      requestManager,
+      qr,
+    );
+
+    const filteredMember = this.memberFilterService.filterMembers(
+      requestManager,
+      data,
+      possibleGroupIds,
+    );
+
+    return new MemberPaginationResponseDto(
+      filteredMember,
+      totalCount,
+      data.length,
+      dto.page,
+      Math.ceil(totalCount / dto.take),
+    );
+  }*/
+
+  /*async getSimpleMembers(church: ChurchModel, dto: GetSimpleMembersDto) {
+    const data = await this.membersDomainService.findSimpleMembers(church, dto);
+
+    return new SimpleMembersPaginationResponseDto(data);
+  }*/
 }

--- a/backend/src/report/education-report/education-report-domain/service/education-report-domain.service.ts
+++ b/backend/src/report/education-report/education-report-domain/service/education-report-domain.service.ts
@@ -11,6 +11,7 @@ import {
   FindOptionsOrder,
   FindOptionsRelations,
   In,
+  IsNull,
   LessThanOrEqual,
   MoreThanOrEqual,
   QueryRunner,
@@ -514,6 +515,7 @@ export class EducationReportDomainService
       where: {
         educationSessionId: educationSession.id,
         receiverId: In(receiverIds),
+        educationReportType: EducationReportType.SESSION,
       },
       relations: relationOptions,
     });
@@ -538,6 +540,8 @@ export class EducationReportDomainService
     const reports = await repository.find({
       where: {
         educationTermId: educationTerm.id,
+        educationSessionId: IsNull(),
+        educationReportType: EducationReportType.TERM,
         receiverId: In(receiverIds),
       },
       relations: relationOptions,

--- a/backend/src/test-login.html
+++ b/backend/src/test-login.html
@@ -64,7 +64,7 @@
 
     async function fetchUserInfo() {
         try {
-            const res = await fetch('http://localhost:3000/users', {
+            const res = await fetch('http://localhost:3000/me', {
                 credentials: 'include',
             });
 

--- a/backend/src/visitation/const/exception/visitation.exception.ts
+++ b/backend/src/visitation/const/exception/visitation.exception.ts
@@ -19,6 +19,9 @@ export const VisitationException = {
   ALREADY_REPORTED_MEMBER: '이미 피보고자로 등록된 교인입니다.',
   NOT_EXIST_REPORTED_MEMBER: '삭제 대상자가 피보고자에 포함되어 있지 않습니다.',
   EXCEED_VISITATION_MEMBER: '심방 대상자는 최대 30명까지만 등록할 수 있습니다.',
+
+  OUT_OF_SCOPE_MEMBER_INCLUDE:
+    '심방 대상 교인 중 권한 범위 밖의 교인이 존재합니다.',
 };
 
 export const VisitationDetailException = {

--- a/backend/src/visitation/controller/visitation.controller.ts
+++ b/backend/src/visitation/controller/visitation.controller.ts
@@ -34,6 +34,9 @@ import { RequestManager } from '../../permission/decorator/request-manager.decor
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import { RequestChurch } from '../../permission/decorator/request-church.decorator';
 import { ChurchModel } from '../../churches/entity/church.entity';
+import { RequestVisitation } from '../decorator/request-visitation.decorator';
+import { VisitationMetaModel } from '../entity/visitation-meta.entity';
+import { GetVisitationResponseDto } from '../dto/response/get-visitation-response.dto';
 
 @ApiTags('Visitations')
 @Controller('visitations')
@@ -77,17 +80,12 @@ export class VisitationController {
   @ApiGetVisitationById()
   @VisitationReadGuard()
   @Get(':visitationId')
-  @UseInterceptors(TransactionInterceptor)
   getVisitingById(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('visitationId', ParseIntPipe) visitationMetaDataId: number,
-    @QueryRunner() qr: QR,
+    @RequestVisitation() visitation: VisitationMetaModel,
   ) {
-    return this.visitationService.getVisitationById(
-      churchId,
-      visitationMetaDataId,
-      qr,
-    );
+    return new GetVisitationResponseDto(visitation);
   }
 
   @ApiPatchVisitationMeta()
@@ -99,13 +97,14 @@ export class VisitationController {
     @Param('visitationId', ParseIntPipe) visitationMetaDataId: number,
     @RequestChurch() church: ChurchModel,
     @RequestManager() requestManager: ChurchUserModel,
+    @RequestVisitation() requestVisitation: VisitationMetaModel,
     @Body() dto: UpdateVisitationDto,
     @QueryRunner() qr: QR,
   ) {
     return this.visitationService.updateVisitationData(
       church,
       requestManager,
-      visitationMetaDataId,
+      requestVisitation,
       dto,
       qr,
     );
@@ -120,12 +119,13 @@ export class VisitationController {
     @Param('visitationId', ParseIntPipe) visitationId: number,
     @RequestChurch() church: ChurchModel,
     @RequestManager() requestManager: ChurchUserModel,
+    @RequestVisitation() requestVisitation: VisitationMetaModel,
     @QueryRunner() qr: QR,
   ) {
     return this.visitationService.deleteVisitation(
       church,
       requestManager,
-      visitationId,
+      requestVisitation,
       qr,
     );
   }

--- a/backend/src/visitation/decorator/request-visitation.decorator.ts
+++ b/backend/src/visitation/decorator/request-visitation.decorator.ts
@@ -1,0 +1,18 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { CustomRequest } from '../../common/custom-request';
+
+export const RequestVisitation = createParamDecorator(
+  (_, ctx: ExecutionContext) => {
+    const req: CustomRequest = ctx.switchToHttp().getRequest();
+
+    if (req.targetVisitation) {
+      return req.targetVisitation;
+    } else {
+      throw new InternalServerErrorException('대상 심방 처리 누락');
+    }
+  },
+);

--- a/backend/src/visitation/guard/visitation-read.guard.ts
+++ b/backend/src/visitation/guard/visitation-read.guard.ts
@@ -5,6 +5,7 @@ import { DomainType } from '../../permission/const/domain-type.enum';
 import { DomainName } from '../../permission/const/domain-name.enum';
 import { DomainAction } from '../../permission/const/domain-action.enum';
 import { ChurchManagerGuard } from '../../permission/guard/church-manager.guard';
+import { VisitationScopeGuard } from './visitation-scope.guard';
 
 export const VisitationReadGuard = () =>
   applyDecorators(
@@ -16,5 +17,6 @@ export const VisitationReadGuard = () =>
         DomainName.VISITATION,
         DomainAction.READ,
       ),
+      VisitationScopeGuard,
     ),
   );

--- a/backend/src/visitation/guard/visitation-scope.guard.ts
+++ b/backend/src/visitation/guard/visitation-scope.guard.ts
@@ -1,0 +1,172 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { CustomRequest } from '../../common/custom-request';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import {
+  ICHURCHES_DOMAIN_SERVICE,
+  IChurchesDomainService,
+} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import {
+  IMANAGER_DOMAIN_SERVICE,
+  IManagerDomainService,
+} from '../../manager/manager-domain/service/interface/manager-domain.service.interface';
+import {
+  IVISITATION_META_DOMAIN_SERVICE,
+  IVisitationMetaDomainService,
+} from '../visitation-domain/interface/visitation-meta-domain.service.interface';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
+import { PermissionScopeModel } from '../../permission/entity/permission-scope.entity';
+import {
+  IGROUPS_DOMAIN_SERVICE,
+  IGroupsDomainService,
+} from '../../management/groups/groups-domain/interface/groups-domain.service.interface';
+import { ChurchUserRole } from '../../user/const/user-role.enum';
+import { VisitationException } from '../const/exception/visitation.exception';
+
+@Injectable()
+export class VisitationScopeGuard implements CanActivate {
+  constructor(
+    @Inject(ICHURCHES_DOMAIN_SERVICE)
+    private readonly churchesDomainService: IChurchesDomainService,
+    @Inject(IMANAGER_DOMAIN_SERVICE)
+    private readonly managerDomainService: IManagerDomainService,
+    @Inject(IVISITATION_META_DOMAIN_SERVICE)
+    private readonly visitationDomainService: IVisitationMetaDomainService,
+    @Inject(IGROUPS_DOMAIN_SERVICE)
+    private readonly groupsDomainService: IGroupsDomainService,
+  ) {}
+
+  private async getRequestChurch(req: CustomRequest) {
+    if (req.church) {
+      return req.church;
+    } else {
+      const churchId = parseInt(req.params.churchId);
+
+      const church =
+        await this.churchesDomainService.findChurchModelById(churchId);
+
+      req.church = church;
+
+      return church;
+    }
+  }
+
+  private async getRequestManager(req: CustomRequest, church: ChurchModel) {
+    if (req.requestManager) {
+      return req.requestManager;
+    } else {
+      const token = req.tokenPayload;
+
+      if (!token) {
+        throw new InternalServerErrorException('토큰 처리 과정 누락');
+      }
+
+      const requestUserId = token.id;
+      const requestManager =
+        await this.managerDomainService.findManagerForPermissionCheck(
+          church,
+          requestUserId,
+        );
+
+      req.requestManager = requestManager;
+
+      return requestManager;
+    }
+  }
+
+  private async getPermissionScopeGroupIds(
+    church: ChurchModel,
+    requestManager: ChurchUserModel,
+  ) {
+    const rootPermissionScopeGroupIds = requestManager.permissionScopes.map(
+      (permissionScope: PermissionScopeModel) => permissionScope.group.id,
+    );
+
+    // 제한된 권한 범위의 관리자 검증
+    return (
+      await this.groupsDomainService.findGroupAndDescendantsByIds(
+        church,
+        rootPermissionScopeGroupIds,
+      )
+    ).map((group) => group.id);
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req: CustomRequest = context.switchToHttp().getRequest();
+
+    const church = await this.getRequestChurch(req);
+    const requestManager = await this.getRequestManager(req, church);
+
+    const visitationId = parseInt(req.params.visitationId);
+
+    // 목록 조회 시 검증 X
+    if (!visitationId) {
+      return true;
+    }
+
+    // 대상 심방
+    const targetVisitation =
+      await this.visitationDomainService.findVisitationMetaById(
+        church,
+        visitationId,
+      );
+
+    req.targetVisitation = targetVisitation;
+
+    // 소유자
+    if (requestManager.role === ChurchUserRole.OWNER) {
+      return true;
+    } else {
+      // 전체 권한 범위
+      if (requestManager.permissionScopes.some((scope) => scope.isAllGroups))
+        return true;
+    }
+
+    // 심방 대상 교인들
+    const members = targetVisitation.members;
+
+    // 심방 대상의 그룹 ID
+    const memberGroupIds = members.map((member) =>
+      member.group ? member.group.id : null,
+    );
+
+    // 소속 그룹이 없는 교인은 전체 권한 범위 매니저만 접근 가능
+    if (memberGroupIds.includes(null)) {
+      throw new ForbiddenException(
+        VisitationException.OUT_OF_SCOPE_MEMBER_INCLUDE,
+      );
+    }
+
+    // 요청자의 권한 범위 내 모든 그룹 ID
+    const permissionGroupIds = await this.getPermissionScopeGroupIds(
+      church,
+      requestManager,
+    );
+
+    const permissionGroupIdsSet = new Set(permissionGroupIds);
+
+    // 심방 대상 교인들의 그룹이 권한 범위 내에 속하는지 확인
+    let isAllowed: boolean = true;
+    for (const memberGroupId of memberGroupIds) {
+      if (memberGroupId === null) {
+        isAllowed = false;
+        throw new ForbiddenException(
+          VisitationException.OUT_OF_SCOPE_MEMBER_INCLUDE,
+        );
+      } else if (!permissionGroupIdsSet.has(memberGroupId)) {
+        isAllowed = false;
+        throw new ForbiddenException(
+          VisitationException.OUT_OF_SCOPE_MEMBER_INCLUDE,
+        );
+      }
+    }
+
+    return isAllowed;
+  }
+}

--- a/backend/src/visitation/guard/visitation-write.guard.ts
+++ b/backend/src/visitation/guard/visitation-write.guard.ts
@@ -6,6 +6,7 @@ import { DomainName } from '../../permission/const/domain-name.enum';
 import { DomainAction } from '../../permission/const/domain-action.enum';
 import { ChurchManagerGuard } from '../../permission/guard/church-manager.guard';
 import { SubscriptionGuard } from '../../subscription/guard/subscription.guard';
+import { VisitationScopeGuard } from './visitation-scope.guard';
 
 export const VisitationWriteGuard = () =>
   applyDecorators(
@@ -18,5 +19,6 @@ export const VisitationWriteGuard = () =>
         DomainName.VISITATION,
         DomainAction.WRITE,
       ),
+      VisitationScopeGuard,
     ),
   );

--- a/backend/src/visitation/service/visitation.service.ts
+++ b/backend/src/visitation/service/visitation.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
 import {
   IVISITATION_META_DOMAIN_SERVICE,
   IVisitationMetaDomainService,
@@ -39,7 +39,6 @@ import {
   IMANAGER_DOMAIN_SERVICE,
   IManagerDomainService,
 } from '../../manager/manager-domain/service/interface/manager-domain.service.interface';
-import { GetVisitationResponseDto } from '../dto/response/get-visitation-response.dto';
 import { PostVisitationResponseDto } from '../dto/response/post-visitation-response.dto';
 import { PatchVisitationResponseDto } from '../dto/response/patch-visitation-response.dto';
 import { DeleteVisitationResponseDto } from '../dto/response/delete-visitation-response.dto';
@@ -48,6 +47,12 @@ import { TIME_ZONE } from '../../common/const/time-zone.const';
 import { VisitationNotificationService } from './visitation-notification.service';
 import { NotificationSourceVisitation } from '../../notification/notification-event.dto';
 import { NotificationDomain } from '../../notification/const/notification-domain.enum';
+import {
+  IMEMBER_FILTER_SERVICE,
+  IMemberFilterService,
+} from '../../members/service/interface/member-filter.service.interface';
+import { VisitationException } from '../const/exception/visitation.exception';
+import { ChurchUserRole } from '../../user/const/user-role.enum';
 
 @Injectable()
 export class VisitationService {
@@ -56,6 +61,8 @@ export class VisitationService {
     private readonly churchesDomainService: IChurchesDomainService,
     @Inject(IMEMBERS_DOMAIN_SERVICE)
     private readonly membersDomainService: IMembersDomainService,
+    @Inject(IMEMBER_FILTER_SERVICE)
+    private readonly memberFilterService: IMemberFilterService,
     @Inject(IMANAGER_DOMAIN_SERVICE)
     private readonly managerDomainService: IManagerDomainService,
 
@@ -81,7 +88,7 @@ export class VisitationService {
     return new VisitationPaginationResultDto(visitations);
   }
 
-  async getVisitationById(
+  /*async getVisitationById(
     churchId: number,
     visitingMetaDataId: number,
     qr: QueryRunner,
@@ -97,6 +104,60 @@ export class VisitationService {
       );
 
     return new GetVisitationResponseDto(visitation);
+  }*/
+
+  private async validateVisitationMember(
+    church: ChurchModel,
+    creatorManager: ChurchUserModel,
+    inCharge: ChurchUserModel,
+    targetMembers: MemberModel[],
+    qr: QueryRunner,
+  ) {
+    if (
+      !creatorManager.permissionScopes.some((scope) => scope.isAllGroups) &&
+      creatorManager.role !== ChurchUserRole.OWNER
+    ) {
+      const creatorScope = await this.memberFilterService.getScopeGroupIds(
+        church,
+        creatorManager,
+        qr,
+      );
+
+      const creatorFiltered = this.memberFilterService.filterMembers(
+        creatorManager,
+        targetMembers,
+        creatorScope,
+      );
+
+      if (creatorFiltered.some((member) => member.isConcealed)) {
+        throw new ForbiddenException(
+          VisitationException.OUT_OF_SCOPE_MEMBER_INCLUDE,
+        );
+      }
+    }
+
+    if (
+      !inCharge.permissionScopes.some((scope) => scope.isAllGroups) &&
+      inCharge.role !== ChurchUserRole.OWNER
+    ) {
+      const inChargeScope = await this.memberFilterService.getScopeGroupIds(
+        church,
+        inCharge,
+        qr,
+      );
+
+      const inChargeFiltered = this.memberFilterService.filterMembers(
+        inCharge,
+        targetMembers,
+        inChargeScope,
+      );
+
+      if (inChargeFiltered.some((member) => member.isConcealed)) {
+        throw new ForbiddenException(
+          VisitationException.OUT_OF_SCOPE_MEMBER_INCLUDE,
+        );
+      }
+    }
   }
 
   async createVisitation(
@@ -121,6 +182,15 @@ export class VisitationService {
     const members = await this.membersDomainService.findMembersById(
       church,
       memberIds,
+      qr,
+      { group: true },
+    );
+
+    await this.validateVisitationMember(
+      church,
+      creatorManager,
+      inCharge,
+      members,
       qr,
     );
 
@@ -216,18 +286,10 @@ export class VisitationService {
   async updateVisitationData(
     church: ChurchModel,
     requestManager: ChurchUserModel,
-    visitationMetaDataId: number,
+    targetMetaData: VisitationMetaModel,
     dto: UpdateVisitationDto,
     qr: QueryRunner,
   ) {
-    const targetMetaData =
-      await this.visitationMetaDomainService.findVisitationMetaModelById(
-        church,
-        visitationMetaDataId,
-        qr,
-        { members: true, reports: true },
-      );
-
     // 심방 진행자 변경 시
     const newInstructor =
       dto.inChargeId && dto.inChargeId !== targetMetaData.inChargeId
@@ -267,6 +329,31 @@ export class VisitationService {
           dto.memberIds,
           qr,
         );
+
+      if (newInstructor) {
+        await this.validateVisitationMember(
+          church,
+          requestManager,
+          newInstructor,
+          newVisitationMembers,
+          qr,
+        );
+      } else if (oldInCharge && oldInCharge) {
+        const oldInChargeChurchUser =
+          await this.managerDomainService.findManagerById(
+            church,
+            oldInCharge.id,
+            qr,
+          );
+
+        await this.validateVisitationMember(
+          church,
+          requestManager,
+          oldInChargeChurchUser,
+          newVisitationMembers,
+          qr,
+        );
+      }
 
       visitationType =
         newVisitationMembers.length > 1
@@ -366,7 +453,8 @@ export class VisitationService {
     const updatedVisitation =
       await this.visitationMetaDomainService.findVisitationMetaById(
         church,
-        visitationMetaDataId,
+        targetMetaData.id,
+        //visitationMetaDataId,
         qr,
       );
 
@@ -376,17 +464,9 @@ export class VisitationService {
   async deleteVisitation(
     church: ChurchModel,
     requestManager: ChurchUserModel,
-    visitationMetaDataId: number,
+    metaData: VisitationMetaModel,
     qr: QueryRunner,
   ) {
-    const metaData =
-      await this.visitationMetaDomainService.findVisitationMetaModelById(
-        church,
-        visitationMetaDataId,
-        qr,
-        { reports: true },
-      );
-
     // 메타 데이터 삭제
     await this.visitationMetaDomainService.deleteVisitationMeta(metaData, qr);
 

--- a/backend/src/visitation/visitation.module.ts
+++ b/backend/src/visitation/visitation.module.ts
@@ -10,6 +10,9 @@ import { VisitationDetailController } from './controller/visitation-detail.contr
 import { VisitationDetailService } from './service/visitation-detail.service';
 import { ManagerDomainModule } from '../manager/manager-domain/manager-domain.module';
 import { VisitationNotificationService } from './service/visitation-notification.service';
+import { GroupsDomainModule } from '../management/groups/groups-domain/groups-domain.module';
+import { MemberFilterService } from '../members/service/member-filter.service';
+import { IMEMBER_FILTER_SERVICE } from '../members/service/interface/member-filter.service.interface';
 
 @Module({
   imports: [
@@ -18,6 +21,7 @@ import { VisitationNotificationService } from './service/visitation-notification
     ]),
     ChurchesDomainModule,
     ManagerDomainModule,
+    GroupsDomainModule,
     MembersDomainModule,
 
     VisitationDomainModule,
@@ -28,6 +32,10 @@ import { VisitationNotificationService } from './service/visitation-notification
     VisitationService,
     VisitationDetailService,
     VisitationNotificationService,
+    {
+      provide: IMEMBER_FILTER_SERVICE,
+      useClass: MemberFilterService,
+    },
   ],
 })
 export class VisitationModule {}

--- a/backend/src/worship/worship-domain/service/worship-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-domain.service.ts
@@ -102,7 +102,8 @@ export class WorshipDomainService implements IWorshipDomainService {
 
     const qb = repository
       .createQueryBuilder('worship')
-      .where('worship.churchId = :churchId', { churchId: church.id });
+      .where('worship.churchId = :churchId', { churchId: church.id })
+      .select(['worship.id']);
 
     return qb.getMany();
   }


### PR DESCRIPTION
## 주요 내용
- **심방 읽기/쓰기 시 권한 범위 검증 강화**
  - 요청자의 권한 범위 내에 심방 대상자가 존재하지 않으면 `ForbiddenException` 발생
  - 권한 범위 밖 교인에 대한 접근을 차단하여 개인정보 보호 강화

- **심방 생성/수정 시 권한 검증 추가**
  - 심방 대상자가 담당자(inCharge) 또는 생성자(creator)의 권한 범위 내에 존재하지 않으면 `ForbiddenException` 발생
  - 담당자와 생성자의 권한 범위를 벗어난 심방 대상 등록을 방지

## 세부 내용
### VisitationService
- `findOne`, `update`, `delete` 등 심방 조회/수정/삭제 시 대상자의 권한 범위 검증 로직 추가
- `create`, `update` 시 심방 대상자가 담당자·생성자의 권한 범위 내에 있는지 확인하는 로직 추가
- 검증 실패 시 일관되게 `ForbiddenException`을 던지도록 수정