### PR TITLE
fix: WorshipSession 출석 새로고침 시 중복 체크 로직 오류 수정

### DIFF
--- a/backend/src/permission/guard/church-manager.guard.ts
+++ b/backend/src/permission/guard/church-manager.guard.ts
@@ -57,11 +57,9 @@ export class ChurchManagerGuard implements CanActivate {
     const cachedManager = await this.cache.get<ChurchUserModel>(managerKey);
 
     if (cachedManager) {
-      console.log('cache');
       return cachedManager;
     }
 
-    console.log('db');
     const requestManager =
       await this.managerDomainService.findManagerForPermissionCheck(
         church,

--- a/backend/src/worship/service/worship-attendance.service.ts
+++ b/backend/src/worship/service/worship-attendance.service.ts
@@ -188,7 +188,9 @@ export class WorshipAttendanceService {
       await this.worshipAttendanceDomainService.findAllAttendances(session, qr);
 
     const existWorshipAttendanceEnrollmentIds = new Set(
-      existWorshipAttendances.map((attendance) => attendance.id),
+      existWorshipAttendances.map(
+        (attendance) => attendance.worshipEnrollment.id,
+      ),
     );
 
     const notExistAttendanceEnrollments: WorshipEnrollmentModel[] = [];


### PR DESCRIPTION
## 주요 내용
- WorshipSession 출석 정보 새로고침 시 중복된 Attendance 가 생성되는 문제 해결
- 기존 중복 체크 로직이 정상적으로 동작하지 않아 동일 교인·세션에 대해 다중 출석 데이터가 기록되던 현상 수정

## 세부 내용
### WorshipAttendance
- 새로고침 시 `worshipEnrollment.id` 기준으로 중복 여부를 정확히 검증하도록 로직 보완
- 이미 존재하는 출석 데이터는 재생성되지 않도록 예외 처리 강화
- 불필요한 중복 데이터 생성으로 인한 통계 오류 및 조회 혼선을 방지