### PR TITLE
fix: 전체 출석 처리 시 미소속 교인 출석 및 Enrollment 중복 생성 문제 해결

### DIFF
--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -42,7 +42,10 @@ export interface IMembersDomainService {
     query: GetSimpleMemberListDto,
   ): Promise<DomainCursorPaginationResultDto<MemberModel>>;
 
-  findAllMembers(church: ChurchModel, qr?: QueryRunner): Promise<MemberModel[]>;
+  findAllMemberIds(
+    church: ChurchModel,
+    qr?: QueryRunner,
+  ): Promise<MemberModel[]>;
 
   findRecommendLinkMember(
     church: ChurchModel,

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -151,12 +151,15 @@ export class MembersDomainService implements IMembersDomainService {
     return query.getMany();
   }
 
-  async findAllMembers(church: ChurchModel, qr?: QueryRunner) {
+  async findAllMemberIds(church: ChurchModel, qr?: QueryRunner) {
     const repository = this.getMembersRepository(qr);
 
     return repository.find({
       where: {
         churchId: church.id,
+      },
+      select: {
+        id: true,
       },
       order: {
         id: 'asc',

--- a/backend/src/worship/controller/worship-attendance.controller.ts
+++ b/backend/src/worship/controller/worship-attendance.controller.ts
@@ -12,7 +12,7 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { WorshipAttendanceService } from '../service/worship-attendance.service';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { GetWorshipAttendancesDto } from '../dto/request/worship-attendance/get-worship-attendances.dto';
 import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
@@ -53,7 +53,8 @@ export class WorshipAttendanceController {
     private readonly worshipAttendanceService: WorshipAttendanceService,
   ) {}
 
-  @ApiGetWorshipAttendance()
+  //@ApiGetWorshipAttendance()
+  @ApiOperation({ deprecated: true })
   @Get()
   @UseGuards(
     AccessTokenGuard,

--- a/backend/src/worship/dto/request/worship-attendance/update-worship-all-attended.dto.ts
+++ b/backend/src/worship/dto/request/worship-attendance/update-worship-all-attended.dto.ts
@@ -1,10 +1,17 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsNumber, IsOptional, Min } from 'class-validator';
+import { IsOptional } from 'class-validator';
+import { Transform } from 'class-transformer';
 
 export class UpdateWorshipAllAttendedDto {
-  @ApiPropertyOptional({ description: '그룹 ID' })
+  @ApiPropertyOptional({ description: '그룹 ID', type: 'string' })
   @IsOptional()
-  @IsNumber()
-  @Min(1)
+  //@IsNumber()
+  @Transform(({ value }) => {
+    if (value === null) {
+      return NaN;
+    }
+
+    return +value;
+  })
   groupId?: number;
 }

--- a/backend/src/worship/guard/worship-group-filter.guard.ts
+++ b/backend/src/worship/guard/worship-group-filter.guard.ts
@@ -85,18 +85,31 @@ export class WorshipGroupFilterGuard implements CanActivate {
     if (req.query.groupId) {
       // 쿼리 파라미터
       requestGroupId = +(req.query.groupId as string); // number | NaN
-    } else if (req.body.groupId) {
-      // 요청 본문
-      requestGroupId = +(req.body.groupId as string); // number | NaN
+
+      if (Number.isNaN(requestGroupId)) {
+        if (req.query.groupId !== 'null') {
+          throw new BadRequestException();
+        }
+      }
+    } else if (req.body.groupId !== undefined) {
+      const value = req.body.groupId;
+
+      if (value === null) {
+        // 요청 본문에 null 을 넣은 경우
+        requestGroupId = NaN;
+      } else {
+        // 요청 본문에 숫자 or "null" 을 넣은 경우
+        requestGroupId = +(req.body.groupId as string); // number | NaN
+
+        if (Number.isNaN(requestGroupId)) {
+          if (value !== 'null') {
+            throw new BadRequestException();
+          }
+        }
+      }
     } else {
       // 필터링 없을 때
       requestGroupId = undefined;
-    }
-
-    if (Number.isNaN(requestGroupId)) {
-      if (req.query.groupId !== 'null') {
-        throw new BadRequestException();
-      }
     }
 
     const rootTargetGroupIds = worship.worshipTargetGroups.map(

--- a/backend/src/worship/service/worship-enrollment.service.ts
+++ b/backend/src/worship/service/worship-enrollment.service.ts
@@ -160,7 +160,8 @@ export class WorshipEnrollmentService {
       qr,
     );
 
-    const allMembers = await this.membersDomainService.findAllMembers(
+    // MemberModel 의 ID 만
+    const allMembers = await this.membersDomainService.findAllMemberIds(
       church,
       qr,
     );

--- a/backend/src/worship/service/worship.service.ts
+++ b/backend/src/worship/service/worship.service.ts
@@ -134,7 +134,7 @@ export class WorshipService {
       qr,
     );
 
-    const allMembers = await this.membersDomainService.findAllMembers(
+    const allMembers = await this.membersDomainService.findAllMemberIds(
       church,
       qr,
     );

--- a/backend/src/worship/worship-domain/service/worship-enrollment-domain.service.ts
+++ b/backend/src/worship/worship-domain/service/worship-enrollment-domain.service.ts
@@ -145,6 +145,7 @@ export class WorshipEnrollmentDomainService
       },
       select: {
         id: true,
+        memberId: true,
       },
     });
   }


### PR DESCRIPTION
## 주요 내용
- **미소속 교인 출석 처리 오류 수정**
  - 전체 출석 처리에서 `groupId = null` 전달 시 미소속 교인들의 출석이 정상적으로 처리되지 않던 문제 해결
- **Enrollment 중복 생성 문제 해결**
  - WorshipEnrollment 생성 로직에서 이미 Enrollment가 존재하는 교인에 대해 중복으로 생성되던 문제 수정

## 세부 내용
### WorshipAttendanceService
- `groupId = null` 조건 처리 로직 보완 → 미소속 교인들의 출석 상태가 올바르게 반영되도록 수정
- WorshipEnrollment 생성 시 기존 Enrollment 존재 여부를 확인하여 중복 생성 방지