### PR TITLE
feat: 임시 유저 자동 정리, 교인 대량 등록 API 추가, DB 에러 로깅 개선

### DIFF
--- a/backend/src/auth/temp-user-domain/service/interface/temp-user.service.interface.ts
+++ b/backend/src/auth/temp-user-domain/service/interface/temp-user.service.interface.ts
@@ -50,4 +50,6 @@ export interface ITempUserDomainService {
     tempUser: TempUserModel,
     qr?: QueryRunner,
   ): Promise<DeleteResult>;
+
+  cleanUp(): Promise<DeleteResult>;
 }

--- a/backend/src/auth/temp-user-domain/service/temp-user-domain.service.ts
+++ b/backend/src/auth/temp-user-domain/service/temp-user-domain.service.ts
@@ -5,10 +5,11 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { TempUserModel } from '../../entity/temp-user.entity';
-import { QueryRunner, Repository } from 'typeorm';
+import { DeleteResult, LessThan, QueryRunner, Repository } from 'typeorm';
 import { UpdateTempUserDto } from '../../../user/dto/update-temp-user.dto';
 import { ITempUserDomainService } from './interface/temp-user.service.interface';
 import { TempUserException } from '../../const/exception/auth.exception';
+import { subWeeks } from 'date-fns';
 
 @Injectable()
 export class TempUserDomainService implements ITempUserDomainService {
@@ -131,5 +132,15 @@ export class TempUserDomainService implements ITempUserDomainService {
     const tempUserRepository = this.getTempUserRepository(qr);
 
     return tempUserRepository.delete(tempUser.id);
+  }
+
+  cleanUp(): Promise<DeleteResult> {
+    const repository = this.getTempUserRepository();
+
+    const pivotDate = subWeeks(new Date(), 1);
+
+    return repository.delete({
+      createdAt: LessThan(pivotDate),
+    });
   }
 }

--- a/backend/src/common/filter/typeorm-exception.filter.ts
+++ b/backend/src/common/filter/typeorm-exception.filter.ts
@@ -3,6 +3,7 @@ import {
   Catch,
   ExceptionFilter,
   HttpStatus,
+  Logger,
 } from '@nestjs/common';
 import { QueryFailedError } from 'typeorm';
 import { CommonException } from '../const/exception/common.exception';
@@ -13,6 +14,8 @@ const ErrorType = {
 
 @Catch(QueryFailedError)
 export class TypeOrmExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(TypeOrmExceptionFilter.name);
+
   catch(exception: any, host: ArgumentsHost): any {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse();
@@ -40,6 +43,8 @@ export class TypeOrmExceptionFilter implements ExceptionFilter {
       errorType = ErrorType.BAD_REQUEST;
       message = CommonException.NOT_NULL(error.column);
     }
+
+    this.logger.error(exception);
 
     response.status(HttpStatus.BAD_REQUEST).json({
       message,

--- a/backend/src/members/controller/members.controller.ts
+++ b/backend/src/members/controller/members.controller.ts
@@ -38,6 +38,7 @@ import { endOfToday, startOfToday, subYears } from 'date-fns';
 import { fromZonedTime } from 'date-fns-tz';
 import { TIME_ZONE } from '../../common/const/time-zone.const';
 import { GetMemberWorshipAttendancesDto } from '../dto/request/worship/get-member-worship-attendances.dto';
+import { CreateBulkMemberDto } from '../dto/request/create-bulk-member.dto';
 
 @ApiTags('Churches:Members')
 @Controller('members')
@@ -65,6 +66,16 @@ export class MembersController {
     @QueryRunner() qr: QR,
   ) {
     return this.membersService.createMember(church, dto, qr);
+  }
+
+  @Post('bulk')
+  @MemberWriteGuard()
+  postBulkMembers(
+    @Param('churchId', ParseIntPipe) churchId: number,
+    @RequestChurch() church: ChurchModel,
+    @Body() dto: CreateBulkMemberDto,
+  ) {
+    return this.membersService.createBulkMember(church, dto);
   }
 
   @Get('v2')

--- a/backend/src/members/dto/request/create-bulk-member.dto.ts
+++ b/backend/src/members/dto/request/create-bulk-member.dto.ts
@@ -1,0 +1,112 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  IsBoolean,
+  IsDateString,
+  IsIn,
+  IsNotEmpty,
+  IsOptional,
+  IsPhoneNumber,
+  IsString,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+import { IsYYYYMMDD } from '../../../common/decorator/validator/is-yyyy-mm-dd.validator';
+import { RemoveSpaces } from '../../../common/decorator/transformer/remove-spaces';
+import { IsNoSpecialChar } from '../../../common/decorator/validator/is-no-special-char.validator';
+
+export class BulkMemberDto {
+  @ApiPropertyOptional({
+    description: '교회 등록일자 (YYYY-MM-DD)',
+    default: new Date().toISOString().slice(0, 10),
+  })
+  @IsDateString({ strict: true })
+  @IsYYYYMMDD('등록일쟈')
+  @IsOptional()
+  등록일자?: string; //"2025-09-22",
+
+  @ApiProperty()
+  @IsString()
+  @RemoveSpaces()
+  @IsNotEmpty()
+  @IsNoSpecialChar()
+  @MaxLength(30)
+  이름: string; //"김철수",
+
+  @ApiProperty()
+  @IsString()
+  @IsPhoneNumber('KR')
+  휴대전화번호: string; //"01043215678",
+
+  @ApiPropertyOptional({
+    description: '생년월일 (YYYY-MM-DD)',
+    default: new Date().toISOString().slice(0, 10),
+  })
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? undefined : value))
+  @IsYYYYMMDD('생년월일')
+  생년월일?: string; //"1999-04-15",
+
+  @ApiProperty()
+  @IsBoolean()
+  음력: boolean; //"",
+
+  @ApiProperty()
+  @IsBoolean()
+  윤달: boolean; //"",
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? undefined : value))
+  @IsIn(['남', '여', ''])
+  성별?: string; //"남",
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? undefined : value))
+  @IsString()
+  주소?: string; //"",
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? undefined : value))
+  @IsString()
+  상세주소?: string; //"",
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? undefined : value))
+  @IsString()
+  직업?: string; //"",
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? undefined : value))
+  @IsString()
+  학교?: string; //"",
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? undefined : value))
+  @IsIn(['기혼', '미혼', ''])
+  결혼여부?: string; //"미혼",
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? undefined : value))
+  @IsString()
+  차량번호?: string; //"123가4567"
+}
+
+export class CreateBulkMemberDto {
+  @ApiProperty({
+    description: '교인 데이터 배열',
+    type: BulkMemberDto,
+    isArray: true,
+  })
+  @ValidateNested({ each: true })
+  @Type(() => BulkMemberDto)
+  @ArrayMaxSize(500)
+  members: BulkMemberDto[];
+}

--- a/backend/src/members/dto/response/post-bulk-members-response.dto.ts
+++ b/backend/src/members/dto/response/post-bulk-members-response.dto.ts
@@ -1,0 +1,7 @@
+export class PostBulkMembersResponseDto {
+  constructor(
+    public readonly timestamp: Date,
+    public readonly count: number,
+    public readonly success: boolean,
+  ) {}
+}

--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -110,6 +110,11 @@ export interface IMembersDomainService {
     qr: QueryRunner,
   ): Promise<MemberModel>;
 
+  createBulkMembers(
+    church: ChurchModel,
+    createBulkMemberDto: CreateMemberDto[],
+  ): any;
+
   updateMember(
     church: ChurchModel,
     member: MemberModel,

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -448,6 +448,24 @@ export class MembersDomainService implements IMembersDomainService {
     return !!member;
   }
 
+  async createBulkMembers(
+    church: ChurchModel,
+    createBulkMemberDto: CreateMemberDto[],
+  ): Promise<boolean> {
+    const repository = this.getMembersRepository();
+
+    const members = repository.create(
+      createBulkMemberDto.map((dto) => ({
+        ...dto,
+        churchId: church.id,
+      })),
+    );
+
+    await repository.save(members, { chunk: 100 });
+
+    return true;
+  }
+
   async createMember(
     church: ChurchModel,
     dto: CreateMemberDto,


### PR DESCRIPTION
## 주요 내용
- **임시 유저 자동 삭제**: 회원가입 과정에서 생성된 임시 유저 중 생성 후 7일이 지난 데이터를 매일 오전 4시(KST)에 자동 삭제
- **교인 대량 등록 API 추가**: `POST /churches/{churchId}/member/bulk` 엔드포인트 신설
- **DB 에러 로깅 개선**: 데이터베이스 에러(특히 QueryFailedError) 로깅 강화

## 세부 내용
### Scheduler
- 매일 오전 4시(KST) 실행 스케줄 추가
- 대상: 생성된 지 7일이 경과한 임시 유저 레코드
- 처리: 자동 삭제(운영 정책에 따라 물리 삭제 적용)

### Members
- `POST /churches/{churchId}/member/bulk` 엔드포인트 구현
  - 교인 데이터 대량 등록 처리용 서비스 로직 추가
  - 트랜잭션 단위 처리 및 기본 유효성 검증 적용

### Infra/Logging
- 데이터베이스 에러 로깅 강화
  - 에러 코드, 메시지, 세부(detail), 파라미터를 포함하여 구조화된 로그 출력
  - 운영 환경에서의 원인 파악 및 추적성 개선