### PR TITLE
feat: 예배 세션 일괄 출석 시 groupId 기반 그룹 선택 기능 추가

### DIFF
--- a/backend/src/worship/controller/worship-attendance.controller.ts
+++ b/backend/src/worship/controller/worship-attendance.controller.ts
@@ -176,6 +176,7 @@ export class WorshipAttendanceController {
       church,
       worship,
       sessionId,
+      dto,
       defaultTargetGroupIds,
       permissionScopeGroupIds,
       qr,

--- a/backend/src/worship/guard/worship-group-filter.guard.ts
+++ b/backend/src/worship/guard/worship-group-filter.guard.ts
@@ -78,7 +78,16 @@ export class WorshipGroupFilterGuard implements CanActivate {
     req.worship = worship;
 
     // 조회 요청 그룹 ID
-    const requestGroupId = parseInt(req.query.groupId as string);
+    //const requestGroupId = parseInt(req.query.groupId as string);
+    let requestGroupId: number;
+
+    if (parseInt(req.query.groupId as string)) {
+      requestGroupId = parseInt(req.query.groupId as string);
+    } else if (parseInt(req.body.groupId as string)) {
+      requestGroupId = parseInt(req.body.groupId as string);
+    } else {
+      requestGroupId = NaN;
+    }
 
     const rootTargetGroupIds = worship.worshipTargetGroups.map(
       (targetGroup) => targetGroup.groupId,

--- a/backend/src/worship/service/worship-attendance.service.ts
+++ b/backend/src/worship/service/worship-attendance.service.ts
@@ -35,6 +35,7 @@ import { GetWorshipAttendanceListDto } from '../dto/request/worship-attendance/g
 import { getIntersectionGroupIds } from '../utils/worship-utils';
 import { WorshipAttendanceListResponseDto } from '../dto/response/worship-attendance/worship-attendance-list-response.dto';
 import { PatchWorshipAllAttendedResponseDto } from '../dto/response/worship-attendance/patch-worship-all-attended-response.dto';
+import { UpdateWorshipAllAttendedDto } from '../dto/request/worship-attendance/update-worship-all-attended.dto';
 
 @Injectable()
 export class WorshipAttendanceService {
@@ -328,6 +329,7 @@ export class WorshipAttendanceService {
     church: ChurchModel,
     worship: WorshipModel,
     sessionId: number,
+    dto: UpdateWorshipAllAttendedDto,
     defaultTargetGroupIds: number[],
     permissionScopeGroupIds: number[],
     qr: QueryRunner,
@@ -335,6 +337,7 @@ export class WorshipAttendanceService {
     const requestGroupIds = await this.getRequestGroupIds(
       church,
       defaultTargetGroupIds,
+      dto.groupId,
     );
 
     const intersectionGroupIds = getIntersectionGroupIds(


### PR DESCRIPTION
## 주요 내용
- 예배 세션 일괄 출석 처리 시 요청 본문에 `groupId`를 전달하여 특정 그룹에 속한 교인들만 대상으로 일괄 출석 처리할 수 있도록 기능 추가

## 세부 내용
### WorshipAttendanceService
- `patchAllAttended` 로직에서 `groupId` 파라미터를 인식하도록 수정
- 전달된 `groupId`가 있을 경우 해당 그룹 소속 교인들만 필터링하여 출석 처리
- `groupId`가 없을 경우 기존 방식(전체 대상)에 대해 일괄 출석 처리 유지