### PR TITLE
fix: 심방 대상자 권한 검증 로직 개선 및 에러 메시지 구분

### DIFF
--- a/backend/src/visitation/const/exception/visitation.exception.ts
+++ b/backend/src/visitation/const/exception/visitation.exception.ts
@@ -22,6 +22,8 @@ export const VisitationException = {
 
   OUT_OF_SCOPE_MEMBER_INCLUDE:
     '심방 대상 교인 중 권한 범위 밖의 교인이 존재합니다.',
+  OUT_OF_IN_CHARGE_SCOPE_MEMBER_INCLUDE:
+    '심방 대상 교인 중 담당자의 권한 범위 밖의 교인이 존재합니다.',
 };
 
 export const VisitationDetailException = {

--- a/backend/src/visitation/service/visitation.service.ts
+++ b/backend/src/visitation/service/visitation.service.ts
@@ -154,7 +154,7 @@ export class VisitationService {
 
       if (inChargeFiltered.some((member) => member.isConcealed)) {
         throw new ForbiddenException(
-          VisitationException.OUT_OF_SCOPE_MEMBER_INCLUDE,
+          VisitationException.OUT_OF_IN_CHARGE_SCOPE_MEMBER_INCLUDE,
         );
       }
     }
@@ -372,6 +372,19 @@ export class VisitationService {
       await this.visitationMetaDomainService.updateVisitationMember(
         targetMetaData,
         newVisitationMembers,
+        qr,
+      );
+    } else if (newInstructor) {
+      // 대상 교인 변경 없이, 담당자만 변경
+      const targetMembers = targetMetaData.members;
+
+      console.log('tt');
+
+      await this.validateVisitationMember(
+        church,
+        requestManager,
+        newInstructor,
+        targetMembers,
         qr,
       );
     }

--- a/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
+++ b/backend/src/visitation/visitation-domain/service/visitation-meta-domain.service.ts
@@ -272,7 +272,14 @@ export class VisitationMetaDomainService
         id: visitationMetaData.id,
       },
       {
-        ...dto,
+        status: dto.status,
+        visitationMethod: dto.visitationMethod,
+        visitationType: dto.visitationType,
+        title: dto.title,
+        inChargeId: dto.inCharge && dto.inCharge.member.id,
+        startDate: dto.startDate,
+        endDate: dto.endDate,
+        //...dto,
       },
     );
 


### PR DESCRIPTION
## 주요 내용
- **담당자 변경 시 권한 검증 강화**
  - 심방 대상 교인을 수정하지 않고 담당자만 변경하는 경우, 기존 심방 대상자들이 새로운 담당자의 권한 범위 내에 존재하는지 확인하도록 개선
  - 권한 범위 밖 대상자가 포함될 경우 `ForbiddenException` 발생

- **생성/수정 시 에러 메시지 구분**
  - 심방 대상 교인이 **요청자의 권한 범위 밖**에 존재할 경우 → 요청자 권한 오류 메시지 반환
  - 심방 대상 교인이 **담당자의 권한 범위 밖**에 존재할 경우 → 담당자 권한 오류 메시지 반환
  - 권한 범위 위반 주체를 명확히 하여 클라이언트 피드백 개선

## 세부 내용
### VisitationService
- `createVisitation`, `updateVisitation` 로직에서 권한 검증 분기 처리
- 담당자 변경 시 기존 대상자에 대한 권한 범위 검증 로직 추가
- 요청자/담당자 권한 범위 위반 상황에 따른 에러 메시지 구분 적용