### PR TITLE
feat: 그룹 단건 조회 응답 확장, 그룹 리더 제거 기능 추가, /me 엔드포인트 접근 범위 완화

### DIFF
--- a/backend/src/management/groups/controller/groups.controller.ts
+++ b/backend/src/management/groups/controller/groups.controller.ts
@@ -102,7 +102,8 @@ export class GroupsController {
     @RequestChurch() church: ChurchModel,
     @Param('groupId', ParseIntPipe) groupId: number,
   ) {
-    return this.groupsService.getGroupByIdWithParents(church, groupId);
+    return this.groupsService.getGroupById(church, groupId);
+    //return this.groupsService.getGroupByIdWithParents(church, groupId);
   }
 
   @ApiDeleteGroup()

--- a/backend/src/management/groups/dto/request/update-group-leader.dto.ts
+++ b/backend/src/management/groups/dto/request/update-group-leader.dto.ts
@@ -7,7 +7,7 @@ export class UpdateGroupLeaderDto {
     description: '리더로 지정할 교인 ID',
   })
   @IsNumber()
-  @Min(1)
+  @Min(0)
   newLeaderMemberId: number;
 
   @ApiProperty({

--- a/backend/src/management/groups/entity/group.entity.ts
+++ b/backend/src/management/groups/entity/group.entity.ts
@@ -1,4 +1,12 @@
-import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  OneToOne,
+} from 'typeorm';
 import { BaseModel } from '../../../common/entity/base.entity';
 import { ChurchModel } from '../../../churches/entity/church.entity';
 import { MemberModel } from '../../../members/entity/member.entity';
@@ -42,6 +50,10 @@ export class GroupModel extends BaseModel {
 
   @Column({ type: 'int', nullable: true })
   leaderMemberId: number | null;
+
+  @OneToOne(() => MemberModel, { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'leaderMemberId' })
+  leaderMember: MemberModel | null;
 
   @OneToMany(() => MemberModel, (member) => member.group)
   members: MemberModel[];

--- a/backend/src/management/groups/groups-domain/service/groups-domain.service.ts
+++ b/backend/src/management/groups/groups-domain/service/groups-domain.service.ts
@@ -36,6 +36,10 @@ import { UpdateGroupStructureDto } from '../../dto/request/update-group-structur
 import { MemberModel } from '../../../../members/entity/member.entity';
 import { GroupRole } from '../../const/group-role.enum';
 import { Cache, CACHE_MANAGER } from '@nestjs/cache-manager';
+import {
+  MemberSimpleSelect,
+  MemberSummarizedRelation,
+} from '../../../../members/const/member-find-options.const';
 
 @Injectable()
 export class GroupsDomainService implements IGroupsDomainService {
@@ -181,6 +185,17 @@ export class GroupsDomainService implements IGroupsDomainService {
       where: {
         churchId: church.id,
         id: groupId,
+      },
+      relations: { leaderMember: MemberSummarizedRelation },
+      select: {
+        /*id: true,
+        createdAt: true,
+        updatedAt: true,
+        name: true,
+        parentGroupId: true,
+        childGroupIds: true,
+        membersCount: true,*/
+        leaderMember: MemberSimpleSelect,
       },
     });
 

--- a/backend/src/user/user-domain/service/user-domain.service.ts
+++ b/backend/src/user/user-domain/service/user-domain.service.ts
@@ -65,7 +65,7 @@ export class UserDomainService implements IUserDomainService {
 
     const user = await repository
       .createQueryBuilder('user')
-      .innerJoin('user.churchUser', 'churchUser', 'churchUser.leftAt IS NULL')
+      .leftJoin('user.churchUser', 'churchUser', 'churchUser.leftAt IS NULL')
       .addSelect([
         'churchUser.id',
         'churchUser.createdAt',


### PR DESCRIPTION
## 주요 내용
- **그룹 단건 조회 응답 구조 변경**
  - 기존: 부모 그룹들과 자신의 최소 정보만 반환
  - 변경: 그룹의 상세 정보와 그룹 리더(Member 요약 정보 포함)를 함께 반환

- **그룹 리더 변경 로직 확장**
  - `newLeaderMemberId = 0` 입력 시 그룹 리더를 해제할 수 있도록 기능 추가
  - 기존에는 특정 교인을 반드시 리더로 지정해야 했던 제약을 완화

- **/me 엔드포인트 개선**
  - 교회 미가입 사용자도 `/me` 엔드포인트 접근 가능
  - 로그인 사용자 정보 확인을 교회 가입 여부와 무관하게 제공

## 세부 내용
### GroupController / Service
- 단건 조회 시 상세 DTO로 응답 변경 (그룹 기본 정보 + 리더 요약 정보)
- 리더 변경 로직에서 `0` 값 처리 분기 추가

### UserController (/me)
- 교회 미가입 상태에서도 기본 사용자 정보를 반환하도록 가드 조건 완화