### PR TITLE
feat: 교회 삭제 플로우 및 교회 가입 코드 검색 기능 추가

### DIFF
--- a/backend/src/church-join/church-join-domain/interface/church-join-requests-domain.service.interface.ts
+++ b/backend/src/church-join/church-join-domain/interface/church-join-requests-domain.service.interface.ts
@@ -59,4 +59,6 @@ export interface IChurchJoinRequestDomainService {
     user: UserModel,
     qr?: QueryRunner,
   ): Promise<ChurchJoinModel>;
+
+  isExistJoinRequest(user: UserModel, qr: QueryRunner): Promise<boolean>;
 }

--- a/backend/src/church-join/church-join-domain/service/church-join-requests-domain.service.ts
+++ b/backend/src/church-join/church-join-domain/service/church-join-requests-domain.service.ts
@@ -65,7 +65,7 @@ export class ChurchJoinRequestsDomainService
     const repository = this.getRepository(qr);
 
     return repository.save({
-      church,
+      churchId: church.id,
       user,
       status: ChurchJoinRequestStatusEnum.PENDING,
     });
@@ -283,5 +283,18 @@ export class ChurchJoinRequestsDomainService
     }
 
     return joinRequest;
+  }
+
+  async isExistJoinRequest(user: UserModel, qr: QueryRunner): Promise<boolean> {
+    const repository = this.getRepository(qr);
+
+    const joinRequest = await repository.findOne({
+      where: {
+        user: { id: user.id },
+        status: ChurchJoinRequestStatusEnum.PENDING,
+      },
+    });
+
+    return !!joinRequest;
   }
 }

--- a/backend/src/church-join/controller/church-join.controller.ts
+++ b/backend/src/church-join/controller/church-join.controller.ts
@@ -18,7 +18,7 @@ import { JwtAccessPayload } from '../../auth/type/jwt';
 import { TransactionInterceptor } from '../../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../../common/decorator/query-runner.decorator';
 import { QueryRunner as QR } from 'typeorm/query-runner/QueryRunner';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { ApproveJoinRequestDto } from '../dto/request/approve-join-request.dto';
 import { ChurchJoinService } from '../service/church-join.service';
 import { CreateJoinRequestDto } from '../dto/request/create-join-request.dto';
@@ -41,6 +41,16 @@ import { ChurchModel } from '../../churches/entity/church.entity';
 @Controller('churches')
 export class ChurchJoinController {
   constructor(private readonly churchJoinRequestService: ChurchJoinService) {}
+
+  @ApiOperation({ summary: '가입코드로 교회 검색' })
+  @Get('join/search')
+  @ApiQuery({ name: 'joinCode' })
+  @UseGuards(AccessTokenGuard)
+  getChurchByJoinCode(@Query('joinCode') joinCodeInput: string) {
+    const joinCode = joinCodeInput.toUpperCase();
+
+    return this.churchJoinRequestService.getChurchByJoinCode(joinCode);
+  }
 
   @ApiPostChurchJoinRequest()
   @Post('join')

--- a/backend/src/church-join/exception/church-join.exception.ts
+++ b/backend/src/church-join/exception/church-join.exception.ts
@@ -9,6 +9,8 @@ export const ChurchJoinException = {
   NOT_FOUND: '가입 요청을 찾을 수 없습니다.',
   UPDATE_ERROR: '가입 요청 업데이트 도중 에러 발생',
   DELETE_ERROR: '가입 요청 삭제 도중 에러 발생',
+  ALREADY_JOINED_OTHER_CHURCH: '타 교회에 가입된 계정입니다.',
+
   TOO_MANY_REQUESTS: (maxAttempts: number) =>
     `하루 최대 ${maxAttempts}회의 가입 신청만 가능합니다.`,
 };

--- a/backend/src/church-join/service/church-join.service.ts
+++ b/backend/src/church-join/service/church-join.service.ts
@@ -43,6 +43,7 @@ import { PostJoinRequestResponseDto } from '../dto/response/post-join-request-re
 import { MemberException } from '../../members/exception/member.exception';
 import { ChurchModel } from '../../churches/entity/church.entity';
 import { DeleteJoinRequestResponseDto } from '../dto/response/delete-join-request-response.dto';
+import { GetChurchResponseDto } from '../../churches/dto/response/get-church-response.dto';
 
 @Injectable()
 export class ChurchJoinService {
@@ -61,6 +62,13 @@ export class ChurchJoinService {
     @Inject(IMEMBERS_DOMAIN_SERVICE)
     private readonly membersDomainService: IMembersDomainService,
   ) {}
+
+  async getChurchByJoinCode(joinCode: string) {
+    const church =
+      await this.churchesDomainService.findChurchByJoinCode(joinCode);
+
+    return new GetChurchResponseDto(church);
+  }
 
   async postChurchJoinRequest(
     accessPayload: JwtAccessPayload,
@@ -130,6 +138,12 @@ export class ChurchJoinService {
         joinId,
         qr,
       );
+
+    if (joinRequest.user.role !== UserRole.NONE) {
+      throw new ConflictException(
+        ChurchJoinException.ALREADY_JOINED_OTHER_CHURCH,
+      );
+    }
 
     if (joinRequest.status !== ChurchJoinRequestStatusEnum.PENDING) {
       // 취소된 가입 신청일 경우

--- a/backend/src/church-user/church-user-domain/service/church-user-domain.service.ts
+++ b/backend/src/church-user/church-user-domain/service/church-user-domain.service.ts
@@ -12,6 +12,7 @@ import {
   DeleteResult,
   FindOptionsOrder,
   ILike,
+  In,
   IsNull,
   QueryRunner,
   Repository,
@@ -388,5 +389,39 @@ export class ChurchUserDomainService implements IChurchUserDomainService {
     const repository = this.getChurchUserRepository(qr);
 
     return repository.delete({ churchId: church.id });
+  }
+
+  findAllChurchUserId(
+    church: ChurchModel,
+    qr: QueryRunner,
+  ): Promise<ChurchUserModel[]> {
+    const repository = this.getChurchUserRepository(qr);
+
+    return repository.find({
+      where: {
+        church: { id: church.id },
+        leftAt: IsNull(),
+      },
+      select: {
+        id: true,
+        userId: true,
+      },
+    });
+  }
+
+  leaveAllChurchUsers(
+    churchUsers: ChurchUserModel[],
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const repository = this.getChurchUserRepository(qr);
+
+    const ids = churchUsers.map((churchUser) => churchUser.id);
+
+    return repository.update(
+      { id: In(ids) },
+      {
+        leftAt: new Date(),
+      },
+    );
   }
 }

--- a/backend/src/church-user/church-user-domain/service/interface/church-user-domain.service.interface.ts
+++ b/backend/src/church-user/church-user-domain/service/interface/church-user-domain.service.interface.ts
@@ -88,4 +88,14 @@ export interface IChurchUserDomainService {
     church: ChurchModel,
     qr: QueryRunner,
   ): Promise<DeleteResult>;
+
+  findAllChurchUserId(
+    church: ChurchModel,
+    qr: QueryRunner,
+  ): Promise<ChurchUserModel[]>;
+
+  leaveAllChurchUsers(
+    churchUsers: ChurchUserModel[],
+    qr: QueryRunner,
+  ): Promise<UpdateResult>;
 }

--- a/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
+++ b/backend/src/churches/churches-domain/interface/churches-domain.service.interface.ts
@@ -19,6 +19,8 @@ export interface IChurchesDomainService {
 
   findChurchById(id: number, qr?: QueryRunner): Promise<ChurchModel>;
 
+  findChurchByJoinCode(joinCode: string): Promise<ChurchModel>;
+
   findChurchModelByJoinCode(
     joinCode: string,
     qr?: QueryRunner,
@@ -60,7 +62,7 @@ export interface IChurchesDomainService {
     qr: QueryRunner,
   ): Promise<UpdateResult>;
 
-  deleteChurch(church: ChurchModel, qr?: QueryRunner): Promise<string>;
+  deleteChurch(church: ChurchModel, qr?: QueryRunner): Promise<UpdateResult>;
 
   deleteChurchCascade(
     church: ChurchModel,
@@ -74,10 +76,6 @@ export interface IChurchesDomainService {
       | RequestLimitValidationType.INCREASE,
     qr: QueryRunner,
   ): Promise<UpdateResult>;
-
-  //getChurchManagerIds(churchId: number, qr?: QueryRunner): Promise<number[]>;
-
-  //getChurchOwnerIds(churchId: number, qr?: QueryRunner): Promise<number[]>;
 
   updateChurchJoinCode(
     church: ChurchModel,
@@ -142,4 +140,6 @@ export interface IChurchesDomainService {
     targetChurchIds: number[],
     qr?: QueryRunner,
   ): Promise<ChurchModel[]>;
+
+  cleanUpChurch(): Promise<DeleteResult>;
 }

--- a/backend/src/churches/churches.module.ts
+++ b/backend/src/churches/churches.module.ts
@@ -12,6 +12,8 @@ import { OfficerHistoryDomainModule } from '../member-history/officer-history/of
 import { GroupHistoryDomainModule } from '../member-history/group-history/group-history-domain/group-history-domain.module';
 import { TrialChurchesService } from './service/trial-churches.service';
 import { ChurchesNotificationService } from './service/churches-notification.service';
+import { MobileVerificationDomainModule } from '../mobile-verification/mobile-verification-domain/mobile-verification-domain.module';
+import { CommonModule } from '../common/common.module';
 
 @Module({
   imports: [
@@ -25,6 +27,9 @@ import { ChurchesNotificationService } from './service/churches-notification.ser
     DummyDataDomainModule,
     OfficerHistoryDomainModule,
     GroupHistoryDomainModule,
+
+    CommonModule,
+    MobileVerificationDomainModule,
   ],
   controllers: [ChurchesController],
   providers: [

--- a/backend/src/churches/dto/request/delete-church-verification-confirm.dto.ts
+++ b/backend/src/churches/dto/request/delete-church-verification-confirm.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, Length } from 'class-validator';
+
+export class DeleteChurchVerificationConfirmDto {
+  @ApiProperty({ description: '인증 코드' })
+  @IsString()
+  @Length(6, 6)
+  inputCode: string;
+}

--- a/backend/src/churches/dto/request/delete-church-verification-request.dto.ts
+++ b/backend/src/churches/dto/request/delete-church-verification-request.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean } from 'class-validator';
+
+export class DeleteChurchVerificationRequestDto {
+  @ApiProperty({ description: '테스트 여부' })
+  @IsBoolean()
+  isTest: boolean;
+
+  /*@ApiProperty({ description: '변경할 휴대전화 번호' })
+  @IsString()
+  @Length(10, 11)
+  mobilePhone: string;*/
+}

--- a/backend/src/churches/dto/response/delete-church-response.dto.ts
+++ b/backend/src/churches/dto/response/delete-church-response.dto.ts
@@ -1,0 +1,7 @@
+export class DeleteChurchResponseDto {
+  constructor(
+    public readonly timestamp: Date,
+    public readonly id: number,
+    public readonly success: boolean,
+  ) {}
+}

--- a/backend/src/churches/dto/response/get-church-response.dto.ts
+++ b/backend/src/churches/dto/response/get-church-response.dto.ts
@@ -1,0 +1,8 @@
+import { BaseGetResponseDto } from '../../../common/dto/reponse/base-get-response.dto';
+import { ChurchModel } from '../../entity/church.entity';
+
+export class GetChurchResponseDto extends BaseGetResponseDto<ChurchModel> {
+  constructor(data: ChurchModel) {
+    super(data);
+  }
+}

--- a/backend/src/mobile-verification/entity/mobile-verification.entity.ts
+++ b/backend/src/mobile-verification/entity/mobile-verification.entity.ts
@@ -5,6 +5,7 @@ import { VerificationType } from '../const/verification-type.enum';
 
 @Entity()
 @Index(['userId', 'createdAt'])
+@Index(['userId', 'verificationType', 'createdAt'])
 export class MobileVerificationModel extends BaseModel {
   @Index()
   @Column()

--- a/backend/src/mobile-verification/exception/mobile-verification.exception.ts
+++ b/backend/src/mobile-verification/exception/mobile-verification.exception.ts
@@ -6,4 +6,5 @@ export const MobileVerificationException = {
   ALREADY_VERIFIED: '인증 완료된 번호입니다.',
   EXPIRED_CODE: '유효 시간을 초과했습니다.',
   WRONG_CODE: '인증 번호가 일치하지 않습니다.',
+  NOT_FOUND_VERIFIED_REQUEST: '인증 완료된 요청을 찾을 수 없습니다.',
 };

--- a/backend/src/mobile-verification/mobile-verification-domain/interface/mobile-verification-domain.service.interface.ts
+++ b/backend/src/mobile-verification/mobile-verification-domain/interface/mobile-verification-domain.service.interface.ts
@@ -22,5 +22,11 @@ export interface IMobileVerificationDomainService {
     qr?: QueryRunner,
   ): Promise<string>;
 
+  findVerifiedRequest(
+    user: UserModel,
+    verificationType: VerificationType,
+    qr: QueryRunner,
+  ): Promise<MobileVerificationModel>;
+
   cleanUp(): Promise<DeleteResult>;
 }

--- a/backend/src/mobile-verification/mobile-verification-domain/service/mobile-verification-domain.service.ts
+++ b/backend/src/mobile-verification/mobile-verification-domain/service/mobile-verification-domain.service.ts
@@ -138,6 +138,33 @@ export class MobileVerificationDomainService
     }
   }
 
+  async findVerifiedRequest(
+    user: UserModel,
+    verificationType: VerificationType,
+    qr: QueryRunner,
+  ): Promise<MobileVerificationModel> {
+    const repository = this.getRepository(qr);
+
+    const verifiedRequest = await repository.findOne({
+      where: {
+        user: {
+          id: user.id,
+        },
+        verificationType,
+        isActive: true,
+        isVerified: true,
+      },
+    });
+
+    if (!verifiedRequest) {
+      throw new NotFoundException(
+        MobileVerificationException.NOT_FOUND_VERIFIED_REQUEST,
+      );
+    }
+
+    return verifiedRequest;
+  }
+
   async cleanUp() {
     const repository = this.getRepository();
 

--- a/backend/src/permission/guard/church-owner.guard.ts
+++ b/backend/src/permission/guard/church-owner.guard.ts
@@ -90,11 +90,6 @@ export class ChurchOwnerGuard implements CanActivate {
     }
 
     req.requestOwner = await this.getChurchOwner(church, token.id);
-    /*await this.managerDomainService.findManagerForPermissionCheck(
-        church,
-        token.id,
-        req.queryRunner,
-      );*/
 
     return true;
   }

--- a/backend/src/subscription/service/subscription.service.ts
+++ b/backend/src/subscription/service/subscription.service.ts
@@ -28,6 +28,10 @@ import {
   IPAYMENT_METHOD_DOMAIN_SERVICE,
   IPaymentMethodDomainService,
 } from '../../payment-method/payment-method-domain/interface/payment-method-domain.service.interface';
+import {
+  ICHURCH_JOIN_REQUESTS_DOMAIN_SERVICE,
+  IChurchJoinRequestDomainService,
+} from '../../church-join/church-join-domain/interface/church-join-requests-domain.service.interface';
 
 @Injectable()
 export class SubscriptionService {
@@ -42,6 +46,9 @@ export class SubscriptionService {
     private readonly paymentMethodDomainService: IPaymentMethodDomainService,
     @Inject(ICHURCHES_DOMAIN_SERVICE)
     private readonly churchesDomainService: IChurchesDomainService,
+
+    @Inject(ICHURCH_JOIN_REQUESTS_DOMAIN_SERVICE)
+    private readonly churchJoinRequestDomainService: IChurchJoinRequestDomainService,
   ) {}
 
   async getCurrentSubscription(user: UserModel) {
@@ -55,8 +62,16 @@ export class SubscriptionService {
       );
     }
 
+    const isExistJoinRequest =
+      await this.churchJoinRequestDomainService.isExistJoinRequest(user, qr);
+
+    if (isExistJoinRequest) {
+      throw new ConflictException('대기중인 교회 가입 신청 이력이 있습니다.');
+    }
+
     if (user.hasUsedFreeTrial) {
-      throw new ForbiddenException('이미 무료체험 이력이 있습니다.');
+      throw new ConflictException('현재 진행중인 구독이 있습니다.');
+      //throw new ForbiddenException('이미 무료체험 이력이 있습니다.');
     }
 
     const trialSubscription =

--- a/backend/src/user/user-domain/interface/user-domain.service.interface.ts
+++ b/backend/src/user/user-domain/interface/user-domain.service.interface.ts
@@ -40,6 +40,8 @@ export interface IUserDomainService {
     qr?: QueryRunner,
   ): Promise<UpdateResult>;
 
+  bulkUpdateUserRole(userIds: number[], qr: QueryRunner): Promise<UpdateResult>;
+
   updateUserInfo(
     user: UserModel,
     dto: UpdateUserInfoDto,

--- a/backend/src/user/user-domain/service/user-domain.service.ts
+++ b/backend/src/user/user-domain/service/user-domain.service.ts
@@ -189,6 +189,22 @@ export class UserDomainService implements IUserDomainService {
     );
   }
 
+  bulkUpdateUserRole(
+    userIds: number[],
+    qr: QueryRunner,
+  ): Promise<UpdateResult> {
+    const userRepository = this.getUserRepository(qr);
+
+    return userRepository.update(
+      {
+        id: In(userIds),
+      },
+      {
+        role: UserRole.NONE,
+      },
+    );
+  }
+
   async updateUserInfo(
     user: UserModel,
     dto: UpdateUserInfoDto,


### PR DESCRIPTION
## 주요 내용
- **교회 삭제 기능 구현**
  - 교회 소유자가 교회 삭제를 신청하고 본인 계정의 휴대전화 번호로 인증번호를 발송받음
  - 발송된 인증번호를 검증하면 교회가 삭제되도록 처리
  - 삭제 플로우는 교회 소유자만 접근 가능

- **교회 가입 코드 검색 기능 추가**
  - `GET /churches/join/search` 엔드포인트로 교회 가입 코드(joinCode) 기반 교회 검색 지원

## 세부 내용
### 교회 삭제 플로우
- `POST /churches/{churchId}/delete/phone-verification/request`
  - 교회 소유자만 접근 가능
  - 교회 삭제 신청 → 계정에 등록된 휴대전화 번호로 인증번호 발송
- `DELETE /churches/{churchId}/delete/phone-verification/request`
  - 교회 소유자만 접근 가능
  - 인증번호 제출 → 인증 성공 시 교회 삭제 처리

### 교회 가입 코드 검색
- `GET /churches/join/search?joinCode=XXXX`
  - joinCode 값으로 교회를 검색하여 응답 반환