### PR TITLE
fix: 권한 범위 내 교인 단건 조회 시 개인정보 마스킹 오류 수정

### DIFF
--- a/backend/src/members/member-domain/service/members-domain.service.ts
+++ b/backend/src/members/member-domain/service/members-domain.service.ts
@@ -313,6 +313,8 @@ export class MembersDomainService implements IMembersDomainService {
       .addSelect(['officer_history.id', 'officer_history.startDate'])
       .leftJoin('officer_history.officer', 'officer_history_officer')
       .addSelect(['officer_history_officer.id', 'officer_history_officer.name'])
+      .leftJoin('member.group', 'group')
+      .addSelect(['group.id', 'group.name'])
       .leftJoin(
         'member.groupHistory',
         'group_history',


### PR DESCRIPTION
## 주요 내용
- 교인 단건 조회 시 권한 범위 내의 교인임에도 불구하고 개인정보가 마스킹되던 문제 해결
- 권한 검증 로직을 보완하여 접근 가능한 교인의 개인정보가 정상적으로 반환되도록 수정

## 세부 내용
### MembersService / Controller
- 권한 범위 판별 로직과 개인정보 마스킹 로직의 충돌 문제 수정
- 권한 범위 내 교인 조회 시 이름, 연락처 등 개인정보가 그대로 응답되도록 보장