### PR TITLE
feat: 관리자 권한 변경 시 캐시 만료 처리 및 교회 중복 조회 로직 제거

### DIFF
--- a/backend/src/church-join/church-join-domain/interface/church-join-requests-domain.service.interface.ts
+++ b/backend/src/church-join/church-join-domain/interface/church-join-requests-domain.service.interface.ts
@@ -4,7 +4,6 @@ import { QueryRunner, UpdateResult } from 'typeorm';
 import { ChurchJoinModel } from '../../entity/church-join.entity';
 import { ChurchJoinRequestStatusEnum } from '../../const/church-join-request-status.enum';
 import { GetJoinRequestDto } from '../../dto/request/get-join-request.dto';
-import { ChurchJoinDomainPaginationResultDto } from '../dto/church-join-domain-pagination-result.dto';
 
 export const ICHURCH_JOIN_REQUESTS_DOMAIN_SERVICE = Symbol(
   'ICHURCH_JOIN_REQUESTS_DOMAIN_SERVICE',
@@ -26,7 +25,7 @@ export interface IChurchJoinRequestDomainService {
     church: ChurchModel,
     dto: GetJoinRequestDto,
     qr?: QueryRunner,
-  ): Promise<ChurchJoinDomainPaginationResultDto>;
+  ): Promise<ChurchJoinModel[]>;
 
   findChurchJoinRequestById(
     church: ChurchModel,

--- a/backend/src/church-join/church-join-domain/service/church-join-requests-domain.service.ts
+++ b/backend/src/church-join/church-join-domain/service/church-join-requests-domain.service.ts
@@ -21,7 +21,6 @@ import { UserModel } from '../../../user/entity/user.entity';
 import { ChurchJoinRequestStatusEnum } from '../../const/church-join-request-status.enum';
 import { GetJoinRequestDto } from '../../dto/request/get-join-request.dto';
 import { ChurchJoinException } from '../../exception/church-join.exception';
-import { ChurchJoinDomainPaginationResultDto } from '../dto/church-join-domain-pagination-result.dto';
 
 @Injectable()
 export class ChurchJoinRequestsDomainService
@@ -88,10 +87,32 @@ export class ChurchJoinRequestsDomainService
     church: ChurchModel,
     dto: GetJoinRequestDto,
     qr?: QueryRunner,
-  ): Promise<{ data: ChurchJoinModel[]; totalCount: number }> {
+  ): Promise<ChurchJoinModel[]> {
     const repository = this.getRepository(qr);
 
-    const [data, totalCount] = await Promise.all([
+    return repository.find({
+      where: {
+        churchId: church.id,
+        createdAt: this.parseCreatedAt(dto),
+        status: dto.status && In(dto.status),
+      },
+      relations: {
+        user: true,
+      },
+      select: {
+        user: {
+          name: true,
+          mobilePhone: true,
+        },
+      },
+      order: {
+        [dto.order]: dto.orderDirection,
+      },
+      take: dto.take,
+      skip: dto.take * (dto.page - 1),
+    });
+
+    /*const [data, totalCount] = await Promise.all([
       repository.find({
         where: {
           churchId: church.id,
@@ -122,7 +143,7 @@ export class ChurchJoinRequestsDomainService
       }),
     ]);
 
-    return new ChurchJoinDomainPaginationResultDto(data, totalCount);
+    return new ChurchJoinDomainPaginationResultDto(data, totalCount);*/
   }
 
   async findChurchJoinRequestById(

--- a/backend/src/church-join/dto/response/join-request-pagination-result.dto.ts
+++ b/backend/src/church-join/dto/response/join-request-pagination-result.dto.ts
@@ -1,14 +1,8 @@
-import { BaseOffsetPaginationResponseDto } from '../../../common/dto/reponse/base-offset-pagination-response.dto';
 import { ChurchJoinModel } from '../../entity/church-join.entity';
 
-export class JoinRequestPaginationResult extends BaseOffsetPaginationResponseDto<ChurchJoinModel> {
+export class JoinRequestPaginationResult {
   constructor(
     public readonly data: ChurchJoinModel[],
-    public readonly totalCount: number,
-    public readonly count: number,
-    public readonly page: number,
-    public readonly totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/church-join/service/church-join.service.ts
+++ b/backend/src/church-join/service/church-join.service.ts
@@ -42,6 +42,7 @@ import { ChurchJoinException } from '../exception/church-join.exception';
 import { PostJoinRequestResponseDto } from '../dto/response/post-join-request-response.dto';
 import { MemberException } from '../../members/exception/member.exception';
 import { ChurchModel } from '../../churches/entity/church.entity';
+import { DeleteJoinRequestResponseDto } from '../dto/response/delete-join-request-response.dto';
 
 @Injectable()
 export class ChurchJoinService {
@@ -102,19 +103,19 @@ export class ChurchJoinService {
   }
 
   async getChurchJoinRequests(church: ChurchModel, dto: GetJoinRequestDto) {
-    const { data, totalCount } =
+    /*const { data, totalCount } =
+      await this.churchJoinRequestsDomainService.findChurchJoinRequests(
+        church,
+        dto,
+      );*/
+
+    const data =
       await this.churchJoinRequestsDomainService.findChurchJoinRequests(
         church,
         dto,
       );
 
-    return new JoinRequestPaginationResult(
-      data,
-      totalCount,
-      data.length,
-      dto.page,
-      Math.ceil(totalCount / dto.take),
-    );
+    return new JoinRequestPaginationResult(data);
   }
 
   async approveChurchJoinRequest(
@@ -227,7 +228,7 @@ export class ChurchJoinService {
       qr,
     );
 
-    return `ChurchJoinRequest id: ${joinId} deleted`;
+    return new DeleteJoinRequestResponseDto(new Date(), joinRequest.id, true);
   }
 
   getTopRequestUsers() {

--- a/backend/src/church-user/church-user-domain/service/church-user-domain.service.ts
+++ b/backend/src/church-user/church-user-domain/service/church-user-domain.service.ts
@@ -26,7 +26,6 @@ import {
   MemberSummarizedRelation,
   MemberSummarizedSelect,
 } from '../../../members/const/member-find-options.const';
-import { ChurchUserDomainPaginationResultDto } from '../dto/church-user-domain-pagination-result.dto';
 import { GetChurchUsersDto } from '../../dto/request/get-church-users.dto';
 import { ChurchUserOrder } from '../../const/church-user-order.enum';
 import { ChurchUserException } from '../../exception/church-user.exception';
@@ -189,7 +188,31 @@ export class ChurchUserDomainService implements IChurchUserDomainService {
       order.createdAt = 'asc';
     }
 
-    const [data, totalCount] = await Promise.all([
+    return repository.find({
+      where: {
+        churchId: church.id,
+        leftAt: IsNull(),
+        role: dto.role ? dto.role : undefined,
+        member: {
+          name: dto.name && ILike(`%${dto.name}%`),
+        },
+      },
+      order,
+      relations: {
+        member: MemberSummarizedRelation,
+        user: true,
+      },
+      select: {
+        member: MemberSummarizedSelect,
+        user: {
+          id: true,
+          name: true,
+          mobilePhone: true,
+        },
+      },
+    });
+
+    /*const [data, totalCount] = await Promise.all([
       repository.find({
         where: {
           churchId: church.id,
@@ -225,7 +248,7 @@ export class ChurchUserDomainService implements IChurchUserDomainService {
       }),
     ]);
 
-    return new ChurchUserDomainPaginationResultDto(data, totalCount);
+    return new ChurchUserDomainPaginationResultDto(data, totalCount);*/
   }
 
   async findChurchUserByUser(

--- a/backend/src/church-user/church-user-domain/service/interface/church-user-domain.service.interface.ts
+++ b/backend/src/church-user/church-user-domain/service/interface/church-user-domain.service.interface.ts
@@ -5,7 +5,6 @@ import { GetChurchUsersDto } from '../../../dto/request/get-church-users.dto';
 import { MemberModel } from '../../../../members/entity/member.entity';
 import { ChurchUserRole } from '../../../../user/const/user-role.enum';
 import { ChurchUserModel } from '../../../entity/church-user.entity';
-import { ChurchUserDomainPaginationResultDto } from '../../dto/church-user-domain-pagination-result.dto';
 
 export const ICHURCH_USER_DOMAIN_SERVICE = Symbol(
   'ICHURCH_USER_DOMAIN_SERVICE',
@@ -43,7 +42,7 @@ export interface IChurchUserDomainService {
     church: ChurchModel,
     dto: GetChurchUsersDto,
     qr?: QueryRunner,
-  ): Promise<ChurchUserDomainPaginationResultDto>;
+  ): Promise<ChurchUserModel[]>;
 
   findChurchUserById(
     church: ChurchModel,

--- a/backend/src/church-user/controller/church-user.controller.ts
+++ b/backend/src/church-user/controller/church-user.controller.ts
@@ -1,18 +1,15 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Get,
-  GoneException,
   Param,
   ParseIntPipe,
   Patch,
   Query,
 } from '@nestjs/common';
 import { ChurchUserService } from '../service/church-user.service';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { GetChurchUsersDto } from '../dto/request/get-church-users.dto';
-import { UpdateChurchUserRoleDto } from '../dto/request/update-church-user-role.dto';
 import { ChurchUserReadGuard } from '../guard/church-user-read.guard';
 import { ChurchUserWriteGuard } from '../guard/church-user-write.guard';
 import { RequestChurch } from '../../permission/decorator/request-church.decorator';
@@ -21,53 +18,53 @@ import { LinkMemberDto } from '../dto/request/link-member.dto';
 import { UseTransaction } from '../../common/decorator/use-transaction.decorator';
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm';
+import {
+  ApiChangeMember,
+  ApiGetChurchUserById,
+  ApiGetChurchUsers,
+  ApiLeaveChurch,
+} from '../swagger/church-user.swagger';
 
 @ApiTags('Churches:Church-Users')
 @Controller('church-users')
 export class ChurchUserController {
   constructor(private readonly churchUserService: ChurchUserService) {}
 
-  @ApiOperation({
-    summary: '교회 가입 계정(교인) 조회',
-  })
+  @ApiGetChurchUsers()
   @Get()
   @ChurchUserReadGuard()
   getChurchUsers(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Query() dto: GetChurchUsersDto,
   ) {
-    return this.churchUserService.getChurchUsers(churchId, dto);
+    return this.churchUserService.getChurchUsers(church, dto);
   }
 
-  @ApiOperation({
-    summary: '교회 가입 계정(교인) 단건 조회',
-  })
+  @ApiGetChurchUserById()
   @Get(':churchUserId')
   @ChurchUserReadGuard()
   getChurchUserById(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('churchUserId', ParseIntPipe) churchUserId: number,
+    @RequestChurch() church: ChurchModel,
   ) {
-    return this.churchUserService.getChurchUserById(churchId, churchUserId);
+    return this.churchUserService.getChurchUserById(church, churchUserId);
   }
 
-  @ApiOperation({
-    summary: '계정 - 교인 연결 수정',
-  })
+  @ApiChangeMember()
   @Patch(':churchUserId/change-member')
   @ChurchUserWriteGuard()
   changeMember(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('churchUserId', ParseIntPipe) churchUserId: number,
-    @Body() dto: LinkMemberDto,
     @RequestChurch() church: ChurchModel,
+    @Body() dto: LinkMemberDto,
   ) {
     return this.churchUserService.changeMemberLink(church, churchUserId, dto);
   }
 
-  @ApiOperation({
-    summary: '교회 계정 가입 취소',
-  })
+  @ApiLeaveChurch()
   @Patch(':churchUserId/leave-church')
   @UseTransaction()
   @ChurchUserWriteGuard()
@@ -80,7 +77,7 @@ export class ChurchUserController {
     return this.churchUserService.leaveChurchUser(church, churchUserId, qr);
   }
 
-  @ApiOperation({
+  /*@ApiOperation({
     deprecated: true,
     summary: '교회 가입 교인의 role 변경',
     description:
@@ -96,11 +93,9 @@ export class ChurchUserController {
     @Body() dto: UpdateChurchUserRoleDto,
   ) {
     throw new BadRequestException('현재 개발 범위 외의 기능');
+  }*/
 
-    //return this.churchUserService.patchChurchUserRole(churchId, userId, dto);
-  }
-
-  @ApiOperation({
+  /*@ApiOperation({
     deprecated: true,
     summary: '계정 - 교인 정보 연결',
   })
@@ -113,10 +108,9 @@ export class ChurchUserController {
     @RequestChurch() church: ChurchModel,
   ) {
     throw new GoneException('다른 엔드포인트로 대체 됨.');
-    //return this.churchUserService.changeMemberLink(church, churchUserId, dto);
-  }
+  }*/
 
-  @ApiOperation({
+  /*@ApiOperation({
     deprecated: true,
     summary: '계정 - 교인 정보 연결 해제',
   })
@@ -128,6 +122,5 @@ export class ChurchUserController {
     @RequestChurch() church: ChurchModel,
   ) {
     throw new GoneException('다른 엔드포인트로 대체 됨.');
-    //return this.churchUserService.unLinkMember(church, churchUserId);
-  }
+  }*/
 }

--- a/backend/src/church-user/dto/response/church-user-pagination-response.dto.ts
+++ b/backend/src/church-user/dto/response/church-user-pagination-response.dto.ts
@@ -1,14 +1,8 @@
-import { BaseOffsetPaginationResponseDto } from '../../../common/dto/reponse/base-offset-pagination-response.dto';
 import { ChurchUserModel } from '../../entity/church-user.entity';
 
-export class ChurchUserPaginationResponseDto extends BaseOffsetPaginationResponseDto<ChurchUserModel> {
+export class ChurchUserPaginationResponseDto {
   constructor(
-    data: ChurchUserModel[],
-    totalCount: number,
-    count: number,
-    page: number,
-    totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly data: ChurchUserModel[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/church-user/service/church-user.service.ts
+++ b/backend/src/church-user/service/church-user.service.ts
@@ -3,10 +3,6 @@ import {
   ICHURCH_USER_DOMAIN_SERVICE,
   IChurchUserDomainService,
 } from '../church-user-domain/service/interface/church-user-domain.service.interface';
-import {
-  ICHURCHES_DOMAIN_SERVICE,
-  IChurchesDomainService,
-} from '../../churches/churches-domain/interface/churches-domain.service.interface';
 import { QueryRunner } from 'typeorm';
 import { GetChurchUsersDto } from '../dto/request/get-church-users.dto';
 import {
@@ -28,8 +24,6 @@ import { UserRole } from '../../user/const/user-role.enum';
 @Injectable()
 export class ChurchUserService {
   constructor(
-    @Inject(ICHURCHES_DOMAIN_SERVICE)
-    private readonly churchesDomainService: IChurchesDomainService,
     @Inject(IUSER_DOMAIN_SERVICE)
     private readonly userDomainService: IUserDomainService,
 
@@ -39,38 +33,20 @@ export class ChurchUserService {
     private readonly churchUserDomainService: IChurchUserDomainService,
   ) {}
 
-  async getChurchUsers(
-    churchId: number,
-    dto: GetChurchUsersDto,
-    qr?: QueryRunner,
-  ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
+  async getChurchUsers(church: ChurchModel, dto: GetChurchUsersDto) {
+    const data = await this.churchUserDomainService.findChurchUsers(
+      church,
+      dto,
     );
 
-    const { data, totalCount } =
-      await this.churchUserDomainService.findChurchUsers(church, dto);
-
-    return new ChurchUserPaginationResponseDto(
-      data,
-      totalCount,
-      data.length,
-      dto.page,
-      Math.ceil(totalCount / dto.take),
-    );
+    return new ChurchUserPaginationResponseDto(data);
   }
 
   async getChurchUserById(
-    churchId: number,
+    church: ChurchModel,
     churchUserId: number,
     qr?: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
     const churchUser = await this.churchUserDomainService.findChurchUserById(
       church,
       churchUserId,

--- a/backend/src/church-user/swagger/church-user.swagger.ts
+++ b/backend/src/church-user/swagger/church-user.swagger.ts
@@ -1,0 +1,26 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+export const ApiGetChurchUsers = () =>
+  applyDecorators(ApiOperation({ summary: '교회 가입 계정(교인) 조회' }));
+
+export const ApiGetChurchUserById = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교회 가입 계정(교인) 단건 조회',
+    }),
+  );
+
+export const ApiChangeMember = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '계정 - 교인 연결 수정',
+    }),
+  );
+
+export const ApiLeaveChurch = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '교회 계정 가입 취소',
+    }),
+  );

--- a/backend/src/churches/controller/churches.controller.ts
+++ b/backend/src/churches/controller/churches.controller.ts
@@ -158,14 +158,11 @@ export class ChurchesController {
   @UseInterceptors(TransactionInterceptor)
   patchChurchJoinCode(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Body() dto: UpdateChurchJoinCodeDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.churchesService.updateChurchJoinCode(
-      churchId,
-      dto.joinCode,
-      qr,
-    );
+    return this.churchesService.updateChurchJoinCode(church, dto.joinCode, qr);
   }
 
   @ApiOperation({
@@ -176,10 +173,11 @@ export class ChurchesController {
   @UseInterceptors(TransactionInterceptor)
   transferMainAdmin(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Body() dto: TransferOwnerDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.churchesService.transferOwner(churchId, dto, qr);
+    return this.churchesService.transferOwner(church, dto, qr);
   }
 
   @ApiOperation({
@@ -187,7 +185,10 @@ export class ChurchesController {
   })
   @ChurchWriteGuard()
   @Patch(':churchId/refresh-member-count')
-  refreshMemberCount(@Param('churchId', ParseIntPipe) churchId: number) {
-    return this.churchesService.refreshMemberCount(churchId);
+  refreshMemberCount(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
+  ) {
+    return this.churchesService.refreshMemberCount(church);
   }
 }

--- a/backend/src/churches/service/churches.service.ts
+++ b/backend/src/churches/service/churches.service.ts
@@ -88,10 +88,6 @@ export class ChurchesService {
 
     const subscription =
       await this.subscriptionDomainService.findTrialSubscription(ownerUser, qr);
-    /*await this.subscriptionDomainService.findAbleToCreateChurchSubscription(
-        ownerUser,
-        qr,
-      );*/
 
     const newChurch = await this.churchesDomainService.createChurch(
       dto,
@@ -160,18 +156,15 @@ export class ChurchesService {
   }
 
   async updateChurchJoinCode(
-    churchId: number,
+    church: ChurchModel,
     newCode: string,
     qr?: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
     await this.churchesDomainService.updateChurchJoinCode(church, newCode, qr);
 
-    return this.churchesDomainService.findChurchModelById(churchId, qr);
+    church.joinCode = newCode;
+
+    return new PatchChurchResponseDto(church);
   }
 
   // TODO 구독 상태에 따른 교회 삭제 후 처리 로직 필요
@@ -182,13 +175,6 @@ export class ChurchesService {
     user: UserModel,
     qr: QueryRunner,
   ) {
-    /*const church = await this.churchesDomainService.findChurchModelById(
-      id,
-      qr,
-      { subscription: true },
-    );*/
-
-    //const subscription = church.subscription;
     const subscription =
       await this.subscriptionDomainService.findSubscriptionByChurch(church, qr);
 
@@ -204,10 +190,6 @@ export class ChurchesService {
       );
     }
 
-    /*const ownerUser = await this.userDomainService.findUserModelById(
-      church.ownerUserId,
-    );*/
-
     await this.userDomainService.updateUserRole(
       //ownerUser,
       user,
@@ -219,15 +201,10 @@ export class ChurchesService {
   }
 
   async transferOwner(
-    churchId: number,
+    church: ChurchModel,
     dto: TransferOwnerDto,
     qr: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
     if (!church.ownerUserId) {
       throw new ConflictException('교회 소유자 누락');
     }
@@ -298,15 +275,10 @@ export class ChurchesService {
       qr,
     );
 
-    return this.churchesDomainService.findChurchById(churchId, qr);
+    return this.churchesDomainService.findChurchById(church.id, qr);
   }
 
-  async refreshMemberCount(churchId: number, qr?: QueryRunner) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
+  async refreshMemberCount(church: ChurchModel, qr?: QueryRunner) {
     const memberCount = await this.membersDomainService.countAllMembers(
       church,
       qr,

--- a/backend/src/educations/education-domain/service/session-attendance-domain.service.ts
+++ b/backend/src/educations/education-domain/service/session-attendance-domain.service.ts
@@ -284,23 +284,21 @@ export class SessionAttendanceDomainService
 
     const sessionAttendanceRepository = this.getSessionAttendanceRepository(qr);
 
-    const [currentSessionAttendances] = await Promise.all([
-      sessionAttendanceRepository.find({
-        where: {
-          educationSession: {
-            educationTermId: educationTerm.id,
-          },
+    const currentSessionAttendances = await sessionAttendanceRepository.find({
+      where: {
+        educationSession: {
+          educationTermId: educationTerm.id,
         },
-        order: {
-          educationEnrollmentId: 'asc',
-          educationSessionId: 'asc',
-        },
-        select: {
-          educationSessionId: true,
-          educationEnrollmentId: true,
-        },
-      }),
-    ]);
+      },
+      order: {
+        educationEnrollmentId: 'asc',
+        educationSessionId: 'asc',
+      },
+      select: {
+        educationSessionId: true,
+        educationEnrollmentId: true,
+      },
+    });
 
     const totalExpectedAttendances =
       educationTerm.educationEnrollments.length *

--- a/backend/src/management/groups/dto/response/group-pagination-response.dto.ts
+++ b/backend/src/management/groups/dto/response/group-pagination-response.dto.ts
@@ -1,14 +1,8 @@
-import { BaseOffsetPaginationResponseDto } from '../../../../common/dto/reponse/base-offset-pagination-response.dto';
 import { GroupModel } from '../../entity/group.entity';
 
-export class GroupPaginationResponseDto extends BaseOffsetPaginationResponseDto<GroupModel> {
+export class GroupPaginationResponseDto {
   constructor(
     public readonly data: GroupModel[],
-    public readonly totalCount: number,
-    public readonly count: number,
-    public readonly page: number,
-    public readonly totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
+++ b/backend/src/management/groups/groups-domain/interface/groups-domain.service.interface.ts
@@ -4,7 +4,6 @@ import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { CreateGroupDto } from '../../dto/request/create-group.dto';
 import { UpdateGroupNameDto } from '../../dto/request/update-group-name.dto';
 import { GetGroupDto } from '../../dto/request/get-group.dto';
-import { GroupDomainPaginationResultDto } from '../dto/group-domain-pagination-result.dto';
 import { UpdateGroupStructureDto } from '../../dto/request/update-group-structure.dto';
 import { MemberModel } from '../../../../members/entity/member.entity';
 
@@ -29,10 +28,7 @@ export interface GroupModelWithParentGroups extends GroupModel {
 export const IGROUPS_DOMAIN_SERVICE = Symbol('IGROUPS_DOMAIN_SERVICE');
 
 export interface IGroupsDomainService {
-  findGroups(
-    church: ChurchModel,
-    dto: GetGroupDto,
-  ): Promise<GroupDomainPaginationResultDto>;
+  findGroups(church: ChurchModel, dto: GetGroupDto): Promise<GroupModel[]>;
 
   findGroupById(
     church: ChurchModel,

--- a/backend/src/management/groups/groups-domain/service/groups-domain.service.ts
+++ b/backend/src/management/groups/groups-domain/service/groups-domain.service.ts
@@ -32,7 +32,6 @@ import { GroupException } from '../../const/exception/group.exception';
 import { GroupDepthConstraint } from '../../../const/group-depth.constraint';
 import { GetGroupDto } from '../../dto/request/get-group.dto';
 import { GroupOrderEnum } from '../../const/group-order.enum';
-import { GroupDomainPaginationResultDto } from '../dto/group-domain-pagination-result.dto';
 import { UpdateGroupStructureDto } from '../../dto/request/update-group-structure.dto';
 import { MemberModel } from '../../../../members/entity/member.entity';
 import { GroupRole } from '../../const/group-role.enum';
@@ -83,7 +82,7 @@ export class GroupsDomainService implements IGroupsDomainService {
   async findGroups(
     church: ChurchModel,
     dto: GetGroupDto,
-  ): Promise<{ data: GroupModel[]; totalCount: number }> {
+  ): Promise<GroupModel[]> {
     const groupsRepository = this.getGroupsRepository();
 
     const order: FindOptionsOrder<GroupModel> = {
@@ -94,7 +93,17 @@ export class GroupsDomainService implements IGroupsDomainService {
       order.createdAt = 'asc';
     }
 
-    const [data, totalCount] = await Promise.all([
+    return groupsRepository.find({
+      where: {
+        churchId: church.id,
+        parentGroupId: dto.parentGroupId === 0 ? IsNull() : dto.parentGroupId,
+      },
+      order,
+      take: dto.take,
+      skip: dto.take * (dto.page - 1),
+    });
+
+    /*const [data, totalCount] = await Promise.all([
       groupsRepository.find({
         where: {
           churchId: church.id,
@@ -112,7 +121,7 @@ export class GroupsDomainService implements IGroupsDomainService {
       }),
     ]);
 
-    return new GroupDomainPaginationResultDto(data, totalCount);
+    return new GroupDomainPaginationResultDto(data, totalCount);*/
   }
 
   async findGroupModelById(

--- a/backend/src/management/groups/service/groups.service.ts
+++ b/backend/src/management/groups/service/groups.service.ts
@@ -74,18 +74,9 @@ export class GroupsService {
   ) {}
 
   async getGroups(church: ChurchModel, dto: GetGroupDto) {
-    const { data, totalCount } = await this.groupsDomainService.findGroups(
-      church,
-      dto,
-    );
+    const data = await this.groupsDomainService.findGroups(church, dto);
 
-    return new GroupPaginationResponseDto(
-      data,
-      totalCount,
-      data.length,
-      dto.page,
-      Math.ceil(totalCount / dto.take),
-    );
+    return new GroupPaginationResponseDto(data);
   }
 
   async getGroupByIdWithParents(

--- a/backend/src/management/ministries/dto/ministry-group/response/ministry-group-pagination-result.dto.ts
+++ b/backend/src/management/ministries/dto/ministry-group/response/ministry-group-pagination-result.dto.ts
@@ -1,14 +1,8 @@
-import { BaseOffsetPaginationResponseDto } from '../../../../../common/dto/reponse/base-offset-pagination-response.dto';
 import { MinistryGroupModel } from '../../../entity/ministry-group.entity';
 
-export class MinistryGroupPaginationResultDto extends BaseOffsetPaginationResponseDto<MinistryGroupModel> {
+export class MinistryGroupPaginationResultDto {
   constructor(
-    data: MinistryGroupModel[],
-    totalCount: number,
-    count: number,
-    page: number,
-    totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly data: MinistryGroupModel[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface.ts
+++ b/backend/src/management/ministries/ministries-domain/interface/ministry-groups-domain.service.interface.ts
@@ -4,7 +4,6 @@ import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { CreateMinistryGroupDto } from '../../dto/ministry-group/request/create-ministry-group.dto';
 import { UpdateMinistryGroupNameDto } from '../../dto/ministry-group/request/update-ministry-group-name.dto';
 import { GetMinistryGroupDto } from '../../dto/ministry-group/request/get-ministry-group.dto';
-import { MinistryGroupDomainPaginationResponseDto } from '../../dto/ministry-group/response/ministry-group-domain-pagination-response.dto';
 import { UpdateMinistryGroupStructureDto } from '../../dto/ministry-group/request/update-ministry-group-structure.dto';
 import { MemberModel } from '../../../../members/entity/member.entity';
 
@@ -29,7 +28,7 @@ export interface IMinistryGroupsDomainService {
     parentMinistryGroup: MinistryGroupModel | null,
     dto: GetMinistryGroupDto,
     qr?: QueryRunner,
-  ): Promise<MinistryGroupDomainPaginationResponseDto>;
+  ): Promise<MinistryGroupModel[]>;
 
   findMinistryGroupModelById(
     church: ChurchModel,

--- a/backend/src/management/ministries/ministries-domain/service/ministry-groups-domain.service.ts
+++ b/backend/src/management/ministries/ministries-domain/service/ministry-groups-domain.service.ts
@@ -28,7 +28,6 @@ import { CreateMinistryGroupDto } from '../../dto/ministry-group/request/create-
 import { UpdateMinistryGroupNameDto } from '../../dto/ministry-group/request/update-ministry-group-name.dto';
 import { GroupDepthConstraint } from '../../../const/group-depth.constraint';
 import { GetMinistryGroupDto } from '../../dto/ministry-group/request/get-ministry-group.dto';
-import { MinistryGroupDomainPaginationResponseDto } from '../../dto/ministry-group/response/ministry-group-domain-pagination-response.dto';
 import { MinistryGroupOrderEnum } from '../../const/ministry-group-order.enum';
 import { UpdateMinistryGroupStructureDto } from '../../dto/ministry-group/request/update-ministry-group-structure.dto';
 import { MemberModel } from '../../../../members/entity/member.entity';
@@ -98,7 +97,19 @@ export class MinistryGroupsDomainService
       order.createdAt = 'asc';
     }
 
-    const [data, totalCount] = await Promise.all([
+    return ministryGroupsRepository.find({
+      where: {
+        churchId: church.id,
+        parentMinistryGroupId: parentMinistryGroup
+          ? parentMinistryGroup.id
+          : IsNull(),
+      },
+      order,
+      take: dto.take,
+      skip: dto.take * (dto.page - 1),
+    });
+
+    /*const [data, totalCount] = await Promise.all([
       ministryGroupsRepository.find({
         where: {
           churchId: church.id,
@@ -117,7 +128,7 @@ export class MinistryGroupsDomainService
       }),
     ]);
 
-    return new MinistryGroupDomainPaginationResponseDto(data, totalCount);
+    return new MinistryGroupDomainPaginationResponseDto(data, totalCount);*/
   }
 
   async findMinistryGroupModelById(

--- a/backend/src/management/ministries/service/ministry-group.service.ts
+++ b/backend/src/management/ministries/service/ministry-group.service.ts
@@ -91,13 +91,7 @@ export class MinistryGroupService {
       dto,
     );
 
-    return new MinistryGroupPaginationResultDto(
-      result.data,
-      result.totalCount,
-      result.data.length,
-      dto.page,
-      Math.ceil(result.totalCount / dto.take),
-    );
+    return new MinistryGroupPaginationResultDto(result);
   }
 
   async getMinistryGroupById(

--- a/backend/src/management/officers/dto/response/officer-pagination-response.dto.ts
+++ b/backend/src/management/officers/dto/response/officer-pagination-response.dto.ts
@@ -1,14 +1,8 @@
 import { OfficerModel } from '../../entity/officer.entity';
-import { BaseOffsetPaginationResponseDto } from '../../../../common/dto/reponse/base-offset-pagination-response.dto';
 
-export class OfficerPaginationResponseDto extends BaseOffsetPaginationResponseDto<OfficerModel> {
+export class OfficerPaginationResponseDto {
   constructor(
     public readonly data: OfficerModel[],
-    public readonly totalCount: number,
-    public readonly count: number,
-    public readonly page: number,
-    public readonly totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/management/officers/officer-domain/interface/officers-domain.service.interface.ts
+++ b/backend/src/management/officers/officer-domain/interface/officers-domain.service.interface.ts
@@ -4,7 +4,6 @@ import { OfficerModel } from '../../entity/officer.entity';
 import { CreateOfficerDto } from '../../dto/request/create-officer.dto';
 import { UpdateOfficerNameDto } from '../../dto/request/update-officer-name.dto';
 import { GetOfficersDto } from '../../dto/request/get-officers.dto';
-import { OfficerDomainPaginationResultDto } from '../../dto/officer-domain-pagination-result.dto';
 
 export const IOFFICERS_DOMAIN_SERVICE = Symbol('IOFFICERS_DOMAIN_SERVICE');
 
@@ -13,7 +12,7 @@ export interface IOfficersDomainService {
     church: ChurchModel,
     dto: GetOfficersDto,
     qr?: QueryRunner,
-  ): Promise<OfficerDomainPaginationResultDto>;
+  ): Promise<OfficerModel[]>;
 
   findOfficerById(
     church: ChurchModel,

--- a/backend/src/management/officers/officer-domain/service/officers-domain.service.ts
+++ b/backend/src/management/officers/officer-domain/service/officers-domain.service.ts
@@ -23,7 +23,6 @@ import { OfficersException } from '../../exception/officers.exception';
 import { CreateOfficerDto } from '../../dto/request/create-officer.dto';
 import { UpdateOfficerNameDto } from '../../dto/request/update-officer-name.dto';
 import { GetOfficersDto } from '../../dto/request/get-officers.dto';
-import { OfficerDomainPaginationResultDto } from '../../dto/officer-domain-pagination-result.dto';
 import { OfficerOrderEnum } from '../../const/officer-order.enum';
 
 @Injectable()
@@ -64,7 +63,15 @@ export class OfficersDomainService implements IOfficersDomainService {
       order.createdAt = 'asc';
     }
 
-    const [data, totalCount] = await Promise.all([
+    return officersRepository.find({
+      where: {
+        churchId: church.id,
+      },
+      order,
+      take: dto.take,
+      skip: dto.take * (dto.page - 1),
+    });
+    /*const [data, totalCount] = await Promise.all([
       officersRepository.find({
         where: {
           churchId: church.id,
@@ -80,7 +87,7 @@ export class OfficersDomainService implements IOfficersDomainService {
       }),
     ]);
 
-    return new OfficerDomainPaginationResultDto(data, totalCount);
+    return new OfficerDomainPaginationResultDto(data, totalCount);*/
   }
 
   async findOfficerById(
@@ -170,7 +177,6 @@ export class OfficersDomainService implements IOfficersDomainService {
     if (existOfficer) {
       throw new ConflictException(OfficersException.ALREADY_EXIST);
     }
-
 
     const [lastOrderOfficer] = await this.officersRepository.find({
       where: {

--- a/backend/src/management/officers/service/officers.service.ts
+++ b/backend/src/management/officers/service/officers.service.ts
@@ -52,19 +52,9 @@ export class OfficersService {
     dto: GetOfficersDto,
     qr?: QueryRunner,
   ) {
-    const { data, totalCount } = await this.officersDomainService.findOfficers(
-      church,
-      dto,
-      qr,
-    );
+    const data = await this.officersDomainService.findOfficers(church, dto, qr);
 
-    return new OfficerPaginationResponseDto(
-      data,
-      totalCount,
-      data.length,
-      dto.page,
-      Math.ceil(totalCount / dto.take),
-    );
+    return new OfficerPaginationResponseDto(data);
   }
 
   async createOfficer(

--- a/backend/src/manager/const/manager-find-options.const.ts
+++ b/backend/src/manager/const/manager-find-options.const.ts
@@ -1,8 +1,8 @@
 import { FindOptionsRelations, FindOptionsSelect } from 'typeorm';
 import { ChurchUserModel } from '../../church-user/entity/church-user.entity';
 import {
+  MemberSimpleSelect,
   MemberSummarizedRelation,
-  MemberSummarizedSelect,
 } from '../../members/const/member-find-options.const';
 
 export const ManagersFindOptionsRelations: FindOptionsRelations<ChurchUserModel> =
@@ -14,11 +14,12 @@ export const ManagersFindOptionsRelations: FindOptionsRelations<ChurchUserModel>
   };
 
 export const ManagersFindOptionsSelect: FindOptionsSelect<ChurchUserModel> = {
-  member: MemberSummarizedSelect,
+  member: MemberSimpleSelect,
   user: {
     id: true,
     name: true,
     mobilePhone: true,
+    role: true,
   },
   permissionTemplate: {
     id: true,
@@ -43,7 +44,7 @@ export const ManagerFindOptionsRelations: FindOptionsRelations<ChurchUserModel> 
   };
 
 export const ManagerFindOptionsSelect: FindOptionsSelect<ChurchUserModel> = {
-  member: MemberSummarizedSelect,
+  member: MemberSimpleSelect,
   user: {
     id: true,
     name: true,

--- a/backend/src/manager/dto/response/manager-pagination-response.dto.ts
+++ b/backend/src/manager/dto/response/manager-pagination-response.dto.ts
@@ -1,14 +1,8 @@
-import { BaseOffsetPaginationResponseDto } from '../../../common/dto/reponse/base-offset-pagination-response.dto';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 
-export class ManagerPaginationResponseDto extends BaseOffsetPaginationResponseDto<ChurchUserModel> {
+export class ManagerPaginationResponseDto {
   constructor(
-    data: ChurchUserModel[],
-    totalCount: number,
-    count: number,
-    page: number,
-    totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly data: ChurchUserModel[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
+++ b/backend/src/manager/manager-domain/service/interface/manager-domain.service.interface.ts
@@ -2,7 +2,6 @@ import { ChurchModel } from '../../../../churches/entity/church.entity';
 import { GetManagersDto } from '../../../dto/request/get-managers.dto';
 import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { PermissionTemplateModel } from '../../../../permission/entity/permission-template.entity';
-import { ManagerDomainPaginationResultDto } from '../../dto/manager-domain-pagination-result.dto';
 import { ChurchUserModel } from '../../../../church-user/entity/church-user.entity';
 import { GetManagersByPermissionTemplateDto } from '../../../../permission/dto/template/request/get-managers-by-permission-template.dto';
 
@@ -13,14 +12,14 @@ export interface IManagerDomainService {
     church: ChurchModel,
     dto: GetManagersDto,
     qr?: QueryRunner,
-  ): Promise<ManagerDomainPaginationResultDto>;
+  ): Promise<ChurchUserModel[]>;
 
   findManagersByPermissionTemplate(
     church: ChurchModel,
     permissionTemplate: PermissionTemplateModel,
     dto: GetManagersByPermissionTemplateDto,
     qr?: QueryRunner,
-  ): Promise<ManagerDomainPaginationResultDto>;
+  ): Promise<ChurchUserModel[]>;
 
   findManagerById(
     church: ChurchModel,

--- a/backend/src/manager/manager-domain/service/manager-domain.service.ts
+++ b/backend/src/manager/manager-domain/service/manager-domain.service.ts
@@ -18,7 +18,6 @@ import {
   ChurchUserManagers,
   ChurchUserRole,
 } from '../../../user/const/user-role.enum';
-import { ManagerDomainPaginationResultDto } from '../dto/manager-domain-pagination-result.dto';
 import { IManagerDomainService } from './interface/manager-domain.service.interface';
 import {
   BadRequestException,
@@ -55,7 +54,7 @@ export class ManagerDomainService implements IManagerDomainService {
     church: ChurchModel,
     dto: GetManagersDto,
     qr?: QueryRunner,
-  ): Promise<ManagerDomainPaginationResultDto> {
+  ): Promise<ChurchUserModel[]> {
     const repository = this.getRepository(qr);
 
     const orderOptions: FindOptionsOrder<ChurchUserModel> = {
@@ -75,7 +74,14 @@ export class ManagerDomainService implements IManagerDomainService {
       },
     };
 
-    const [data, totalCount] = await Promise.all([
+    return repository.find({
+      where: whereOptions,
+      order: orderOptions,
+      relations: ManagersFindOptionsRelations,
+      select: ManagersFindOptionsSelect,
+    });
+
+    /*const [data, totalCount] = await Promise.all([
       repository.find({
         where: whereOptions,
         order: orderOptions,
@@ -87,7 +93,7 @@ export class ManagerDomainService implements IManagerDomainService {
       }),
     ]);
 
-    return new ManagerDomainPaginationResultDto(data, totalCount);
+    return new ManagerDomainPaginationResultDto(data, totalCount);*/
   }
 
   async findManagersByPermissionTemplate(
@@ -95,7 +101,7 @@ export class ManagerDomainService implements IManagerDomainService {
     permissionTemplate: PermissionTemplateModel,
     dto: GetManagersByPermissionTemplateDto,
     qr?: QueryRunner,
-  ): Promise<ManagerDomainPaginationResultDto> {
+  ): Promise<ChurchUserModel[]> {
     const repository = this.getRepository(qr);
 
     const whereOptions: FindOptionsWhere<ChurchUserModel> = {
@@ -112,7 +118,24 @@ export class ManagerDomainService implements IManagerDomainService {
       orderOptions.createdAt = 'asc';
     }
 
-    const [data, totalCount] = await Promise.all([
+    return repository.find({
+      where: whereOptions,
+      relations: {
+        ...ManagersFindOptionsRelations,
+        permissionTemplate: false,
+        permissionScopes: false,
+      },
+      select: {
+        ...ManagersFindOptionsSelect,
+        permissionTemplate: undefined,
+        permissionScopes: undefined,
+      },
+      take: dto.take,
+      order: orderOptions,
+      skip: dto.take * (dto.page - 1),
+    });
+
+    /*const [data, totalCount] = await Promise.all([
       repository.find({
         where: whereOptions,
         relations: {
@@ -130,7 +153,7 @@ export class ManagerDomainService implements IManagerDomainService {
       }),
     ]);
 
-    return new ManagerDomainPaginationResultDto(data, totalCount);
+    return new ManagerDomainPaginationResultDto(data, totalCount);*/
   }
 
   async findManagerModelById(
@@ -295,6 +318,7 @@ export class ManagerDomainService implements IManagerDomainService {
       },
       select: {
         id: true,
+        userId: true,
       },
     });
   }

--- a/backend/src/member-history/education-history/dto/education-history-pagination-result.dto.ts
+++ b/backend/src/member-history/education-history/dto/education-history-pagination-result.dto.ts
@@ -1,17 +1,10 @@
-import { BaseOffsetPaginationResponseDto } from '../../../common/dto/reponse/base-offset-pagination-response.dto';
 import { EducationEnrollmentModel } from '../../../educations/education-enrollment/entity/education-enrollment.entity';
 
-export class EducationHistoryPaginationResultDto extends BaseOffsetPaginationResponseDto<EducationEnrollmentModel> {
+export class EducationHistoryPaginationResultDto {
   constructor(
     public readonly data: EducationEnrollmentModel[],
-    public readonly totalCount: number,
-    public readonly count: number,
-    public readonly page: number,
-    public readonly totalPage: number,
     //public readonly inProgressCount: number,
     public readonly completedCount: number,
     public readonly incompleteCount: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+  ) {}
 }

--- a/backend/src/member-history/education-history/education-history-domain/interface/education-history-domain.service.interface.ts
+++ b/backend/src/member-history/education-history/education-history-domain/interface/education-history-domain.service.interface.ts
@@ -12,8 +12,5 @@ export interface IEducationHistoryDomainService {
     member: MemberModel,
     dto: GetEducationHistoryDto,
     qr?: QueryRunner,
-  ): Promise<{
-    educationHistories: EducationEnrollmentModel[];
-    totalCount: number;
-  }>;
+  ): Promise<EducationEnrollmentModel[]>;
 }

--- a/backend/src/member-history/education-history/education-history-domain/service/education-history-domain.service.ts
+++ b/backend/src/member-history/education-history/education-history-domain/service/education-history-domain.service.ts
@@ -34,7 +34,22 @@ export class EducationHistoryDomainService
       status: dto.status,
     };
 
-    const [educationHistories, totalCount] = await Promise.all([
+    return educationEnrollmentsRepository.find({
+      where: findOptionsWhere,
+      relations: {
+        educationTerm: true,
+      },
+      order: {
+        educationTerm: {
+          endDate: dto.orderDirection,
+          startDate: dto.orderDirection,
+        },
+      },
+      take: dto.take,
+      skip: dto.take * (dto.page - 1),
+    });
+
+    /*const [educationHistories, totalCount] = await Promise.all([
       educationEnrollmentsRepository.find({
         where: findOptionsWhere,
         relations: {
@@ -54,6 +69,6 @@ export class EducationHistoryDomainService
       }),
     ]);
 
-    return { educationHistories, totalCount };
+    return { educationHistories, totalCount };*/
   }
 }

--- a/backend/src/member-history/education-history/service/education-history.service.ts
+++ b/backend/src/member-history/education-history/service/education-history.service.ts
@@ -45,24 +45,20 @@ export class EducationHistoryService {
       qr,
     );
 
-    const { educationHistories, totalCount } =
+    const educationHistories =
       await this.educationHistoryDomainService.paginateEducationHistory(
         member,
         dto,
         qr,
       );
 
-    const totalPage = Math.ceil(totalCount / dto.take);
+    //const totalPage = Math.ceil(totalCount / dto.take);
 
     const educationStatusCount =
       this.getEducationStatusCount(educationHistories);
 
     return new EducationHistoryPaginationResultDto(
       educationHistories,
-      totalCount,
-      educationHistories.length,
-      dto.page,
-      totalPage,
       educationStatusCount.completedMembersCount,
       educationStatusCount.incompleteMembersCount,
     );

--- a/backend/src/permission/dto/template/response/permission-template-pagination-response.dto.ts
+++ b/backend/src/permission/dto/template/response/permission-template-pagination-response.dto.ts
@@ -1,14 +1,8 @@
-import { BaseOffsetPaginationResponseDto } from '../../../../common/dto/reponse/base-offset-pagination-response.dto';
 import { PermissionTemplateModel } from '../../../entity/permission-template.entity';
 
-export class PermissionTemplatePaginationResponseDto extends BaseOffsetPaginationResponseDto<PermissionTemplateModel> {
+export class PermissionTemplatePaginationResponseDto {
   constructor(
-    data: PermissionTemplateModel[],
-    totalCount: number,
-    count: number,
-    page: number,
-    totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+    public readonly data: PermissionTemplateModel[],
+    public readonly timestamp: Date = new Date(),
+  ) {}
 }

--- a/backend/src/permission/guard/church-manager.guard.ts
+++ b/backend/src/permission/guard/church-manager.guard.ts
@@ -57,9 +57,11 @@ export class ChurchManagerGuard implements CanActivate {
     const cachedManager = await this.cache.get<ChurchUserModel>(managerKey);
 
     if (cachedManager) {
+      console.log('cache');
       return cachedManager;
     }
 
+    console.log('db');
     const requestManager =
       await this.managerDomainService.findManagerForPermissionCheck(
         church,

--- a/backend/src/permission/permission-domain/service/interface/permission-domain.service.interface.ts
+++ b/backend/src/permission/permission-domain/service/interface/permission-domain.service.interface.ts
@@ -3,7 +3,6 @@ import { DomainType } from '../../../const/domain-type.enum';
 import { ChurchModel } from '../../../../churches/entity/church.entity';
 import { GetPermissionTemplateDto } from '../../../dto/template/request/get-permission-template.dto';
 import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
-import { PermissionTemplateDomainPaginationResultDto } from '../../dto/permission-template-domain-pagination-result.dto';
 import { CreatePermissionTemplateDto } from '../../../dto/template/request/create-permission-template.dto';
 import { PermissionTemplateModel } from '../../../entity/permission-template.entity';
 import { UpdatePermissionTemplateDto } from '../../../dto/template/request/update-permission-template.dto';
@@ -17,7 +16,7 @@ export interface IPermissionDomainService {
     church: ChurchModel,
     dto: GetPermissionTemplateDto,
     qr?: QueryRunner,
-  ): Promise<PermissionTemplateDomainPaginationResultDto>;
+  ): Promise<PermissionTemplateModel[]>;
 
   createPermissionTemplate(
     church: ChurchModel,

--- a/backend/src/permission/permission-domain/service/permission-domain.service.ts
+++ b/backend/src/permission/permission-domain/service/permission-domain.service.ts
@@ -23,7 +23,6 @@ import {
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { GetPermissionTemplateDto } from '../../dto/template/request/get-permission-template.dto';
 import { PermissionTemplateOrder } from '../../const/permission-template-order.enum';
-import { PermissionTemplateDomainPaginationResultDto } from '../dto/permission-template-domain-pagination-result.dto';
 import { CreatePermissionTemplateDto } from '../../dto/template/request/create-permission-template.dto';
 import { UpdatePermissionTemplateDto } from '../../dto/template/request/update-permission-template.dto';
 import { PermissionException } from '../../exception/permission.exception';
@@ -75,7 +74,15 @@ export class PermissionDomainService implements IPermissionDomainService {
       order.createdAt = 'asc';
     }
 
-    const [data, totalCount] = await Promise.all([
+    return repository.find({
+      where: {
+        churchId: church.id,
+      },
+      order,
+      take: dto.take,
+      skip: dto.take * (dto.page - 1),
+    });
+    /*const [data, totalCount] = await Promise.all([
       repository.find({
         where: {
           churchId: church.id,
@@ -91,7 +98,7 @@ export class PermissionDomainService implements IPermissionDomainService {
       }),
     ]);
 
-    return new PermissionTemplateDomainPaginationResultDto(data, totalCount);
+    return new PermissionTemplateDomainPaginationResultDto(data, totalCount);*/
   }
 
   private async assertValidTemplateTitle(

--- a/backend/src/task/controller/task.controller.ts
+++ b/backend/src/task/controller/task.controller.ts
@@ -48,9 +48,10 @@ export class TaskController {
   @Get()
   getTasks(
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Query() dto: GetTasksDto,
   ) {
-    return this.taskService.getTasks(churchId, dto);
+    return this.taskService.getTasks(church, dto);
   }
 
   @ApiPostTask()
@@ -60,10 +61,11 @@ export class TaskController {
   postTask(
     @RequestManager() manager: ChurchUserModel,
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Body() dto: CreateTaskDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.taskService.postTask(churchId, manager, dto, qr);
+    return this.taskService.postTask(church, manager, dto, qr);
   }
 
   @ApiRefreshTaskCount()
@@ -83,8 +85,9 @@ export class TaskController {
   async getTaskById(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('taskId', ParseIntPipe) taskId: number,
+    @RequestChurch() church: ChurchModel,
   ) {
-    return this.taskService.getTaskById(churchId, taskId);
+    return this.taskService.getTaskById(church, taskId);
   }
 
   @ApiGetSubTasks()
@@ -93,8 +96,9 @@ export class TaskController {
   async getSubTasks(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('taskId', ParseIntPipe) taskId: number,
+    @RequestChurch() church: ChurchModel,
   ) {
-    return this.taskService.getSubTasks(churchId, taskId);
+    return this.taskService.getSubTasks(church, taskId);
   }
 
   @ApiPatchTask()
@@ -119,10 +123,11 @@ export class TaskController {
   deleteTask(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('taskId', ParseIntPipe) taskId: number,
+    @RequestChurch() church: ChurchModel,
     @RequestManager() requestManager: ChurchUserModel,
     @QueryRunner() qr: QR,
   ) {
-    return this.taskService.deleteTask(requestManager, churchId, taskId, qr);
+    return this.taskService.deleteTask(requestManager, church, taskId, qr);
   }
 
   @ApiAddReportReceivers()
@@ -132,12 +137,13 @@ export class TaskController {
   addReportReceivers(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('taskId', ParseIntPipe) taskId: number,
+    @RequestChurch() church: ChurchModel,
     @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: AddTaskReportReceiverDto,
     @QueryRunner() qr: QR,
   ) {
     return this.taskService.addTaskReportReceivers(
-      churchId,
+      church,
       taskId,
       requestManager,
       dto,
@@ -152,12 +158,13 @@ export class TaskController {
   deleteReportReceivers(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('taskId', ParseIntPipe) taskId: number,
+    @RequestChurch() church: ChurchModel,
     @RequestManager() requestManager: ChurchUserModel,
     @Body() dto: DeleteTaskReportReceiverDto,
     @QueryRunner() qr: QR,
   ) {
     return this.taskService.deleteTaskReportReceivers(
-      churchId,
+      church,
       taskId,
       requestManager,
       dto,

--- a/backend/src/task/dto/response/task-pagination-result.dto.ts
+++ b/backend/src/task/dto/response/task-pagination-result.dto.ts
@@ -1,14 +1,5 @@
-import { BaseOffsetPaginationResponseDto } from '../../../common/dto/reponse/base-offset-pagination-response.dto';
 import { TaskModel } from '../../entity/task.entity';
 
-export class TaskPaginationResultDto extends BaseOffsetPaginationResponseDto<TaskModel> {
-  constructor(
-    data: TaskModel[],
-    totalCount: number,
-    count: number,
-    page: number,
-    totalPage: number,
-  ) {
-    super(data, totalCount, count, page, totalPage);
-  }
+export class TaskPaginationResultDto {
+  constructor(public readonly data: TaskModel[]) {}
 }

--- a/backend/src/task/service/task.service.ts
+++ b/backend/src/task/service/task.service.ts
@@ -55,29 +55,13 @@ export class TaskService {
     private readonly taskReportDomainService: ITaskReportDomainService,
   ) {}
 
-  async getTasks(churchId: number, dto: GetTasksDto, qr?: QueryRunner) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
+  async getTasks(church: ChurchModel, dto: GetTasksDto, qr?: QueryRunner) {
     const result = await this.taskDomainService.findTasks(church, dto, qr);
 
-    return new TaskPaginationResultDto(
-      result.data,
-      result.totalCount,
-      result.data.length,
-      dto.page,
-      Math.ceil(result.totalCount / dto.take),
-    );
+    return new TaskPaginationResultDto(result);
   }
 
-  async getSubTasks(churchId: number, taskId: number, qr?: QueryRunner) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
+  async getSubTasks(church: ChurchModel, taskId: number, qr?: QueryRunner) {
     const parentTask = await this.taskDomainService.findParentTaskModelById(
       church,
       taskId,
@@ -94,16 +78,11 @@ export class TaskService {
   }
 
   async postTask(
-    churchId: number,
+    church: ChurchModel,
     creatorManager: ChurchUserModel,
     dto: CreateTaskDto,
     qr: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
     const inCharge = dto.inChargeId
       ? await this.managerDomainService.findManagerByMemberId(
           church,
@@ -154,10 +133,7 @@ export class TaskService {
     return new PostTaskResponseDto(newTask, new Date());
   }
 
-  async getTaskById(churchId: number, taskId: number) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
+  async getTaskById(church: ChurchModel, taskId: number) {
     const task = await this.taskDomainService.findTaskById(church, taskId);
 
     return new GetTaskResponseDto(task, new Date());
@@ -285,15 +261,10 @@ export class TaskService {
 
   async deleteTask(
     requestManager: ChurchUserModel,
-    churchId: number,
+    church: ChurchModel,
     taskId: number,
     qr: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
     const targetTask = await this.taskDomainService.findTaskModelById(
       church,
       taskId,
@@ -337,17 +308,12 @@ export class TaskService {
   }
 
   async addTaskReportReceivers(
-    churchId: number,
+    church: ChurchModel,
     taskId: number,
     requestManager: ChurchUserModel,
     dto: AddTaskReportReceiverDto,
     qr: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
     const task = await this.taskDomainService.findTaskModelById(
       church,
       taskId,
@@ -400,17 +366,12 @@ export class TaskService {
   }
 
   async deleteTaskReportReceivers(
-    churchId: number,
+    church: ChurchModel,
     taskId: number,
     requestManager: ChurchUserModel,
     dto: DeleteTaskReportReceiverDto,
     qr: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
     const task = await this.taskDomainService.findTaskModelById(
       church,
       taskId,

--- a/backend/src/task/task-domain/interface/task-domain.service.interface.ts
+++ b/backend/src/task/task-domain/interface/task-domain.service.interface.ts
@@ -3,7 +3,6 @@ import { FindOptionsRelations, QueryRunner, UpdateResult } from 'typeorm';
 import { TaskModel } from '../../entity/task.entity';
 import { CreateTaskDto } from '../../dto/request/create-task.dto';
 import { GetTasksDto } from '../../dto/request/get-tasks.dto';
-import { TaskDomainPaginationResultDto } from '../../dto/task-domain-pagination-result.dto';
 import { UpdateTaskDto } from '../../dto/request/update-task.dto';
 import { ChurchUserModel } from '../../../church-user/entity/church-user.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
@@ -17,7 +16,7 @@ export interface ITaskDomainService {
     church: ChurchModel,
     dto: GetTasksDto,
     qr?: QueryRunner,
-  ): Promise<TaskDomainPaginationResultDto>;
+  ): Promise<TaskModel[]>;
 
   findSubTasks(
     church: ChurchModel,

--- a/backend/src/task/task-domain/service/task-domain.service.ts
+++ b/backend/src/task/task-domain/service/task-domain.service.ts
@@ -19,7 +19,6 @@ import {
   Repository,
 } from 'typeorm';
 import { ChurchModel } from '../../../churches/entity/church.entity';
-import { TaskDomainPaginationResultDto } from '../../dto/task-domain-pagination-result.dto';
 import { TaskException } from '../../const/exception-message/task.exception';
 import { CreateTaskDto } from '../../dto/request/create-task.dto';
 import { ITaskDomainService } from '../interface/task-domain.service.interface';
@@ -91,7 +90,23 @@ export class TaskDomainService implements ITaskDomainService {
       order.createdAt = 'asc';
     }
 
-    const [data, totalCount] = await Promise.all([
+    return taskRepository.find({
+      where: {
+        churchId: church.id,
+        taskType: TaskType.parent,
+        title: dto.title && Like(`%${dto.title}%`),
+        startDate: this.parseTaskDate(dto),
+        status: dto.status,
+        inChargeId: dto.inChargeId,
+      },
+      relations: TasksFindOptionsRelation,
+      select: TasksFindOptionsSelect,
+      order,
+      take: dto.take,
+      skip: dto.take * (dto.page - 1),
+    });
+
+    /*const [data, totalCount] = await Promise.all([
       taskRepository.find({
         where: {
           churchId: church.id,
@@ -119,7 +134,7 @@ export class TaskDomainService implements ITaskDomainService {
       }),
     ]);
 
-    return new TaskDomainPaginationResultDto(data, totalCount);
+    return new TaskDomainPaginationResultDto(data, totalCount);*/
   }
 
   async findSubTasks(

--- a/backend/src/visitation/controller/visitation-detail.controller.ts
+++ b/backend/src/visitation/controller/visitation-detail.controller.ts
@@ -4,6 +4,8 @@ import { UpdateVisitationDetailDto } from '../dto/internal/detail/update-visitat
 import { ApiTags } from '@nestjs/swagger';
 import { VisitationDetailService } from '../service/visitation-detail.service';
 import { VisitationWriteGuard } from '../guard/visitation-write.guard';
+import { RequestChurch } from '../../permission/decorator/request-church.decorator';
+import { ChurchModel } from '../../churches/entity/church.entity';
 
 @ApiTags('Visitations:Details')
 @Controller('visitations/:visitationId/details')
@@ -18,10 +20,11 @@ export class VisitationDetailController {
   patchVisitationDetail(
     @Param('churchId', ParseIntPipe) churchId: number,
     @Param('visitationId', ParseIntPipe) visitationId: number,
+    @RequestChurch() church: ChurchModel,
     @Body() dto: UpdateVisitationDetailDto,
   ) {
     return this.visitationDetailService.updateVisitationDetail(
-      churchId,
+      church,
       visitationId,
       dto,
     );

--- a/backend/src/visitation/controller/visitation.controller.ts
+++ b/backend/src/visitation/controller/visitation.controller.ts
@@ -60,10 +60,11 @@ export class VisitationController {
   postVisitationReservation(
     @RequestManager() manager: ChurchUserModel,
     @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
     @Body() dto: CreateVisitationDto,
     @QueryRunner() qr: QR,
   ) {
-    return this.visitationService.createVisitation(manager, churchId, dto, qr);
+    return this.visitationService.createVisitation(manager, church, dto, qr);
   }
 
   @ApiRefreshVisitationCount()

--- a/backend/src/visitation/service/visitation-detail.service.ts
+++ b/backend/src/visitation/service/visitation-detail.service.ts
@@ -12,16 +12,11 @@ import {
   IVisitationMetaDomainService,
 } from '../visitation-domain/interface/visitation-meta-domain.service.interface';
 import { UpdateVisitationDetailDto } from '../dto/internal/detail/update-visitation-detail.dto';
-import {
-  ICHURCHES_DOMAIN_SERVICE,
-  IChurchesDomainService,
-} from '../../churches/churches-domain/interface/churches-domain.service.interface';
+import { ChurchModel } from '../../churches/entity/church.entity';
 
 @Injectable()
 export class VisitationDetailService {
   constructor(
-    @Inject(ICHURCHES_DOMAIN_SERVICE)
-    private readonly churchesDomainService: IChurchesDomainService,
     /*@Inject(IMEMBERS_DOMAIN_SERVICE)
     private readonly membersDomainService: IMembersDomainService,*/
     @Inject(IVISITATION_META_DOMAIN_SERVICE)
@@ -45,13 +40,10 @@ export class VisitationDetailService {
   }
 
   async updateVisitationDetail(
-    churchId: number,
+    church: ChurchModel,
     visitationId: number,
     dto: UpdateVisitationDetailDto,
   ) {
-    const church =
-      await this.churchesDomainService.findChurchModelById(churchId);
-
     const metaData =
       await this.visitationMetaDomainService.findVisitationMetaModelById(
         church,

--- a/backend/src/visitation/service/visitation.service.ts
+++ b/backend/src/visitation/service/visitation.service.ts
@@ -160,15 +160,10 @@ export class VisitationService {
 
   async createVisitation(
     creatorManager: ChurchUserModel,
-    churchId: number,
+    church: ChurchModel,
     dto: CreateVisitationDto,
     qr: QueryRunner,
   ) {
-    const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-
     const inCharge = await this.managerDomainService.findManagerByMemberId(
       church,
       dto.inChargeId,

--- a/backend/src/worship/controller/worship-attendance.controller.ts
+++ b/backend/src/worship/controller/worship-attendance.controller.ts
@@ -143,8 +143,6 @@ export class WorshipAttendanceController {
     @QueryRunner() qr: QR,
   ) {
     return this.worshipAttendanceService.refreshAttendance(
-      //churchId,
-      //worshipId,
       church,
       worshipId,
       sessionId,


### PR DESCRIPTION
## 주요 내용
- **관리자 권한 변경 시 캐시 무효화**
  - 권한 템플릿 및 관리자 권한에 변동이 발생할 경우 관련 캐시를 만료시키도록 구현
  - 이후 요청 시 최신 권한 정보가 반영되도록 보장

- **교회 중복 조회 코드 제거**
  - 각 엔드포인트에서 불필요하게 반복되던 교회 조회 로직을 제거
  - 공통 가드 및 서비스 계층에서 교회 유효성 검증을 일원화하여 중복 제거 및 유지보수성 향상

## 세부 내용
### 권한 관리
- 권한 템플릿 수정·삭제·배정 등 관리자 권한 변경 지점에서 캐시 만료 처리 추가
- 권한 변경 후 캐시 재사용으로 인한 접근 오류 발생 가능성을 차단

### 엔드포인트 구조
- 모든 `/churches/{churchId}` 엔드포인트에서 중복된 `findChurchById` 호출 제거
- 가드/미들웨어에서 처리된 교회 컨텍스트를 주입받도록 리팩토링