### PR TITLE
feat: 인증 문자 멘트 수정 및 교회 리소스 생성 제한 설정

### DIFF
--- a/backend/src/auth/const/verification-message.const.ts
+++ b/backend/src/auth/const/verification-message.const.ts
@@ -1,9 +1,15 @@
-export const VerificationMessage = (code: string) =>
-  `목장 회원 가입 인증번호: ${code}`;
+export const SignInVerificationMessage = (code: string) =>
+  `[에클리] 회원 가입 인증번호: ${code}`;
+
+export const DeleteChurchVerificationMessage = (code: string) =>
+  `[에클리] 교회 삭제 인증번호: ${code}`;
+
+export const UpdatePhoneVerificationMessage = (code: string) =>
+  `[에클리] 인증번호: ${code}`;
 
 export const BetaVerificationMessage = (
   code: string,
   name: string,
   requestPhoneNumber: string,
 ) =>
-  `인증 요청자 이름: ${name}\n인증 요청 휴대폰 번호: ${requestPhoneNumber}\n목장 인증번호 : ${code}`;
+  `인증 요청자 이름: ${name}\n인증 요청 휴대폰 번호: ${requestPhoneNumber}\n에클리 인증번호 : ${code}`;

--- a/backend/src/auth/service/auth.service.ts
+++ b/backend/src/auth/service/auth.service.ts
@@ -23,7 +23,7 @@ import { JwtTemporalPayload } from '../type/jwt';
 import { TestEnvironment } from '../const/enum/test-environment.enum';
 import {
   BetaVerificationMessage,
-  VerificationMessage,
+  SignInVerificationMessage,
 } from '../const/verification-message.const';
 import { CreateUserDto } from '../../user/dto/create-user.dto';
 import { UpdateTempUserDto } from '../../user/dto/update-temp-user.dto';
@@ -163,7 +163,7 @@ export class AuthService {
     const message =
       dto.isTest === TestEnvironment.BetaTest
         ? BetaVerificationMessage(code, dto.name, dto.mobilePhone)
-        : VerificationMessage(code);
+        : SignInVerificationMessage(code);
 
     if (dto.isTest === TestEnvironment.Production) {
       return this.messagesService.sendMessage(dto.mobilePhone, message);
@@ -177,7 +177,7 @@ export class AuthService {
         // 사용자에게 전송
         this.messagesService.sendMessage(
           dto.mobilePhone,
-          VerificationMessage(code),
+          SignInVerificationMessage(code),
         ),
       ]);
     } else {

--- a/backend/src/church-user/service/church-user.service.ts
+++ b/backend/src/church-user/service/church-user.service.ts
@@ -121,17 +121,21 @@ export class ChurchUserService {
         churchUserId,
         qr,
       );
-    const user = await this.userDomainService.findUserById(
-      targetChurchUser.userId,
-      qr,
-    );
+
+    try {
+      const user = await this.userDomainService.findUserById(
+        targetChurchUser.userId,
+        qr,
+      );
+
+      await this.userDomainService.updateUserRole(
+        user,
+        { role: UserRole.NONE },
+        qr,
+      );
+    } catch (error) {}
 
     await this.churchUserDomainService.leaveChurch(targetChurchUser, qr);
-    await this.userDomainService.updateUserRole(
-      user,
-      { role: UserRole.NONE },
-      qr,
-    );
 
     return {
       success: true,

--- a/backend/src/churches/service/churches.service.ts
+++ b/backend/src/churches/service/churches.service.ts
@@ -53,6 +53,7 @@ import { DeleteChurchVerificationConfirmDto } from '../dto/request/delete-church
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { TIME_ZONE } from '../../common/const/time-zone.const';
 import { DeleteChurchResponseDto } from '../dto/response/delete-church-response.dto';
+import { DeleteChurchVerificationMessage } from '../../auth/const/verification-message.const';
 
 @Injectable()
 export class ChurchesService {
@@ -336,7 +337,7 @@ export class ChurchesService {
 
     return this.messageService.sendMessage(
       mobilePhone,
-      `[에클리 인증번호] ${verification.verificationCode}`,
+      DeleteChurchVerificationMessage(verification.verificationCode), //`[에클리] 인증번호: ${verification.verificationCode}`,
     );
   }
 

--- a/backend/src/common/filter/log-all-errors.filter.ts
+++ b/backend/src/common/filter/log-all-errors.filter.ts
@@ -1,0 +1,21 @@
+import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
+
+@Catch()
+export class LogAllErrorsFilter implements ExceptionFilter {
+  catch(exception: any, host: ArgumentsHost) {
+    if (exception instanceof AggregateError) {
+      console.error('AggregateError:', exception.message, exception.stack);
+      for (const [i, e] of exception.errors.entries()) {
+        console.error(` └─ [${i}]`, e?.name, e?.message, e?.stack);
+      }
+    } else {
+      console.error(
+        'Error:',
+        exception?.name,
+        exception?.message,
+        exception?.stack,
+      );
+    }
+    // 기존 응답 처리 로직…
+  }
+}

--- a/backend/src/management/const/group-depth.constraint.ts
+++ b/backend/src/management/const/group-depth.constraint.ts
@@ -1,3 +1,0 @@
-export const GroupDepthConstraint = {
-  MAX_DEPTH: 5,
-};

--- a/backend/src/management/groups/const/exception/group.exception.ts
+++ b/backend/src/management/groups/const/exception/group.exception.ts
@@ -1,3 +1,5 @@
+import { MAX_GROUP_COUNT } from '../../../management.constraints';
+
 export const GroupException = {
   NOT_FOUND: '해당 그룹을 찾을 수 없습니다.',
   ALREADY_EXIST: '이미 존재하는 그룹입니다.',
@@ -7,4 +9,5 @@ export const GroupException = {
   GROUP_HAS_DEPENDENCIES: '해당 그룹에 속한 하위 그룹 또는 교인이 존재합니다.',
   UPDATE_ERROR: '업데이트 도중 에러 발생',
   INVALID_ORDER: '지정할 수 없는 순서입니다.',
+  EXCEED_MAX_GROUP_COUNT: `최대 생성 가능 그룹 수에 도달했습니다. (${MAX_GROUP_COUNT}개)`,
 };

--- a/backend/src/management/groups/groups-domain/service/groups-domain.service.ts
+++ b/backend/src/management/groups/groups-domain/service/groups-domain.service.ts
@@ -29,7 +29,6 @@ import { GroupModel } from '../../entity/group.entity';
 import { UpdateGroupNameDto } from '../../dto/request/update-group-name.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { GroupException } from '../../const/exception/group.exception';
-import { GroupDepthConstraint } from '../../../const/group-depth.constraint';
 import { GetGroupDto } from '../../dto/request/get-group.dto';
 import { GroupOrderEnum } from '../../const/group-order.enum';
 import { UpdateGroupStructureDto } from '../../dto/request/update-group-structure.dto';
@@ -40,6 +39,7 @@ import {
   MemberSimpleSelect,
   MemberSummarizedRelation,
 } from '../../../../members/const/member-find-options.const';
+import { MAX_GROUP_DEPTH } from '../../../management.constraints';
 
 @Injectable()
 export class GroupsDomainService implements IGroupsDomainService {
@@ -875,7 +875,7 @@ export class GroupsDomainService implements IGroupsDomainService {
     // 새 상위 그룹의 depth 와 타겟 그룹의 depth 의 합이 5 를 넘는지 확인
     const newDepth = newParentDepth + maxChildGroupDepth + 1;
 
-    if (newDepth > GroupDepthConstraint.MAX_DEPTH) {
+    if (newDepth > MAX_GROUP_DEPTH) {
       throw new BadRequestException(GroupException.LIMIT_DEPTH_REACHED);
     }
   }

--- a/backend/src/management/management.constraints.ts
+++ b/backend/src/management/management.constraints.ts
@@ -1,0 +1,11 @@
+export const MAX_GROUP_COUNT = 100;
+
+export const MAX_MINISTRY_GROUP_COUNT = 100;
+
+export const MAX_MINISTRY_COUNT = 30;
+
+export const MAX_OFFICER_COUNT = 100;
+
+export const MAX_GROUP_DEPTH = 5;
+
+export const MAX_MINISTRY_GROUP_DEPTH = 5;

--- a/backend/src/management/ministries/exception/ministry-group.exception.ts
+++ b/backend/src/management/ministries/exception/ministry-group.exception.ts
@@ -1,3 +1,5 @@
+import { MAX_MINISTRY_GROUP_COUNT } from '../../management.constraints';
+
 export const MinistryGroupException = {
   NOT_FOUND: '해당 사역 그룹을 찾을 수 없습니다.',
   ALREADY_EXIST: '이미 존재하는 사역 그룹입니다.',
@@ -7,4 +9,5 @@ export const MinistryGroupException = {
   GROUP_HAS_DEPENDENCIES: '해당 그룹에 속한 사역이 존재합니다.',
   UPDATE_ERROR: '업데이트 도중 에러 발생',
   INVALID_ORDER: '지정할 수 없는 순서입니다.',
+  EXCEED_MAX_MINISTRY_GROUP_COUNT: `최대 생성 가능 사역 그룹 수에 도달했습니다. (${MAX_MINISTRY_GROUP_COUNT}개)`,
 };

--- a/backend/src/management/ministries/exception/ministry.exception.ts
+++ b/backend/src/management/ministries/exception/ministry.exception.ts
@@ -1,3 +1,5 @@
+import { MAX_MINISTRY_COUNT } from '../../management.constraints';
+
 export const MinistryException = {
   NOT_FOUND: '해당 사역을 찾을 수 없습니다.',
   ALREADY_EXIST: '해당 사역 그룹에 이미 존재하는 사역 이름입니다.',
@@ -5,4 +7,5 @@ export const MinistryException = {
   EMPTY_MEMBER_COUNT:
     '해당 사역을 수행하는 교인 수에 오류가 있습니다.\n사역 관리 화면에서 교인 수를 새로고침 해주세요.',
   ALREADY_ASSIGNED_MINISTRY: '이미 부여된 사역입니다.',
+  EXCEED_MAX_MINISTRY_COUNT: `사역은 그룹 당 최대 ${MAX_MINISTRY_COUNT}개까지 생성 가능합니다.`,
 };

--- a/backend/src/management/ministries/ministries-domain/service/ministry-groups-domain.service.ts
+++ b/backend/src/management/ministries/ministries-domain/service/ministry-groups-domain.service.ts
@@ -26,11 +26,11 @@ import { ChurchModel } from '../../../../churches/entity/church.entity';
 import { MinistryGroupException } from '../../exception/ministry-group.exception';
 import { CreateMinistryGroupDto } from '../../dto/ministry-group/request/create-ministry-group.dto';
 import { UpdateMinistryGroupNameDto } from '../../dto/ministry-group/request/update-ministry-group-name.dto';
-import { GroupDepthConstraint } from '../../../const/group-depth.constraint';
 import { GetMinistryGroupDto } from '../../dto/ministry-group/request/get-ministry-group.dto';
 import { MinistryGroupOrderEnum } from '../../const/ministry-group-order.enum';
 import { UpdateMinistryGroupStructureDto } from '../../dto/ministry-group/request/update-ministry-group-structure.dto';
 import { MemberModel } from '../../../../members/entity/member.entity';
+import { MAX_MINISTRY_GROUP_DEPTH } from '../../../management.constraints';
 
 @Injectable()
 export class MinistryGroupsDomainService
@@ -581,7 +581,7 @@ export class MinistryGroupsDomainService
     // 부모 그룹 depth + 자식 그룹 depth + 자신
     const newDepth = newParentsDepth + maxChildMinistryGroupDepth + 1;
 
-    if (newDepth > GroupDepthConstraint.MAX_DEPTH) {
+    if (newDepth > MAX_MINISTRY_GROUP_DEPTH) {
       throw new BadRequestException(MinistryGroupException.LIMIT_DEPTH_REACHED);
     }
   }

--- a/backend/src/management/ministries/service/ministry.service.ts
+++ b/backend/src/management/ministries/service/ministry.service.ts
@@ -24,6 +24,8 @@ import {
 } from '../../../churches/entity/church.entity';
 import { GetMinistryResponseDto } from '../dto/ministry/response/get-ministry-response.dto';
 import { RefreshMinistryCountResponseDto } from '../dto/ministry/response/refresh-ministry-count-response.dto';
+import { MAX_MINISTRY_COUNT } from '../../management.constraints';
+import { MinistryException } from '../exception/ministry.exception';
 
 @Injectable()
 export class MinistryService {
@@ -89,10 +91,8 @@ export class MinistryService {
         qr,
       );
 
-    if (ministryGroup.ministriesCount >= 30) {
-      throw new ConflictException(
-        '사역그룹 내 사역은 최대 30개까지 생성 가능합니다.',
-      );
+    if (ministryGroup.ministriesCount >= MAX_MINISTRY_COUNT) {
+      throw new ConflictException(MinistryException.EXCEED_MAX_MINISTRY_COUNT);
     }
 
     const ministry = await this.ministriesDomainService.createMinistry(

--- a/backend/src/management/officers/exception/officers.exception.ts
+++ b/backend/src/management/officers/exception/officers.exception.ts
@@ -1,7 +1,10 @@
+import { MAX_OFFICER_COUNT } from '../../management.constraints';
+
 export const OfficersException = {
   NOT_FOUND: '해당 직분을 찾을 수 없습니다.',
   ALREADY_EXIST: '이미 존재하는 직분입니다.',
   HAS_DEPENDENCIES: '해당 직분에 속한 교인이 존재합니다.',
   INVALID_ORDER: '지정할 수 없는 순서입니다.',
   UPDATE_ERROR: '직분 수정 도중 에러 발생',
+  EXCEED_MAX_OFFICER_COUNT: `최대 생성 가능 직분 수에 도달했습니다. (${MAX_OFFICER_COUNT}개)`,
 };

--- a/backend/src/management/officers/service/officers.service.ts
+++ b/backend/src/management/officers/service/officers.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { ConflictException, Inject, Injectable } from '@nestjs/common';
 import { QueryRunner } from 'typeorm';
 import { CreateOfficerDto } from '../dto/request/create-officer.dto';
 import { UpdateOfficerNameDto } from '../dto/request/update-officer-name.dto';
@@ -32,6 +32,8 @@ import {
   IMemberFilterService,
 } from '../../../members/service/interface/member-filter.service.interface';
 import { RefreshOfficerCountResponseDto } from '../dto/response/refresh-officer-count-response.dto';
+import { MAX_OFFICER_COUNT } from '../../management.constraints';
+import { OfficersException } from '../exception/officers.exception';
 
 @Injectable()
 export class OfficersService {
@@ -62,6 +64,15 @@ export class OfficersService {
     dto: CreateOfficerDto,
     qr: QueryRunner,
   ) {
+    const officerCount = await this.officersDomainService.countAllOfficers(
+      church,
+      qr,
+    );
+
+    if (officerCount > MAX_OFFICER_COUNT) {
+      throw new ConflictException(OfficersException.EXCEED_MAX_OFFICER_COUNT);
+    }
+
     const officer = await this.officersDomainService.createOfficer(
       church,
       dto,

--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -25,6 +25,7 @@ import {
 import { VerificationType } from '../../mobile-verification/const/verification-type.enum';
 import { MessageService } from '../../common/service/message.service';
 import { VerifyUserMobilePhoneDto } from '../dto/request/verify-user-mobile-phone.dto';
+import { UpdatePhoneVerificationMessage } from '../../auth/const/verification-message.const';
 
 @Injectable()
 export class UserService {
@@ -92,7 +93,7 @@ export class UserService {
 
     return this.messageService.sendMessage(
       dto.mobilePhone,
-      verification.verificationCode,
+      UpdatePhoneVerificationMessage(verification.verificationCode), //`[에클리] 인증번호: ${verification.verificationCode}`,
     );
   }
 

--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -190,6 +190,10 @@ export class UserService {
   }
 
   async deleteUser(user: UserModel, qr: QueryRunner) {
+    if (user.churchUser[0]) {
+      await this.churchUserDomainService.leaveChurch(user.churchUser[0], qr);
+    }
+
     await this.userDomainService.deleteUser(user, qr);
 
     return {

--- a/backend/src/worship/constraints/worship.constraints.ts
+++ b/backend/src/worship/constraints/worship.constraints.ts
@@ -1,4 +1,5 @@
 // --------------------Worship Constraints----------------------
+export const MAX_WORSHIP_COUNT = 50;
 export const MAX_WORSHIP_TITLE = 50;
 export const MAX_WORSHIP_DESCRIPTION = 500;
 // -------------------------------------------------------------

--- a/backend/src/worship/exception/worship.exception.ts
+++ b/backend/src/worship/exception/worship.exception.ts
@@ -1,3 +1,5 @@
+import { MAX_WORSHIP_COUNT } from '../constraints/worship.constraints';
+
 export const WorshipException = {
   NOT_FOUND: '해당 예배를 찾을 수 없습니다.',
   ALREADY_EXIST: '이미 존재하는 예배 제목입니다.',
@@ -5,4 +7,5 @@ export const WorshipException = {
   UPDATE_ERROR: '예배 업데이트 도중 에러 발생',
 
   INVALID_TARGET_GROUP: '에배 대상 그룹이 아닙니다.',
+  EXCEED_MAX_WORSHIP_COUNT: `최대 생성 가능 예배 수에 도달했습니다. (${MAX_WORSHIP_COUNT}개)`,
 };

--- a/backend/src/worship/service/worship.service.ts
+++ b/backend/src/worship/service/worship.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { ConflictException, Inject, Injectable } from '@nestjs/common';
 import {
   ICHURCHES_DOMAIN_SERVICE,
   IChurchesDomainService,
@@ -55,6 +55,8 @@ import {
 } from '../../member-history/history-date.utils';
 import { WorshipGroupIdsVo } from '../vo/worship-group-ids.vo';
 import { PermissionScopeIdsVo } from '../../permission/vo/permission-scope-ids.vo';
+import { MAX_WORSHIP_COUNT } from '../constraints/worship.constraints';
+import { WorshipException } from '../exception/worship.exception';
 
 @Injectable()
 export class WorshipService {
@@ -103,6 +105,15 @@ export class WorshipService {
     dto: CreateWorshipDto,
     qr: QueryRunner,
   ) {
+    const worshipCount = await this.worshipDomainService.countAllWorships(
+      church,
+      qr,
+    );
+
+    if (worshipCount > MAX_WORSHIP_COUNT) {
+      throw new ConflictException(WorshipException.EXCEED_MAX_WORSHIP_COUNT);
+    }
+
     const newWorship = await this.worshipDomainService.createWorship(
       church,
       dto,


### PR DESCRIPTION
## 주요 내용
- **인증 문자 멘트 수정**
  - 휴대폰 인증 문자 발송 시 사용자에게 전달되는 메시지 내용을 개선

- **교회 리소스 생성 제한 추가**
  - 직분, 사역, 그룹, 예배 생성 시 교회별 최대 개수를 제한하는 정책 적용
  - 제한 초과 시 생성 요청 거부 및 적절한 예외 반환

## 세부 내용
### AuthService
- 휴대폰 인증번호 발송 시 메시지 멘트 수정

### Management/Worship Domain
- 직분(`Officer`), 사역(`Ministry`), 그룹(`Group`), 예배(`Worship`) 생성 시 최대 개수 제한 검증 로직 추가
- 교회 엔티티에 각 리소스별 최대 허용 개수 설정값 반영