### PR TITLE
fix: 대량 교인 등록 시 413(Content Too Large) 발생 문제 해결 — JSON 바디 제한 상향

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,10 +6,13 @@ import { TypeOrmExceptionFilter } from './common/filter/typeorm-exception.filter
 import * as cookieParser from 'cookie-parser';
 import { XssSanitizerPipe } from './common/pipe/xss-sanitizer.pipe';
 import helmet from 'helmet';
+import * as bodyParser from 'body-parser';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.use(cookieParser.default());
+  app.use(bodyParser.json({ limit: '20mb' }));
+  app.use(bodyParser.urlencoded({ limit: '20mb', extended: true }));
   app.use(
     helmet({
       // 1. 콘덴츠 스니핑 방지


### PR DESCRIPTION
## 주요 내용
- 프론트에서 JSON으로 전송되는 대량 교인 데이터가 Express 기본 body 제한을 초과해 413 에러가 발생하던 문제 해결
- 애플리케이션 전역 JSON/x-www-form-urlencoded 요청 본문 크기 제한을 20MB로 상향하여 대량 등록 요청 처리 안정화

## 세부 내용
### main.ts
- `bodyParser.json({ limit: '20mb' })` 적용
- `bodyParser.urlencoded({ limit: '20mb', extended: true })` 적용
- 대용량 배열(예: 수백 명 단위의 교인 등록) 처리 시 요청 차단 없이 서비스 레이어로 전달되도록 개선