### PR TITLE
fix: 예배 대상 그룹이 전체인 경우 조회되지 않는 문제 해결

### DIFF
--- a/backend/src/worship/guard/worship-group-filter.guard.ts
+++ b/backend/src/worship/guard/worship-group-filter.guard.ts
@@ -89,6 +89,8 @@ export class WorshipGroupFilterGuard implements CanActivate {
       await this.groupsDomainService.findGroupAndDescendantsByIds(
         church,
         rootTargetGroupIds,
+        undefined,
+        rootTargetGroupIds.length === 0,
       )
     ).map((group) => group.id);
 


### PR DESCRIPTION
## 주요 내용
- 예배 대상 그룹이 **전체 교인 대상**인 예배가 조회되지 않던 문제 수정
- 대상 그룹을 불러오지 못해 조회가 누락되는 오류 해결

## 세부 내용
### Worship Query
- 대상 그룹이 전체일 경우에도 그룹 데이터를 정상적으로 로드하도록 로직 보완
- 예배 조회 시 대상 그룹 배열이 비어 있더라도 전체 그룹으로 인식되도록 처리