### PR TITLE
feat: 관리자 목록 권한 활성 상태 필터링 추가 및 교인 필터링 버그 수정

### DIFF
--- a/backend/src/manager/dto/request/get-managers.dto.ts
+++ b/backend/src/manager/dto/request/get-managers.dto.ts
@@ -1,8 +1,15 @@
 import { BaseOffsetPaginationRequestDto } from '../../../common/dto/request/base-offset-pagination-request.dto';
 import { ManagerOrder } from '../../const/manager-order.enum';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 import { IsOptionalNotNull } from '../../../common/decorator/validator/is-optional-not.null.validator';
+import { QueryBoolean } from '../../../common/decorator/transformer/query-boolean.decorator';
 
 export class GetManagersDto extends BaseOffsetPaginationRequestDto<ManagerOrder> {
   @ApiProperty({
@@ -23,4 +30,13 @@ export class GetManagersDto extends BaseOffsetPaginationRequestDto<ManagerOrder>
   @IsString()
   @IsNotEmpty()
   name?: string;
+
+  @ApiProperty({
+    description: '활성 여부',
+    required: false,
+  })
+  @IsOptional()
+  @QueryBoolean()
+  @IsBoolean()
+  isPermissionActive?: boolean;
 }

--- a/backend/src/manager/manager-domain/service/manager-domain.service.ts
+++ b/backend/src/manager/manager-domain/service/manager-domain.service.ts
@@ -72,6 +72,7 @@ export class ManagerDomainService implements IManagerDomainService {
       member: {
         name: dto.name && ILike(`%${dto.name}%`),
       },
+      isPermissionActive: dto.isPermissionActive,
     };
 
     return repository.find({

--- a/backend/src/members/service/member-filter.service.ts
+++ b/backend/src/members/service/member-filter.service.ts
@@ -38,13 +38,13 @@ export class MemberFilterService implements IMemberFilterService {
       return { ...member, isConcealed: false };
     }
 
-    if (!member.groupId) {
+    if (!member.group.id) {
       return { ...this.concealInfo(member), isConcealed: true };
     }
 
     const possibleGroupIds = new Set(scopeGroupIds);
 
-    if (possibleGroupIds.has(member.groupId)) {
+    if (possibleGroupIds.has(member.group.id)) {
       return { ...member, isConcealed: false };
     } else {
       return { ...this.concealInfo(member), isConcealed: true };

--- a/backend/src/members/service/members.service.ts
+++ b/backend/src/members/service/members.service.ts
@@ -352,6 +352,8 @@ export class MembersService {
       requestManager,
     );
 
+    console.log(possibleGroupIds);
+
     const filteredMembers = this.memberFilterService.filterMembers(
       requestManager,
       result.items,


### PR DESCRIPTION
## 주요 내용
- **관리자 목록 조회 개선**
  - 쿼리 파라미터 `isPermissionActive` 추가
  - `undefined` → 활성/비활성 무관 전체 조회
  - `true` → 활성 권한만 조회
  - `false` → 비활성 권한만 조회

- **교인 필터링 버그 수정**
  - 특정 조건에서 모든 교인이 잘못 필터링되는 문제 해결
  - 필터 조건 검증 로직 보완으로 정상적인 결과 반환 보장

## 세부 내용
### AdminController
- 관리자 목록 조회 시 `isPermissionActive` 쿼리 파라미터 처리 로직 추가
- Repository 레벨에서 권한 활성 여부 조건 동적 적용

### Members
- 교인 목록 필터링 로직 오류 수정
- 불필요한 조건 중첩 제거 및 where 절 재구성으로 전체 필터링 문제 해결