### PR TITLE
fix: 사역그룹, 직분, 교인그룹 관리 시 권한 인증 추가

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/cache-manager": "^3.0.1",
         "@nestjs/common": "^10.4.8",
         "@nestjs/config": "^3.3.0",
         "@nestjs/core": "^10.4.8",
@@ -19,6 +20,7 @@
         "@nestjs/schedule": "^6.0.0",
         "@nestjs/swagger": "^8.0.7",
         "@nestjs/typeorm": "^10.0.2",
+        "cache-manager": "^7.2.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "cookie-parser": "^1.4.7",
@@ -1685,6 +1687,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "license": "MIT"
+    },
     "node_modules/@ljharb/through": {
       "version": "2.3.14",
       "resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.14.tgz",
@@ -1712,6 +1720,19 @@
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
       "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
       "license": "MIT"
+    },
+    "node_modules/@nestjs/cache-manager": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/cache-manager/-/cache-manager-3.0.1.tgz",
+      "integrity": "sha512-4UxTnR0fsmKL5YDalU2eLFVnL+OBebWUpX+hEduKGncrVKH4PPNoiRn1kXyOCjmzb0UvWgqubpssNouc8e0MCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "cache-manager": ">=6",
+        "keyv": ">=5",
+        "rxjs": "^7.8.1"
+      }
     },
     "node_modules/@nestjs/cli": {
       "version": "10.4.9",
@@ -3686,6 +3707,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cache-manager": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.0.tgz",
+      "integrity": "sha512-GRv0Ji8Xgqtrg1Mmi4ygYpIt+SOApQNjJb5+rYIl+5y3u+tyBf+Csx79LL4wQjKLio63A6x1OpuBzhMzRv9jJg==",
+      "license": "MIT",
+      "dependencies": {
+        "keyv": "^5.5.0"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -5453,6 +5483,16 @@
         "node": ">=16"
       }
     },
+    "node_modules/flat-cache/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
@@ -7208,13 +7248,12 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.1.tgz",
+      "integrity": "sha512-eF3cHZ40bVsjdlRi/RvKAuB0+B61Q1xWvohnrJrnaQslM3h1n79IV+mc9EGag4nrA9ZOlNyr3TUzW5c8uy8vNA==",
       "license": "MIT",
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/kleur": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/cache-manager": "^3.0.1",
     "@nestjs/common": "^10.4.8",
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.4.8",
@@ -30,6 +31,7 @@
     "@nestjs/schedule": "^6.0.0",
     "@nestjs/swagger": "^8.0.7",
     "@nestjs/typeorm": "^10.0.2",
+    "cache-manager": "^7.2.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "cookie-parser": "^1.4.7",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -84,12 +84,17 @@ import { NotificationModule } from './notification/notification.module';
 import { NotificationModel } from './notification/entity/notification.entity';
 import { MobileVerificationModel } from './mobile-verification/entity/mobile-verification.entity';
 import { MobileVerificationModule } from './mobile-verification/mobile-verification.module';
+import { CacheModule } from '@nestjs/cache-manager';
 
 //import { EducationTermReportModel } from './report/education-report/entity/education-term-report.entity';
 
 @Module({
   imports: [
     EventEmitterModule.forRoot(),
+    CacheModule.register({
+      isGlobal: true,
+      ttl: 300_000,
+    }),
     ConfigModule.forRoot({
       isGlobal: true,
       validationSchema: Joi.object({

--- a/backend/src/management/groups/controller/group-members.controller.ts
+++ b/backend/src/management/groups/controller/group-members.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Patch,
   Query,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { GroupMembersService } from '../service/group-members.service';
@@ -17,24 +18,41 @@ import { AddMembersToGroupDto } from '../dto/request/members/add-members-to-grou
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
 import { RemoveMembersFromGroupDto } from '../dto/request/members/remove-members-from-group.dto';
+import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
+import { ChurchManagerGuard } from '../../../permission/guard/church-manager.guard';
+import { RequestChurch } from '../../../permission/decorator/request-church.decorator';
+import { ChurchModel } from '../../../churches/entity/church.entity';
+import { RequestManager } from '../../../permission/decorator/request-manager.decorator';
+import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
+import { GroupWriteGuard } from '../guard/group-write.guard';
 
 @ApiTags('Management:Groups:Members')
 @Controller('groups/:groupId/members')
 export class GroupMembersController {
   constructor(private readonly groupMembersService: GroupMembersService) {}
 
-  @ApiOperation({ summary: '그룹 내 교인 조회' })
+  @ApiOperation({
+    summary: '그룹 내 교인 조회',
+    description: '관리자는 조회 가능, 권한 범위로 필터링',
+  })
   @Get()
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   getGroupMembers(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('groupId', ParseIntPipe) groupId: number,
+    @RequestChurch() church: ChurchModel,
+    @RequestManager() requestManager: ChurchUserModel,
     @Query() dto: GetGroupMembersDto,
   ) {
     return this.groupMembersService.getGroupMembers(churchId, groupId, dto);
   }
 
-  @ApiOperation({ summary: '그룹에 교인 추가' })
+  @ApiOperation({
+    summary: '그룹에 교인 추가',
+    description: 'management 권한 관리자만 가능',
+  })
   @Patch()
+  @GroupWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   addMembersToGroup(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -50,8 +68,12 @@ export class GroupMembersController {
     );
   }
 
-  @ApiOperation({ summary: '그룹에서 교인 삭제' })
+  @ApiOperation({
+    summary: '그룹에서 교인 삭제',
+    description: 'management 권한 관리자만 가능',
+  })
   @Delete()
+  @GroupWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   removeMembersFromGroup(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -67,8 +89,12 @@ export class GroupMembersController {
     );
   }
 
-  @ApiOperation({ summary: '그룹 내 교인 수 새로고침' })
+  @ApiOperation({
+    summary: '그룹 내 교인 수 새로고침',
+    description: 'management 권한 관리자만 가능',
+  })
   @Patch('refresh-count')
+  @GroupWriteGuard()
   refreshMembersCount(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('groupId', ParseIntPipe) groupId: number,

--- a/backend/src/management/ministries/controller/ministries-members.controller.ts
+++ b/backend/src/management/ministries/controller/ministries-members.controller.ts
@@ -45,6 +45,7 @@ export class MinistriesMembersController {
       '<p>기존 사역이 있을 경우, 기존 사역은 종료 처리</p>',
   })
   @Patch('members')
+  @MinistryWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   addMemberToMinistry(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -63,6 +64,7 @@ export class MinistriesMembersController {
   }
 
   @Delete('members')
+  @MinistryWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   removeMemberFromMinistry(
     @Param('churchId', ParseIntPipe) churchId: number,

--- a/backend/src/management/ministries/controller/ministry-groups-members.controller.ts
+++ b/backend/src/management/ministries/controller/ministry-groups-members.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Patch,
   Query,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
@@ -24,6 +25,9 @@ import {
   ApiRemoveMembersFromMinistryGroup,
   ApiSearchMembersForMinistryGroup,
 } from '../const/swagger/ministry-group-member.swagger';
+import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
+import { ChurchManagerGuard } from '../../../permission/guard/church-manager.guard';
+import { MinistryWriteGuard } from '../guard/ministry-write.guard';
 
 @ApiTags('Management:MinistryGroups:Members')
 @Controller('ministry-groups')
@@ -33,6 +37,7 @@ export class MinistryGroupsMembersController {
   ) {}
 
   @ApiSearchMembersForMinistryGroup()
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   @Get(':ministryGroupId/member-search')
   searchMembersForMinistryGroup(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -48,6 +53,7 @@ export class MinistryGroupsMembersController {
 
   @ApiGetMinistryGroupMembers()
   @Get(':ministryGroupId/members')
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   getMinistryGroupMembers(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('ministryGroupId', ParseIntPipe) ministryGroupId: number,
@@ -62,6 +68,7 @@ export class MinistryGroupsMembersController {
 
   @ApiAddMemberToGroup()
   @Patch(':ministryGroupId/members')
+  @MinistryWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   addMemberToGroup(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -79,6 +86,7 @@ export class MinistryGroupsMembersController {
 
   @ApiRemoveMembersFromMinistryGroup()
   @Delete(':ministryGroupId/members')
+  @MinistryWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   removeMembersFromMinistryGroup(
     @Param('churchId', ParseIntPipe) churchId: number,

--- a/backend/src/management/officers/controller/officers-members.controller.ts
+++ b/backend/src/management/officers/controller/officers-members.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Patch,
   Query,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
@@ -17,6 +18,9 @@ import { GetOfficerMembersDto } from '../dto/request/members/get-officer-members
 import { TransactionInterceptor } from '../../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
+import { MinistryWriteGuard } from '../../ministries/guard/ministry-write.guard';
+import { AccessTokenGuard } from '../../../auth/guard/jwt.guard';
+import { ChurchManagerGuard } from '../../../permission/guard/church-manager.guard';
 
 @ApiTags('Management:Officers:Members')
 @Controller('officers/:officerId/members')
@@ -25,6 +29,7 @@ export class OfficersMembersController {
 
   @ApiOperation({ summary: '해당 직분 교인 조회' })
   @Get()
+  @UseGuards(AccessTokenGuard, ChurchManagerGuard)
   getOfficerMembers(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('officerId', ParseIntPipe) officerId: number,
@@ -39,6 +44,7 @@ export class OfficersMembersController {
 
   @ApiOperation({ summary: '직분에 교인 추가' })
   @Patch()
+  @MinistryWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   addMembersToOfficer(
     @Param('churchId', ParseIntPipe) churchId: number,
@@ -56,6 +62,7 @@ export class OfficersMembersController {
 
   @ApiOperation({ summary: '직분에서 교인 삭제' })
   @Delete()
+  @MinistryWriteGuard()
   @UseInterceptors(TransactionInterceptor)
   deleteMembersFromOfficer(
     @Param('churchId', ParseIntPipe) churchId: number,

--- a/backend/src/permission/guard/church-manager.guard.ts
+++ b/backend/src/permission/guard/church-manager.guard.ts
@@ -22,6 +22,8 @@ export class ChurchManagerGuard implements CanActivate {
     private readonly churchesDomainService: IChurchesDomainService,
     @Inject(IMANAGER_DOMAIN_SERVICE)
     private readonly managerDomainService: IManagerDomainService,
+    /*@Inject(CACHE_MANAGER)
+    private readonly cache: Cache,*/
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {

--- a/backend/src/visitation/service/visitation.service.ts
+++ b/backend/src/visitation/service/visitation.service.ts
@@ -378,8 +378,6 @@ export class VisitationService {
       // 대상 교인 변경 없이, 담당자만 변경
       const targetMembers = targetMetaData.members;
 
-      console.log('tt');
-
       await this.validateVisitationMember(
         church,
         requestManager,


### PR DESCRIPTION
## 주요 내용
- **사역그룹, 직분, 교인그룹**에 교인을 추가하거나 속한 교인들을 관리할 때 요청자의 권한을 검증하도록 수정
- 권한 범위 밖의 교인에 대해 추가/관리 요청이 들어올 경우 `ForbiddenException` 발생

## 세부 내용
### Group/Ministry/Officer Service
- 교인 추가 시 요청자의 권한 인증 로직 추가
- 속한 교인 관리(수정/삭제) 시 권한 범위 검증 적용
- 권한 범위 밖 대상 접근 시 일관된 예외 처리 적용