### PR TITLE
feat: 예배 교인그룹 필터링 시 null 지원으로 그룹 미소속 교인 처리 기능 추가

### DIFF
--- a/backend/src/common/custom-request.ts
+++ b/backend/src/common/custom-request.ts
@@ -7,6 +7,8 @@ import { MemberModel } from '../members/entity/member.entity';
 import { QueryRunner } from 'typeorm';
 import { UserModel } from '../user/entity/user.entity';
 import { VisitationMetaModel } from '../visitation/entity/visitation-meta.entity';
+import { WorshipGroupIdsVo } from '../worship/vo/worship-group-ids.vo';
+import { PermissionScopeIdsVo } from '../permission/vo/permission-scope-ids.vo';
 
 export interface CustomRequest extends Request {
   queryRunner: QueryRunner;
@@ -17,11 +19,13 @@ export interface CustomRequest extends Request {
   requestManager: ChurchUserModel;
   requestOwner: ChurchUserModel;
   permissionScopeGroupIds: number[]; // 요청자의 권한 범위 내 모든 그룹 ID
+  permissionScopeIds: PermissionScopeIdsVo; // 요청자의 권한 범위 내 모든 그룹 + 전체권한 여부
   tokenPayload: JwtAccessPayload;
   user: UserModel;
 
   targetMember: MemberModel;
   targetVisitation: VisitationMetaModel;
 
-  worshipTargetGroupIds: number[] | undefined;
+  worshipTargetGroupIds: number[];
+  worshipGroupIds: WorshipGroupIdsVo;
 }

--- a/backend/src/permission/exception/permission-scope.exception.ts
+++ b/backend/src/permission/exception/permission-scope.exception.ts
@@ -1,7 +1,10 @@
 export const PermissionScopeException = {
   DELETE_ERROR: '권한 범위 삭제 도중 에러 발생',
+
   OWNER: '소유자 권한 관리자는 권한 범위를 설정할 수 없습니다.',
+
   OUT_OF_SCOPE_MEMBER: '권한 범위 밖의 교인입니다.',
-  OUT_OF_SCOPE_GROUP: '권한 범위 밖의 그룹입니다.',
+  OUT_OF_SCOPE_GROUP: '권한 범위 밖의 요청입니다.',
+
   NO_PERMISSION_SCOPE: '권한 범위가 부여되지 않았습니다.',
 };

--- a/backend/src/permission/vo/permission-scope-ids.vo.ts
+++ b/backend/src/permission/vo/permission-scope-ids.vo.ts
@@ -1,0 +1,6 @@
+export class PermissionScopeIdsVo {
+  constructor(
+    public groupIds: number[],
+    public isAllGroups: boolean,
+  ) {}
+}

--- a/backend/src/worship/controller/worship-attendance.controller.ts
+++ b/backend/src/worship/controller/worship-attendance.controller.ts
@@ -41,6 +41,10 @@ import { GetWorshipAttendanceListDto } from '../dto/request/worship-attendance/g
 import { WorshipTargetGroupIds } from '../decorator/worship-target-group-ids.decorator';
 import { UpdateWorshipAllAttendedDto } from '../dto/request/worship-attendance/update-worship-all-attended.dto';
 import { ChurchManagerGuard } from '../../permission/guard/church-manager.guard';
+import { DefaultWorshipGroupIds } from '../decorator/default-worship-group-ids.decorator';
+import { WorshipGroupIdsVo } from '../vo/worship-group-ids.vo';
+import { PermissionScopeIds } from '../decorator/permission-scope-ids.decorator';
+import { PermissionScopeIdsVo } from '../../permission/vo/permission-scope-ids.vo';
 
 @ApiTags('Worships:Attendance')
 @Controller(':worshipId/sessions/:sessionId/attendances')
@@ -105,16 +109,16 @@ export class WorshipAttendanceController {
     @Query() query: GetWorshipAttendanceListDto,
     @RequestChurch() church: ChurchModel,
     @RequestWorship() worship: WorshipModel,
-    @WorshipTargetGroupIds() defaultTargetGroupIds: number[],
-    @PermissionScopeGroups() permissionScopeGroupIds: number[],
+    @DefaultWorshipGroupIds() defaultWorshipGroupIds: WorshipGroupIdsVo,
+    @PermissionScopeIds() permissionScopeIds: PermissionScopeIdsVo,
   ) {
     return this.worshipAttendanceService.getAttendancesV2(
       church,
       worship,
       sessionId,
       query,
-      defaultTargetGroupIds,
-      permissionScopeGroupIds,
+      defaultWorshipGroupIds,
+      permissionScopeIds,
     );
   }
 
@@ -168,8 +172,8 @@ export class WorshipAttendanceController {
     @Body() dto: UpdateWorshipAllAttendedDto,
     @RequestChurch() church: ChurchModel,
     @RequestWorship() worship: WorshipModel,
-    @WorshipTargetGroupIds() defaultTargetGroupIds: number[],
-    @PermissionScopeGroups() permissionScopeGroupIds: number[],
+    @DefaultWorshipGroupIds() defaultWorshipGroupIds: WorshipGroupIdsVo,
+    @PermissionScopeIds() permissionScopeIds: PermissionScopeIdsVo,
     @QueryRunner() qr: QR,
   ) {
     return this.worshipAttendanceService.patchAllAttended(
@@ -177,8 +181,8 @@ export class WorshipAttendanceController {
       worship,
       sessionId,
       dto,
-      defaultTargetGroupIds,
-      permissionScopeGroupIds,
+      defaultWorshipGroupIds,
+      permissionScopeIds,
       qr,
     );
   }

--- a/backend/src/worship/controller/worship-enrollment.controller.ts
+++ b/backend/src/worship/controller/worship-enrollment.controller.ts
@@ -26,9 +26,12 @@ import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
 import { DomainType } from '../../permission/const/domain-type.enum';
 import { DomainName } from '../../permission/const/domain-name.enum';
 import { DomainAction } from '../../permission/const/domain-action.enum';
-import { PermissionScopeGroups } from '../decorator/permission-scope-groups.decorator';
 import { ChurchManagerGuard } from '../../permission/guard/church-manager.guard';
-import { WorshipTargetGroupIds } from '../decorator/worship-target-group-ids.decorator';
+import { DefaultWorshipGroupIds } from '../decorator/default-worship-group-ids.decorator';
+import { WorshipGroupIdsVo } from '../vo/worship-group-ids.vo';
+import { PermissionScopeIds } from '../decorator/permission-scope-ids.decorator';
+import { PermissionScopeIdsVo } from '../../permission/vo/permission-scope-ids.vo';
+import { ApiGetWorshipEnrollments } from '../swagger/worship-enrollment.swagger';
 
 @ApiTags('Worships:Enrollments')
 @Controller(':worshipId/enrollments')
@@ -37,6 +40,7 @@ export class WorshipEnrollmentController {
     private readonly worshipEnrollmentService: WorshipEnrollmentService,
   ) {}
 
+  @ApiGetWorshipEnrollments()
   @Get()
   @UseGuards(
     AccessTokenGuard,
@@ -55,15 +59,15 @@ export class WorshipEnrollmentController {
     @Query() dto: GetWorshipEnrollmentsDto,
     @RequestChurch() church: ChurchModel,
     @RequestWorship() worship: WorshipModel,
-    @WorshipTargetGroupIds() defaultTargetGroupIds: number[], // 예배 대상 그룹
-    @PermissionScopeGroups() permissionScopeGroupIds: number[], // 요청자의 권한 범위 내 그룹들
+    @DefaultWorshipGroupIds() defaultWorshipGroupIds: WorshipGroupIdsVo,
+    @PermissionScopeIds() permissionScopeIds: PermissionScopeIdsVo,
   ) {
     return this.worshipEnrollmentService.getEnrollments(
       church,
       worship,
       dto,
-      permissionScopeGroupIds,
-      defaultTargetGroupIds,
+      permissionScopeIds,
+      defaultWorshipGroupIds,
     );
   }
 

--- a/backend/src/worship/controller/worship-session.controller.ts
+++ b/backend/src/worship/controller/worship-session.controller.ts
@@ -34,7 +34,6 @@ import { WorshipReadGuard } from '../guard/worship-read.guard';
 import { WorshipWriteGuard } from '../guard/worship-write.guard';
 import { GetWorshipSessionDto } from '../dto/request/worship-session/get-worship-session.dto';
 import { GetWorshipSessionStatsDto } from '../dto/request/worship-session/get-worship-session-stats.dto';
-import { WorshipTargetGroupIds } from '../decorator/worship-target-group-ids.decorator';
 import { AccessTokenGuard } from '../../auth/guard/jwt.guard';
 import { createDomainGuard } from '../../permission/guard/generic-domain.guard';
 import { DomainType } from '../../permission/const/domain-type.enum';
@@ -46,9 +45,12 @@ import { RequestChurch } from '../../permission/decorator/request-church.decorat
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { RequestWorship } from '../decorator/request-worship.decorator';
 import { WorshipModel } from '../entity/worship.entity';
-import { PermissionScopeGroups } from '../decorator/permission-scope-groups.decorator';
 import { GetWorshipSessionCheckStatusDto } from '../dto/request/worship-session/get-worship-session-check-status.dto';
 import { ChurchManagerGuard } from '../../permission/guard/church-manager.guard';
+import { DefaultWorshipGroupIds } from '../decorator/default-worship-group-ids.decorator';
+import { WorshipGroupIdsVo } from '../vo/worship-group-ids.vo';
+import { PermissionScopeIds } from '../decorator/permission-scope-ids.decorator';
+import { PermissionScopeIdsVo } from '../../permission/vo/permission-scope-ids.vo';
 
 @ApiTags('Worships:Sessions')
 @Controller(':worshipId/sessions')
@@ -107,14 +109,14 @@ export class WorshipSessionController {
     @Query() dto: GetWorshipSessionCheckStatusDto,
     @RequestChurch() church: ChurchModel,
     @RequestWorship() worship: WorshipModel,
-    @WorshipTargetGroupIds() defaultTargetGroupIds: number[],
-    @PermissionScopeGroups() permissionScopeGroupIds: number[],
+    @DefaultWorshipGroupIds() defaultWorshipGroupIds: WorshipGroupIdsVo,
+    @PermissionScopeIds() permissionScope: PermissionScopeIdsVo,
   ) {
     return this.worshipSessionService.getSessionCheckStatus(
       church,
       worship,
-      defaultTargetGroupIds,
-      permissionScopeGroupIds,
+      defaultWorshipGroupIds,
+      permissionScope,
       dto,
     );
   }
@@ -136,16 +138,16 @@ export class WorshipSessionController {
     @RequestChurch() church: ChurchModel,
     @RequestWorship() worship: WorshipModel,
     @Param('sessionId', ParseIntPipe) sessionId: number,
-    @WorshipTargetGroupIds() defaultWorshipTargetGroupIds: number[],
-    @PermissionScopeGroups() permissionScopeGroupIds: number[],
+    @DefaultWorshipGroupIds() defaultWorshipGroupIds: WorshipGroupIdsVo,
+    @PermissionScopeIds() permissionScope: PermissionScopeIdsVo,
     @Query() dto: GetWorshipSessionStatsDto,
   ) {
     return this.worshipSessionService.getWorshipSessionStatistics(
       church,
       worship,
       sessionId,
-      defaultWorshipTargetGroupIds,
-      permissionScopeGroupIds,
+      defaultWorshipGroupIds,
+      permissionScope,
       dto,
     );
   }

--- a/backend/src/worship/controller/worship.controller.ts
+++ b/backend/src/worship/controller/worship.controller.ts
@@ -34,7 +34,6 @@ import { WorshipGroupFilterGuard } from '../guard/worship-group-filter.guard';
 import { WorshipScopeGuard } from '../guard/worship-scope.guard';
 import { RequestWorship } from '../decorator/request-worship.decorator';
 import { WorshipModel } from '../entity/worship.entity';
-import { WorshipTargetGroupIds } from '../decorator/worship-target-group-ids.decorator';
 import {
   ApiDeleteWorship,
   ApiGetWorshipById,
@@ -44,7 +43,10 @@ import {
   ApiPostWorship,
   ApiRefreshWorshipCount,
 } from '../swagger/worship.swagger';
-import { PermissionScopeGroups } from '../decorator/permission-scope-groups.decorator';
+import { DefaultWorshipGroupIds } from '../decorator/default-worship-group-ids.decorator';
+import { WorshipGroupIdsVo } from '../vo/worship-group-ids.vo';
+import { PermissionScopeIds } from '../decorator/permission-scope-ids.decorator';
+import { PermissionScopeIdsVo } from '../../permission/vo/permission-scope-ids.vo';
 
 @ApiTags('Worships')
 @Controller()
@@ -142,15 +144,15 @@ export class WorshipController {
     @Param('worshipId', ParseIntPipe) worshipId: number,
     @RequestChurch() church: ChurchModel,
     @RequestWorship() worship: WorshipModel,
-    @WorshipTargetGroupIds() defaultTargetGroupIds: number[],
-    @PermissionScopeGroups() permissionScopeGroupIds: number[],
+    @DefaultWorshipGroupIds() defaultWorshipGroupIds: WorshipGroupIdsVo,
+    @PermissionScopeIds() permissionScopeIds: PermissionScopeIdsVo,
     @Query() dto: GetWorshipStatsDto,
   ) {
     return this.worshipService.getWorshipStatistics(
       church,
       worship,
-      defaultTargetGroupIds,
-      permissionScopeGroupIds,
+      defaultWorshipGroupIds,
+      permissionScopeIds,
       dto,
     );
   }

--- a/backend/src/worship/decorator/default-worship-group-ids.decorator.ts
+++ b/backend/src/worship/decorator/default-worship-group-ids.decorator.ts
@@ -1,0 +1,18 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { CustomRequest } from '../../common/custom-request';
+
+export const DefaultWorshipGroupIds = createParamDecorator(
+  (_, ctx: ExecutionContext) => {
+    const req: CustomRequest = ctx.switchToHttp().getRequest();
+
+    if (req.worshipGroupIds) {
+      return req.worshipGroupIds;
+    }
+
+    throw new InternalServerErrorException('예배 대상 그룹 처리 누락');
+  },
+);

--- a/backend/src/worship/decorator/permission-scope-ids.decorator.ts
+++ b/backend/src/worship/decorator/permission-scope-ids.decorator.ts
@@ -1,0 +1,18 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { CustomRequest } from '../../common/custom-request';
+
+export const PermissionScopeIds = createParamDecorator(
+  (_, ctx: ExecutionContext) => {
+    const req: CustomRequest = ctx.switchToHttp().getRequest();
+
+    if (req.permissionScopeIds) {
+      return req.permissionScopeIds;
+    }
+
+    throw new InternalServerErrorException('관리자 권한범위 처리 누락');
+  },
+);

--- a/backend/src/worship/dto/request/worship-attendance/get-worship-attendance-list.dto.ts
+++ b/backend/src/worship/dto/request/worship-attendance/get-worship-attendance-list.dto.ts
@@ -1,7 +1,8 @@
 import { BaseCursorPaginationRequestDto } from '../../../../common/dto/request/base-cursor-pagination-request.dto';
 import { WorshipAttendanceSortColumn } from '../../../const/worship-attendance-sort-column.enum';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsEnum, IsNumber, IsOptional, Min } from 'class-validator';
+import { IsEnum, IsOptional } from 'class-validator';
+import { Transform } from 'class-transformer';
 
 export class GetWorshipAttendanceListDto extends BaseCursorPaginationRequestDto<WorshipAttendanceSortColumn> {
   @ApiPropertyOptional({
@@ -15,10 +16,9 @@ export class GetWorshipAttendanceListDto extends BaseCursorPaginationRequestDto<
 
   @ApiPropertyOptional({
     description: '조회할 그룹 ID',
-    minimum: 1,
+    type: 'string',
   })
   @IsOptional()
-  @IsNumber()
-  @Min(1)
+  @Transform(({ value }) => +value)
   groupId?: number;
 }

--- a/backend/src/worship/dto/request/worship-enrollment/get-worship-enrollments.dto.ts
+++ b/backend/src/worship/dto/request/worship-enrollment/get-worship-enrollments.dto.ts
@@ -1,11 +1,12 @@
 import { BaseOffsetPaginationRequestDto } from '../../../../common/dto/request/base-offset-pagination-request.dto';
 import { WorshipEnrollmentOrderEnum } from '../../../const/worship-enrollment-order.enum';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDateString, IsEnum, IsNumber } from 'class-validator';
+import { IsDateString, IsEnum, IsOptional } from 'class-validator';
 import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
 import { fromZonedTime } from 'date-fns-tz';
 import { TIME_ZONE } from '../../../../common/const/time-zone.const';
 import { IsYYYYMMDD } from '../../../../common/decorator/validator/is-yyyy-mm-dd.validator';
+import { Transform } from 'class-transformer';
 
 export class GetWorshipEnrollmentsDto extends BaseOffsetPaginationRequestDto<WorshipEnrollmentOrderEnum> {
   @ApiProperty({
@@ -20,10 +21,11 @@ export class GetWorshipEnrollmentsDto extends BaseOffsetPaginationRequestDto<Wor
   @ApiProperty({
     description: '교인 그룹',
     required: false,
+    type: 'string',
   })
-  @IsOptionalNotNull()
-  @IsNumber()
-  groupId: number;
+  @IsOptional()
+  @Transform(({ value }) => +value)
+  groupId?: number;
 
   @ApiProperty({
     description: '불러올 예배 세션 시작 날짜 (YYYY-MM-DD)',

--- a/backend/src/worship/dto/request/worship-session/get-worship-session-check-status.dto.ts
+++ b/backend/src/worship/dto/request/worship-session/get-worship-session-check-status.dto.ts
@@ -1,16 +1,18 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsOptionalNotNull } from '../../../../common/decorator/validator/is-optional-not.null.validator';
-import { IsDateString, IsNumber } from 'class-validator';
+import { IsDateString, IsOptional } from 'class-validator';
 import { IsYYYYMMDD } from '../../../../common/decorator/validator/is-yyyy-mm-dd.validator';
+import { Transform } from 'class-transformer';
 
 export class GetWorshipSessionCheckStatusDto {
   @ApiProperty({
     description: '교인 그룹',
     required: false,
+    type: 'string',
   })
-  @IsOptionalNotNull()
-  @IsNumber()
-  groupId: number;
+  @IsOptional()
+  @Transform(({ value }) => +value)
+  groupId?: number;
 
   @ApiProperty({
     description: '불러올 예배 세션 시작 날짜 (YYYY-MM-DD)',

--- a/backend/src/worship/dto/request/worship-session/get-worship-session-stats.dto.ts
+++ b/backend/src/worship/dto/request/worship-session/get-worship-session-stats.dto.ts
@@ -1,9 +1,10 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsNumber, IsOptional } from 'class-validator';
+import { IsOptional } from 'class-validator';
+import { Transform } from 'class-transformer';
 
 export class GetWorshipSessionStatsDto {
-  @ApiPropertyOptional({ description: '조회할 그룹' })
+  @ApiPropertyOptional({ description: '조회할 그룹', type: 'string' })
   @IsOptional()
-  @IsNumber()
+  @Transform(({ value }) => +value)
   groupId?: number;
 }

--- a/backend/src/worship/dto/request/worship/get-worship-stats.dto.ts
+++ b/backend/src/worship/dto/request/worship/get-worship-stats.dto.ts
@@ -1,7 +1,8 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsDateString, IsNumber, IsOptional } from 'class-validator';
+import { IsDateString, IsOptional } from 'class-validator';
 import { IsYYYYMMDD } from '../../../../common/decorator/validator/is-yyyy-mm-dd.validator';
 import { IsAfterDate } from '../../../../common/decorator/validator/is-after-date.decorator';
+import { Transform } from 'class-transformer';
 
 export class GetWorshipStatsDto {
   @ApiProperty({ description: '출석률 집계 시작' })
@@ -19,8 +20,8 @@ export class GetWorshipStatsDto {
 
   utcTo: Date;
 
-  @ApiPropertyOptional({ description: '조회할 그룹' })
+  @ApiPropertyOptional({ description: '조회할 그룹', type: 'string' })
   @IsOptional()
-  @IsNumber()
+  @Transform(({ value }) => +value)
   groupId?: number;
 }

--- a/backend/src/worship/dto/response/worship-session/get-worship-session-check-status-response.dto.ts
+++ b/backend/src/worship/dto/response/worship-session/get-worship-session-check-status-response.dto.ts
@@ -1,0 +1,10 @@
+export class GetWorshipSessionCheckStatusResponseDto {
+  constructor(
+    public readonly data: {
+      id: number;
+      sessionDate: Date;
+      completeAttendanceCheck: boolean;
+    }[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/worship/service/worship.service.ts
+++ b/backend/src/worship/service/worship.service.ts
@@ -46,13 +46,15 @@ import {
   IWorshipAttendanceDomainService,
 } from '../worship-domain/interface/worship-attendance-domain.service.interface';
 import { GetWorshipStatsResponseDto } from '../dto/response/worship/get-worship-stats-response.dto';
-import { getIntersectionGroupIds } from '../utils/worship-utils';
+import { getIntersection } from '../utils/worship-utils';
 import { GetWorshipStatsDto } from '../dto/request/worship/get-worship-stats.dto';
 import { TIME_ZONE } from '../../common/const/time-zone.const';
 import {
   getFromDate,
   getToDate,
 } from '../../member-history/history-date.utils';
+import { WorshipGroupIdsVo } from '../vo/worship-group-ids.vo';
+import { PermissionScopeIdsVo } from '../../permission/vo/permission-scope-ids.vo';
 
 @Injectable()
 export class WorshipService {
@@ -313,22 +315,27 @@ export class WorshipService {
   async getWorshipStatistics(
     church: ChurchModel,
     worship: WorshipModel,
-    defaultWorshipTargetGroupIds: number[],
-    permissionScopeGroupIds: number[],
+    defaultWorshipGroupIds: WorshipGroupIdsVo,
+    permissionScopeIds: PermissionScopeIdsVo,
+    //defaultWorshipTargetGroupIds: number[],
+    //permissionScopeGroupIds: number[],
     dto: GetWorshipStatsDto,
   ) {
     const requestGroupIds = await this.getRequestGroupIds(
       church,
-      defaultWorshipTargetGroupIds,
+      defaultWorshipGroupIds,
       dto.groupId,
     );
 
-    const intersectionGroupIds = getIntersectionGroupIds(
+    const intersectionGroupIds = getIntersection(
       requestGroupIds,
-      permissionScopeGroupIds,
+      permissionScopeIds,
     );
 
-    if (intersectionGroupIds.length === 0) {
+    if (
+      intersectionGroupIds.groupIds.length === 0 &&
+      !permissionScopeIds.isAllGroups
+    ) {
       return new GetWorshipStatsResponseDto(worship.id, 0, {
         overall: 0,
         period: 0,
@@ -342,7 +349,6 @@ export class WorshipService {
       // 전체 기간 출석률
       this.worshipAttendanceDomainService.getOverallAttendanceStats(
         worship,
-        //requestGroupIds,
         intersectionGroupIds,
       ),
       // 선택기간 출석률
@@ -366,19 +372,21 @@ export class WorshipService {
 
   private async getRequestGroupIds(
     church: ChurchModel,
-    defaultTargetGroupIds: number[],
+    defaultTargetGroupIds: WorshipGroupIdsVo, //number[],
     groupId?: number,
   ) {
     // 조회 대상 groupId 가 있는 경우
     if (groupId) {
-      return (
+      const groupIds = (
         await this.groupsDomainService.findGroupAndDescendantsByIds(church, [
           groupId,
         ])
       ).map((group) => group.id);
+
+      return new WorshipGroupIdsVo(groupIds, false);
+    } else if (Number.isNaN(groupId)) {
+      return new WorshipGroupIdsVo([], false);
     } else {
-      // 조회 대상 groupId 가 없을 경우
-      // 예배 대상 그룹
       return defaultTargetGroupIds;
     }
   }

--- a/backend/src/worship/swagger/worship-enrollment.swagger.ts
+++ b/backend/src/worship/swagger/worship-enrollment.swagger.ts
@@ -1,0 +1,21 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+export const ApiGetWorshipEnrollments = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '예배 등록(+출석) 목록 조회',
+      description:
+        '<h2>예배 등록 정보와 기간 내 출석 정보 목록을 조회합니다.</h2>' +
+        '<h3>교인 그룹</h3>' +
+        '<p><b>값이 없을 경우:</b></p>' +
+        '<p>예배 대상 그룹과 요청자의 권한 범위의 교집합</p>' +
+        '<p><b>값이 있을 경우:</b></p>' +
+        '<p>예배 대상 그룹과 요청자의 권한 범위의 교집합</p>' +
+        '<p>권한 범위 외의 그룹 요청 불가능</p>' +
+        '<p><b>null 값을 넣을 경우:</b></p>' +
+        '<p>예배 대상 그룹이 전체일 경우 그룹이 없는 교인들만 조회</p>' +
+        '<p>예배 대상 그룹이 있을 경우 "예배 대상 그룹이 아닙니다." ForbiddenException</p>' +
+        '<p>요청자의 권한 범위가 전체가 아닐 경우 "권한 범위 밖의 요청입니다." ForbiddenException</p>',
+    }),
+  );

--- a/backend/src/worship/utils/worship-utils.ts
+++ b/backend/src/worship/utils/worship-utils.ts
@@ -2,6 +2,9 @@ import { WorshipModel } from '../entity/worship.entity';
 import { TIME_ZONE } from '../../common/const/time-zone.const';
 import { fromZonedTime, toZonedTime } from 'date-fns-tz';
 import { getDay, startOfDay, subDays } from 'date-fns';
+import { WorshipGroupIdsVo } from '../vo/worship-group-ids.vo';
+import { PermissionScopeIdsVo } from '../../permission/vo/permission-scope-ids.vo';
+import { ForbiddenException } from '@nestjs/common';
 
 export function getRecentSessionDate(
   worship: WorshipModel,
@@ -24,31 +27,45 @@ export function getRecentSessionDate(
   return fromZonedTime(lastWorshipDateKst, timeZone);
 }
 
-/**
- *
- * @param defaultWorshipTargetGroupIds
- * @param permissionScopeGroupIds
- */
-export function getIntersectionGroupIds(
-  defaultWorshipTargetGroupIds: number[],
-  permissionScopeGroupIds: number[],
+export function getIntersection(
+  worshipGroupIds: WorshipGroupIdsVo,
+  permissionScope: PermissionScopeIdsVo,
 ) {
-  if (!defaultWorshipTargetGroupIds) {
-    // 요청 그룹이 없고, 예배 대상이 전체인 경우
-    // 요청자의 권한 범위 전체 --> number[] | undefined
-    return permissionScopeGroupIds;
+  /**
+   * WorshipGroupIds
+   * case 1. groupIds: [1, 2, 3], isAllGroups: false --> 전체 대상 예배 + 필터링 O or 일부 대상 예배 + 필터링 X or 일부 대상 예배 + 필터링 O
+   * - 두 객체의 groupIds 의 교집합
+   * case 2. groupIds: [1, 2, 3, 4, 5], isAllGroups: true --> 전체 대상 예배 + 필터링 X
+   * - 요청자 권한 범위로 좁혀야 함.
+   * case 3. groupIds: [], isAllGroups: false --> 그룹없음을 조회 요청
+   * - 요청자에게 전체권한 범위가 있는지 확인
+   */
+
+  // 전체 범위 관리자 --> 요청한대로 조회
+  if (permissionScope.isAllGroups) {
+    return worshipGroupIds;
   }
 
-  // 요청 그룹이 특정된 경우 (요청 그룹이 있거나, 예배 대상이 있는 경우)
-  if (!permissionScopeGroupIds) {
-    // 요청자의 권한 범위가 전체인 경우
-    // 특정 예배 대상 그룹
-    return defaultWorshipTargetGroupIds;
+  // 일부 범위 관리자 검증
+
+  if (worshipGroupIds.isAllGroups) {
+    return new WorshipGroupIdsVo(permissionScope.groupIds, false);
   }
 
-  const targetGroupIdSet = new Set(defaultWorshipTargetGroupIds);
+  // 그룹 없는 교인들 필터링 요청 시 --> 전체 권한
+  if (worshipGroupIds.groupIds.length === 0) {
+    if (!permissionScope.isAllGroups) {
+      throw new ForbiddenException('전체 권한 없음');
+    }
 
-  return permissionScopeGroupIds.filter((scopeGroupId) =>
-    targetGroupIdSet.has(scopeGroupId),
+    return worshipGroupIds;
+  }
+
+  const targetGroupIdSet = new Set(worshipGroupIds.groupIds);
+
+  const allowedGroupIds = permissionScope.groupIds.filter((groupId) =>
+    targetGroupIdSet.has(groupId),
   );
+
+  return new WorshipGroupIdsVo(allowedGroupIds, false);
 }

--- a/backend/src/worship/vo/worship-group-ids.vo.ts
+++ b/backend/src/worship/vo/worship-group-ids.vo.ts
@@ -1,0 +1,6 @@
+export class WorshipGroupIdsVo {
+  constructor(
+    public groupIds: number[],
+    public isAllGroups: boolean = false,
+  ) {}
+}

--- a/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-attendance-domain.service.interface.ts
@@ -10,6 +10,7 @@ import { GetWorshipAttendanceListDto } from '../../dto/request/worship-attendanc
 import { DomainCursorPaginationResultDto } from '../../../common/dto/domain-cursor-pagination-result.dto';
 import { MemberModel } from '../../../members/entity/member.entity';
 import { GetMemberWorshipAttendancesDto } from '../../../members/dto/request/worship/get-member-worship-attendances.dto';
+import { WorshipGroupIdsVo } from '../../vo/worship-group-ids.vo';
 
 export const IWORSHIP_ATTENDANCE_DOMAIN_SERVICE = Symbol(
   'IWORSHIP_ATTENDANCE_DOMAIN_SERVICE',
@@ -19,7 +20,7 @@ export interface IWorshipAttendanceDomainService {
   findAttendanceList(
     session: WorshipSessionModel,
     dto: GetWorshipAttendanceListDto,
-    groupIds: number[] | undefined,
+    groupIds: WorshipGroupIdsVo,
     qr?: QueryRunner,
   ): Promise<DomainCursorPaginationResultDto<WorshipAttendanceModel>>;
 
@@ -83,7 +84,7 @@ export interface IWorshipAttendanceDomainService {
 
   getAttendanceStatsBySession(
     worshipSession: WorshipSessionModel,
-    requestGroupIds: number[] | undefined,
+    requestGroupIds: WorshipGroupIdsVo,
     qr?: QueryRunner,
   ): Promise<{
     presentCount: number;
@@ -93,12 +94,12 @@ export interface IWorshipAttendanceDomainService {
 
   getOverallAttendanceStats(
     worship: WorshipModel,
-    requestGroupIds: number[] | undefined,
+    requestGroupIds: WorshipGroupIdsVo,
   ): Promise<{ overallRate: number; attendanceCheckRate: number }>;
 
   getAttendanceStatsByPeriod(
     worship: WorshipModel,
-    requestGroupIds: number[] | undefined,
+    requestGroupIds: WorshipGroupIdsVo,
     from: Date,
     to: Date | undefined,
   ): Promise<{ rate: number; attendanceCheckRate: number }>;
@@ -118,13 +119,13 @@ export interface IWorshipAttendanceDomainService {
 
   findUnknownAttendances(
     session: WorshipSessionModel,
-    groupIds: number[] | undefined,
+    groupIds: WorshipGroupIdsVo,
     qr: QueryRunner,
   ): Promise<WorshipAttendanceModel[]>;
 
   findAbsentAttendances(
     session: WorshipSessionModel,
-    groupIds: number[] | undefined,
+    groupIds: WorshipGroupIdsVo,
     qr: QueryRunner,
   ): Promise<WorshipAttendanceModel[]>;
 

--- a/backend/src/worship/worship-domain/interface/worship-enrollment-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-enrollment-domain.service.interface.ts
@@ -5,23 +5,17 @@ import { WorshipEnrollmentModel } from '../../entity/worship-enrollment.entity';
 import { GetWorshipEnrollmentsDto } from '../../dto/request/worship-enrollment/get-worship-enrollments.dto';
 import { GetLowWorshipAttendanceMembersDto } from '../../../home/dto/request/get-low-worship-attendance-members.dto';
 import { WorshipAttendanceModel } from '../../entity/worship-attendance.entity';
+import { WorshipGroupIdsVo } from '../../vo/worship-group-ids.vo';
 
 export const IWORSHIP_ENROLLMENT_DOMAIN_SERVICE = Symbol(
   'IWORSHIP_ENROLLMENT_DOMAIN',
 );
 
 export interface IWorshipEnrollmentDomainService {
-  /*findEnrollments(
-    worship: WorshipModel,
-    dto: GetWorshipEnrollmentsDto,
-    groupIds?: number[],
-    qr?: QueryRunner,
-  ): Promise<WorshipEnrollmentDomainPaginationResultDto>;*/
-
   findEnrollmentsByQueryBuilder(
     worship: WorshipModel,
     dto: GetWorshipEnrollmentsDto,
-    groupIds?: number[],
+    groupIds: WorshipGroupIdsVo,
     qr?: QueryRunner,
   ): Promise<WorshipEnrollmentModel[]>;
 

--- a/backend/src/worship/worship-domain/interface/worship-session-domain.service.interface.ts
+++ b/backend/src/worship/worship-domain/interface/worship-session-domain.service.interface.ts
@@ -5,6 +5,7 @@ import { WorshipSessionModel } from '../../entity/worship-session.entity';
 import { GetWorshipSessionsDto } from '../../dto/request/worship-session/get-worship-sessions.dto';
 import { UpdateWorshipSessionDto } from '../../dto/request/worship-session/update-worship-session.dto';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
+import { WorshipGroupIdsVo } from '../../vo/worship-group-ids.vo';
 
 export const IWORSHIP_SESSION_DOMAIN_SERVICE = Symbol(
   'IWORSHIP_SESSION_DOMAIN_SERVICE',
@@ -70,8 +71,10 @@ export interface IWorshipSessionDomainService {
 
   findSessionCheckStatus(
     worship: WorshipModel,
-    intersectionGroupIds: number[] | undefined,
+    intersectionGroupIds: WorshipGroupIdsVo,
     from: Date,
     to: Date,
-  ): Promise<any>;
+  ): Promise<
+    { id: number; sessionDate: Date; completeAttendanceCheck: boolean }[]
+  >;
 }

--- a/backend/src/worship/worship-domain/service/worship-session-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-session-domain.service.ts
@@ -32,6 +32,7 @@ import {
 } from '../../../members/const/member-find-options.const';
 import { session } from 'passport';
 import { AttendanceStatus } from '../../const/attendance-status.enum';
+import { WorshipGroupIdsVo } from '../../vo/worship-group-ids.vo';
 
 @Injectable()
 export class WorshipSessionDomainService
@@ -347,7 +348,7 @@ export class WorshipSessionDomainService
 
   async findSessionCheckStatus(
     worship: WorshipModel,
-    intersectionGroupIds: number[] | undefined,
+    intersectionGroupIds: WorshipGroupIdsVo,
     from: Date,
     to: Date,
   ): Promise<any> {
@@ -367,10 +368,15 @@ export class WorshipSessionDomainService
       ])
       .setParameter('unknown', AttendanceStatus.UNKNOWN);
 
-    if (intersectionGroupIds && intersectionGroupIds.length > 0) {
+    if (
+      intersectionGroupIds.groupIds.length > 0 &&
+      !intersectionGroupIds.isAllGroups
+    ) {
       query.andWhere('member.groupId IN (:...groupIds)', {
-        groupIds: intersectionGroupIds,
+        groupIds: intersectionGroupIds.groupIds,
       });
+    } else if (!intersectionGroupIds.isAllGroups) {
+      query.andWhere('member.groupId IS NULL');
     }
 
     const results = await query


### PR DESCRIPTION
## 주요 내용
- 예배에서 교인그룹을 필터링할 때 `null` 값을 전달하면 **그룹에 속하지 않은 교인들**만 조회하거나 출석 처리할 수 있도록 기능 확장

## 세부 내용
### WorshipEnrollment / WorshipAttendance
- 조회 시 `groupId = null` 조건을 적용하여 미소속 교인만 필터링 가능하도록 수정
- 일괄 출석 처리 시 요청 본문에 `groupId: null` 전달 시 미소속 교인만 대상으로 출석 처리
- 기존 그룹 ID 필터링 동작은 그대로 유지