### PR TITLE
feat: 예배 출석 권한 유형 추가 및 권한/조회 성능 개선

### DIFF
--- a/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
+++ b/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
@@ -95,6 +95,7 @@ export interface IGroupsDomainService {
     church: ChurchModel,
     rootGroupIds: number[],
     qr?: QueryRunner,
+    isAllGroups?: boolean,
   ): Promise<GroupModel[]>;
 
   incrementMembersCount(

--- a/backend/src/permission/const/domain-name.enum.ts
+++ b/backend/src/permission/const/domain-name.enum.ts
@@ -3,7 +3,8 @@ export enum DomainName {
   VISITATION = '심방',
   EDUCATION = '교육',
   TASK = '업무',
-  WORSHIP = '예배/출석',
+  WORSHIP = '예배',
+  WORSHIP_ATTENDANCE = '예배 출석',
 
   MANAGEMENT = '교회정보 설정',
   OFFICER = '직분 관리',

--- a/backend/src/permission/const/domain-type.enum.ts
+++ b/backend/src/permission/const/domain-type.enum.ts
@@ -4,6 +4,7 @@ export enum DomainType {
   EDUCATION = 'education', // 교육 관리
   TASK = 'task', // 업무 관리
   WORSHIP = 'worship', // 예배 관리
+  WORSHIP_ATTENDANCE = 'worshipAttendance', // 예배 출석 관리
   MANAGEMENT = 'management', // 교회정보 관리
   PERMISSION = 'permission', // 관리자 관리
 }

--- a/backend/src/permission/exception/permission-scope.exception.ts
+++ b/backend/src/permission/exception/permission-scope.exception.ts
@@ -3,4 +3,5 @@ export const PermissionScopeException = {
   OWNER: '소유자 권한 관리자는 권한 범위를 설정할 수 없습니다.',
   OUT_OF_SCOPE_MEMBER: '권한 범위 밖의 교인입니다.',
   OUT_OF_SCOPE_GROUP: '권한 범위 밖의 그룹입니다.',
+  NO_PERMISSION_SCOPE: '권한 범위가 부여되지 않았습니다.',
 };

--- a/backend/src/worship/controller/worship-enrollment.controller.ts
+++ b/backend/src/worship/controller/worship-enrollment.controller.ts
@@ -38,13 +38,12 @@ export class WorshipEnrollmentController {
   ) {}
 
   @Get()
-  //@WorshipReadGuard()
   @UseGuards(
     AccessTokenGuard,
     ChurchManagerGuard,
     createDomainGuard(
-      DomainType.WORSHIP,
-      DomainName.WORSHIP,
+      DomainType.WORSHIP_ATTENDANCE,
+      DomainName.WORSHIP_ATTENDANCE,
       DomainAction.READ,
     ),
     WorshipGroupFilterGuard,
@@ -56,8 +55,8 @@ export class WorshipEnrollmentController {
     @Query() dto: GetWorshipEnrollmentsDto,
     @RequestChurch() church: ChurchModel,
     @RequestWorship() worship: WorshipModel,
-    @PermissionScopeGroups() permissionScopeGroupIds?: number[],
-    @WorshipTargetGroupIds() defaultTargetGroupIds?: number[],
+    @WorshipTargetGroupIds() defaultTargetGroupIds: number[], // 예배 대상 그룹
+    @PermissionScopeGroups() permissionScopeGroupIds: number[], // 요청자의 권한 범위 내 그룹들
   ) {
     return this.worshipEnrollmentService.getEnrollments(
       church,
@@ -77,6 +76,7 @@ export class WorshipEnrollmentController {
   postEnrollment(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('worshipId', ParseIntPipe) worshipId: number,
+    @RequestChurch() church: ChurchModel,
     @QueryRunner() qr: QR,
   ) {
     return this.worshipEnrollmentService.refreshEnrollment(

--- a/backend/src/worship/controller/worship-session.controller.ts
+++ b/backend/src/worship/controller/worship-session.controller.ts
@@ -94,8 +94,8 @@ export class WorshipSessionController {
     AccessTokenGuard,
     ChurchManagerGuard,
     createDomainGuard(
-      DomainType.WORSHIP,
-      DomainName.WORSHIP,
+      DomainType.WORSHIP_ATTENDANCE,
+      DomainName.WORSHIP_ATTENDANCE,
       DomainAction.READ,
     ),
     WorshipGroupFilterGuard,
@@ -107,8 +107,8 @@ export class WorshipSessionController {
     @Query() dto: GetWorshipSessionCheckStatusDto,
     @RequestChurch() church: ChurchModel,
     @RequestWorship() worship: WorshipModel,
-    @WorshipTargetGroupIds() defaultTargetGroupIds?: number[],
-    @PermissionScopeGroups() permissionScopeGroupIds?: number[],
+    @WorshipTargetGroupIds() defaultTargetGroupIds: number[],
+    @PermissionScopeGroups() permissionScopeGroupIds: number[],
   ) {
     return this.worshipSessionService.getSessionCheckStatus(
       church,
@@ -125,8 +125,8 @@ export class WorshipSessionController {
     AccessTokenGuard,
     ChurchManagerGuard,
     createDomainGuard(
-      DomainType.WORSHIP,
-      DomainName.WORSHIP,
+      DomainType.WORSHIP_ATTENDANCE,
+      DomainName.WORSHIP_ATTENDANCE,
       DomainAction.READ,
     ),
     WorshipGroupFilterGuard,
@@ -136,8 +136,8 @@ export class WorshipSessionController {
     @RequestChurch() church: ChurchModel,
     @RequestWorship() worship: WorshipModel,
     @Param('sessionId', ParseIntPipe) sessionId: number,
-    @WorshipTargetGroupIds() defaultWorshipTargetGroupIds: number[] | undefined,
-    @PermissionScopeGroups() permissionScopeGroupIds: number[] | undefined,
+    @WorshipTargetGroupIds() defaultWorshipTargetGroupIds: number[],
+    @PermissionScopeGroups() permissionScopeGroupIds: number[],
     @Query() dto: GetWorshipSessionStatsDto,
   ) {
     return this.worshipSessionService.getWorshipSessionStatistics(
@@ -158,11 +158,12 @@ export class WorshipSessionController {
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('worshipId', ParseIntPipe) worshipId: number,
     @Param('sessionId', ParseIntPipe) sessionId: number,
+    @RequestChurch() church: ChurchModel,
     @Body() dto: UpdateWorshipSessionDto,
     @QueryRunner() qr: QR,
   ) {
     return this.worshipSessionService.patchWorshipSessionById(
-      churchId,
+      church,
       worshipId,
       sessionId,
       dto,
@@ -178,10 +179,11 @@ export class WorshipSessionController {
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('worshipId', ParseIntPipe) worshipId: number,
     @Param('sessionId', ParseIntPipe) sessionId: number,
+    @RequestChurch() church: ChurchModel,
     @QueryRunner() qr: QR,
   ) {
     return this.worshipSessionService.deleteWorshipSessionById(
-      churchId,
+      church,
       worshipId,
       sessionId,
       qr,

--- a/backend/src/worship/controller/worship.controller.ts
+++ b/backend/src/worship/controller/worship.controller.ts
@@ -130,8 +130,8 @@ export class WorshipController {
     AccessTokenGuard,
     ChurchManagerGuard,
     createDomainGuard(
-      DomainType.WORSHIP,
-      DomainName.WORSHIP,
+      DomainType.WORSHIP_ATTENDANCE,
+      DomainName.WORSHIP_ATTENDANCE,
       DomainAction.READ,
     ),
     WorshipGroupFilterGuard,
@@ -142,8 +142,8 @@ export class WorshipController {
     @Param('worshipId', ParseIntPipe) worshipId: number,
     @RequestChurch() church: ChurchModel,
     @RequestWorship() worship: WorshipModel,
-    @WorshipTargetGroupIds() defaultTargetGroupIds: number[] | undefined,
-    @PermissionScopeGroups() permissionScopeGroupIds: number[] | undefined,
+    @WorshipTargetGroupIds() defaultTargetGroupIds: number[],
+    @PermissionScopeGroups() permissionScopeGroupIds: number[],
     @Query() dto: GetWorshipStatsDto,
   ) {
     return this.worshipService.getWorshipStatistics(

--- a/backend/src/worship/dto/response/worship-enrollment/worship-enrollment-pagination-response.dto.ts
+++ b/backend/src/worship/dto/response/worship-enrollment/worship-enrollment-pagination-response.dto.ts
@@ -1,14 +1,8 @@
-import { BaseOffsetPaginationResponseDto } from '../../../../common/dto/reponse/base-offset-pagination-response.dto';
 import { WorshipEnrollmentModel } from '../../../entity/worship-enrollment.entity';
 
-export class WorshipEnrollmentPaginationResponseDto extends BaseOffsetPaginationResponseDto<WorshipEnrollmentModel> {
+export class WorshipEnrollmentPaginationResponseDto {
   constructor(
-    data: WorshipEnrollmentModel[],
-    totalCount: number,
-    count: number,
-    page: number,
-    totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly data: WorshipEnrollmentModel[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/worship/dto/response/worship-session/worship-session-pagination-response.dto.ts
+++ b/backend/src/worship/dto/response/worship-session/worship-session-pagination-response.dto.ts
@@ -1,14 +1,8 @@
-import { BaseOffsetPaginationResponseDto } from '../../../../common/dto/reponse/base-offset-pagination-response.dto';
 import { WorshipSessionModel } from '../../../entity/worship-session.entity';
 
-export class WorshipSessionPaginationResponseDto extends BaseOffsetPaginationResponseDto<WorshipSessionModel> {
+export class WorshipSessionPaginationResponseDto {
   constructor(
-    data: WorshipSessionModel[],
-    totalCount: number,
-    count: number,
-    page: number,
-    totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly data: WorshipSessionModel[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/worship/dto/response/worship/worship-pagination-response.dto.ts
+++ b/backend/src/worship/dto/response/worship/worship-pagination-response.dto.ts
@@ -1,14 +1,8 @@
-import { BaseOffsetPaginationResponseDto } from '../../../../common/dto/reponse/base-offset-pagination-response.dto';
 import { WorshipModel } from '../../../entity/worship.entity';
 
-export class WorshipPaginationResponseDto extends BaseOffsetPaginationResponseDto<WorshipModel> {
+export class WorshipPaginationResponseDto {
   constructor(
-    data: WorshipModel[],
-    totalCount: number,
-    count: number,
-    page: number,
-    totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly data: WorshipModel[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/worship/guard/worship-group-filter.guard.ts
+++ b/backend/src/worship/guard/worship-group-filter.guard.ts
@@ -84,12 +84,6 @@ export class WorshipGroupFilterGuard implements CanActivate {
       (targetGroup) => targetGroup.groupId,
     );
 
-    // 대상 그룹이 전체인 예배
-    if (rootTargetGroupIds.length === 0) {
-      req.worshipTargetGroupIds = undefined;
-      return true;
-    }
-
     // 대상 그룹과 그 하위 그룹의 ID 들
     const allowedGroupIds = (
       await this.groupsDomainService.findGroupAndDescendantsByIds(
@@ -98,6 +92,7 @@ export class WorshipGroupFilterGuard implements CanActivate {
       )
     ).map((group) => group.id);
 
+    // 예배 대상 그룹
     req.worshipTargetGroupIds = allowedGroupIds;
 
     // 필터링할 그룹이 없을 경우 통과

--- a/backend/src/worship/guard/worship-scope.guard.ts
+++ b/backend/src/worship/guard/worship-scope.guard.ts
@@ -107,11 +107,29 @@ export class WorshipScopeGuard implements CanActivate {
 
     // 소유자
     if (requestManager.role === ChurchUserRole.OWNER) {
+      req.permissionScopeGroupIds = (
+        await this.groupsDomainService.findGroupAndDescendantsByIds(
+          church,
+          [],
+          undefined,
+          true,
+        )
+      ).map((group) => group.id);
+
       return true;
     }
 
     // 전체 권한 범위
     if (requestManager.permissionScopes.some((scope) => scope.isAllGroups)) {
+      req.permissionScopeGroupIds = (
+        await this.groupsDomainService.findGroupAndDescendantsByIds(
+          church,
+          [],
+          undefined,
+          true,
+        )
+      ).map((group) => group.id);
+
       return true;
     }
 
@@ -120,6 +138,13 @@ export class WorshipScopeGuard implements CanActivate {
       church,
       requestManager,
     );
+
+    // 권한 범위가 지정되지 않은 관리자
+    if (permissionGroupIds.length === 0) {
+      throw new ForbiddenException(
+        PermissionScopeException.NO_PERMISSION_SCOPE,
+      );
+    }
 
     req.permissionScopeGroupIds = permissionGroupIds;
 

--- a/backend/src/worship/swagger/worship-attendance.swagger.ts
+++ b/backend/src/worship/swagger/worship-attendance.swagger.ts
@@ -4,6 +4,20 @@ import { ApiOperation } from '@nestjs/swagger';
 export const ApiGetWorshipAttendance = () =>
   applyDecorators(
     ApiOperation({
-      summary: '예배 세션의 출석 정보 조회',
+      summary: '예배 세션의 출석 정보 조회 (예배 출석 읽기 권한)',
+    }),
+  );
+
+export const ApiRefreshWorshipAttendance = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '예배 세션의 출석 정보 새로고침 (예배 출석 쓰기 권한)',
+    }),
+  );
+
+export const ApiPatchAllAttended = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '예배 세션 전체 출석 체크 (예배 출석 쓰기 권한)',
     }),
   );

--- a/backend/src/worship/swagger/worship.swagger.ts
+++ b/backend/src/worship/swagger/worship.swagger.ts
@@ -4,14 +4,14 @@ import { ApiOperation, ApiParam } from '@nestjs/swagger';
 export const ApiGetWorships = () =>
   applyDecorators(
     ApiParam({ name: 'churchId' }),
-    ApiOperation({ summary: '예배 목록 조회' }),
+    ApiOperation({ summary: '예배 목록 조회 (예배 읽기 권한)' }),
   );
 
 export const ApiPostWorship = () =>
   applyDecorators(
     ApiParam({ name: 'churchId' }),
     ApiOperation({
-      summary: '예배 생성',
+      summary: '예배 생성 (예배 쓰기 권한)',
     }),
   );
 
@@ -19,7 +19,7 @@ export const ApiRefreshWorshipCount = () =>
   applyDecorators(
     ApiParam({ name: 'churchId' }),
     ApiOperation({
-      summary: '교회 예배 수 새로고침',
+      summary: '교회 예배 수 새로고침 (예배 쓰기 권한)',
     }),
   );
 
@@ -27,7 +27,7 @@ export const ApiGetWorshipById = () =>
   applyDecorators(
     ApiParam({ name: 'churchId' }),
     ApiOperation({
-      summary: '예배 단건 조회',
+      summary: '예배 단건 조회 (예배 읽기 권한)',
     }),
   );
 
@@ -35,7 +35,7 @@ export const ApiPatchWorship = () =>
   applyDecorators(
     ApiParam({ name: 'churchId' }),
     ApiOperation({
-      summary: '예배 수정',
+      summary: '예배 수정 (예배 쓰기 권한)',
     }),
   );
 
@@ -43,7 +43,7 @@ export const ApiDeleteWorship = () =>
   applyDecorators(
     ApiParam({ name: 'churchId' }),
     ApiOperation({
-      summary: '예배 삭제',
+      summary: '예배 삭제 (예배 쓰기 권한)',
       description: '하위 enrollment, session, attendance 삭제',
     }),
   );
@@ -53,6 +53,6 @@ export const ApiGetWorshipStatistics = () =>
     ApiParam({ name: 'churchId' }),
     ApiParam({ name: 'worshipId' }),
     ApiOperation({
-      summary: '예배 출석률 통계',
+      summary: '예배 출석률 통계 (예배 출석 읽기 권한)',
     }),
   );

--- a/backend/src/worship/utils/worship-utils.ts
+++ b/backend/src/worship/utils/worship-utils.ts
@@ -24,9 +24,14 @@ export function getRecentSessionDate(
   return fromZonedTime(lastWorshipDateKst, timeZone);
 }
 
+/**
+ *
+ * @param defaultWorshipTargetGroupIds
+ * @param permissionScopeGroupIds
+ */
 export function getIntersectionGroupIds(
-  defaultWorshipTargetGroupIds: number[] | undefined,
-  permissionScopeGroupIds: number[] | undefined,
+  defaultWorshipTargetGroupIds: number[],
+  permissionScopeGroupIds: number[],
 ) {
   if (!defaultWorshipTargetGroupIds) {
     // 요청 그룹이 없고, 예배 대상이 전체인 경우

--- a/backend/src/worship/worship-domain/dto/worship-domain-pagination-result.dto.ts
+++ b/backend/src/worship/worship-domain/dto/worship-domain-pagination-result.dto.ts
@@ -1,8 +1,0 @@
-import { BaseDomainOffsetPaginationResultDto } from '../../../common/dto/base-domain-offset-pagination-result.dto';
-import { WorshipModel } from '../../entity/worship.entity';
-
-export class WorshipDomainPaginationResultDto extends BaseDomainOffsetPaginationResultDto<WorshipModel> {
-  constructor(data: WorshipModel[], totalCount: number) {
-    super(data, totalCount);
-  }
-}

--- a/backend/src/worship/worship-domain/interface/worship-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-domain.service.interface.ts
@@ -1,7 +1,6 @@
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { GetWorshipsDto } from '../../dto/request/worship/get-worships.dto';
 import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
-import { WorshipDomainPaginationResultDto } from '../dto/worship-domain-pagination-result.dto';
 import { WorshipModel } from '../../entity/worship.entity';
 import { CreateWorshipDto } from '../../dto/request/worship/create-worship.dto';
 import { UpdateWorshipDto } from '../../dto/request/worship/update-worship.dto';
@@ -14,7 +13,7 @@ export interface IWorshipDomainService {
     church: ChurchModel,
     dto: GetWorshipsDto,
     qr?: QueryRunner,
-  ): Promise<WorshipDomainPaginationResultDto>;
+  ): Promise<WorshipModel[]>;
 
   findAllWorships(
     church: ChurchModel,

--- a/backend/src/worship/worship-domain/interface/worship-enrollment-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-enrollment-domain.service.interface.ts
@@ -23,7 +23,7 @@ export interface IWorshipEnrollmentDomainService {
     dto: GetWorshipEnrollmentsDto,
     groupIds?: number[],
     qr?: QueryRunner,
-  ): Promise<any>;
+  ): Promise<WorshipEnrollmentModel[]>;
 
   createNewMemberEnrollments(
     newMember: MemberModel,

--- a/backend/src/worship/worship-domain/interface/worship-session-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-session-domain.service.interface.ts
@@ -3,7 +3,6 @@ import { CreateWorshipSessionDto } from '../../dto/request/worship-session/creat
 import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { WorshipSessionModel } from '../../entity/worship-session.entity';
 import { GetWorshipSessionsDto } from '../../dto/request/worship-session/get-worship-sessions.dto';
-import { WorshipSessionDomainPaginationResultDto } from '../dto/worship-session-domain-pagination-result.dto';
 import { UpdateWorshipSessionDto } from '../../dto/request/worship-session/update-worship-session.dto';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 
@@ -16,7 +15,7 @@ export interface IWorshipSessionDomainService {
     worship: WorshipModel,
     dto: GetWorshipSessionsDto,
     qr?: QueryRunner,
-  ): Promise<WorshipSessionDomainPaginationResultDto>;
+  ): Promise<WorshipSessionModel[]>;
 
   createWorshipSession(
     worship: WorshipModel,

--- a/backend/src/worship/worship-domain/service/worship-attendance-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-attendance-domain.service.ts
@@ -23,6 +23,7 @@ import { WorshipAttendanceDomainPaginationResultDto } from '../dto/worship-atten
 import { WorshipEnrollmentModel } from '../../entity/worship-enrollment.entity';
 import { WorshipAttendanceException } from '../../exception/worship-attendance.exception';
 import {
+  MemberSimpleSelect,
   MemberSimpleSelectQB,
   MemberSummarizedGroupSelectQB,
   MemberSummarizedOfficerSelectQB,
@@ -87,7 +88,7 @@ export class WorshipAttendanceDomainService
   async findAttendanceList(
     session: WorshipSessionModel,
     dto: GetWorshipAttendanceListDto,
-    groupIds: number[] | undefined,
+    groupIds: number[],
     qr?: QueryRunner,
   ) {
     const repository = this.getRepository(qr);
@@ -300,7 +301,7 @@ export class WorshipAttendanceDomainService
             updatedAt: true,
             presentCount: true,
             absentCount: true,
-            member: MemberSummarizedSelect,
+            member: MemberSimpleSelect,
           },
         },
       }),

--- a/backend/src/worship/worship-domain/service/worship-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-domain.service.ts
@@ -18,7 +18,6 @@ import {
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { GetWorshipsDto } from '../../dto/request/worship/get-worships.dto';
 import { WorshipOrderEnum } from '../../const/worship-order.enum';
-import { WorshipDomainPaginationResultDto } from '../dto/worship-domain-pagination-result.dto';
 import { WorshipException } from '../../exception/worship.exception';
 import { CreateWorshipDto } from '../../dto/request/worship/create-worship.dto';
 import { UpdateWorshipDto } from '../../dto/request/worship/update-worship.dto';
@@ -60,7 +59,29 @@ export class WorshipDomainService implements IWorshipDomainService {
       orderOptions.createdAt = 'ASC';
     }
 
-    const [data, totalCount] = await Promise.all([
+    return repository.find({
+      where: {
+        churchId: church.id,
+      },
+      relations: {
+        worshipTargetGroups: {
+          group: true,
+        },
+      },
+      select: {
+        worshipTargetGroups: {
+          id: true,
+          group: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+      order: orderOptions,
+      take: dto.take,
+      skip: dto.take * (dto.page - 1),
+    });
+    /*const [data, totalCount] = await Promise.all([
       repository.find({
         where: {
           churchId: church.id,
@@ -92,6 +113,7 @@ export class WorshipDomainService implements IWorshipDomainService {
     ]);
 
     return new WorshipDomainPaginationResultDto(data, totalCount);
+    */
   }
 
   async findAllWorships(

--- a/backend/src/worship/worship-domain/service/worship-enrollment-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-enrollment-domain.service.ts
@@ -13,7 +13,6 @@ import {
 import { WorshipModel } from '../../entity/worship.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { GetWorshipEnrollmentsDto } from '../../dto/request/worship-enrollment/get-worship-enrollments.dto';
-import { WorshipEnrollmentDomainPaginationResultDto } from '../dto/worship-enrollment-domain-pagination-result.dto';
 import { WorshipEnrollmentOrderEnum } from '../../const/worship-enrollment-order.enum';
 import { GetLowWorshipAttendanceMembersDto } from '../../../home/dto/request/get-low-worship-attendance-members.dto';
 import { LowAttendanceOrder } from '../../../home/const/low-attendance-order.enum';
@@ -112,12 +111,14 @@ export class WorshipEnrollmentDomainService
 
     qb.skip(dto.take * (dto.page - 1)).take(dto.take);
 
-    const [{ entities, raw }, totalCount] = await Promise.all([
+    /*const [{ entities, raw }, totalCount] = await Promise.all([
       qb.getRawAndEntities(),
       qb.getCount(),
-    ]);
+    ]);*/
 
-    const data = entities.map((entity, i) => {
+    const { entities, raw } = await qb.getRawAndEntities();
+
+    return entities.map((entity, i) => {
       const rate = Number(raw[i].attendance_rate);
       return {
         ...entity,
@@ -125,7 +126,7 @@ export class WorshipEnrollmentDomainService
       };
     });
 
-    return new WorshipEnrollmentDomainPaginationResultDto(data, totalCount);
+    //return new WorshipEnrollmentDomainPaginationResultDto(data, totalCount);
   }
 
   async findAllEnrollments(

--- a/backend/src/worship/worship-domain/service/worship-session-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-session-domain.service.ts
@@ -20,7 +20,6 @@ import { CreateWorshipSessionDto } from '../../dto/request/worship-session/creat
 import { WorshipSessionException } from '../../exception/worship-session.exception';
 import { GetWorshipSessionsDto } from '../../dto/request/worship-session/get-worship-sessions.dto';
 import { WorshipSessionOrderEnum } from '../../const/worship-session-order.enum';
-import { WorshipSessionDomainPaginationResultDto } from '../dto/worship-session-domain-pagination-result.dto';
 import { UpdateWorshipSessionDto } from '../../dto/request/worship-session/update-worship-session.dto';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { ManagerException } from '../../../manager/exception/manager.exception';
@@ -74,7 +73,13 @@ export class WorshipSessionDomainService
       orderOptions.createdAt = 'asc';
     }
 
-    const [data, totalCount] = await Promise.all([
+    return repository.find({
+      where: whereOptions,
+      order: orderOptions,
+      select: selectOptions,
+    });
+
+    /*const [data, totalCount] = await Promise.all([
       repository.find({
         where: whereOptions,
         order: orderOptions,
@@ -86,7 +91,7 @@ export class WorshipSessionDomainService
       }),
     ]);
 
-    return new WorshipSessionDomainPaginationResultDto(data, totalCount);
+    return new WorshipSessionDomainPaginationResultDto(data, totalCount);*/
   }
 
   private async assertValidNewSession(


### PR DESCRIPTION
## 주요 내용
- **권한 유형 추가**
  - `WORSHIP_ATTENDANCE = 'worshipAttendance'` 권한 유형을 신설
  - 예배 출석 관련 도메인 접근을 세분화하여 제어 가능하도록 개선
- **캐시 처리**
  - 교회 내 그룹 전체 조회 결과를 캐시 처리하여 성능 향상
- **권한 범위 검증 강화**
  - 예배 대상 그룹과 요청자의 권한 범위 교차 여부를 검증하도록 로직 보완
  - 권한 범위 외 접근 시 `ForbiddenException` 발생
- **목록 응답 단순화**
  - 목록 조회 API 응답에서 `totalCount` 제거

## 세부 내용
### Permission
- `PermissionType` enum에 `WORSHIP_ATTENDANCE` 항목 추가
- 관련 가드 및 권한 평가 로직 확장

### Group Query
- 교회 그룹 전체 조회 시 캐싱 로직 추가
- 동일 요청에 대해 DB 부하 최소화

### Worship Service
- 대상 그룹과 요청자 권한 범위 교차 검증 로직 강화
- 범위 외 요청 시 예외 처리 일관화

### List API
- 응답 포맷에서 `totalCount` 필드 제거
- 클라이언트는 데이터 배열만 활용하도록 단순화
