### PR TITLE
feat: Helmet 보안 헤더 기본 설정 추가

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,6 +29,7 @@
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "dotenv": "^16.4.5",
+        "helmet": "^8.1.0",
         "joi": "^17.13.3",
         "korean-lunar-calendar": "^0.3.6",
         "ms": "^2.1.3",
@@ -5911,6 +5912,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/hexoid": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -40,6 +40,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "dotenv": "^16.4.5",
+    "helmet": "^8.1.0",
     "joi": "^17.13.3",
     "korean-lunar-calendar": "^0.3.6",
     "ms": "^2.1.3",

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,10 +6,41 @@ import { GetHandlerGuard } from './common/guard/get-handler.guard';
 import { TypeOrmExceptionFilter } from './common/filter/typeorm-exception.filter';
 import * as cookieParser from 'cookie-parser';
 import { XssSanitizerPipe } from './common/pipe/xss-sanitizer.pipe';
+import helmet from 'helmet';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.use(cookieParser.default());
+  app.use(
+    helmet({
+      // 1. 콘덴츠 스니핑 방지
+      xContentTypeOptions: true,
+
+      // 2. 클릭 재킹 방지 (iframe 삽입 금지)
+      frameguard: { action: 'deny' },
+
+      // 3. referrer 최소화
+      referrerPolicy: { policy: 'no-referrer' },
+
+      // 4. hsts - 프로덕션 환경에서만
+      hsts: process.env.NODE_ENV === 'production' && {
+        maxAge: 60 * 60 * 24 * 365,
+        includeSubDomains: true,
+        preload: true,
+      },
+
+      // 5. DNS Prefetch 제어
+      dnsPrefetchControl: { allow: false },
+
+      // 6. Cross-Origin 정책
+      crossOriginEmbedderPolicy: false, // 필요 시 true
+      crossOriginOpenerPolicy: { policy: 'same-origin' },
+      crossOriginResourcePolicy: { policy: 'same-origin' },
+
+      // 7. CSP
+      contentSecurityPolicy: false,
+    }),
+  );
 
   // CORS 설정
   app.enableCors({


### PR DESCRIPTION
## 주요 내용
- **Helmet 미들웨어 적용**
  - `main.ts`에서 `app.use(helmet({...}))`을 사용하여 공통 보안 헤더 자동 설정
  - API 서버 환경에 적합한 옵션만 활성화하여 기본 보안 강화

## 세부 내용
### Helmet 설정
- `xContentTypeOptions: true` → MIME 타입 스니핑 방지 (`X-Content-Type-Options: nosniff`)
- `frameguard: { action: 'deny' }` → iframe 삽입 차단 (`X-Frame-Options: DENY`)
- `referrerPolicy: { policy: 'no-referrer' }` → Referer 헤더 비공개
- `hsts` → HTTPS 환경에서 HSTS 헤더 설정 (`Strict-Transport-Security`)
- `dnsPrefetchControl: { allow: false }` → DNS Prefetch 차단
- `crossOriginOpenerPolicy: { policy: 'same-origin' }` → 교차 출처 opener 제어
- `crossOriginResourcePolicy: { policy: 'same-origin' }` → 교차 출처 리소스 제어
- `crossOriginEmbedderPolicy: false` → API 서버 특성상 embedder 정책 비활성화
- `contentSecurityPolicy: false` → API 서버이므로 CSP는 적용하지 않음

### 기대 효과
- 클릭재킹, MIME 스니핑, Referrer 노출 등 기본적인 웹 보안 취약점 방지
- HTTPS 환경에서 브라우저가 안전하게 리소스를 처리하도록 강제
- API 서버 특성에 맞춰 CSP 및 Embedder 정책 충돌 방지