### PR TITLE
feat: 교인 목록 조회 그룹 필터링 파라미터 개편

### DIFF
--- a/backend/src/members/dto/list/get-member-list.dto.ts
+++ b/backend/src/members/dto/list/get-member-list.dto.ts
@@ -59,6 +59,14 @@ export class GetMemberListDto {
   displayColumns: MemberDisplayColumn[] = [];
 
   @ApiPropertyOptional({
+    description: '그룹 ID 목록 ("null" = 그룹 없는 교인 조회)',
+    type: 'string',
+  })
+  @IsOptional()
+  @Transform(({ value }) => +value)
+  groupId?: number;
+
+  /*@ApiPropertyOptional({
     description: '그룹 ID 목록 ("null" 포함 시 그룹 없는 교인 조회)',
     type: [String],
     example: ['1', '2', 'null'],
@@ -71,7 +79,7 @@ export class GetMemberListDto {
   @IsOptional()
   @IsArray()
   @ArrayUnique()
-  groupIds?: (number | 'null')[];
+  groupIds?: (number | 'null')[];*/
 
   @ApiPropertyOptional({
     description: '직분 ID 목록 ("null" 포함 시 직분 없는 교인 조회)',

--- a/backend/src/members/member-domain/interface/members-domain.service.interface.ts
+++ b/backend/src/members/member-domain/interface/members-domain.service.interface.ts
@@ -36,6 +36,7 @@ export interface IMembersDomainService {
   getMemberListWithPagination(
     church: ChurchModel,
     dto: GetMemberListDto,
+    groupIds: number[] | null | undefined,
   ): Promise<DomainCursorPaginationResultDto<MemberModel>>;
 
   findSimpleMemberList(

--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -670,6 +670,7 @@ export class MembersDomainService implements IMembersDomainService {
   async getMemberListWithPagination(
     church: ChurchModel,
     dto: GetMemberListDto,
+    groupIds: number[] | null | undefined,
   ) {
     const repository = this.getMembersRepository();
 
@@ -734,7 +735,7 @@ export class MembersDomainService implements IMembersDomainService {
         query.addSelect(sortColumn);
     }
 
-    this.applyFilters(query, dto);
+    this.applyFilters(query, dto, groupIds);
     this.applySearch(query, dto.search);
 
     // 정렬 적용 (1순위: 사용자 지정(기본값-등록일자), 2순위: ID)
@@ -820,6 +821,7 @@ export class MembersDomainService implements IMembersDomainService {
   private applyFilters(
     query: SelectQueryBuilder<MemberModel>,
     filter: GetMemberListDto,
+    groupIds: number[] | null | undefined,
   ) {
     // 1. 직분 필터 (OR 조건, NULL 처리)
     if (filter.officerIds && filter.officerIds.length > 0) {
@@ -843,7 +845,17 @@ export class MembersDomainService implements IMembersDomainService {
     }
 
     // 2. 그룹 필터
-    if (filter.groupIds && filter.groupIds.length > 0) {
+    //query.andWhere('(member.groupId = :groupIds)', { groupIds: 3 });
+    if (groupIds === null) {
+      query.andWhere('(member.groupId IS NULL)');
+    } else if (groupIds === undefined) {
+    } else {
+      console.log('dd');
+      query.andWhere('member.groupId IN (:...groupIds)', {
+        groupIds,
+      });
+    }
+    /*if (filter.groupIds && filter.groupIds.length > 0) {
       const hasNull = filter.groupIds.includes('null');
       const realIds = filter.groupIds.filter((id) => id !== 'null') as number[];
 
@@ -859,7 +871,7 @@ export class MembersDomainService implements IMembersDomainService {
           groupIds: realIds,
         });
       }
-    }
+    }*/
 
     // 3. 결혼 상태 필터 (OR 조건, NULL 처리)
     if (filter.marriageStatuses && filter.marriageStatuses.length > 0) {

--- a/backend/src/members/service/member-filter.service.ts
+++ b/backend/src/members/service/member-filter.service.ts
@@ -38,7 +38,7 @@ export class MemberFilterService implements IMemberFilterService {
       return { ...member, isConcealed: false };
     }
 
-    if (!member.group.id) {
+    if (!member.group) {
       return { ...this.concealInfo(member), isConcealed: true };
     }
 

--- a/backend/src/members/service/members.service.ts
+++ b/backend/src/members/service/members.service.ts
@@ -342,17 +342,26 @@ export class MembersService {
     requestManager: ChurchUserModel,
     dto: GetMemberListDto,
   ) {
+    const targetGroupIds = dto.groupId
+      ? (
+          await this.groupsDomainService.findGroupAndDescendantsByIds(church, [
+            dto.groupId,
+          ])
+        ).map((group) => group.id)
+      : Number.isNaN(dto.groupId)
+        ? null
+        : undefined;
+
     const result = await this.membersDomainService.getMemberListWithPagination(
       church,
       dto,
+      targetGroupIds,
     );
 
     const possibleGroupIds = await this.getScopeGroupIds(
       church,
       requestManager,
     );
-
-    console.log(possibleGroupIds);
 
     const filteredMembers = this.memberFilterService.filterMembers(
       requestManager,


### PR DESCRIPTION
## 주요 내용
- **쿼리 파라미터 변경**
  - `groupIds` 파라미터 제거
  - 단일 `groupId` 파라미터로 변경

- **그룹 필터링 기능 확장**
  - 특정 `groupId` 전달 시 해당 그룹 및 모든 하위 그룹에 속한 교인까지 포함하여 조회
  - `"null"` 값 전달 시 어떠한 그룹에도 속하지 않은 교인만 응답

## 세부 내용
### MembersController
- `GET /churches/{churchId}/members` 쿼리 파라미터 수정
- `groupId` 기반 하위 그룹 탐색 로직 추가
- `"null"` 문자열 처리 분기 추가

### MembersService
- 그룹 계층 구조 탐색 및 해당 교인 조회 기능 구현
- 기존 `groupIds` 배열 기반 필터링 로직 제거