### PR TITLE
fix: 회원 탈퇴 시 교회 탈퇴 처리 추가 및 관리자 삭제 오류 수정

### DIFF
--- a/backend/src/church-user/service/church-user.service.ts
+++ b/backend/src/church-user/service/church-user.service.ts
@@ -121,17 +121,21 @@ export class ChurchUserService {
         churchUserId,
         qr,
       );
-    const user = await this.userDomainService.findUserById(
-      targetChurchUser.userId,
-      qr,
-    );
+
+    try {
+      const user = await this.userDomainService.findUserById(
+        targetChurchUser.userId,
+        qr,
+      );
+
+      await this.userDomainService.updateUserRole(
+        user,
+        { role: UserRole.NONE },
+        qr,
+      );
+    } catch (error) {}
 
     await this.churchUserDomainService.leaveChurch(targetChurchUser, qr);
-    await this.userDomainService.updateUserRole(
-      user,
-      { role: UserRole.NONE },
-      qr,
-    );
 
     return {
       success: true,

--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -190,6 +190,10 @@ export class UserService {
   }
 
   async deleteUser(user: UserModel, qr: QueryRunner) {
+    if (user.churchUser[0]) {
+      await this.churchUserDomainService.leaveChurch(user.churchUser[0], qr);
+    }
+
     await this.userDomainService.deleteUser(user, qr);
 
     return {


### PR DESCRIPTION
## 주요 내용
- **회원 탈퇴 플로우 개선**
  - 회원 탈퇴 시 해당 회원이 가입한 교회가 존재하면 자동으로 교회 탈퇴 처리되도록 수정
  - 교회와의 관계를 일관되게 정리하여 데이터 정합성 확보

- **교회 관리자 삭제 오류 수정**
  - 교회에서 관리자를 삭제할 때 계정 정보가 누락된 경우 삭제가 불가능하던 문제 해결
  - 계정 정보 유무와 관계없이 관리자를 정상적으로 삭제 가능하도록 로직 보완

## 세부 내용
### UserService
- `DELETE /users` 처리 시 교회 가입 내역 확인 후 `ChurchUser` 탈퇴 처리 로직 추가

### ChurchUserService
- 관리자 삭제 시 계정 정보 누락 케이스를 허용하도록 검증 로직 수정
- 관리자 삭제 처리 일관성 확보