### PR TITLE
feat: 전역 Throttler 적용으로 초당 요청 제한 설정

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "@nestjs/platform-express": "^10.4.8",
         "@nestjs/schedule": "^6.0.0",
         "@nestjs/swagger": "^8.0.7",
+        "@nestjs/throttler": "^6.4.0",
         "@nestjs/typeorm": "^10.0.2",
         "cache-manager": "^7.2.0",
         "class-transformer": "^0.5.1",
@@ -2132,6 +2133,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.4.0.tgz",
+      "integrity": "sha512-osL67i0PUuwU5nqSuJjtUJZMkxAnYB4VldgYUMGzvYRJDCqGRFMWbsbzm/CkUtPLRL30I8T74Xgt/OQxnYokiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@nestjs/typeorm": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "@nestjs/platform-express": "^10.4.8",
     "@nestjs/schedule": "^6.0.0",
     "@nestjs/swagger": "^8.0.7",
+    "@nestjs/throttler": "^6.4.0",
     "@nestjs/typeorm": "^10.0.2",
     "cache-manager": "^7.2.0",
     "class-transformer": "^0.5.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,7 +3,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ChurchModel } from './churches/entity/church.entity';
-import { APP_INTERCEPTOR } from '@nestjs/core';
+import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthModule } from './auth/auth.module';
 import * as Joi from 'joi';
@@ -85,12 +85,19 @@ import { NotificationModel } from './notification/entity/notification.entity';
 import { MobileVerificationModel } from './mobile-verification/entity/mobile-verification.entity';
 import { MobileVerificationModule } from './mobile-verification/mobile-verification.module';
 import { CacheModule } from '@nestjs/cache-manager';
-
-//import { EducationTermReportModel } from './report/education-report/entity/education-term-report.entity';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 
 @Module({
   imports: [
     EventEmitterModule.forRoot(),
+    ThrottlerModule.forRoot({
+      throttlers: [
+        {
+          ttl: 1000,
+          limit: 10,
+        },
+      ],
+    }),
     CacheModule.register({
       isGlobal: true,
       ttl: 300_000,
@@ -271,6 +278,10 @@ import { CacheModule } from '@nestjs/cache-manager';
     {
       provide: APP_INTERCEPTOR,
       useClass: ClassSerializerInterceptor,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
     },
     //DummyDataService,
   ],

--- a/backend/src/worship/service/worship-attendance.service.ts
+++ b/backend/src/worship/service/worship-attendance.service.ts
@@ -164,12 +164,6 @@ export class WorshipAttendanceService {
     sessionId: number,
     qr: QueryRunner,
   ) {
-    /*const church = await this.churchesDomainService.findChurchModelById(
-      churchId,
-      qr,
-    );
-    */
-
     const worship = await this.worshipDomainService.findWorshipModelById(
       church,
       worshipId,


### PR DESCRIPTION
## 주요 내용
- **전역 요청 제한(Throttler) 적용**
  - 모든 엔드포인트에 대해 초당 최대 10회 요청 가능하도록 설정
  - NestJS ThrottlerModule을 전역으로 등록하고 ThrottlerGuard를 활성화

## 세부 내용
### AppModule
- `ThrottlerModule.forRoot({ ttl: 1, limit: 10 })` 적용
- 요청 단위(`ttl=1초`) 동안 허용되는 요청 수(`limit=10`)로 제한

### main.ts
- `ThrottlerGuard`를 전역 가드로 적용하여 모든 컨트롤러에 일관된 정책 적용

### 효과
- 비정상적인 과도한 요청으로 인한 서버 부하 방지
- Rate Limit 초과 시 `429 Too Many Requests` 응답 반환