### PR TITLE
perf: 권한 체크 시 교회 및 요청자 교회가입 정보 캐시 처리

### DIFF
--- a/backend/src/permission/guard/church-manager.guard.ts
+++ b/backend/src/permission/guard/church-manager.guard.ts
@@ -14,6 +14,9 @@ import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
 } from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import { CACHE_MANAGER, Cache } from '@nestjs/cache-manager';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 
 @Injectable()
 export class ChurchManagerGuard implements CanActivate {
@@ -22,9 +25,51 @@ export class ChurchManagerGuard implements CanActivate {
     private readonly churchesDomainService: IChurchesDomainService,
     @Inject(IMANAGER_DOMAIN_SERVICE)
     private readonly managerDomainService: IManagerDomainService,
-    /*@Inject(CACHE_MANAGER)
-    private readonly cache: Cache,*/
+    @Inject(CACHE_MANAGER)
+    private readonly cache: Cache,
   ) {}
+
+  private async getChurch(req: CustomRequest) {
+    const churchId = parseInt(req.params.churchId);
+
+    const churchKey = `church-${churchId}`;
+
+    const cachedChurch = await this.cache.get<ChurchModel>(churchKey);
+
+    if (cachedChurch) {
+      return cachedChurch;
+    }
+
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      undefined,
+      { subscription: true },
+    );
+
+    await this.cache.set(churchKey, church);
+
+    return church;
+  }
+
+  private async getChurchManager(church: ChurchModel, requestUserId: number) {
+    const managerKey = `manager-${requestUserId}`;
+
+    const cachedManager = await this.cache.get<ChurchUserModel>(managerKey);
+
+    if (cachedManager) {
+      return cachedManager;
+    }
+
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    await this.cache.set(managerKey, requestManager);
+
+    return requestManager;
+  }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const req: CustomRequest = context.switchToHttp().getRequest();
@@ -35,21 +80,17 @@ export class ChurchManagerGuard implements CanActivate {
       throw new InternalServerErrorException('JWT 처리 과정 누락');
     }
 
-    const churchId = parseInt(req.params.churchId);
     const requestUserId = token.id;
 
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      req.queryRunner,
-      { subscription: true },
-    );
+    const church = await this.getChurch(req);
 
-    req.requestManager =
-      await this.managerDomainService.findManagerForPermissionCheck(
+    req.requestManager = await this.getChurchManager(church, requestUserId);
+    /*await this.managerDomainService.findManagerForPermissionCheck(
         church,
         requestUserId,
         req.queryRunner,
-      );
+      );*/
+
     req.church = church;
 
     return true;

--- a/backend/src/permission/guard/church-owner.guard.ts
+++ b/backend/src/permission/guard/church-owner.guard.ts
@@ -15,6 +15,9 @@ import {
   IMANAGER_DOMAIN_SERVICE,
   IManagerDomainService,
 } from '../../manager/manager-domain/service/interface/manager-domain.service.interface';
+import { CACHE_MANAGER, Cache } from '@nestjs/cache-manager';
+import { ChurchModel } from '../../churches/entity/church.entity';
+import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 
 @Injectable()
 export class ChurchOwnerGuard implements CanActivate {
@@ -23,7 +26,51 @@ export class ChurchOwnerGuard implements CanActivate {
     private readonly churchesDomainService: IChurchesDomainService,
     @Inject(IMANAGER_DOMAIN_SERVICE)
     private readonly managerDomainService: IManagerDomainService,
+    @Inject(CACHE_MANAGER)
+    private readonly cache: Cache,
   ) {}
+
+  private async getChurch(req: CustomRequest) {
+    const churchId = parseInt(req.params.churchId);
+
+    const churchKey = `church-${churchId}`;
+
+    const cachedChurch = await this.cache.get<ChurchModel>(churchKey);
+
+    if (cachedChurch) {
+      return cachedChurch;
+    }
+
+    const church = await this.churchesDomainService.findChurchModelById(
+      churchId,
+      undefined,
+      { subscription: true },
+    );
+
+    await this.cache.set(churchKey, church);
+
+    return church;
+  }
+
+  private async getChurchOwner(church: ChurchModel, requestUserId: number) {
+    const managerKey = `manager-${requestUserId}`;
+
+    const cachedManager = await this.cache.get<ChurchUserModel>(managerKey);
+
+    if (cachedManager) {
+      return cachedManager;
+    }
+
+    const requestManager =
+      await this.managerDomainService.findManagerForPermissionCheck(
+        church,
+        requestUserId,
+      );
+
+    await this.cache.set(managerKey, requestManager);
+
+    return requestManager;
+  }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const req: CustomRequest = context.switchToHttp().getRequest();
@@ -34,12 +81,7 @@ export class ChurchOwnerGuard implements CanActivate {
       throw new InternalServerErrorException('JWT 처리 과정 누락');
     }
 
-    const churchId = parseInt(req.params.churchId);
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      req.queryRunner,
-      { subscription: true },
-    );
+    const church = await this.getChurch(req);
 
     req.church = church;
 
@@ -47,12 +89,12 @@ export class ChurchOwnerGuard implements CanActivate {
       throw new ForbiddenException('교회 소유자만 접근할 수 있습니다.');
     }
 
-    req.requestOwner =
-      await this.managerDomainService.findManagerForPermissionCheck(
+    req.requestOwner = await this.getChurchOwner(church, token.id);
+    /*await this.managerDomainService.findManagerForPermissionCheck(
         church,
         token.id,
         req.queryRunner,
-      );
+      );*/
 
     return true;
   }

--- a/backend/src/permission/guard/generic-domain.guard.ts
+++ b/backend/src/permission/guard/generic-domain.guard.ts
@@ -48,7 +48,7 @@ export function createDomainGuard(
       return false;
     }
 
-    async canActivate(context: ExecutionContext): Promise<boolean> {
+    canActivate(context: ExecutionContext): boolean {
       const req: CustomRequest = context.switchToHttp().getRequest();
 
       const token = req.tokenPayload;


### PR DESCRIPTION
## 주요 내용
- 권한 체크 과정에서 반복적으로 수행되던 **교회 조회**와 **요청자의 교회가입 정보 조회**를 캐시 처리
- 동일 요청 수명 주기 내 불필요한 DB 접근 최소화
- 권한 검증 시 성능 개선 및 응답 속도 향상 기대

## 세부 내용
### Authorization Layer
- `PermissionGuard` 및 관련 서비스에서 교회/교회가입 정보 조회 결과를 1회만 로드 후 캐싱
- 요청 내 다중 호출 시 캐시된 결과를 재사용하도록 수정
- 추후 Redis 등 외부 캐시로 확장 가능하도록 구조 단순화
